### PR TITLE
refactor(chatStore): reduce internal duplication in config and review flows

### DIFF
--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -2534,6 +2534,16 @@ describe("chatStore", () => {
         const detachedSessionId = "persisted:history-42";
         const resumedSessionId = "codex-session-resumed";
         const messageId = "plan:resume";
+        const queuedMessage = createQueuedMessage(
+            "queued-resume",
+            "Queued after resume",
+        );
+        const editedQueuedMessage = createQueuedMessage(
+            "queued-edit",
+            "Edit after resume",
+        );
+        const draftParts = createTextParts("Resume draft");
+        const previousDraftParts = createTextParts("Previous draft");
         const activeSession =
             useChatStore.getState().sessionsById[getActiveSessionId()]!;
 
@@ -2569,6 +2579,58 @@ describe("chatStore", () => {
         useChatRowUiStore.getState().patchRow(detachedSessionId, messageId, {
             expanded: false,
         });
+        useChatTabsStore.setState({
+            tabs: [
+                {
+                    id: "tab-detached",
+                    sessionId: detachedSessionId,
+                },
+            ],
+            activeTabId: "tab-detached",
+        });
+        useChatStore.setState((state) => ({
+            composerPartsBySessionId: {
+                ...state.composerPartsBySessionId,
+                [detachedSessionId]: draftParts,
+            },
+            queuedMessagesBySessionId: {
+                ...state.queuedMessagesBySessionId,
+                [detachedSessionId]: [queuedMessage, editedQueuedMessage],
+            },
+            queuedMessageEditBySessionId: {
+                ...state.queuedMessageEditBySessionId,
+                [detachedSessionId]: {
+                    item: editedQueuedMessage,
+                    originalIndex: 1,
+                    previousItemId: queuedMessage.id,
+                    nextItemId: null,
+                    previousComposerParts: previousDraftParts,
+                    previousAttachments: [],
+                },
+            },
+            activeQueuedMessageBySessionId: {
+                ...state.activeQueuedMessageBySessionId,
+                [detachedSessionId]: {
+                    item: queuedMessage,
+                    originalIndex: 0,
+                    previousItemId: null,
+                    nextItemId: editedQueuedMessage.id,
+                },
+            },
+            pausedQueueBySessionId: {
+                ...state.pausedQueueBySessionId,
+                [detachedSessionId]: {
+                    reinstateAfterNextManualSend: [
+                        {
+                            item: editedQueuedMessage,
+                            originalIndex: 1,
+                            previousItemId: queuedMessage.id,
+                            nextItemId: null,
+                        },
+                    ],
+                },
+            },
+        }));
 
         invokeMock.mockImplementation(async (command, args) => {
             if (command === "ai_create_session") {
@@ -2608,6 +2670,76 @@ describe("chatStore", () => {
             useChatStore.getState().sessionsById[resumedSessionId]
                 ?.activePlanMessageId,
         ).toBe(messageId);
+        expect(
+            serializeComposerParts(
+                useChatStore.getState().composerPartsBySessionId[
+                    resumedSessionId
+                ] ?? [],
+            ),
+        ).toBe("Resume draft");
+        expect(
+            useChatStore.getState().queuedMessagesBySessionId[resumedSessionId],
+        ).toEqual([queuedMessage, editedQueuedMessage]);
+        expect(
+            useChatStore.getState().queuedMessageEditBySessionId[
+                resumedSessionId
+            ],
+        ).toMatchObject({
+            item: editedQueuedMessage,
+            previousComposerParts: previousDraftParts,
+        });
+        expect(
+            useChatStore.getState().activeQueuedMessageBySessionId[
+                resumedSessionId
+            ],
+        ).toMatchObject({
+            item: queuedMessage,
+            nextItemId: editedQueuedMessage.id,
+        });
+        expect(
+            useChatStore.getState().pausedQueueBySessionId[resumedSessionId],
+        ).toMatchObject({
+            reinstateAfterNextManualSend: [
+                expect.objectContaining({
+                    item: editedQueuedMessage,
+                }),
+            ],
+        });
+        expect(
+            useChatStore.getState().composerPartsBySessionId[detachedSessionId],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().queuedMessagesBySessionId[
+                detachedSessionId
+            ],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().queuedMessageEditBySessionId[
+                detachedSessionId
+            ],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().activeQueuedMessageBySessionId[
+                detachedSessionId
+            ],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().pausedQueueBySessionId[detachedSessionId],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().sessionsById[resumedSessionId],
+        ).toMatchObject({
+            isResumingSession: false,
+            runtimeState: "live",
+        });
+        expect(useChatTabsStore.getState().tabs).toEqual([
+            {
+                id: "tab-detached",
+                sessionId: resumedSessionId,
+                historySessionId: "history-42",
+                runtimeId: "codex-acp",
+            },
+        ]);
     });
 
     it("adds the user message and turns the session into error when the runtime fails", async () => {
@@ -8248,6 +8380,100 @@ describe("chatStore", () => {
         ).toEqual(["low", "medium", "high", "xhigh"]);
     });
 
+    it('keeps setModel observably aligned with setConfigOption("model") for live ACP sessions', async () => {
+        await useChatStore.getState().initialize();
+
+        const firstSessionId = getActiveSessionId();
+        const firstSession =
+            useChatStore.getState().sessionsById[firstSessionId]!;
+        const secondSessionId = "codex-session-model-compare";
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_set_config_option") {
+                const input =
+                    typeof args === "object" && args !== null && "input" in args
+                        ? (args.input as {
+                              session_id?: string;
+                              option_id?: string;
+                              value?: string;
+                          })
+                        : undefined;
+
+                if (input?.option_id === "model") {
+                    return {
+                        ...sessionPayload,
+                        session_id:
+                            input.session_id ?? sessionPayload.session_id,
+                        model_id: input.value ?? "test-model",
+                        config_options: [
+                            {
+                                ...acpConfigOptions[0],
+                                value: input.value ?? "test-model",
+                            },
+                            {
+                                ...acpConfigOptions[1],
+                                value: "low",
+                                options: [
+                                    { value: "low", label: "Low" },
+                                    { value: "medium", label: "Medium" },
+                                    { value: "high", label: "High" },
+                                    { value: "xhigh", label: "Extra High" },
+                                ],
+                            },
+                        ],
+                    };
+                }
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().upsertSession(
+            cloneSessionForTest(firstSession, secondSessionId, {
+                historySessionId: "history-model-compare",
+                runtimeState: "live",
+                isPersistedSession: false,
+            }),
+            true,
+        );
+
+        await useChatStore.getState().setModel("wide-model", firstSessionId);
+        await useChatStore
+            .getState()
+            .setConfigOption("model", "wide-model", secondSessionId);
+
+        const modelSession =
+            useChatStore.getState().sessionsById[firstSessionId]!;
+        const configSession =
+            useChatStore.getState().sessionsById[secondSessionId]!;
+        const prefs = JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}");
+        const modelSelectionCalls = invokeMock.mock.calls.filter(
+            ([command, args]) =>
+                command === "ai_set_config_option" &&
+                typeof args === "object" &&
+                args !== null &&
+                "input" in args &&
+                (args.input as { option_id?: string; value?: string })
+                    .option_id === "model" &&
+                (args.input as { option_id?: string; value?: string }).value ===
+                    "wide-model",
+        );
+
+        expect(modelSession.modelId).toBe("wide-model");
+        expect(configSession.modelId).toBe("wide-model");
+        expect(modelSession.modeId).toBe(configSession.modeId);
+        expect(modelSession.configOptions).toEqual(configSession.configOptions);
+        expect(prefs).toMatchObject({
+            modelId: "wide-model",
+        });
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) => command === "ai_set_model",
+            ),
+        ).toHaveLength(0);
+        expect(modelSelectionCalls).toHaveLength(2);
+    });
+
     it("preserves a fresher session-updated model change when ai_set_config_option returns stale data", async () => {
         await useChatStore.getState().initialize();
 
@@ -8829,6 +9055,262 @@ describe("chatStore", () => {
         ).toHaveLength(3);
     });
 
+    it("resumes a persisted session before applying a config option mutation", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const persistedSessionId = "codex-session-restored-option";
+        const resumedSessionId = "codex-session-restored-option-live";
+        const activeSession =
+            useChatStore.getState().sessionsById[activeSessionId]!;
+        const resumeSession = vi.fn(async (sessionId: string) => {
+            const persistedSession =
+                useChatStore.getState().sessionsById[sessionId]!;
+            useChatStore.setState((state) => {
+                const resumedSession = cloneSessionForTest(
+                    activeSession,
+                    resumedSessionId,
+                    {
+                        historySessionId:
+                            persistedSession.historySessionId ?? sessionId,
+                        runtimeState: "live",
+                        isPersistedSession: false,
+                    },
+                );
+                const nextSessionsById = { ...state.sessionsById };
+                delete nextSessionsById[sessionId];
+                nextSessionsById[resumedSessionId] = resumedSession;
+
+                return {
+                    sessionsById: nextSessionsById,
+                    sessionOrder: state.sessionOrder.map((id) =>
+                        id === sessionId ? resumedSessionId : id,
+                    ),
+                    activeSessionId:
+                        state.activeSessionId === sessionId
+                            ? resumedSessionId
+                            : state.activeSessionId,
+                };
+            });
+
+            return resumedSessionId;
+        });
+
+        useChatStore.getState().upsertSession(
+            cloneSessionForTest(activeSession, persistedSessionId, {
+                historySessionId: "history-restored-option",
+                runtimeState: "persisted_only",
+                isPersistedSession: true,
+                models: [],
+                modes: [],
+                configOptions: [],
+            }),
+            true,
+        );
+        useChatStore.setState({ resumeSession });
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_set_config_option") {
+                const input =
+                    typeof args === "object" && args !== null && "input" in args
+                        ? (args.input as {
+                              session_id?: string;
+                              option_id?: string;
+                              value?: string;
+                          })
+                        : undefined;
+
+                expect(input).toMatchObject({
+                    session_id: resumedSessionId,
+                    option_id: "reasoning_effort",
+                    value: "high",
+                });
+
+                return {
+                    ...sessionPayload,
+                    session_id: resumedSessionId,
+                    config_options: [
+                        {
+                            ...acpConfigOptions[0],
+                            value: "test-model",
+                        },
+                        {
+                            ...acpConfigOptions[1],
+                            value: "high",
+                        },
+                    ],
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore
+            .getState()
+            .setConfigOption("reasoning_effort", "high", persistedSessionId);
+
+        const restored = useChatStore.getState().sessionsById[resumedSessionId];
+        const prefs = JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}");
+
+        expect(resumeSession).toHaveBeenCalledWith(persistedSessionId);
+        expect(useChatStore.getState().sessionsById[persistedSessionId]).toBe(
+            undefined,
+        );
+        expect(
+            restored?.configOptions.find(
+                (option) => option.id === "reasoning_effort",
+            )?.value,
+        ).toBe("high");
+        expect(prefs).toMatchObject({
+            configOptions: {
+                reasoning_effort: "high",
+            },
+        });
+    });
+
+    it("does not simulate a persisted model change when resumeSession cannot make it live", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const persistedSessionId = "codex-session-model-resume-failure";
+        const activeSession =
+            useChatStore.getState().sessionsById[activeSessionId]!;
+        const resumeSession = vi.fn(async () => null);
+
+        useChatStore.getState().upsertSession(
+            cloneSessionForTest(activeSession, persistedSessionId, {
+                historySessionId: "history-model-resume-failure",
+                runtimeState: "persisted_only",
+                isPersistedSession: true,
+                modelId: "test-model",
+                models: [],
+                modes: [],
+                configOptions: [],
+            }),
+            true,
+        );
+        useChatStore.setState({ resumeSession });
+
+        await useChatStore
+            .getState()
+            .setModel("wide-model", persistedSessionId);
+
+        expect(resumeSession).toHaveBeenCalledWith(persistedSessionId);
+        expect(
+            useChatStore.getState().sessionsById[persistedSessionId],
+        ).toMatchObject({
+            sessionId: persistedSessionId,
+            runtimeState: "persisted_only",
+            modelId: "test-model",
+        });
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) =>
+                    command === "ai_set_model" ||
+                    command === "ai_set_config_option",
+            ),
+        ).toHaveLength(0);
+        expect(localStorage.getItem(AI_PREFS_KEY)).toBeNull();
+    });
+
+    it("does not simulate a resumed config option change when the remote mutation fails", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const persistedSessionId = "codex-session-option-remote-failure";
+        const resumedSessionId = "codex-session-option-remote-failure-live";
+        const activeSession =
+            useChatStore.getState().sessionsById[activeSessionId]!;
+        const resumeSession = vi.fn(async (sessionId: string) => {
+            const persistedSession =
+                useChatStore.getState().sessionsById[sessionId]!;
+            useChatStore.setState((state) => {
+                const resumedSession = cloneSessionForTest(
+                    activeSession,
+                    resumedSessionId,
+                    {
+                        historySessionId:
+                            persistedSession.historySessionId ?? sessionId,
+                        runtimeState: "live",
+                        isPersistedSession: false,
+                    },
+                );
+                const nextSessionsById = { ...state.sessionsById };
+                delete nextSessionsById[sessionId];
+                nextSessionsById[resumedSessionId] = resumedSession;
+
+                return {
+                    sessionsById: nextSessionsById,
+                    sessionOrder: state.sessionOrder.map((id) =>
+                        id === sessionId ? resumedSessionId : id,
+                    ),
+                    activeSessionId:
+                        state.activeSessionId === sessionId
+                            ? resumedSessionId
+                            : state.activeSessionId,
+                };
+            });
+
+            return resumedSessionId;
+        });
+
+        useChatStore.getState().upsertSession(
+            cloneSessionForTest(activeSession, persistedSessionId, {
+                historySessionId: "history-option-remote-failure",
+                runtimeState: "persisted_only",
+                isPersistedSession: true,
+                models: [],
+                modes: [],
+                configOptions: [],
+            }),
+            true,
+        );
+        useChatStore.setState({ resumeSession });
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_set_config_option") {
+                const input =
+                    typeof args === "object" && args !== null && "input" in args
+                        ? (args.input as {
+                              session_id?: string;
+                              option_id?: string;
+                              value?: string;
+                          })
+                        : undefined;
+
+                expect(input).toMatchObject({
+                    session_id: resumedSessionId,
+                    option_id: "reasoning_effort",
+                    value: "high",
+                });
+                throw new Error("remote option failure");
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore
+            .getState()
+            .setConfigOption("reasoning_effort", "high", persistedSessionId);
+
+        const restored =
+            useChatStore.getState().sessionsById[resumedSessionId] ?? null;
+        const prefs = JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}");
+
+        expect(resumeSession).toHaveBeenCalledWith(persistedSessionId);
+        expect(restored?.runtimeState).toBe("live");
+        expect(
+            restored?.configOptions.find(
+                (option) => option.id === "reasoning_effort",
+            )?.value,
+        ).toBe("medium");
+        expect(restored?.messages.at(-1)).toMatchObject({
+            kind: "error",
+            content: "remote option failure",
+        });
+        expect(prefs.configOptions ?? {}).toEqual({});
+    });
+
     it("supports targeting a non-active live session for send, user input and stop actions", async () => {
         await useChatStore.getState().initialize();
 
@@ -9329,6 +9811,82 @@ describe("chatStore", () => {
         });
     });
 
+    it("resolveReviewHunks marks rejected hunks as conflict when the applied file changed on disk", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-hunk-conflict",
+            title: "Edit file",
+            kind: "edit",
+            status: "completed",
+            diffs: [
+                {
+                    path: "/notes/file.md",
+                    kind: "update",
+                    old_text: "aaa\nbbb\nccc",
+                    new_text: "aaa\nBBB\nccc",
+                },
+            ],
+        });
+        useEditorStore.getState().openReview(activeSessionId, {
+            title: "Review Codex",
+        });
+
+        const entry = getVisibleBuffer(activeSessionId)[0]!;
+        const projection = buildReviewProjection(entry);
+
+        invokeMock.mockImplementation(async (command) => {
+            if (command === "ai_get_text_file_hash") {
+                return "different-hash";
+            }
+
+            if (
+                command === "ai_save_session_history" ||
+                command === "ai_prune_session_histories"
+            ) {
+                return undefined;
+            }
+
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        await useChatStore
+            .getState()
+            .resolveReviewHunks(
+                activeSessionId,
+                entry.identityKey,
+                "rejected",
+                entry.version,
+                [projection.hunks[0]!.id],
+            );
+
+        const [remaining] = getVisibleBuffer(activeSessionId);
+        expect(remaining).toMatchObject({
+            identityKey: entry.identityKey,
+            conflictHash: "different-hash",
+        });
+        expect(
+            useChatStore.getState().sessionsById[activeSessionId]?.actionLog
+                ?.lastRejectUndo,
+        ).toBeNull();
+        expect(
+            useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) =>
+                        isReviewTab(tab) && tab.sessionId === activeSessionId,
+                ),
+        ).toBeDefined();
+        expect(invokeMock).not.toHaveBeenCalledWith(
+            "ai_restore_text_file",
+            expect.anything(),
+        );
+    });
+
     it("resolveReviewHunks accepts only the selected accumulated hunk and preserves later agent hunks", async () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
         await useChatStore.getState().initialize();
@@ -9415,6 +9973,49 @@ describe("chatStore", () => {
             "aaXa\nBBB\nccc\nDDD",
         );
         expect(buildReviewProjection(remaining!).hunks).toHaveLength(1);
+    });
+
+    it("keeps move-only tracked files pending after accepting the last text hunk", async () => {
+        const file = createTrackedFile(
+            "/notes/file-renamed.md",
+            "alpha\nbeta\ngamma",
+            "alpha\nBETA\ngamma",
+            {
+                originPath: "/notes/file.md",
+                previousPath: "/notes/file.md",
+                reviewState: "finalized",
+            },
+        );
+        const session = createSessionWithTrackedFiles("session-move-only", [
+            file,
+        ]);
+        const projection = buildReviewProjection(file);
+
+        useChatStore.setState({
+            activeSessionId: session.sessionId,
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+        });
+
+        await useChatStore
+            .getState()
+            .resolveReviewHunks(
+                session.sessionId,
+                file.identityKey,
+                "accepted",
+                file.version,
+                [projection.hunks[0]!.id],
+            );
+
+        const [remaining] = getVisibleBuffer(session.sessionId);
+        expect(remaining).toMatchObject({
+            path: "/notes/file-renamed.md",
+            originPath: "/notes/file.md",
+            previousPath: "/notes/file.md",
+        });
+        expect(remaining?.unreviewedEdits).toEqual(emptyPatch());
+        expect(buildReviewProjection(remaining!).hunks).toHaveLength(0);
     });
 
     it("resolveReviewHunks does not depend on the visual projection to accept hunks", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1732,6 +1732,138 @@ function canRecreateSessionForAdditionalRoots(
     return !state.queuedMessageEditBySessionId[sessionId];
 }
 
+type SessionLocalStateSnapshot = {
+    composerParts: AIComposerPart[];
+    queuedMessages: QueuedChatMessage[];
+    queuedMessageEdit: QueuedMessageEditState | undefined;
+    activeQueuedMessage: DeferredQueuedMessage | undefined;
+    pausedQueue: PausedQueueState | undefined;
+};
+
+function snapshotSessionLocalState(
+    state: Pick<
+        ChatStore,
+        | "composerPartsBySessionId"
+        | "queuedMessagesBySessionId"
+        | "queuedMessageEditBySessionId"
+        | "activeQueuedMessageBySessionId"
+        | "pausedQueueBySessionId"
+    >,
+    sessionId: string,
+): SessionLocalStateSnapshot {
+    return {
+        composerParts:
+            state.composerPartsBySessionId[sessionId] ??
+            createEmptyComposerParts(),
+        queuedMessages: state.queuedMessagesBySessionId[sessionId] ?? [],
+        queuedMessageEdit: state.queuedMessageEditBySessionId[sessionId],
+        activeQueuedMessage: state.activeQueuedMessageBySessionId[sessionId],
+        pausedQueue: state.pausedQueueBySessionId[sessionId],
+    };
+}
+
+function migrateSessionLocalState(
+    fromSessionId: string,
+    toSession: AIChatSession,
+    shouldApply?: (state: ChatStore) => boolean,
+): boolean {
+    let migrated = false;
+
+    useChatStore.setState((state) => {
+        if (shouldApply && !shouldApply(state)) {
+            return state;
+        }
+
+        const localState = snapshotSessionLocalState(state, fromSessionId);
+        const nextSessionsById = { ...state.sessionsById };
+        delete nextSessionsById[fromSessionId];
+
+        const nextComposerParts = {
+            ...state.composerPartsBySessionId,
+        };
+        delete nextComposerParts[fromSessionId];
+        nextComposerParts[toSession.sessionId] = localState.composerParts;
+
+        const nextQueuedMessagesBySessionId = {
+            ...state.queuedMessagesBySessionId,
+        };
+        delete nextQueuedMessagesBySessionId[fromSessionId];
+        if (localState.queuedMessages.length > 0) {
+            nextQueuedMessagesBySessionId[toSession.sessionId] =
+                localState.queuedMessages;
+        }
+
+        const nextQueuedMessageEditBySessionId = {
+            ...state.queuedMessageEditBySessionId,
+        };
+        delete nextQueuedMessageEditBySessionId[fromSessionId];
+        if (localState.queuedMessageEdit) {
+            nextQueuedMessageEditBySessionId[toSession.sessionId] =
+                localState.queuedMessageEdit;
+        }
+
+        const nextActiveQueuedMessageBySessionId = {
+            ...state.activeQueuedMessageBySessionId,
+        };
+        delete nextActiveQueuedMessageBySessionId[fromSessionId];
+        if (localState.activeQueuedMessage) {
+            nextActiveQueuedMessageBySessionId[toSession.sessionId] =
+                localState.activeQueuedMessage;
+        }
+
+        const nextPausedQueueBySessionId = {
+            ...state.pausedQueueBySessionId,
+        };
+        delete nextPausedQueueBySessionId[fromSessionId];
+        if (localState.pausedQueue) {
+            nextPausedQueueBySessionId[toSession.sessionId] =
+                localState.pausedQueue;
+        }
+
+        migrated = true;
+
+        return {
+            runtimes: hydrateRuntimesFromSessions(state.runtimes, [toSession]),
+            sessionsById: {
+                ...nextSessionsById,
+                [toSession.sessionId]: toSession,
+            },
+            sessionOrder: touchSessionOrder(
+                state.sessionOrder.filter((id) => id !== fromSessionId),
+                toSession.sessionId,
+            ),
+            activeSessionId:
+                state.activeSessionId === fromSessionId
+                    ? toSession.sessionId
+                    : state.activeSessionId,
+            composerPartsBySessionId: nextComposerParts,
+            queuedMessagesBySessionId: nextQueuedMessagesBySessionId,
+            queuedMessageEditBySessionId: nextQueuedMessageEditBySessionId,
+            activeQueuedMessageBySessionId: nextActiveQueuedMessageBySessionId,
+            pausedQueueBySessionId: nextPausedQueueBySessionId,
+        };
+    });
+
+    if (!migrated) {
+        return false;
+    }
+
+    clearStaleStreamingCheck(fromSessionId);
+    _queueDrainLocks.delete(fromSessionId);
+    replaceChatRowUiSessionId(fromSessionId, toSession.sessionId);
+    useChatTabsStore
+        .getState()
+        .replaceSessionId(
+            fromSessionId,
+            toSession.sessionId,
+            toSession.historySessionId,
+            toSession.runtimeId,
+        );
+    registerOpenEditorBaselines(toSession.sessionId);
+
+    return true;
+}
+
 function registerOpenEditorBaselines(sessionId: string) {
     const tabs = useEditorStore.getState().tabs;
     for (const tab of tabs) {
@@ -1966,117 +2098,38 @@ async function replaceEmptySessionForAdditionalRoots(
         return sessionId;
     }
 
-    const previousParts =
-        latestState.composerPartsBySessionId[sessionId] ??
-        createEmptyComposerParts();
-    const previousQueue =
-        latestState.queuedMessagesBySessionId[sessionId] ?? [];
-    const previousQueuedMessageEdit =
-        latestState.queuedMessageEditBySessionId[sessionId];
-    const previousActiveQueuedMessage =
-        latestState.activeQueuedMessageBySessionId[sessionId];
-    const previousPausedQueue = latestState.pausedQueueBySessionId[sessionId];
     const migratedSession: AIChatSession = {
         ...replacementSession,
         attachments: latestSession.attachments.map(cloneAttachment),
         resumeContextPending: latestSession.resumeContextPending ?? false,
     };
 
-    useChatStore.setState((currentState) => {
-        const currentSession = currentState.sessionsById[sessionId];
-        if (
-            !currentSession ||
-            !canRecreateSessionForAdditionalRoots(
-                currentSession,
-                sessionId,
-                currentState,
-            )
-        ) {
-            return currentState;
+    const migrated = migrateSessionLocalState(
+        sessionId,
+        migratedSession,
+        (currentState) => {
+            const currentSession = currentState.sessionsById[sessionId];
+            return Boolean(
+                currentSession &&
+                canRecreateSessionForAdditionalRoots(
+                    currentSession,
+                    sessionId,
+                    currentState,
+                ),
+            );
+        },
+    );
+    if (!migrated) {
+        await aiDeleteRuntimeSession(migratedSession.sessionId).catch(() => {});
+        if (vaultPath) {
+            await aiDeleteSessionHistory(
+                vaultPath,
+                migratedSession.historySessionId,
+            ).catch(() => {});
         }
+        return sessionId;
+    }
 
-        const nextSessionsById = { ...currentState.sessionsById };
-        delete nextSessionsById[sessionId];
-
-        const nextComposerParts = {
-            ...currentState.composerPartsBySessionId,
-        };
-        delete nextComposerParts[sessionId];
-        nextComposerParts[migratedSession.sessionId] = previousParts;
-
-        const nextQueuedMessagesBySessionId = {
-            ...currentState.queuedMessagesBySessionId,
-        };
-        delete nextQueuedMessagesBySessionId[sessionId];
-        if (previousQueue.length > 0) {
-            nextQueuedMessagesBySessionId[migratedSession.sessionId] =
-                previousQueue;
-        }
-
-        const nextQueuedMessageEditBySessionId = {
-            ...currentState.queuedMessageEditBySessionId,
-        };
-        delete nextQueuedMessageEditBySessionId[sessionId];
-        if (previousQueuedMessageEdit) {
-            nextQueuedMessageEditBySessionId[migratedSession.sessionId] =
-                previousQueuedMessageEdit;
-        }
-
-        const nextActiveQueuedMessageBySessionId = {
-            ...currentState.activeQueuedMessageBySessionId,
-        };
-        delete nextActiveQueuedMessageBySessionId[sessionId];
-        if (previousActiveQueuedMessage) {
-            nextActiveQueuedMessageBySessionId[migratedSession.sessionId] =
-                previousActiveQueuedMessage;
-        }
-
-        const nextPausedQueueBySessionId = {
-            ...currentState.pausedQueueBySessionId,
-        };
-        delete nextPausedQueueBySessionId[sessionId];
-        if (previousPausedQueue) {
-            nextPausedQueueBySessionId[migratedSession.sessionId] =
-                previousPausedQueue;
-        }
-
-        return {
-            runtimes: hydrateRuntimesFromSessions(currentState.runtimes, [
-                migratedSession,
-            ]),
-            sessionsById: {
-                ...nextSessionsById,
-                [migratedSession.sessionId]: migratedSession,
-            },
-            sessionOrder: touchSessionOrder(
-                currentState.sessionOrder.filter((id) => id !== sessionId),
-                migratedSession.sessionId,
-            ),
-            activeSessionId:
-                currentState.activeSessionId === sessionId
-                    ? migratedSession.sessionId
-                    : currentState.activeSessionId,
-            composerPartsBySessionId: nextComposerParts,
-            queuedMessagesBySessionId: nextQueuedMessagesBySessionId,
-            queuedMessageEditBySessionId: nextQueuedMessageEditBySessionId,
-            activeQueuedMessageBySessionId: nextActiveQueuedMessageBySessionId,
-            pausedQueueBySessionId: nextPausedQueueBySessionId,
-        };
-    });
-
-    clearStaleStreamingCheck(sessionId);
-    _queueDrainLocks.delete(sessionId);
-    replaceChatRowUiSessionId(sessionId, migratedSession.sessionId);
-    useChatTabsStore
-        .getState()
-        .replaceSessionId(
-            sessionId,
-            migratedSession.sessionId,
-            migratedSession.historySessionId,
-            migratedSession.runtimeId,
-        );
-
-    registerOpenEditorBaselines(migratedSession.sessionId);
     await persistSessionNow(migratedSession);
     await aiDeleteRuntimeSession(sessionId).catch(() => {});
     if (vaultPath) {
@@ -5732,8 +5785,6 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     );
                 }
 
-                registerOpenEditorBaselines(resumedSession.sessionId);
-
                 const migratedSession = startNewWorkCycle(
                     replaceSessionTranscript(
                         {
@@ -5768,106 +5819,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     ),
                 );
 
-                set((currentState) => {
-                    const previousParts =
-                        currentState.composerPartsBySessionId[sessionId] ??
-                        createEmptyComposerParts();
-                    const previousQueue =
-                        currentState.queuedMessagesBySessionId[sessionId] ?? [];
-                    const previousQueuedMessageEdit =
-                        currentState.queuedMessageEditBySessionId[sessionId];
-                    const previousActiveQueuedMessage =
-                        currentState.activeQueuedMessageBySessionId[sessionId];
-                    const previousPausedQueue =
-                        currentState.pausedQueueBySessionId[sessionId];
-                    const nextSessionsById = { ...currentState.sessionsById };
-                    delete nextSessionsById[sessionId];
-
-                    const nextComposerParts = {
-                        ...currentState.composerPartsBySessionId,
-                    };
-                    delete nextComposerParts[sessionId];
-                    nextComposerParts[migratedSession.sessionId] =
-                        previousParts;
-
-                    const nextQueuedMessagesBySessionId = {
-                        ...currentState.queuedMessagesBySessionId,
-                    };
-                    delete nextQueuedMessagesBySessionId[sessionId];
-                    if (previousQueue.length > 0) {
-                        nextQueuedMessagesBySessionId[
-                            migratedSession.sessionId
-                        ] = previousQueue;
-                    }
-
-                    const nextQueuedMessageEditBySessionId = {
-                        ...currentState.queuedMessageEditBySessionId,
-                    };
-                    delete nextQueuedMessageEditBySessionId[sessionId];
-                    if (previousQueuedMessageEdit) {
-                        nextQueuedMessageEditBySessionId[
-                            migratedSession.sessionId
-                        ] = previousQueuedMessageEdit;
-                    }
-
-                    const nextActiveQueuedMessageBySessionId = {
-                        ...currentState.activeQueuedMessageBySessionId,
-                    };
-                    delete nextActiveQueuedMessageBySessionId[sessionId];
-                    if (previousActiveQueuedMessage) {
-                        nextActiveQueuedMessageBySessionId[
-                            migratedSession.sessionId
-                        ] = previousActiveQueuedMessage;
-                    }
-
-                    const nextPausedQueueBySessionId = {
-                        ...currentState.pausedQueueBySessionId,
-                    };
-                    delete nextPausedQueueBySessionId[sessionId];
-                    if (previousPausedQueue) {
-                        nextPausedQueueBySessionId[migratedSession.sessionId] =
-                            previousPausedQueue;
-                    }
-
-                    return {
-                        runtimes: hydrateRuntimesFromSessions(
-                            currentState.runtimes,
-                            [migratedSession],
-                        ),
-                        sessionsById: {
-                            ...nextSessionsById,
-                            [migratedSession.sessionId]: migratedSession,
-                        },
-                        sessionOrder: touchSessionOrder(
-                            currentState.sessionOrder.filter(
-                                (id) => id !== sessionId,
-                            ),
-                            migratedSession.sessionId,
-                        ),
-                        activeSessionId:
-                            currentState.activeSessionId === sessionId
-                                ? migratedSession.sessionId
-                                : currentState.activeSessionId,
-                        composerPartsBySessionId: nextComposerParts,
-                        queuedMessagesBySessionId:
-                            nextQueuedMessagesBySessionId,
-                        queuedMessageEditBySessionId:
-                            nextQueuedMessageEditBySessionId,
-                        activeQueuedMessageBySessionId:
-                            nextActiveQueuedMessageBySessionId,
-                        pausedQueueBySessionId: nextPausedQueueBySessionId,
-                    };
-                });
-                _queueDrainLocks.delete(sessionId);
-                replaceChatRowUiSessionId(sessionId, migratedSession.sessionId);
-                useChatTabsStore
-                    .getState()
-                    .replaceSessionId(
-                        sessionId,
-                        migratedSession.sessionId,
-                        migratedSession.historySessionId,
-                        migratedSession.runtimeId,
-                    );
+                migrateSessionLocalState(sessionId, migratedSession);
 
                 return migratedSession.sessionId;
             } catch (error) {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2551,6 +2551,12 @@ function markTrackedFileConflictAndPersist(
     }
 }
 
+function isTextTrackedFile(
+    tracked: TrackedFile | null | undefined,
+): tracked is TrackedFile & { isText: true } {
+    return tracked?.isText === true;
+}
+
 type ReadyTrackedFileMutation = {
     session: AIChatSession;
     tracked: TrackedFile & { isText: true };
@@ -2580,7 +2586,7 @@ async function prepareTrackedFileMutation(
     }
 
     const tracked = findTrackedFileInAccumulatedSession(session, identityKey);
-    if (!tracked || !tracked.isText) {
+    if (!isTextTrackedFile(tracked)) {
         return { kind: "abort" };
     }
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2517,7 +2517,7 @@ function markTrackedConflict(
     };
 }
 
-function markTrackedFileConflictAndPersist(
+function markTrackedFileConflict(
     sessionId: string,
     identityKey: string,
     currentHash: string | null,
@@ -2537,7 +2537,14 @@ function markTrackedFileConflictAndPersist(
             },
         };
     });
+}
 
+function markTrackedFileConflictAndPersist(
+    sessionId: string,
+    identityKey: string,
+    currentHash: string | null,
+) {
+    markTrackedFileConflict(sessionId, identityKey, currentHash);
     const updatedSession = useChatStore.getState().sessionsById[sessionId];
     if (updatedSession) {
         void persistSession(updatedSession);
@@ -2939,6 +2946,20 @@ async function executeRestoreAction(
     return { action, change };
 }
 
+async function rejectTrackedFileAndReload(
+    vaultPath: string,
+    tracked: TrackedFile,
+): Promise<RestoreAction> {
+    const liveText = await readTrackedFileLiveText(tracked);
+    const { action: restoreAction, change } = await executeRestoreAction(
+        vaultPath,
+        tracked,
+        liveText,
+    );
+    reloadEditorAfterRestore(tracked, restoreAction, change);
+    return restoreAction;
+}
+
 /**
  * After a reject/undo writes content to disk, force-reload the open editor tab
  * so CodeMirror reflects the new content immediately.
@@ -3005,6 +3026,43 @@ function reloadEditorAfterRestore(
     } else {
         reloadOpenEditorContent(restoredPath, action.content, change);
     }
+}
+
+function canRestoreRejectUndoSnapshot(
+    snapshot: TrackedFile,
+    currentHash: string | null,
+) {
+    if (
+        snapshot.status.kind === "created" &&
+        snapshot.status.existingFileContent === null
+    ) {
+        return currentHash === null;
+    }
+
+    const expectedContent =
+        snapshot.status.kind === "created"
+            ? (snapshot.status.existingFileContent ?? snapshot.diffBase)
+            : snapshot.diffBase;
+    return currentHash === hashTextContent(expectedContent);
+}
+
+async function restoreRejectUndoSnapshotAndReload(
+    vaultPath: string,
+    snapshot: TrackedFile,
+) {
+    const change = await aiRestoreTextFile({
+        vaultPath,
+        path: snapshot.path,
+        previousPath:
+            snapshot.status.kind === "created" &&
+            snapshot.status.existingFileContent === null
+                ? undefined
+                : snapshot.originPath !== snapshot.path
+                  ? snapshot.originPath
+                  : null,
+        content: snapshot.currentText,
+    });
+    reloadOpenEditorContent(snapshot.path, snapshot.currentText, change);
 }
 
 function applyUserEditToTrackedFileInSession(
@@ -6999,10 +7057,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const {
                     ctx: { tracked, vaultPath },
                 } = prepared;
-                const liveText = await readTrackedFileLiveText(tracked);
-                const { action: restoreAction, change } =
-                    await executeRestoreAction(vaultPath, tracked, liveText);
-                reloadEditorAfterRestore(tracked, restoreAction, change);
+                const restoreAction = await rejectTrackedFileAndReload(
+                    vaultPath,
+                    tracked,
+                );
 
                 set((state) => {
                     const currentSession = state.sessionsById[sessionId];
@@ -7147,33 +7205,18 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     const restoreCheck = await hasConflict(vaultPath, tracked);
 
                     if (restoreCheck.conflict) {
-                        set((state) => {
-                            const currentSession =
-                                state.sessionsById[sessionId];
-                            if (!currentSession) return state;
-
-                            return {
-                                sessionsById: {
-                                    ...state.sessionsById,
-                                    [sessionId]: markTrackedConflict(
-                                        currentSession,
-                                        identityKey,
-                                        restoreCheck.currentHash,
-                                    ),
-                                },
-                            };
-                        });
+                        markTrackedFileConflict(
+                            sessionId,
+                            identityKey,
+                            restoreCheck.currentHash,
+                        );
                         continue;
                     }
 
-                    const liveText = await readTrackedFileLiveText(tracked);
-                    const { action: restoreAction, change } =
-                        await executeRestoreAction(
-                            vaultPath,
-                            tracked,
-                            liveText,
-                        );
-                    reloadEditorAfterRestore(tracked, restoreAction, change);
+                    const restoreAction = await rejectTrackedFileAndReload(
+                        vaultPath,
+                        tracked,
+                    );
 
                     removedIdentityKeys.add(identityKey);
                     if (restoreAction.kind !== "skip") {
@@ -7487,64 +7530,18 @@ export const useChatStore = create<ChatStore>((set, get) => {
             // Restore each file on disk from its pre-reject snapshot
             for (const [identityKey, snapshot] of Object.entries(snapshots)) {
                 try {
-                    // Verify the disk hasn't changed since the reject
                     const currentHash = await aiGetTextFileHash(
                         vaultPath,
                         snapshot.path,
                     );
-                    if (
-                        snapshot.status.kind === "created" &&
-                        snapshot.status.existingFileContent === null
-                    ) {
-                        // Reject deleted this file. If it exists now, someone
-                        // created a new file at the same path — skip to avoid
-                        // overwriting.
-                        if (currentHash !== null) continue;
-                    } else {
-                        // Reject restored diffBase (or existingFileContent).
-                        // If the disk differs from what the reject wrote,
-                        // someone edited it — skip.
-                        const expectedContent =
-                            snapshot.status.kind === "created"
-                                ? (snapshot.status.existingFileContent ??
-                                  snapshot.diffBase)
-                                : snapshot.diffBase;
-                        const expectedHash = hashTextContent(expectedContent);
-                        if (currentHash !== expectedHash) continue;
+                    if (!canRestoreRejectUndoSnapshot(snapshot, currentHash)) {
+                        continue;
                     }
 
-                    // Write the agent's currentText back (undo the rejection)
-                    if (
-                        snapshot.status.kind === "created" &&
-                        snapshot.status.existingFileContent === null
-                    ) {
-                        // File was created by agent — re-create it
-                        const change = await aiRestoreTextFile({
-                            vaultPath,
-                            path: snapshot.path,
-                            content: snapshot.currentText,
-                        });
-                        reloadOpenEditorContent(
-                            snapshot.path,
-                            snapshot.currentText,
-                            change,
-                        );
-                    } else {
-                        const change = await aiRestoreTextFile({
-                            vaultPath,
-                            path: snapshot.path,
-                            previousPath:
-                                snapshot.originPath !== snapshot.path
-                                    ? snapshot.originPath
-                                    : null,
-                            content: snapshot.currentText,
-                        });
-                        reloadOpenEditorContent(
-                            snapshot.path,
-                            snapshot.currentText,
-                            change,
-                        );
-                    }
+                    await restoreRejectUndoSnapshotAndReload(
+                        vaultPath,
+                        snapshot,
+                    );
                     restoredSnapshots[identityKey] = snapshot;
                 } catch (error) {
                     caughtError = error;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -646,6 +646,15 @@ type PreparedAgentConfigSession =
     | { kind: "live"; session: AIChatSession }
     | { kind: "preference-only"; session: AIChatSession };
 
+type AgentConfigMutationArgs = {
+    requestedSessionId?: string;
+    change: AgentSelectionChange;
+    applyLocal(session: AIChatSession): AIChatSession;
+    applyRemote(session: AIChatSession): Promise<AIChatSession>;
+    persistPreference(): void;
+    errorMessage: string;
+};
+
 async function prepareSessionForAgentConfigMutation(
     requestedSessionId?: string,
 ): Promise<PreparedAgentConfigSession> {
@@ -737,6 +746,53 @@ type AgentSelectionChange =
     | { kind: "mode"; value: string }
     | { kind: "config"; optionId: string; value: string };
 
+function applyLocalModeSelection(
+    session: AIChatSession,
+    modeId: string,
+): AIChatSession {
+    return {
+        ...session,
+        modeId,
+    };
+}
+
+function applyLocalConfigOptionSelection(
+    session: AIChatSession,
+    optionId: string,
+    value: string,
+): AIChatSession {
+    if (optionId === "model") {
+        return applyLocalModelSelection(session, value);
+    }
+
+    return {
+        ...session,
+        configOptions: session.configOptions.map((option) =>
+            option.id === optionId ? { ...option, value } : option,
+        ),
+    };
+}
+
+function persistModelPreference(modelId: string) {
+    saveAiPreferences({ modelId });
+}
+
+function persistModePreference(modeId: string) {
+    saveAiPreferences({ modeId });
+}
+
+function persistConfigOptionSelectionPreference(
+    optionId: string,
+    value: string,
+) {
+    if (optionId === "model") {
+        persistModelPreference(value);
+        return;
+    }
+
+    saveConfigOptionPreference(optionId, value);
+}
+
 function sessionReflectsAgentSelectionChange(
     session: AIChatSession,
     change: AgentSelectionChange,
@@ -814,6 +870,68 @@ function resolveAgentSelectionMutationResult(
                 ? latestSession.effortsByModel
                 : returnedSession.effortsByModel,
     });
+}
+
+async function applyAgentConfigMutation({
+    requestedSessionId,
+    change,
+    applyLocal,
+    applyRemote,
+    persistPreference,
+    errorMessage,
+}: AgentConfigMutationArgs): Promise<void> {
+    const preparedSession =
+        await prepareSessionForAgentConfigMutation(requestedSessionId);
+    if (preparedSession.kind === "abort") {
+        return;
+    }
+
+    if (preparedSession.kind === "preference-only") {
+        const { session } = preparedSession;
+        useChatStore.setState((state) => {
+            const currentSession = state.sessionsById[session.sessionId];
+            if (!currentSession) {
+                return {};
+            }
+
+            const hydratedSession = hydrateSessionCatalogFromRuntime(
+                currentSession,
+                state.runtimes.find(
+                    (runtime) =>
+                        runtime.runtime.id === currentSession.runtimeId,
+                ),
+            );
+
+            return {
+                sessionsById: {
+                    ...state.sessionsById,
+                    [session.sessionId]: applyLocal(hydratedSession),
+                },
+            };
+        });
+        persistPreference();
+        return;
+    }
+
+    const { session } = preparedSession;
+    try {
+        const updatedSession = await applyRemote(session);
+        useChatStore
+            .getState()
+            .upsertSession(
+                resolveAgentSelectionMutationResult(
+                    useChatStore.getState().sessionsById[session.sessionId],
+                    updatedSession,
+                    change,
+                ),
+            );
+        persistPreference();
+    } catch (error) {
+        useChatStore.getState().applySessionError({
+            session_id: session.sessionId,
+            message: getAiErrorMessage(error, errorMessage),
+        });
+    }
 }
 
 function mergeRuntimeCatalog(
@@ -5921,211 +6039,53 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setModel: async (modelId, sessionId) => {
-            const preparedSession =
-                await prepareSessionForAgentConfigMutation(sessionId);
-            if (preparedSession.kind === "abort") {
-                return;
-            }
-
-            if (preparedSession.kind === "preference-only") {
-                const { session } = preparedSession;
-                set((state) => ({
-                    sessionsById: (() => {
-                        const currentSession =
-                            state.sessionsById[session.sessionId]!;
-                        const hydratedSession =
-                            hydrateSessionCatalogFromRuntime(
-                                currentSession,
-                                state.runtimes.find(
-                                    (runtime) =>
-                                        runtime.runtime.id ===
-                                        currentSession.runtimeId,
-                                ),
-                            );
-
-                        return {
-                            ...state.sessionsById,
-                            [session.sessionId]: applyLocalModelSelection(
-                                hydratedSession,
-                                modelId,
-                            ),
-                        };
-                    })(),
-                }));
-                saveAiPreferences({ modelId });
-                return;
-            }
-
-            const { session } = preparedSession;
-            try {
-                const modelConfig = getModelConfigOption(session);
-                const updatedSession =
-                    modelConfig &&
-                    modelConfig.options.some(
-                        (option) => option.value === modelId,
-                    )
-                        ? await aiSetConfigOption(
+            await applyAgentConfigMutation({
+                requestedSessionId: sessionId,
+                change: { kind: "model", value: modelId },
+                applyLocal: (session) =>
+                    applyLocalModelSelection(session, modelId),
+                applyRemote: async (session) => {
+                    const modelConfig = getModelConfigOption(session);
+                    return modelConfig &&
+                        modelConfig.options.some(
+                            (option) => option.value === modelId,
+                        )
+                        ? aiSetConfigOption(
                               session.sessionId,
                               modelConfig.id,
                               modelId,
                           )
-                        : await aiSetModel(session.sessionId, modelId);
-                get().upsertSession(
-                    resolveAgentSelectionMutationResult(
-                        get().sessionsById[session.sessionId],
-                        updatedSession,
-                        { kind: "model", value: modelId },
-                    ),
-                );
-                saveAiPreferences({ modelId });
-            } catch (error) {
-                get().applySessionError({
-                    session_id: session.sessionId,
-                    message: getAiErrorMessage(
-                        error,
-                        "Failed to update the model.",
-                    ),
-                });
-            }
+                        : aiSetModel(session.sessionId, modelId);
+                },
+                persistPreference: () => persistModelPreference(modelId),
+                errorMessage: "Failed to update the model.",
+            });
         },
 
         setMode: async (modeId, sessionId) => {
-            const preparedSession =
-                await prepareSessionForAgentConfigMutation(sessionId);
-            if (preparedSession.kind === "abort") {
-                return;
-            }
-
-            if (preparedSession.kind === "preference-only") {
-                const { session } = preparedSession;
-                set((state) => ({
-                    sessionsById: (() => {
-                        const currentSession =
-                            state.sessionsById[session.sessionId]!;
-                        const hydratedSession =
-                            hydrateSessionCatalogFromRuntime(
-                                currentSession,
-                                state.runtimes.find(
-                                    (runtime) =>
-                                        runtime.runtime.id ===
-                                        currentSession.runtimeId,
-                                ),
-                            );
-
-                        return {
-                            ...state.sessionsById,
-                            [session.sessionId]: {
-                                ...hydratedSession,
-                                modeId,
-                            },
-                        };
-                    })(),
-                }));
-                saveAiPreferences({ modeId });
-                return;
-            }
-
-            const { session } = preparedSession;
-            try {
-                const updatedSession = await aiSetMode(
-                    session.sessionId,
-                    modeId,
-                );
-                get().upsertSession(
-                    resolveAgentSelectionMutationResult(
-                        get().sessionsById[session.sessionId],
-                        updatedSession,
-                        { kind: "mode", value: modeId },
-                    ),
-                );
-                saveAiPreferences({ modeId });
-            } catch (error) {
-                get().applySessionError({
-                    session_id: session.sessionId,
-                    message: getAiErrorMessage(
-                        error,
-                        "Failed to update the mode.",
-                    ),
-                });
-            }
+            await applyAgentConfigMutation({
+                requestedSessionId: sessionId,
+                change: { kind: "mode", value: modeId },
+                applyLocal: (session) =>
+                    applyLocalModeSelection(session, modeId),
+                applyRemote: (session) => aiSetMode(session.sessionId, modeId),
+                persistPreference: () => persistModePreference(modeId),
+                errorMessage: "Failed to update the mode.",
+            });
         },
 
         setConfigOption: async (optionId, value, sessionId) => {
-            const preparedSession =
-                await prepareSessionForAgentConfigMutation(sessionId);
-            if (preparedSession.kind === "abort") {
-                return;
-            }
-
-            if (preparedSession.kind === "preference-only") {
-                const { session } = preparedSession;
-                set((state) => {
-                    const currentSession = hydrateSessionCatalogFromRuntime(
-                        state.sessionsById[session.sessionId]!,
-                        state.runtimes.find(
-                            (runtime) =>
-                                runtime.runtime.id ===
-                                state.sessionsById[session.sessionId]!
-                                    .runtimeId,
-                        ),
-                    );
-                    const nextSession =
-                        optionId === "model"
-                            ? applyLocalModelSelection(currentSession, value)
-                            : {
-                                  ...currentSession,
-                                  configOptions:
-                                      currentSession.configOptions.map(
-                                          (option) =>
-                                              option.id === optionId
-                                                  ? { ...option, value }
-                                                  : option,
-                                      ),
-                              };
-
-                    return {
-                        sessionsById: {
-                            ...state.sessionsById,
-                            [session.sessionId]: nextSession,
-                        },
-                    };
-                });
-                if (optionId === "model") {
-                    saveAiPreferences({ modelId: value });
-                } else {
-                    saveConfigOptionPreference(optionId, value);
-                }
-                return;
-            }
-
-            const { session } = preparedSession;
-            try {
-                const updatedSession = await aiSetConfigOption(
-                    session.sessionId,
-                    optionId,
-                    value,
-                );
-                get().upsertSession(
-                    resolveAgentSelectionMutationResult(
-                        get().sessionsById[session.sessionId],
-                        updatedSession,
-                        { kind: "config", optionId, value },
-                    ),
-                );
-                if (optionId === "model") {
-                    saveAiPreferences({ modelId: value });
-                } else {
-                    saveConfigOptionPreference(optionId, value);
-                }
-            } catch (error) {
-                get().applySessionError({
-                    session_id: session.sessionId,
-                    message: getAiErrorMessage(
-                        error,
-                        "Failed to update the session option.",
-                    ),
-                });
-            }
+            await applyAgentConfigMutation({
+                requestedSessionId: sessionId,
+                change: { kind: "config", optionId, value },
+                applyLocal: (session) =>
+                    applyLocalConfigOptionSelection(session, optionId, value),
+                applyRemote: (session) =>
+                    aiSetConfigOption(session.sessionId, optionId, value),
+                persistPreference: () =>
+                    persistConfigOptionSelectionPreference(optionId, value),
+                errorMessage: "Failed to update the session option.",
+            });
         },
 
         setComposerParts: (parts, sessionId) => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2544,6 +2544,66 @@ function markTrackedFileConflictAndPersist(
     }
 }
 
+type ReadyTrackedFileMutation = {
+    session: AIChatSession;
+    tracked: TrackedFile & { isText: true };
+    vaultPath: string;
+};
+
+type PreparedTrackedFileMutation =
+    | { kind: "abort" }
+    | { kind: "conflict" }
+    | { kind: "ready"; ctx: ReadyTrackedFileMutation };
+
+type TrackedFileMutationScope = "text" | "rejectable-text";
+
+async function prepareTrackedFileMutation(
+    sessionId: string,
+    identityKey: string,
+    scope: TrackedFileMutationScope,
+): Promise<PreparedTrackedFileMutation> {
+    const vaultPath = useVaultStore.getState().vaultPath;
+    if (!vaultPath) {
+        return { kind: "abort" };
+    }
+
+    const session = useChatStore.getState().sessionsById[sessionId];
+    if (!session) {
+        return { kind: "abort" };
+    }
+
+    const tracked = findTrackedFileInAccumulatedSession(session, identityKey);
+    if (!tracked || !tracked.isText) {
+        return { kind: "abort" };
+    }
+
+    if (
+        scope === "rejectable-text" &&
+        getTrackedFileReviewState(tracked) === "pending"
+    ) {
+        return { kind: "abort" };
+    }
+
+    const restoreCheck = await hasConflict(vaultPath, tracked);
+    if (restoreCheck.conflict) {
+        markTrackedFileConflictAndPersist(
+            sessionId,
+            identityKey,
+            restoreCheck.currentHash,
+        );
+        return { kind: "conflict" };
+    }
+
+    return {
+        kind: "ready",
+        ctx: {
+            session,
+            tracked,
+            vaultPath,
+        },
+    };
+}
+
 // ---------------------------------------------------------------------------
 // ActionLog helpers
 // ---------------------------------------------------------------------------
@@ -6928,32 +6988,17 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         rejectEditedFile: async (sessionId, identityKey) => {
-            const { sessionsById } = get();
-            const vaultPath = useVaultStore.getState().vaultPath;
-            if (!vaultPath) return;
-
-            const session = sessionsById[sessionId];
-            if (!session) return;
-
-            const tracked = findTrackedFileInAccumulatedSession(
-                session,
-                identityKey,
-            );
-            if (!tracked || !tracked.isText) return;
-            if (getTrackedFileReviewState(tracked) === "pending") return;
-
             try {
-                const restoreCheck = await hasConflict(vaultPath, tracked);
+                const prepared = await prepareTrackedFileMutation(
+                    sessionId,
+                    identityKey,
+                    "rejectable-text",
+                );
+                if (prepared.kind !== "ready") return;
 
-                if (restoreCheck.conflict) {
-                    markTrackedFileConflictAndPersist(
-                        sessionId,
-                        identityKey,
-                        restoreCheck.currentHash,
-                    );
-                    return;
-                }
-
+                const {
+                    ctx: { tracked, vaultPath },
+                } = prepared;
                 const liveText = await readTrackedFileLiveText(tracked);
                 const { action: restoreAction, change } =
                     await executeRestoreAction(vaultPath, tracked, liveText);
@@ -7019,33 +7064,17 @@ export const useChatStore = create<ChatStore>((set, get) => {
             identityKey,
             mergedText,
         ) => {
-            const { sessionsById } = get();
-            const vaultPath = useVaultStore.getState().vaultPath;
-            if (!vaultPath) return;
-
-            const session = sessionsById[sessionId];
-            if (!session) return;
-
-            const tracked = findTrackedFileInAccumulatedSession(
-                session,
-                identityKey,
-            );
-            if (!tracked || !tracked.isText) {
-                return;
-            }
-
             try {
-                const restoreCheck = await hasConflict(vaultPath, tracked);
+                const prepared = await prepareTrackedFileMutation(
+                    sessionId,
+                    identityKey,
+                    "text",
+                );
+                if (prepared.kind !== "ready") return;
 
-                if (restoreCheck.conflict) {
-                    markTrackedFileConflictAndPersist(
-                        sessionId,
-                        identityKey,
-                        restoreCheck.currentHash,
-                    );
-                    return;
-                }
-
+                const {
+                    ctx: { tracked, vaultPath },
+                } = prepared;
                 const change = await aiRestoreTextFile({
                     vaultPath,
                     path: tracked.path,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -641,6 +641,52 @@ async function ensureSessionAgentCatalogLoaded(
     return resolved ? resolved.sessionId : null;
 }
 
+type PreparedAgentConfigSession =
+    | { kind: "abort" }
+    | { kind: "live"; session: AIChatSession }
+    | { kind: "preference-only"; session: AIChatSession };
+
+async function prepareSessionForAgentConfigMutation(
+    requestedSessionId?: string,
+): Promise<PreparedAgentConfigSession> {
+    const resolvedSessionId =
+        requestedSessionId ?? useChatStore.getState().activeSessionId;
+    if (!resolvedSessionId) {
+        return { kind: "abort" };
+    }
+
+    let session = useChatStore.getState().sessionsById[resolvedSessionId];
+    if (!session || session.isResumingSession) {
+        return { kind: "abort" };
+    }
+
+    if (session.runtimeState !== "live") {
+        const liveSessionId =
+            await ensureLiveSessionForAgentConfigChange(resolvedSessionId);
+        if (
+            liveSessionId &&
+            liveSessionId !== resolvedSessionId &&
+            useChatStore.getState().sessionsById[liveSessionId]
+        ) {
+            session = useChatStore.getState().sessionsById[liveSessionId]!;
+        } else if (session.isPersistedSession) {
+            return { kind: "abort" };
+        }
+    }
+
+    if (session.runtimeState === "live" && !sessionHasAgentCatalog(session)) {
+        await ensureSessionAgentCatalogLoaded(session.sessionId);
+        session =
+            useChatStore.getState().sessionsById[session.sessionId] ?? session;
+    }
+
+    if (session.runtimeState !== "live") {
+        return { kind: "preference-only", session };
+    }
+
+    return { kind: "live", session };
+}
+
 function getModelConfigOption(session: Pick<AIChatSession, "configOptions">) {
     return session.configOptions.find((option) => option.category === "model");
 }
@@ -5875,39 +5921,14 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setModel: async (modelId, sessionId) => {
-            const resolvedSessionId = sessionId ?? get().activeSessionId;
-            if (!resolvedSessionId) return;
-            let session = get().sessionsById[resolvedSessionId];
-            if (!session) return;
-            if (session.isResumingSession) {
+            const preparedSession =
+                await prepareSessionForAgentConfigMutation(sessionId);
+            if (preparedSession.kind === "abort") {
                 return;
             }
 
-            if (session.runtimeState !== "live") {
-                const liveSessionId =
-                    await ensureLiveSessionForAgentConfigChange(
-                        resolvedSessionId,
-                    );
-                if (
-                    liveSessionId &&
-                    liveSessionId !== resolvedSessionId &&
-                    get().sessionsById[liveSessionId]
-                ) {
-                    session = get().sessionsById[liveSessionId]!;
-                } else if (session.isPersistedSession) {
-                    return;
-                }
-            }
-
-            if (
-                session.runtimeState === "live" &&
-                !sessionHasAgentCatalog(session)
-            ) {
-                await ensureSessionAgentCatalogLoaded(session.sessionId);
-                session = get().sessionsById[session.sessionId] ?? session;
-            }
-
-            if (session.runtimeState !== "live") {
+            if (preparedSession.kind === "preference-only") {
+                const { session } = preparedSession;
                 set((state) => ({
                     sessionsById: (() => {
                         const currentSession =
@@ -5935,6 +5956,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 return;
             }
 
+            const { session } = preparedSession;
             try {
                 const modelConfig = getModelConfigOption(session);
                 const updatedSession =
@@ -5968,39 +5990,14 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setMode: async (modeId, sessionId) => {
-            const resolvedSessionId = sessionId ?? get().activeSessionId;
-            if (!resolvedSessionId) return;
-            let session = get().sessionsById[resolvedSessionId];
-            if (!session) return;
-            if (session.isResumingSession) {
+            const preparedSession =
+                await prepareSessionForAgentConfigMutation(sessionId);
+            if (preparedSession.kind === "abort") {
                 return;
             }
 
-            if (session.runtimeState !== "live") {
-                const liveSessionId =
-                    await ensureLiveSessionForAgentConfigChange(
-                        resolvedSessionId,
-                    );
-                if (
-                    liveSessionId &&
-                    liveSessionId !== resolvedSessionId &&
-                    get().sessionsById[liveSessionId]
-                ) {
-                    session = get().sessionsById[liveSessionId]!;
-                } else if (session.isPersistedSession) {
-                    return;
-                }
-            }
-
-            if (
-                session.runtimeState === "live" &&
-                !sessionHasAgentCatalog(session)
-            ) {
-                await ensureSessionAgentCatalogLoaded(session.sessionId);
-                session = get().sessionsById[session.sessionId] ?? session;
-            }
-
-            if (session.runtimeState !== "live") {
+            if (preparedSession.kind === "preference-only") {
+                const { session } = preparedSession;
                 set((state) => ({
                     sessionsById: (() => {
                         const currentSession =
@@ -6028,6 +6025,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 return;
             }
 
+            const { session } = preparedSession;
             try {
                 const updatedSession = await aiSetMode(
                     session.sessionId,
@@ -6053,39 +6051,14 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setConfigOption: async (optionId, value, sessionId) => {
-            const resolvedSessionId = sessionId ?? get().activeSessionId;
-            if (!resolvedSessionId) return;
-            let session = get().sessionsById[resolvedSessionId];
-            if (!session) return;
-            if (session.isResumingSession) {
+            const preparedSession =
+                await prepareSessionForAgentConfigMutation(sessionId);
+            if (preparedSession.kind === "abort") {
                 return;
             }
 
-            if (session.runtimeState !== "live") {
-                const liveSessionId =
-                    await ensureLiveSessionForAgentConfigChange(
-                        resolvedSessionId,
-                    );
-                if (
-                    liveSessionId &&
-                    liveSessionId !== resolvedSessionId &&
-                    get().sessionsById[liveSessionId]
-                ) {
-                    session = get().sessionsById[liveSessionId]!;
-                } else if (session.isPersistedSession) {
-                    return;
-                }
-            }
-
-            if (
-                session.runtimeState === "live" &&
-                !sessionHasAgentCatalog(session)
-            ) {
-                await ensureSessionAgentCatalogLoaded(session.sessionId);
-                session = get().sessionsById[session.sessionId] ?? session;
-            }
-
-            if (session.runtimeState !== "live") {
+            if (preparedSession.kind === "preference-only") {
+                const { session } = preparedSession;
                 set((state) => {
                     const currentSession = hydrateSessionCatalogFromRuntime(
                         state.sessionsById[session.sessionId]!,
@@ -6125,6 +6098,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 return;
             }
 
+            const { session } = preparedSession;
             try {
                 const updatedSession = await aiSetConfigOption(
                     session.sessionId,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2517,6 +2517,33 @@ function markTrackedConflict(
     };
 }
 
+function markTrackedFileConflictAndPersist(
+    sessionId: string,
+    identityKey: string,
+    currentHash: string | null,
+) {
+    useChatStore.setState((state) => {
+        const currentSession = state.sessionsById[sessionId];
+        if (!currentSession) return state;
+
+        return {
+            sessionsById: {
+                ...state.sessionsById,
+                [sessionId]: markTrackedConflict(
+                    currentSession,
+                    identityKey,
+                    currentHash,
+                ),
+            },
+        };
+    });
+
+    const updatedSession = useChatStore.getState().sessionsById[sessionId];
+    if (updatedSession) {
+        void persistSession(updatedSession);
+    }
+}
+
 // ---------------------------------------------------------------------------
 // ActionLog helpers
 // ---------------------------------------------------------------------------
@@ -6919,26 +6946,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const restoreCheck = await hasConflict(vaultPath, tracked);
 
                 if (restoreCheck.conflict) {
-                    set((state) => {
-                        const currentSession = state.sessionsById[sessionId];
-                        if (!currentSession) return state;
-
-                        return {
-                            sessionsById: {
-                                ...state.sessionsById,
-                                [sessionId]: markTrackedConflict(
-                                    currentSession,
-                                    identityKey,
-                                    restoreCheck.currentHash,
-                                ),
-                            },
-                        };
-                    });
-
-                    const updatedSession = get().sessionsById[sessionId];
-                    if (updatedSession) {
-                        void persistSession(updatedSession);
-                    }
+                    markTrackedFileConflictAndPersist(
+                        sessionId,
+                        identityKey,
+                        restoreCheck.currentHash,
+                    );
                     return;
                 }
 
@@ -7026,26 +7038,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const restoreCheck = await hasConflict(vaultPath, tracked);
 
                 if (restoreCheck.conflict) {
-                    set((state) => {
-                        const currentSession = state.sessionsById[sessionId];
-                        if (!currentSession) return state;
-
-                        return {
-                            sessionsById: {
-                                ...state.sessionsById,
-                                [sessionId]: markTrackedConflict(
-                                    currentSession,
-                                    identityKey,
-                                    restoreCheck.currentHash,
-                                ),
-                            },
-                        };
-                    });
-
-                    const updatedSession = get().sessionsById[sessionId];
-                    if (updatedSession) {
-                        void persistSession(updatedSession);
-                    }
+                    markTrackedFileConflictAndPersist(
+                        sessionId,
+                        identityKey,
+                        restoreCheck.currentHash,
+                    );
                     return;
                 }
 
@@ -7343,27 +7340,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     const restoreCheck = await hasConflict(vaultPath, tracked);
 
                     if (restoreCheck.conflict) {
-                        set((state) => {
-                            const currentSession =
-                                state.sessionsById[sessionId];
-                            if (!currentSession) return state;
-
-                            return {
-                                sessionsById: {
-                                    ...state.sessionsById,
-                                    [sessionId]: markTrackedConflict(
-                                        currentSession,
-                                        identityKey,
-                                        restoreCheck.currentHash,
-                                    ),
-                                },
-                            };
-                        });
-
-                        const updatedSession = get().sessionsById[sessionId];
-                        if (updatedSession) {
-                            void persistSession(updatedSession);
-                        }
+                        markTrackedFileConflictAndPersist(
+                            sessionId,
+                            identityKey,
+                            restoreCheck.currentHash,
+                        );
                         return;
                     }
                 }


### PR DESCRIPTION
## Summary

This refactor reduces high-risk internal duplication in `chatStore` without modularizing the file.

It consolidates three sensitive areas:
- session-local state migration during technical session remaps
- agent config preflight and execution for `setModel`, `setMode`, and `setConfigOption`
- tracked-file review preparation and conflict handling for unit and bulk flows

A final follow-up fix restores clean TypeScript narrowing for text tracked-file mutations so the store builds cleanly.

## Main changes

- extract `migrateSessionLocalState(...)`
- extract `prepareSessionForAgentConfigMutation(...)`
- extract `applyAgentConfigMutation(...)`
- extract `markTrackedFileConflictAndPersist(...)`
- extract `prepareTrackedFileMutation(...)`
- keep `rejectAllEditedFiles(...)` and `undoLastReject(...)` explicit while reusing small stable helpers
- expand `chatStore` regression coverage around config, review conflicts, bulk reject, undo, and session remap continuity

## Why

`chatStore.ts` contained repeated preflight and post-action logic in some of the riskiest parts of the app: agent configuration changes, inline review / tracked file review, and session remap flows. This change reduces drift risk while preserving user-visible behavior.

## Validation

- `cd apps/desktop && npm test -- src/features/ai/store/chatStore.test.ts`
- `cd apps/desktop && npm test -- src/features/ai/store/chatTabsStore.test.ts`
- `cd apps/desktop && npm run build`

## Review focus

- persisted session -> live resume before config mutation
- observable equivalence of `setModel(...)` and `setConfigOption("model", ...)`
- conflict semantics in inline review / tracked file review
- partial-failure behavior in `rejectAllEditedFiles(...)` and `undoLastReject(...)`
- continuity of drafts, queue state, and UI mappings when a session id is remapped