### PR TITLE
Refactor editorStore around tab capability registries

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -60,16 +60,17 @@ import {
 } from "./app/windowSession";
 import {
     useEditorStore,
-    type TabInput,
     isFileTab,
     isGraphTab,
     isMapTab,
     isNoteTab,
     isPdfTab,
     isReviewTab,
-    readPersistedSession,
-    markSessionReady,
 } from "./app/store/editorStore";
+import {
+    markSessionReady,
+    restorePersistedSession,
+} from "./app/store/editorSession";
 import { useVaultStore, type VaultNoteChange } from "./app/store/vaultStore";
 import { useLayoutStore } from "./app/store/layoutStore";
 import { useSettingsStore } from "./app/store/settingsStore";
@@ -94,7 +95,6 @@ import {
 import { resetChatStore, useChatStore } from "./features/ai/store/chatStore";
 import { shouldAllowNativeContextMenu } from "./features/spellcheck/contextMenu";
 import { YouTubeModalHost } from "./features/editor/YouTubeModalHost";
-import { toVaultRelativePath } from "./app/utils/vaultPaths";
 
 function shouldApplyVaultChangeToVaultStore(change: VaultNoteChange) {
     return (
@@ -1248,262 +1248,11 @@ export default function App() {
 
     const restoreSessionForCurrentVault = useCallback(async () => {
         const vaultPath = useVaultStore.getState().vaultPath;
-        const session = readPersistedSession(vaultPath);
-        if (
-            !session?.noteIds.length &&
-            !session?.tabs?.length &&
-            !session?.pdfTabs?.length &&
-            !session?.fileTabs?.length &&
-            !session?.mapTabs?.length &&
-            !session?.hasGraphTab
-        ) {
-            return;
-        }
-
-        const restoredTabs: TabInput[] = [];
-
-        if (session?.tabs?.length) {
-            restoredTabs.push(...session.tabs);
-        } else {
-            for (const entry of session?.noteIds ?? []) {
-                try {
-                    const detail = await vaultInvoke<{ content: string }>(
-                        "read_note",
-                        {
-                            noteId: entry.noteId,
-                        },
-                    );
-                    const history = (
-                        entry.history ?? [
-                            { noteId: entry.noteId, title: entry.title },
-                        ]
-                    ).map((h) => ({
-                        noteId: h.noteId,
-                        title: h.title,
-                        content: "",
-                    }));
-                    const historyIndex = Math.min(
-                        entry.historyIndex ?? history.length - 1,
-                        history.length - 1,
-                    );
-                    if (history[historyIndex]) {
-                        history[historyIndex].content = detail.content;
-                    }
-                    restoredTabs.push({
-                        id: crypto.randomUUID(),
-                        noteId: entry.noteId,
-                        title: entry.title,
-                        content: detail.content,
-                        history,
-                        historyIndex,
-                    });
-                } catch {
-                    // Nota eliminada o no encontrada, se omite
-                }
-            }
-
-            for (const pdfEntry of session?.pdfTabs ?? []) {
-                const history = (
-                    pdfEntry.history ?? [
-                        {
-                            entryId: pdfEntry.entryId,
-                            title: pdfEntry.title,
-                            path: pdfEntry.path,
-                            page: pdfEntry.page ?? 1,
-                            zoom: pdfEntry.zoom ?? 1,
-                            viewMode: pdfEntry.viewMode ?? "continuous",
-                        },
-                    ]
-                ).map((entry) => ({
-                    entryId: entry.entryId,
-                    title: entry.title,
-                    path: entry.path,
-                    page: entry.page ?? 1,
-                    zoom: entry.zoom ?? 1,
-                    viewMode: entry.viewMode ?? "continuous",
-                }));
-                const historyIndex = Math.min(
-                    pdfEntry.historyIndex ?? history.length - 1,
-                    history.length - 1,
-                );
-                const currentEntry = history[historyIndex];
-                restoredTabs.push({
-                    id: crypto.randomUUID(),
-                    kind: "pdf",
-                    entryId: currentEntry?.entryId ?? pdfEntry.entryId,
-                    title: currentEntry?.title ?? pdfEntry.title,
-                    path: currentEntry?.path ?? pdfEntry.path,
-                    page: currentEntry?.page ?? pdfEntry.page ?? 1,
-                    zoom: currentEntry?.zoom ?? pdfEntry.zoom ?? 1,
-                    viewMode:
-                        currentEntry?.viewMode ??
-                        pdfEntry.viewMode ??
-                        "continuous",
-                    history,
-                    historyIndex,
-                });
-            }
-
-            for (const fileEntry of session?.fileTabs ?? []) {
-                let content = fileEntry.content ?? "";
-                const viewer =
-                    fileEntry.viewer ??
-                    (fileEntry.mimeType?.startsWith("image/")
-                        ? "image"
-                        : "text");
-
-                if (!content && viewer === "text") {
-                    try {
-                        const detail = await vaultInvoke<{ content: string }>(
-                            "read_vault_file",
-                            {
-                                relativePath: fileEntry.relativePath,
-                            },
-                        );
-                        content = detail.content;
-                    } catch {
-                        content = "";
-                    }
-                }
-
-                const history = (
-                    fileEntry.history ?? [
-                        {
-                            relativePath: fileEntry.relativePath,
-                            title: fileEntry.title,
-                            path: fileEntry.path,
-                            mimeType: fileEntry.mimeType ?? null,
-                            viewer,
-                        },
-                    ]
-                ).map((h) => ({
-                    relativePath: h.relativePath,
-                    title: h.title,
-                    path: h.path,
-                    mimeType: h.mimeType ?? null,
-                    viewer:
-                        h.viewer ??
-                        (h.mimeType?.startsWith("image/") ? "image" : "text"),
-                    content: "",
-                }));
-                const historyIndex = Math.min(
-                    fileEntry.historyIndex ?? history.length - 1,
-                    history.length - 1,
-                );
-                if (history[historyIndex]) {
-                    history[historyIndex].content = content;
-                }
-
-                restoredTabs.push({
-                    id: crypto.randomUUID(),
-                    kind: "file",
-                    relativePath: fileEntry.relativePath,
-                    title: fileEntry.title,
-                    path: fileEntry.path,
-                    mimeType: fileEntry.mimeType ?? null,
-                    viewer,
-                    content,
-                    history,
-                    historyIndex,
-                });
-            }
-        }
-
-        const currentVaultPath = useVaultStore.getState().vaultPath;
-
-        if (EXCALIDRAW_RUNTIME_SUPPORTED) {
-            for (const mapEntry of session?.mapTabs ?? []) {
-                const relativePath =
-                    mapEntry.relativePath ||
-                    (mapEntry.filePath
-                        ? toVaultRelativePath(
-                              mapEntry.filePath,
-                              currentVaultPath,
-                          )
-                        : null);
-                if (!relativePath) {
-                    continue;
-                }
-
-                if (
-                    restoredTabs.some(
-                        (tab) =>
-                            tab.kind === "map" &&
-                            tab.relativePath === relativePath,
-                    )
-                ) {
-                    continue;
-                }
-
-                restoredTabs.push({
-                    id: crypto.randomUUID(),
-                    kind: "map",
-                    relativePath,
-                    title: mapEntry.title,
-                });
-            }
-        }
-
-        if (session?.hasGraphTab) {
-            restoredTabs.push({
-                id: crypto.randomUUID(),
-                kind: "graph",
-                title: "Graph View",
-            });
-        }
-
-        if (!restoredTabs.length) return;
-
-        // Find active tab: check PDF first, then note
-        let activeTab: TabInput | undefined;
-        if (session?.activeGraphTab) {
-            activeTab = restoredTabs.find((tab) => tab.kind === "graph");
-        }
-        const activeLegacyMapRelativePath = session?.activeMapFilePath
-            ? toVaultRelativePath(session.activeMapFilePath, currentVaultPath)
-            : null;
-        if (
-            EXCALIDRAW_RUNTIME_SUPPORTED &&
-            !activeTab &&
-            session?.activeMapRelativePath
-        ) {
-            activeTab = restoredTabs.find(
-                (tab) =>
-                    tab.kind === "map" &&
-                    tab.relativePath === session.activeMapRelativePath,
-            );
-        }
-        if (
-            EXCALIDRAW_RUNTIME_SUPPORTED &&
-            !activeTab &&
-            activeLegacyMapRelativePath
-        ) {
-            activeTab = restoredTabs.find(
-                (tab) =>
-                    tab.kind === "map" &&
-                    tab.relativePath === activeLegacyMapRelativePath,
-            );
-        }
-        if (!activeTab && session?.activePdfEntryId) {
-            activeTab = restoredTabs.find(
-                (tab) =>
-                    tab.kind === "pdf" &&
-                    tab.entryId === session.activePdfEntryId,
-            );
-        }
-        if (!activeTab && session?.activeNoteId) {
-            activeTab = restoredTabs.find(
-                (tab) => isNoteTab(tab) && tab.noteId === session.activeNoteId,
-            );
-        }
-        if (!activeTab && session?.activeFilePath) {
-            activeTab = restoredTabs.find(
-                (tab) =>
-                    isFileTab(tab) &&
-                    tab.relativePath === session.activeFilePath,
-            );
-        }
-        hydrateTabs(restoredTabs, activeTab?.id ?? null);
+        const restored = await restorePersistedSession(vaultPath, {
+            includeMaps: EXCALIDRAW_RUNTIME_SUPPORTED,
+        });
+        if (!restored) return;
+        hydrateTabs(restored.tabs, restored.activeTabId);
     }, [hydrateTabs]);
 
     useEffect(() => {

--- a/apps/desktop/src/app/store/editorResourceRegistry.ts
+++ b/apps/desktop/src/app/store/editorResourceRegistry.ts
@@ -98,6 +98,11 @@ export interface ResourceHandler<K extends ResourceKind> {
     readHistoryEntryContent: (resourceId: string) => Promise<string>;
 }
 
+// Invariants:
+// - Only note/file participate in the editable-resource capability model.
+// - The store owns when a reload/delete should happen.
+// - These handlers own how a note/file tab reacts once that decision is made.
+
 function pushTabToNavigation(
     history: string[],
     index: number,

--- a/apps/desktop/src/app/store/editorResourceRegistry.ts
+++ b/apps/desktop/src/app/store/editorResourceRegistry.ts
@@ -1,0 +1,462 @@
+import { vaultInvoke } from "../utils/vaultInvoke";
+import { normalizeHistoryTab } from "./editorTabRegistry";
+import {
+    buildTabFromHistory,
+    ensureFileTabDefaults,
+    isFileTab,
+    isHistoryTab,
+    isMapTab,
+    isNoteTab,
+    type FileHistoryEntry,
+    type FileTab,
+    type NoteHistoryEntry,
+    type NoteTab,
+    type Tab,
+} from "./editorTabs";
+
+export type ResourceKind = "note" | "file";
+
+export interface ResourceReloadDetail {
+    content: string;
+    title: string;
+    origin?: "user" | "agent" | "external" | "system" | "unknown";
+    opId?: string | null;
+    revision?: number;
+    contentHash?: string | null;
+}
+
+export interface ResourceReloadMetadata {
+    origin: "user" | "agent" | "external" | "system" | "unknown";
+    opId: string | null;
+    revision: number;
+    contentHash: string | null;
+}
+
+interface ResourceTabByKindMap {
+    note: NoteTab;
+    file: FileTab;
+}
+
+interface ResourceHistoryEntryByKindMap {
+    note: NoteHistoryEntry;
+    file: FileHistoryEntry;
+}
+
+interface ResourceReloadState<M extends ResourceReloadMetadata> {
+    tabs: Tab[];
+    pendingForceReloads: Set<string>;
+    reloadVersions: Record<string, number>;
+    reloadMetadata: Record<string, M | undefined>;
+}
+
+interface ResourceDeletionState<
+    M extends ResourceReloadMetadata,
+> extends ResourceReloadState<M> {
+    activeTabId: string | null;
+    activationHistory: string[];
+    tabNavigationHistory: string[];
+    tabNavigationIndex: number;
+    externalConflicts: Set<string>;
+}
+
+interface ResourceDeleteTabsResult {
+    tabs: Tab[];
+    idsToClose: Set<string>;
+    didChange: boolean;
+}
+
+interface ResourceDeleteUpdate<M extends ResourceReloadMetadata> {
+    tabs: Tab[];
+    activeTabId: string | null;
+    activationHistory: string[];
+    tabNavigationHistory: string[];
+    tabNavigationIndex: number;
+    pendingForceReloads: Set<string>;
+    reloadVersions: Record<string, number>;
+    reloadMetadata: Record<string, M | undefined>;
+    externalConflicts: Set<string>;
+}
+
+export interface ResourceHandler<K extends ResourceKind> {
+    kind: K;
+    updateOpenTab: (
+        tab: ResourceTabByKindMap[K],
+        detail: ResourceReloadDetail,
+    ) => ResourceTabByKindMap[K];
+    removeFromTabs: (
+        tabs: Tab[],
+        resourceId: string,
+    ) => ResourceDeleteTabsResult;
+    matchesHistoryEntry: (
+        entry: NoteHistoryEntry | FileHistoryEntry,
+        resourceId: string,
+    ) => entry is ResourceHistoryEntryByKindMap[K];
+    patchHistoryEntryContent: (
+        entry: ResourceHistoryEntryByKindMap[K],
+        content: string,
+    ) => ResourceHistoryEntryByKindMap[K];
+    readHistoryEntryContent: (resourceId: string) => Promise<string>;
+}
+
+function pushTabToNavigation(
+    history: string[],
+    index: number,
+    tabId: string,
+): { history: string[]; index: number } {
+    const truncated = history.slice(0, Math.max(0, index + 1));
+    if (truncated[truncated.length - 1] === tabId) {
+        return {
+            history: truncated,
+            index: truncated.length - 1,
+        };
+    }
+
+    const next = [...truncated, tabId];
+    return { history: next, index: next.length - 1 };
+}
+
+function omitKey<T>(record: Record<string, T>, keyToOmit: string) {
+    return Object.fromEntries(
+        Object.entries(record).filter(([key]) => key !== keyToOmit),
+    ) as Record<string, T>;
+}
+
+function createReloadMetadata(
+    detail: ResourceReloadDetail,
+    fallbackOrigin: ResourceReloadMetadata["origin"],
+): ResourceReloadMetadata {
+    return {
+        origin: detail.origin ?? fallbackOrigin,
+        opId: detail.opId ?? null,
+        revision: detail.revision ?? 0,
+        contentHash: detail.contentHash ?? null,
+    };
+}
+
+const noteResourceHandler: ResourceHandler<"note"> = {
+    kind: "note",
+    updateOpenTab: (tab, detail) => {
+        if (tab.content === detail.content && tab.title === detail.title) {
+            return tab;
+        }
+        return {
+            ...tab,
+            content: detail.content,
+            title: detail.title,
+        };
+    },
+    removeFromTabs: (tabs, noteId) => {
+        const idsToClose = new Set(
+            tabs
+                .filter((tab) => isNoteTab(tab) && tab.noteId === noteId)
+                .map((tab) => tab.id),
+        );
+        return {
+            tabs:
+                idsToClose.size > 0
+                    ? tabs.filter((tab) => !idsToClose.has(tab.id))
+                    : tabs,
+            idsToClose,
+            didChange: idsToClose.size > 0,
+        };
+    },
+    matchesHistoryEntry: (entry, noteId): entry is NoteHistoryEntry =>
+        entry.kind === "note" && entry.noteId === noteId,
+    patchHistoryEntryContent: (entry, content) => ({
+        ...entry,
+        content,
+    }),
+    readHistoryEntryContent: async (noteId) => {
+        const detail = await vaultInvoke<{ content: string }>("read_note", {
+            noteId,
+        });
+        return detail.content;
+    },
+};
+
+const fileResourceHandler: ResourceHandler<"file"> = {
+    kind: "file",
+    updateOpenTab: (tab, detail) => {
+        if (tab.content === detail.content && tab.title === detail.title) {
+            return tab;
+        }
+        return {
+            ...tab,
+            content: detail.content,
+            title: detail.title,
+        };
+    },
+    removeFromTabs: (tabs, relativePath) => {
+        let didChange = false;
+        const idsToClose = new Set(
+            tabs.flatMap((rawTab) => {
+                if (!isFileTab(rawTab)) {
+                    return [];
+                }
+
+                const tab = ensureFileTabDefaults(rawTab);
+                const removedEntries = tab.history.filter(
+                    (entry) =>
+                        entry.kind === "file" &&
+                        entry.relativePath === relativePath,
+                ).length;
+                if (removedEntries === 0) {
+                    return [];
+                }
+
+                didChange = true;
+                return tab.history.length === removedEntries ? [tab.id] : [];
+            }),
+        );
+
+        return {
+            tabs: tabs.flatMap((rawTab): Tab[] => {
+                if (!isFileTab(rawTab)) {
+                    return [rawTab];
+                }
+
+                const tab = ensureFileTabDefaults(rawTab);
+                const removedBeforeOrAtCurrent = tab.history
+                    .slice(0, tab.historyIndex + 1)
+                    .filter(
+                        (entry) =>
+                            entry.kind === "file" &&
+                            entry.relativePath === relativePath,
+                    ).length;
+                const history = tab.history.filter(
+                    (entry) =>
+                        entry.kind !== "file" ||
+                        entry.relativePath !== relativePath,
+                );
+
+                if (history.length === tab.history.length) {
+                    return [rawTab];
+                }
+
+                didChange = true;
+                if (history.length === 0) {
+                    return [];
+                }
+
+                const nextHistoryIndex = Math.min(
+                    Math.max(0, tab.historyIndex - removedBeforeOrAtCurrent),
+                    history.length - 1,
+                );
+                return [buildTabFromHistory(tab.id, history, nextHistoryIndex)];
+            }),
+            idsToClose,
+            didChange,
+        };
+    },
+    matchesHistoryEntry: (entry, relativePath): entry is FileHistoryEntry =>
+        entry.kind === "file" && entry.relativePath === relativePath,
+    patchHistoryEntryContent: (entry, content) => ({
+        ...entry,
+        content,
+    }),
+    readHistoryEntryContent: async (relativePath) => {
+        const detail = await vaultInvoke<{ content: string }>(
+            "read_vault_file",
+            { relativePath },
+        );
+        return detail.content;
+    },
+};
+
+export const resourceHandlers: {
+    [K in ResourceKind]: ResourceHandler<K>;
+} = {
+    note: noteResourceHandler,
+    file: fileResourceHandler,
+};
+
+export function getResourceHandler<K extends ResourceKind>(kind: K) {
+    return resourceHandlers[kind];
+}
+
+export function buildResourceReloadUpdate<
+    K extends ResourceKind,
+    M extends ResourceReloadMetadata,
+>(
+    handler: ResourceHandler<K>,
+    state: ResourceReloadState<M>,
+    resourceId: string,
+    detail: ResourceReloadDetail,
+    options?: { force?: boolean; fallbackOrigin?: M["origin"] },
+) {
+    const nextPendingForceReloads = options?.force
+        ? new Set(state.pendingForceReloads).add(resourceId)
+        : state.pendingForceReloads;
+
+    return {
+        tabs: state.tabs.map((tab) => {
+            if (handler.kind === "note") {
+                return isNoteTab(tab) && tab.noteId === resourceId
+                    ? handler.updateOpenTab(
+                          tab as ResourceTabByKindMap[K],
+                          detail,
+                      )
+                    : tab;
+            }
+            return isFileTab(tab) && tab.relativePath === resourceId
+                ? handler.updateOpenTab(tab as ResourceTabByKindMap[K], detail)
+                : tab;
+        }),
+        pendingForceReloads: nextPendingForceReloads,
+        reloadVersions: {
+            ...state.reloadVersions,
+            [resourceId]: (state.reloadVersions[resourceId] ?? 0) + 1,
+        },
+        reloadMetadata: {
+            ...state.reloadMetadata,
+            [resourceId]: createReloadMetadata(
+                detail,
+                options?.fallbackOrigin ?? "unknown",
+            ) as M,
+        },
+    };
+}
+
+export function buildResourceDeleteUpdate<
+    K extends ResourceKind,
+    M extends ResourceReloadMetadata,
+>(
+    handler: ResourceHandler<K>,
+    state: ResourceDeletionState<M>,
+    resourceId: string,
+): ResourceDeleteUpdate<M> | null {
+    const { tabs, idsToClose, didChange } = handler.removeFromTabs(
+        state.tabs,
+        resourceId,
+    );
+    const pendingForceReloads = new Set(state.pendingForceReloads);
+    const externalConflicts = new Set(state.externalConflicts);
+    const hadPendingForceReload = pendingForceReloads.delete(resourceId);
+    const hadExternalConflict = externalConflicts.delete(resourceId);
+    const hadReloadVersion = resourceId in state.reloadVersions;
+    const hadReloadMetadata = resourceId in state.reloadMetadata;
+    const reloadVersions = hadReloadVersion
+        ? omitKey(state.reloadVersions, resourceId)
+        : state.reloadVersions;
+    const reloadMetadata = hadReloadMetadata
+        ? omitKey(state.reloadMetadata, resourceId)
+        : state.reloadMetadata;
+
+    if (
+        !didChange &&
+        !hadPendingForceReload &&
+        !hadExternalConflict &&
+        !hadReloadVersion &&
+        !hadReloadMetadata
+    ) {
+        return null;
+    }
+
+    const activationHistory = state.activationHistory.filter(
+        (id) => !idsToClose.has(id),
+    );
+    const tabNavigationHistory = state.tabNavigationHistory.filter(
+        (id) => !idsToClose.has(id),
+    );
+
+    let activeTabId = state.activeTabId;
+    if (activeTabId && idsToClose.has(activeTabId)) {
+        const closedIdx = state.tabs.findIndex((tab) => tab.id === activeTabId);
+        activeTabId =
+            [...activationHistory]
+                .reverse()
+                .find((id) => tabs.some((tab) => tab.id === id)) ??
+            tabs[Math.min(closedIdx, tabs.length - 1)]?.id ??
+            null;
+    }
+
+    let tabNavigationIndex = Math.min(
+        state.tabNavigationIndex,
+        tabNavigationHistory.length - 1,
+    );
+    if (activeTabId) {
+        const lastActiveIndex = tabNavigationHistory.lastIndexOf(activeTabId);
+        if (lastActiveIndex === -1) {
+            const navigation = pushTabToNavigation(
+                tabNavigationHistory,
+                tabNavigationIndex,
+                activeTabId,
+            );
+            return {
+                tabs,
+                activeTabId,
+                activationHistory,
+                tabNavigationHistory: navigation.history,
+                tabNavigationIndex: navigation.index,
+                pendingForceReloads,
+                reloadVersions,
+                reloadMetadata,
+                externalConflicts,
+            };
+        }
+        tabNavigationIndex = lastActiveIndex;
+    } else {
+        tabNavigationIndex = -1;
+    }
+
+    return {
+        tabs,
+        activeTabId,
+        activationHistory,
+        tabNavigationHistory,
+        tabNavigationIndex,
+        pendingForceReloads,
+        reloadVersions,
+        reloadMetadata,
+        externalConflicts,
+    };
+}
+
+export async function loadResourceHistoryEntryContent<K extends ResourceKind>(
+    handler: ResourceHandler<K>,
+    tabId: string,
+    historyIndex: number,
+    resourceId: string,
+    setState: (updater: (state: { tabs: Tab[] }) => { tabs: Tab[] }) => void,
+) {
+    try {
+        const content = await handler.readHistoryEntryContent(resourceId);
+        setState((state) => ({
+            tabs: state.tabs.map((tab) => {
+                if (tab.id !== tabId || !isHistoryTab(tab) || isMapTab(tab)) {
+                    return tab;
+                }
+
+                const normalized = normalizeHistoryTab(tab);
+                if (!normalized) {
+                    return tab;
+                }
+
+                const history = [...normalized.history];
+                const entry = history[historyIndex];
+                if (
+                    !entry ||
+                    (entry.kind !== "note" && entry.kind !== "file") ||
+                    !handler.matchesHistoryEntry(entry, resourceId)
+                ) {
+                    return tab;
+                }
+
+                history[historyIndex] = handler.patchHistoryEntryContent(
+                    entry,
+                    content,
+                );
+                return buildTabFromHistory(
+                    normalized.id,
+                    history,
+                    normalized.historyIndex,
+                );
+            }),
+        }));
+    } catch (error) {
+        console.error(
+            `Error loading ${handler.kind} history entry content:`,
+            error,
+        );
+    }
+}

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import {
+    buildPersistedSession,
+    getEditorSessionKey,
+    restorePersistedSession,
+} from "./editorSession";
+import { safeStorageClear } from "../utils/safeStorage";
+import { useVaultStore } from "./vaultStore";
+
+vi.mock("@tauri-apps/api/core", () => ({
+    invoke: vi.fn(),
+}));
+
+describe("editorSession", () => {
+    beforeEach(() => {
+        safeStorageClear();
+        localStorage.clear();
+        useVaultStore.setState({ vaultPath: "/vaults/project-alpha" });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+        safeStorageClear();
+        localStorage.clear();
+    });
+
+    it("serializes persisted session state without review tab payloads", () => {
+        const session = buildPersistedSession({
+            tabs: [
+                {
+                    id: "note-1",
+                    kind: "note",
+                    noteId: "notes/a",
+                    title: "Note A",
+                    content: "Body A",
+                    history: [
+                        {
+                            kind: "note",
+                            noteId: "notes/a",
+                            title: "Note A",
+                            content: "Body A",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+                {
+                    id: "pdf-1",
+                    kind: "pdf",
+                    entryId: "docs/spec",
+                    title: "spec.pdf",
+                    path: "/vault/docs/spec.pdf",
+                    page: 2,
+                    zoom: 1.2,
+                    viewMode: "single",
+                    history: [
+                        {
+                            kind: "pdf",
+                            entryId: "docs/spec",
+                            title: "spec.pdf",
+                            path: "/vault/docs/spec.pdf",
+                            page: 2,
+                            zoom: 1.2,
+                            viewMode: "single",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+                {
+                    id: "file-1",
+                    kind: "file",
+                    relativePath: "src/main.ts",
+                    title: "main.ts",
+                    path: "/vault/src/main.ts",
+                    content: "console.log('ok')",
+                    mimeType: "text/typescript",
+                    viewer: "text",
+                    history: [
+                        {
+                            kind: "file",
+                            relativePath: "src/main.ts",
+                            title: "main.ts",
+                            path: "/vault/src/main.ts",
+                            content: "console.log('ok')",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+                {
+                    id: "map-1",
+                    kind: "map",
+                    relativePath: "Excalidraw/Board.excalidraw",
+                    title: "Board",
+                    history: [],
+                    historyIndex: -1,
+                },
+                {
+                    id: "graph-1",
+                    kind: "graph",
+                    title: "Graph View",
+                },
+                {
+                    id: "review-1",
+                    kind: "ai-review",
+                    sessionId: "review-session",
+                    title: "Review",
+                },
+            ],
+            activeTabId: "file-1",
+        });
+
+        expect(session.noteIds).toEqual([
+            {
+                noteId: "notes/a",
+                title: "Note A",
+                history: [{ noteId: "notes/a", title: "Note A" }],
+                historyIndex: 0,
+            },
+        ]);
+        expect(session.pdfTabs).toEqual([
+            {
+                entryId: "docs/spec",
+                title: "spec.pdf",
+                path: "/vault/docs/spec.pdf",
+                page: 2,
+                zoom: 1.2,
+                viewMode: "single",
+                history: [
+                    {
+                        entryId: "docs/spec",
+                        title: "spec.pdf",
+                        path: "/vault/docs/spec.pdf",
+                        page: 2,
+                        zoom: 1.2,
+                        viewMode: "single",
+                    },
+                ],
+                historyIndex: 0,
+            },
+        ]);
+        expect(session.fileTabs).toEqual([
+            {
+                relativePath: "src/main.ts",
+                title: "main.ts",
+                path: "/vault/src/main.ts",
+                mimeType: "text/typescript",
+                viewer: "text",
+                history: [
+                    {
+                        relativePath: "src/main.ts",
+                        title: "main.ts",
+                        path: "/vault/src/main.ts",
+                        mimeType: "text/typescript",
+                        viewer: "text",
+                    },
+                ],
+                historyIndex: 0,
+            },
+        ]);
+        expect(session.mapTabs).toEqual([
+            {
+                relativePath: "Excalidraw/Board.excalidraw",
+                title: "Board",
+            },
+        ]);
+        expect(session.hasGraphTab).toBe(true);
+        expect(session.activeFilePath).toBe("src/main.ts");
+        expect(session.activeTabId).toBe("file-1");
+    });
+
+    it("restores legacy persisted sessions through the session module", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                noteIds: [
+                    {
+                        noteId: "notes/a",
+                        title: "Note A",
+                        history: [{ noteId: "notes/a", title: "Note A" }],
+                        historyIndex: 0,
+                    },
+                ],
+                pdfTabs: [
+                    {
+                        entryId: "docs/spec",
+                        title: "spec.pdf",
+                        path: "/vault/docs/spec.pdf",
+                        page: 3,
+                        zoom: 1.5,
+                        viewMode: "single",
+                    },
+                ],
+                fileTabs: [
+                    {
+                        relativePath: "src/main.ts",
+                        title: "main.ts",
+                        path: "/vault/src/main.ts",
+                        mimeType: "text/typescript",
+                        viewer: "text",
+                    },
+                ],
+                mapTabs: [
+                    {
+                        relativePath: "",
+                        title: "Board",
+                        filePath:
+                            "/vaults/project-alpha/Excalidraw/Board.excalidraw",
+                    },
+                ],
+                hasGraphTab: true,
+                activeMapRelativePath: "Excalidraw/Board.excalidraw",
+                activeNoteId: null,
+            }),
+        );
+
+        vi.mocked(invoke).mockImplementation(async (command, args) => {
+            if (command === "read_note") {
+                expect(args).toMatchObject({
+                    noteId: "notes/a",
+                    vaultPath: "/vaults/project-alpha",
+                });
+                return { content: "Body A" };
+            }
+            if (command === "read_vault_file") {
+                expect(args).toMatchObject({
+                    relativePath: "src/main.ts",
+                    vaultPath: "/vaults/project-alpha",
+                });
+                return { content: "console.log('ok')" };
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        const restored = await restorePersistedSession("/vaults/project-alpha", {
+            includeMaps: true,
+        });
+
+        expect(restored).not.toBeNull();
+        expect(restored?.tabs.map((tab) => tab.kind ?? "note")).toEqual([
+            "note",
+            "pdf",
+            "file",
+            "map",
+            "graph",
+        ]);
+        expect(restored?.tabs[0]).toMatchObject({
+            kind: "note",
+            noteId: "notes/a",
+            content: "Body A",
+        });
+        expect(restored?.tabs[1]).toMatchObject({
+            kind: "pdf",
+            entryId: "docs/spec",
+            page: 3,
+            zoom: 1.5,
+            viewMode: "single",
+        });
+        expect(restored?.tabs[2]).toMatchObject({
+            kind: "file",
+            relativePath: "src/main.ts",
+            content: "console.log('ok')",
+        });
+        expect(restored?.tabs[3]).toMatchObject({
+            kind: "map",
+            relativePath: "Excalidraw/Board.excalidraw",
+        });
+        expect(restored?.tabs[4]).toMatchObject({
+            kind: "graph",
+            title: "Graph View",
+        });
+        expect(restored?.activeTabId).toBe(restored?.tabs[3]?.id ?? null);
+    });
+});

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -1,0 +1,495 @@
+import {
+    isFileTab,
+    isGraphTab,
+    isHistoryTab,
+    isMapTab,
+    isNoteTab,
+    isPdfTab,
+    isReviewTab,
+    type FileViewerMode,
+    type PdfViewMode,
+    type Tab,
+    type TabInput,
+} from "./editorTabs";
+import { getHistoryTabHandler, normalizeHistoryTab } from "./editorTabRegistry";
+import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
+import { vaultInvoke } from "../utils/vaultInvoke";
+import { toVaultRelativePath } from "../utils/vaultPaths";
+
+const SESSION_KEY = "vaultai.session.tabs";
+const SESSION_KEY_PREFIX = "vaultai.session.tabs:";
+
+export interface PersistedSession {
+    tabs?: TabInput[];
+    activeTabId?: string | null;
+    noteIds: Array<{
+        noteId: string;
+        title: string;
+        history?: Array<{ noteId: string; title: string }>;
+        historyIndex?: number;
+    }>;
+    pdfTabs?: Array<{
+        entryId: string;
+        title: string;
+        path: string;
+        page?: number;
+        zoom?: number;
+        viewMode?: PdfViewMode;
+        history?: Array<{
+            entryId: string;
+            title: string;
+            path: string;
+            page?: number;
+            zoom?: number;
+            viewMode?: PdfViewMode;
+        }>;
+        historyIndex?: number;
+    }>;
+    fileTabs?: Array<{
+        relativePath: string;
+        title: string;
+        path: string;
+        mimeType?: string | null;
+        viewer?: FileViewerMode;
+        content?: string;
+        history?: Array<{
+            relativePath: string;
+            title: string;
+            path: string;
+            mimeType?: string | null;
+            viewer?: FileViewerMode;
+        }>;
+        historyIndex?: number;
+    }>;
+    mapTabs?: Array<{
+        relativePath: string;
+        title: string;
+        filePath?: string;
+    }>;
+    hasGraphTab?: boolean;
+    activeNoteId: string | null;
+    activePdfEntryId?: string | null;
+    activeFilePath?: string | null;
+    activeMapRelativePath?: string | null;
+    activeMapFilePath?: string | null;
+    activeGraphTab?: boolean;
+}
+
+export interface EditorSessionState {
+    tabs: Tab[];
+    activeTabId: string | null;
+}
+
+export interface RestoredEditorSession {
+    tabs: TabInput[];
+    activeTabId: string | null;
+}
+
+let sessionReady = false;
+
+export function markSessionReady() {
+    sessionReady = true;
+}
+
+export function isSessionReady() {
+    return sessionReady;
+}
+
+export function getEditorSessionKey(vaultPath: string) {
+    return `${SESSION_KEY_PREFIX}${vaultPath}`;
+}
+
+export function readPersistedSession(
+    vaultPath: string | null,
+): PersistedSession | null {
+    try {
+        const raw =
+            (vaultPath
+                ? safeStorageGetItem(getEditorSessionKey(vaultPath))
+                : null) ?? safeStorageGetItem(SESSION_KEY);
+        if (!raw) return null;
+        return JSON.parse(raw) as PersistedSession;
+    } catch {
+        return null;
+    }
+}
+
+export function writePersistedSession(
+    vaultPath: string,
+    session: PersistedSession,
+) {
+    safeStorageSetItem(getEditorSessionKey(vaultPath), JSON.stringify(session));
+}
+
+export function hasPersistedSessionData(
+    session: PersistedSession | null | undefined,
+) {
+    return Boolean(
+        session &&
+        (session.noteIds.length ||
+            session.tabs?.length ||
+            session.pdfTabs?.length ||
+            session.fileTabs?.length ||
+            session.mapTabs?.length ||
+            session.hasGraphTab),
+    );
+}
+
+export function getEditorSessionSignature(state: EditorSessionState) {
+    let signature = state.activeTabId ?? "";
+    for (const tab of state.tabs) {
+        if (isReviewTab(tab)) {
+            continue;
+        }
+        if (isGraphTab(tab)) {
+            signature += "|graph";
+            continue;
+        }
+        if (isHistoryTab(tab)) {
+            const normalized = normalizeHistoryTab(tab);
+            if (!normalized) {
+                continue;
+            }
+            signature += getHistoryTabHandler(normalized.kind).fingerprint(
+                normalized as never,
+            );
+        }
+    }
+    return signature;
+}
+
+export function buildPersistedSession(
+    state: EditorSessionState,
+): PersistedSession {
+    const activeTab =
+        state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
+    const normalizedTabs = state.tabs.flatMap((tab) => {
+        if (!isHistoryTab(tab)) {
+            return [];
+        }
+        const normalized = normalizeHistoryTab(tab);
+        return normalized ? [normalized] : [];
+    });
+
+    const noteIds: PersistedSession["noteIds"] = [];
+    const pdfTabs: NonNullable<PersistedSession["pdfTabs"]> = [];
+    const fileTabs: NonNullable<PersistedSession["fileTabs"]> = [];
+    const mapTabs: NonNullable<PersistedSession["mapTabs"]> = [];
+
+    for (const tab of normalizedTabs) {
+        const serialized = getHistoryTabHandler(tab.kind).serializeForSession(
+            tab as never,
+        );
+        if (isNoteTab(tab)) {
+            noteIds.push(serialized as PersistedSession["noteIds"][number]);
+            continue;
+        }
+        if (isPdfTab(tab)) {
+            pdfTabs.push(
+                serialized as NonNullable<PersistedSession["pdfTabs"]>[number],
+            );
+            continue;
+        }
+        if (isMapTab(tab)) {
+            mapTabs.push(
+                serialized as NonNullable<PersistedSession["mapTabs"]>[number],
+            );
+            continue;
+        }
+        fileTabs.push(
+            serialized as NonNullable<PersistedSession["fileTabs"]>[number],
+        );
+    }
+
+    return {
+        activeTabId: activeTab?.id ?? null,
+        noteIds,
+        pdfTabs,
+        fileTabs,
+        mapTabs,
+        hasGraphTab: state.tabs.some((tab) => isGraphTab(tab)),
+        activeNoteId:
+            activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+        activePdfEntryId:
+            activeTab && isPdfTab(activeTab) ? activeTab.entryId : null,
+        activeFilePath:
+            activeTab && isFileTab(activeTab) ? activeTab.relativePath : null,
+        activeMapRelativePath:
+            activeTab && isMapTab(activeTab) ? activeTab.relativePath : null,
+        activeGraphTab: activeTab ? isGraphTab(activeTab) : false,
+    };
+}
+
+async function restoreLegacyNoteTabs(session: PersistedSession) {
+    const restoredTabs: TabInput[] = [];
+    for (const entry of session.noteIds ?? []) {
+        try {
+            const detail = await vaultInvoke<{ content: string }>("read_note", {
+                noteId: entry.noteId,
+            });
+            const history = (
+                entry.history ?? [{ noteId: entry.noteId, title: entry.title }]
+            ).map((historyEntry) => ({
+                noteId: historyEntry.noteId,
+                title: historyEntry.title,
+                content: "",
+            }));
+            const historyIndex = Math.min(
+                entry.historyIndex ?? history.length - 1,
+                history.length - 1,
+            );
+            if (history[historyIndex]) {
+                history[historyIndex].content = detail.content;
+            }
+            restoredTabs.push({
+                id: crypto.randomUUID(),
+                kind: "note",
+                noteId: entry.noteId,
+                title: entry.title,
+                content: detail.content,
+                history,
+                historyIndex,
+            });
+        } catch {
+            // Deleted note or missing file; skip.
+        }
+    }
+    return restoredTabs;
+}
+
+function restoreLegacyPdfTabs(session: PersistedSession) {
+    return (session.pdfTabs ?? []).map((entry) => {
+        const history = (
+            entry.history ?? [
+                {
+                    entryId: entry.entryId,
+                    title: entry.title,
+                    path: entry.path,
+                    page: entry.page ?? 1,
+                    zoom: entry.zoom ?? 1,
+                    viewMode: entry.viewMode ?? "continuous",
+                },
+            ]
+        ).map((historyEntry) => ({
+            entryId: historyEntry.entryId,
+            title: historyEntry.title,
+            path: historyEntry.path,
+            page: historyEntry.page ?? 1,
+            zoom: historyEntry.zoom ?? 1,
+            viewMode: historyEntry.viewMode ?? "continuous",
+        }));
+        const historyIndex = Math.min(
+            entry.historyIndex ?? history.length - 1,
+            history.length - 1,
+        );
+        const currentEntry = history[historyIndex];
+        return {
+            id: crypto.randomUUID(),
+            kind: "pdf" as const,
+            entryId: currentEntry?.entryId ?? entry.entryId,
+            title: currentEntry?.title ?? entry.title,
+            path: currentEntry?.path ?? entry.path,
+            page: currentEntry?.page ?? entry.page ?? 1,
+            zoom: currentEntry?.zoom ?? entry.zoom ?? 1,
+            viewMode: currentEntry?.viewMode ?? entry.viewMode ?? "continuous",
+            history,
+            historyIndex,
+        };
+    });
+}
+
+async function restoreLegacyFileTabs(session: PersistedSession) {
+    const restoredTabs: TabInput[] = [];
+    for (const entry of session.fileTabs ?? []) {
+        let content = entry.content ?? "";
+        const viewer =
+            entry.viewer ??
+            (entry.mimeType?.startsWith("image/") ? "image" : "text");
+
+        if (!content && viewer === "text") {
+            try {
+                const detail = await vaultInvoke<{ content: string }>(
+                    "read_vault_file",
+                    { relativePath: entry.relativePath },
+                );
+                content = detail.content;
+            } catch {
+                content = "";
+            }
+        }
+
+        const history = (
+            entry.history ?? [
+                {
+                    relativePath: entry.relativePath,
+                    title: entry.title,
+                    path: entry.path,
+                    mimeType: entry.mimeType ?? null,
+                    viewer,
+                },
+            ]
+        ).map((historyEntry) => ({
+            relativePath: historyEntry.relativePath,
+            title: historyEntry.title,
+            path: historyEntry.path,
+            mimeType: historyEntry.mimeType ?? null,
+            viewer:
+                historyEntry.viewer ??
+                (historyEntry.mimeType?.startsWith("image/")
+                    ? "image"
+                    : "text"),
+            content: "",
+        }));
+        const historyIndex = Math.min(
+            entry.historyIndex ?? history.length - 1,
+            history.length - 1,
+        );
+        if (history[historyIndex]) {
+            history[historyIndex].content = content;
+        }
+
+        restoredTabs.push({
+            id: crypto.randomUUID(),
+            kind: "file",
+            relativePath: entry.relativePath,
+            title: entry.title,
+            path: entry.path,
+            mimeType: entry.mimeType ?? null,
+            viewer,
+            content,
+            history,
+            historyIndex,
+        });
+    }
+    return restoredTabs;
+}
+
+function restoreLegacyMapTabs(
+    session: PersistedSession,
+    vaultPath: string | null,
+    existingTabs: TabInput[],
+) {
+    const restoredTabs: TabInput[] = [];
+    for (const entry of session.mapTabs ?? []) {
+        const relativePath =
+            entry.relativePath ||
+            (entry.filePath
+                ? toVaultRelativePath(entry.filePath, vaultPath)
+                : null);
+        if (!relativePath) {
+            continue;
+        }
+        if (
+            existingTabs.some(
+                (tab) => isMapTab(tab) && tab.relativePath === relativePath,
+            ) ||
+            restoredTabs.some(
+                (tab) => isMapTab(tab) && tab.relativePath === relativePath,
+            )
+        ) {
+            continue;
+        }
+        restoredTabs.push({
+            id: crypto.randomUUID(),
+            kind: "map",
+            relativePath,
+            title: entry.title,
+        });
+    }
+    return restoredTabs;
+}
+
+function resolveRestoredActiveTabId(
+    session: PersistedSession,
+    tabs: TabInput[],
+    vaultPath: string | null,
+) {
+    if (session.activeGraphTab) {
+        const activeGraph = tabs.find((tab) => isGraphTab(tab));
+        if (activeGraph) return activeGraph.id;
+    }
+
+    const activeLegacyMapRelativePath = session.activeMapFilePath
+        ? toVaultRelativePath(session.activeMapFilePath, vaultPath)
+        : null;
+    if (session.activeMapRelativePath) {
+        const activeMap = tabs.find(
+            (tab) =>
+                isMapTab(tab) &&
+                tab.relativePath === session.activeMapRelativePath,
+        );
+        if (activeMap) return activeMap.id;
+    }
+    if (activeLegacyMapRelativePath) {
+        const activeMap = tabs.find(
+            (tab) =>
+                isMapTab(tab) &&
+                tab.relativePath === activeLegacyMapRelativePath,
+        );
+        if (activeMap) return activeMap.id;
+    }
+    if (session.activePdfEntryId) {
+        const activePdf = tabs.find(
+            (tab) => isPdfTab(tab) && tab.entryId === session.activePdfEntryId,
+        );
+        if (activePdf) return activePdf.id;
+    }
+    if (session.activeNoteId) {
+        const activeNote = tabs.find(
+            (tab) => isNoteTab(tab) && tab.noteId === session.activeNoteId,
+        );
+        if (activeNote) return activeNote.id;
+    }
+    if (session.activeFilePath) {
+        const activeFile = tabs.find(
+            (tab) =>
+                isFileTab(tab) && tab.relativePath === session.activeFilePath,
+        );
+        if (activeFile) return activeFile.id;
+    }
+    return null;
+}
+
+export async function restorePersistedSession(
+    vaultPath: string | null,
+    options?: { includeMaps?: boolean },
+): Promise<RestoredEditorSession | null> {
+    const session = readPersistedSession(vaultPath);
+    if (!hasPersistedSessionData(session)) {
+        return null;
+    }
+
+    const restoredTabs: TabInput[] = [];
+    if (session?.tabs?.length) {
+        restoredTabs.push(...session.tabs);
+    } else if (session) {
+        restoredTabs.push(...(await restoreLegacyNoteTabs(session)));
+        restoredTabs.push(...restoreLegacyPdfTabs(session));
+        restoredTabs.push(...(await restoreLegacyFileTabs(session)));
+    }
+
+    if (session && options?.includeMaps) {
+        restoredTabs.push(
+            ...restoreLegacyMapTabs(session, vaultPath, restoredTabs),
+        );
+    }
+
+    if (session?.hasGraphTab) {
+        restoredTabs.push({
+            id: crypto.randomUUID(),
+            kind: "graph",
+            title: "Graph View",
+        });
+    }
+
+    if (!restoredTabs.length) {
+        return null;
+    }
+
+    return {
+        tabs: restoredTabs,
+        activeTabId: session
+            ? resolveRestoredActiveTabId(session, restoredTabs, vaultPath)
+            : null,
+    };
+}

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -121,6 +121,17 @@ beforeEach(() => {
         activationHistory: [],
         tabNavigationHistory: [],
         tabNavigationIndex: -1,
+        pendingReveal: null,
+        pendingSelectionReveal: null,
+        currentSelection: null,
+        _pendingForceReloads: new Set(),
+        _pendingForceFileReloads: new Set(),
+        _noteReloadVersions: {},
+        _fileReloadVersions: {},
+        _noteReloadMetadata: {},
+        _fileReloadMetadata: {},
+        noteExternalConflicts: new Set(),
+        fileExternalConflicts: new Set(),
     });
     useSettingsStore.getState().reset();
     useVaultStore.setState({ vaultPath: null });
@@ -1640,6 +1651,74 @@ describe("editorStore tab management", () => {
             origin: "external",
             revision: 3,
             opId: "external-3",
+        });
+    });
+
+    it("updates title and content when clean file tabs reload from disk", () => {
+        useEditorStore.setState({
+            tabs: [
+                makeFileTab({
+                    id: "file-tab-a",
+                    relativePath: "src/a.ts",
+                    title: "old.ts",
+                    path: "/vault/src/a.ts",
+                    content: "old body",
+                    mimeType: "text/typescript",
+                    viewer: "text",
+                }),
+            ],
+            activeTabId: "file-tab-a",
+        });
+
+        useEditorStore.getState().reloadFileContent("src/a.ts", {
+            title: "new.ts",
+            content: "new body",
+        });
+
+        expect(useEditorStore.getState().tabs[0]).toMatchObject({
+            title: "new.ts",
+            content: "new body",
+        });
+        expect(useEditorStore.getState()._fileReloadVersions["src/a.ts"]).toBe(
+            1,
+        );
+    });
+
+    it("tracks forced reload state for file tabs through the direct API", () => {
+        useEditorStore.setState({
+            tabs: [
+                makeFileTab({
+                    id: "file-tab-a",
+                    relativePath: "src/a.ts",
+                    title: "a.ts",
+                    path: "/vault/src/a.ts",
+                    content: "before",
+                    mimeType: "text/typescript",
+                    viewer: "text",
+                }),
+            ],
+            activeTabId: "file-tab-a",
+        });
+
+        useEditorStore.getState().forceReloadFileContent("src/a.ts", {
+            title: "a.ts",
+            content: "after",
+            origin: "external",
+            revision: 7,
+            opId: "external-7",
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.tabs[0]).toMatchObject({
+            title: "a.ts",
+            content: "after",
+        });
+        expect(state._pendingForceFileReloads.has("src/a.ts")).toBe(true);
+        expect(state._fileReloadVersions["src/a.ts"]).toBe(1);
+        expect(state._fileReloadMetadata["src/a.ts"]).toMatchObject({
+            origin: "external",
+            revision: 7,
+            opId: "external-7",
         });
     });
 

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -282,6 +282,58 @@ describe("editorStore session persistence", () => {
         });
     });
 
+    it("persists note renames that only affect inactive history entries", async () => {
+        markSessionReady();
+        useVaultStore.setState({ vaultPath: "/vaults/history-rename-2026" });
+
+        useEditorStore.setState({
+            tabs: [
+                {
+                    id: "note-history-tab",
+                    kind: "note",
+                    noteId: "notes/current",
+                    title: "Current",
+                    content: "current body",
+                    history: [
+                        {
+                            kind: "note",
+                            noteId: "notes/old",
+                            title: "Old title",
+                            content: "old body",
+                        },
+                        {
+                            kind: "note",
+                            noteId: "notes/current",
+                            title: "Current",
+                            content: "current body",
+                        },
+                    ],
+                    historyIndex: 1,
+                },
+            ],
+            activeTabId: "note-history-tab",
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        useEditorStore
+            .getState()
+            .handleNoteRenamed("notes/old", "notes/renamed", "Renamed");
+
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        const session = readPersistedSession("/vaults/history-rename-2026");
+        expect(session?.noteIds?.[0]).toEqual({
+            noteId: "notes/current",
+            title: "Current",
+            history: [
+                { noteId: "notes/renamed", title: "Renamed" },
+                { noteId: "notes/current", title: "Current" },
+            ],
+            historyIndex: 1,
+        });
+    });
+
     it("swallows storage quota errors while persisting", async () => {
         markSessionReady();
         useVaultStore.setState({ vaultPath: "/vaults/quota-2026" });
@@ -565,6 +617,37 @@ describe("editorStore hydration and external insertion", () => {
             kind: "graph",
         });
         expect(state.activeTabId).toBe("graph-1");
+    });
+
+    it("preserves graph singleton when inserting an external graph tab", () => {
+        useEditorStore.setState({
+            tabs: [
+                {
+                    id: "graph-existing",
+                    kind: "graph",
+                    title: "Graph View",
+                },
+            ],
+            activeTabId: "graph-existing",
+            activationHistory: ["graph-existing"],
+            tabNavigationHistory: ["graph-existing"],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore.getState().insertExternalTab({
+            id: "graph-new",
+            kind: "graph",
+            title: "Knowledge Graph",
+        });
+
+        const state = useEditorStore.getState();
+        const graphTabs = state.tabs.filter((tab) => isGraphTab(tab));
+        expect(graphTabs).toHaveLength(1);
+        expect(graphTabs[0]).toMatchObject({
+            id: "graph-existing",
+            title: "Knowledge Graph",
+        });
+        expect(state.activeTabId).toBe("graph-existing");
     });
 
     it("skips invalid external map tabs that cannot resolve a relative path", () => {
@@ -1307,6 +1390,62 @@ describe("editorStore tab management", () => {
         const graphTabs = state.tabs.filter((tab) => isGraphTab(tab));
         expect(graphTabs).toHaveLength(1);
         expect(state.activeTabId).toBe(firstGraphTab?.id ?? null);
+    });
+
+    it("updates renamed notes inside inactive history entries", () => {
+        useEditorStore.setState({
+            tabs: [
+                {
+                    id: "note-tab",
+                    kind: "note",
+                    noteId: "notes/current",
+                    title: "Current",
+                    content: "current body",
+                    history: [
+                        {
+                            kind: "note",
+                            noteId: "notes/old",
+                            title: "Old title",
+                            content: "old body",
+                        },
+                        {
+                            kind: "note",
+                            noteId: "notes/current",
+                            title: "Current",
+                            content: "current body",
+                        },
+                    ],
+                    historyIndex: 1,
+                },
+            ],
+            activeTabId: "note-tab",
+        });
+
+        useEditorStore
+            .getState()
+            .handleNoteRenamed("notes/old", "notes/renamed", "Renamed");
+
+        const noteTab = useEditorStore.getState().tabs[0];
+        expect(noteTab).toMatchObject({
+            kind: "note",
+            noteId: "notes/current",
+            title: "Current",
+            historyIndex: 1,
+        });
+        expect(isNoteTab(noteTab) ? noteTab.history : []).toEqual([
+            {
+                kind: "note",
+                noteId: "notes/renamed",
+                title: "Renamed",
+                content: "old body",
+            },
+            {
+                kind: "note",
+                noteId: "notes/current",
+                title: "Current",
+                content: "current body",
+            },
+        ]);
     });
 
     it("opens review tabs in background, updates the existing one, and closes by session id", () => {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
     isFileTab,
+    isGraphTab,
     isMapTab,
     isNoteTab,
+    isPdfTab,
+    isReviewTab,
     markSessionReady,
     readPersistedSession,
     useEditorStore,
@@ -10,6 +13,7 @@ import {
     type MapTabInput,
 } from "./editorStore";
 import { useSettingsStore } from "./settingsStore";
+import { safeStorageClear } from "../utils/safeStorage";
 import { useVaultStore } from "./vaultStore";
 
 function makeTab(overrides: {
@@ -108,6 +112,8 @@ function makeMapTab(overrides: {
 }
 
 beforeEach(() => {
+    safeStorageClear();
+    localStorage.clear();
     useEditorStore.setState({
         tabs: [],
         activeTabId: null,
@@ -117,6 +123,13 @@ beforeEach(() => {
         tabNavigationIndex: -1,
     });
     useSettingsStore.getState().reset();
+    useVaultStore.setState({ vaultPath: null });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+    safeStorageClear();
+    localStorage.clear();
 });
 
 describe("editorStore session persistence", () => {
@@ -294,15 +307,14 @@ describe("editorStore session persistence", () => {
 
         expect(setItemMock).toHaveBeenCalled();
         expect(warnSpy).toHaveBeenCalledWith(
-            "Failed to persist editor session",
+            "Failed to persist safe storage item:",
+            "vaultai.session.tabs:/vaults/quota-2026",
             quotaError,
         );
-
         Object.defineProperty(window.localStorage, "setItem", {
             configurable: true,
             value: originalSetItem,
         });
-        warnSpy.mockRestore();
     });
 
     it("falls back to the legacy global session key when needed", () => {
@@ -363,6 +375,197 @@ describe("editorStore map tabs", () => {
         expect(activeTab && isMapTab(activeTab) && activeTab.relativePath).toBe(
             "Excalidraw/Legacy.excalidraw",
         );
+    });
+});
+
+describe("editorStore hydration and external insertion", () => {
+    beforeEach(() => {
+        useVaultStore.setState({ vaultPath: "/vaults/project-alpha" });
+    });
+
+    it("hydrates mixed persisted tabs, drops review tabs, and keeps the requested active tab", () => {
+        useEditorStore.getState().hydrateTabs(
+            [
+                {
+                    id: "note-1",
+                    noteId: "notes/alpha",
+                    title: "Alpha",
+                    content: "Alpha body",
+                    history: [{ noteId: "notes/alpha", title: "Alpha" }],
+                    historyIndex: 0,
+                },
+                {
+                    id: "pdf-1",
+                    kind: "pdf",
+                    entryId: "docs/spec",
+                    title: "spec.pdf",
+                    path: "/vault/docs/spec.pdf",
+                    history: [
+                        {
+                            entryId: "docs/spec",
+                            title: "spec.pdf",
+                            path: "/vault/docs/spec.pdf",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+                {
+                    id: "file-1",
+                    kind: "file",
+                    relativePath: "src/app.ts",
+                    title: "app.ts",
+                    path: "/vault/src/app.ts",
+                    content: "console.log('ok')",
+                    mimeType: "text/typescript",
+                    viewer: "text",
+                    history: [
+                        {
+                            relativePath: "src/app.ts",
+                            title: "app.ts",
+                            path: "/vault/src/app.ts",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+                {
+                    id: "map-1",
+                    kind: "map",
+                    title: "Board",
+                    relativePath: "",
+                    filePath:
+                        "/vaults/project-alpha/Excalidraw/Board.excalidraw",
+                } as MapTabInput & { filePath: string },
+                {
+                    id: "review-1",
+                    kind: "ai-review",
+                    sessionId: "session-1",
+                    title: "Review",
+                },
+                {
+                    id: "graph-1",
+                    kind: "graph",
+                    title: "Graph View",
+                },
+            ],
+            "graph-1",
+        );
+
+        const state = useEditorStore.getState();
+        expect(state.tabs).toHaveLength(5);
+        expect(state.tabs.some((tab) => isReviewTab(tab))).toBe(false);
+        expect(state.activeTabId).toBe("graph-1");
+        expect(state.tabs.find((tab) => tab.id === "note-1")).toMatchObject({
+            kind: "note",
+            historyIndex: 0,
+        });
+        expect(state.tabs.find((tab) => tab.id === "pdf-1")).toMatchObject({
+            kind: "pdf",
+            page: 1,
+            zoom: 1,
+            viewMode: "continuous",
+        });
+        expect(state.tabs.find((tab) => tab.id === "file-1")).toMatchObject({
+            kind: "file",
+            content: "console.log('ok')",
+        });
+        expect(state.tabs.find((tab) => tab.id === "map-1")).toMatchObject({
+            kind: "map",
+            relativePath: "Excalidraw/Board.excalidraw",
+        });
+        expect(state.tabs.find((tab) => tab.id === "graph-1")).toMatchObject({
+            kind: "graph",
+            title: "Graph View",
+        });
+    });
+
+    it("normalizes external tabs by kind and activates the inserted tab", () => {
+        useEditorStore.setState({
+            tabs: [
+                makeTab({
+                    id: "note-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "A",
+                }),
+            ],
+            activeTabId: "note-a",
+            activationHistory: ["note-a"],
+            tabNavigationHistory: ["note-a"],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore.getState().insertExternalTab(
+            {
+                id: "file-1",
+                kind: "file",
+                relativePath: "src/server.ts",
+                title: "server.ts",
+                path: "/vault/src/server.ts",
+                content: "export {}",
+                mimeType: "text/typescript",
+                viewer: "text",
+                history: [
+                    {
+                        relativePath: "src/server.ts",
+                        title: "server.ts",
+                        path: "/vault/src/server.ts",
+                        mimeType: "text/typescript",
+                        viewer: "text",
+                    },
+                ],
+                historyIndex: 0,
+            },
+            0,
+        );
+
+        let state = useEditorStore.getState();
+        expect(state.tabs.map((tab) => tab.id)).toEqual(["file-1", "note-a"]);
+        expect(state.activeTabId).toBe("file-1");
+        expect(state.tabs[0]).toMatchObject({
+            kind: "file",
+            content: "export {}",
+        });
+
+        useEditorStore.getState().insertExternalTab({
+            id: "review-1",
+            kind: "ai-review",
+            sessionId: "session-1",
+            title: "Review",
+        });
+
+        state = useEditorStore.getState();
+        expect(state.tabs[state.tabs.length - 1]).toMatchObject({
+            id: "review-1",
+            kind: "ai-review",
+        });
+        expect(state.activeTabId).toBe("review-1");
+
+        useEditorStore.getState().insertExternalTab({
+            id: "graph-1",
+            kind: "graph",
+            title: "Graph View",
+        });
+
+        state = useEditorStore.getState();
+        expect(state.tabs[state.tabs.length - 1]).toMatchObject({
+            id: "graph-1",
+            kind: "graph",
+        });
+        expect(state.activeTabId).toBe("graph-1");
+    });
+
+    it("skips invalid external map tabs that cannot resolve a relative path", () => {
+        useEditorStore.getState().insertExternalTab({
+            id: "map-invalid",
+            kind: "map",
+            title: "Broken map",
+            relativePath: "",
+        });
+
+        expect(useEditorStore.getState().tabs).toEqual([]);
+        expect(useEditorStore.getState().activeTabId).toBeNull();
     });
 });
 
@@ -1081,6 +1284,69 @@ describe("editorStore tab history mode", () => {
 });
 
 describe("editorStore tab management", () => {
+    it("opens graph as a singleton and reactivates the existing tab", () => {
+        useEditorStore.getState().openGraph();
+        const firstGraphTab = useEditorStore
+            .getState()
+            .tabs.find((tab) => isGraphTab(tab));
+
+        useEditorStore.getState().openGraph();
+
+        const state = useEditorStore.getState();
+        const graphTabs = state.tabs.filter((tab) => isGraphTab(tab));
+        expect(graphTabs).toHaveLength(1);
+        expect(state.activeTabId).toBe(firstGraphTab?.id ?? null);
+    });
+
+    it("opens review tabs in background, updates the existing one, and closes by session id", () => {
+        useEditorStore.setState({
+            tabs: [
+                makeTab({
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "a",
+                }),
+            ],
+            activeTabId: "tab-a",
+            activationHistory: ["tab-a"],
+            tabNavigationHistory: ["tab-a"],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore.getState().openReview("session-1", {
+            background: true,
+            title: "Initial review",
+        });
+
+        let state = useEditorStore.getState();
+        const reviewTab = state.tabs.find((tab) => isReviewTab(tab));
+        expect(reviewTab).toMatchObject({
+            kind: "ai-review",
+            sessionId: "session-1",
+            title: "Initial review",
+        });
+        expect(state.activeTabId).toBe("tab-a");
+
+        useEditorStore.getState().openReview("session-1", {
+            title: "Updated review",
+        });
+
+        state = useEditorStore.getState();
+        const updatedReviewTab = state.tabs.find((tab) => isReviewTab(tab));
+        expect(state.tabs.filter((tab) => isReviewTab(tab))).toHaveLength(1);
+        expect(updatedReviewTab).toMatchObject({
+            title: "Updated review",
+        });
+        expect(state.activeTabId).toBe(updatedReviewTab?.id ?? null);
+
+        useEditorStore.getState().closeReview("session-1");
+
+        state = useEditorStore.getState();
+        expect(state.tabs.some((tab) => isReviewTab(tab))).toBe(false);
+        expect(state.activeTabId).toBe("tab-a");
+    });
+
     it("returns to the most recently active tab when closing the current one", () => {
         useEditorStore.setState({
             tabs: [
@@ -1464,6 +1730,44 @@ describe("editorStore tab management", () => {
             origin: "agent",
             revision: 5,
             opId: "agent-5",
+        });
+    });
+
+    it("updates pdf page, zoom, and view mode on the current history entry", () => {
+        useEditorStore.setState({
+            tabs: [
+                makePdfTab({
+                    id: "pdf-tab-a",
+                    entryId: "docs/guide",
+                    title: "guide.pdf",
+                    path: "/vault/docs/guide.pdf",
+                    page: 1,
+                    zoom: 1,
+                    viewMode: "continuous",
+                }),
+            ],
+            activeTabId: "pdf-tab-a",
+        });
+
+        useEditorStore.getState().updatePdfPage("pdf-tab-a", 4);
+        useEditorStore.getState().updatePdfZoom("pdf-tab-a", 1.75);
+        useEditorStore.getState().updatePdfViewMode("pdf-tab-a", "single");
+
+        const pdfTab = useEditorStore
+            .getState()
+            .tabs.find((tab) => tab.id === "pdf-tab-a");
+        expect(isPdfTab(pdfTab) ? pdfTab : null).toMatchObject({
+            page: 4,
+            zoom: 1.75,
+            viewMode: "single",
+        });
+        expect(
+            isPdfTab(pdfTab) ? pdfTab.history[pdfTab.historyIndex] : null,
+        ).toMatchObject({
+            kind: "pdf",
+            page: 4,
+            zoom: 1.75,
+            viewMode: "single",
         });
     });
 });

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -718,11 +718,22 @@ function ensurePdfTabDefaults(tab: PdfTabInput): PdfTab {
         const history = tab.history.map((entry) =>
             normalizeHistoryEntry(entry, "pdf"),
         );
-        return buildTabFromHistory(
-            tab.id,
-            history,
-            tab.historyIndex ?? history.length - 1,
-        ) as PdfTab;
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createPdfHistoryEntry(
+            tab.entryId,
+            tab.title,
+            tab.path,
+            tab.page ?? 1,
+            tab.zoom ?? 1,
+            tab.viewMode ?? "continuous",
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as PdfTab;
     }
 
     const history = [
@@ -748,11 +759,22 @@ function ensureFileTabHistory(tab: FileTabInput): FileTab {
         const history = tab.history.map((entry) =>
             normalizeHistoryEntry(entry, "file"),
         );
-        return buildTabFromHistory(
-            tab.id,
-            history,
-            tab.historyIndex ?? history.length - 1,
-        ) as FileTab;
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createFileHistoryEntry(
+            tab.relativePath,
+            tab.title,
+            tab.path,
+            tab.content,
+            tab.mimeType ?? null,
+            tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as FileTab;
     }
 
     const viewer =
@@ -811,11 +833,19 @@ function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {
         const history = tab.history.map((entry) =>
             normalizeHistoryEntry(entry, "note"),
         );
-        return buildTabFromHistory(
-            tab.id,
-            history,
-            tab.historyIndex ?? history.length - 1,
-        ) as NoteTab;
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createNoteHistoryEntry(
+            tab.noteId,
+            tab.title,
+            tab.content,
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as NoteTab;
     }
     return buildTabFromHistory(
         tab.id,

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -5,7 +5,6 @@ import {
     createGraphTab,
     createMapTab,
     ensureFileTabDefaults,
-    ensureFileTabHistory,
     ensureNoteTabHistory,
     ensurePdfTabDefaults,
     isFileTab,
@@ -46,6 +45,12 @@ import {
     type OpenableHistoryTabKind,
 } from "./editorTabRegistry";
 import {
+    buildResourceDeleteUpdate,
+    buildResourceReloadUpdate,
+    getResourceHandler,
+    loadResourceHistoryEntryContent,
+} from "./editorResourceRegistry";
+import {
     buildPersistedSession,
     getEditorSessionSignature,
     isSessionReady,
@@ -53,7 +58,6 @@ import {
     readPersistedSession,
     writePersistedSession,
 } from "./editorSession";
-import { vaultInvoke } from "../utils/vaultInvoke";
 import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
 
@@ -627,14 +631,22 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         set({ tabs });
 
         if (entry.kind === "note" && !entry.content) {
-            void loadNoteHistoryEntryContent(tab.id, targetIndex, entry.noteId);
+            void loadResourceHistoryEntryContent(
+                getResourceHandler("note"),
+                tab.id,
+                targetIndex,
+                entry.noteId,
+                useEditorStore.setState,
+            );
         }
 
         if (entry.kind === "file" && !entry.content) {
-            void loadFileHistoryEntryContent(
+            void loadResourceHistoryEntryContent(
+                getResourceHandler("file"),
                 tab.id,
                 targetIndex,
                 entry.relativePath,
+                useEditorStore.setState,
             );
         }
     },
@@ -940,129 +952,95 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     clearCurrentSelection: () => set({ currentSelection: null }),
 
     reloadNoteContent: (noteId, detail) => {
-        set((state) => ({
-            _noteReloadVersions: {
-                ...state._noteReloadVersions,
-                [noteId]: (state._noteReloadVersions[noteId] ?? 0) + 1,
-            },
-            _noteReloadMetadata: {
-                ...state._noteReloadMetadata,
-                [noteId]: {
-                    origin: detail.origin ?? "unknown",
-                    opId: detail.opId ?? null,
-                    revision: detail.revision ?? 0,
-                    contentHash: detail.contentHash ?? null,
+        set((state) => {
+            const next = buildResourceReloadUpdate(
+                getResourceHandler("note"),
+                {
+                    tabs: state.tabs,
+                    pendingForceReloads: state._pendingForceReloads,
+                    reloadVersions: state._noteReloadVersions,
+                    reloadMetadata: state._noteReloadMetadata,
                 },
-            },
-            tabs: state.tabs.map((t) => {
-                if (!isNoteTab(t) || t.noteId !== noteId) return t;
-                if (t.content === detail.content && t.title === detail.title) {
-                    return t;
-                }
-                return { ...t, content: detail.content, title: detail.title };
-            }),
-        }));
+                noteId,
+                detail,
+                { fallbackOrigin: "unknown" },
+            );
+
+            return {
+                tabs: next.tabs,
+                _noteReloadVersions: next.reloadVersions,
+                _noteReloadMetadata: next.reloadMetadata,
+            };
+        });
     },
 
     reloadFileContent: (relativePath, detail) => {
-        set((state) => ({
-            _fileReloadVersions: {
-                ...state._fileReloadVersions,
-                [relativePath]:
-                    (state._fileReloadVersions[relativePath] ?? 0) + 1,
-            },
-            _fileReloadMetadata: {
-                ...state._fileReloadMetadata,
-                [relativePath]: {
-                    origin: detail.origin ?? "unknown",
-                    opId: detail.opId ?? null,
-                    revision: detail.revision ?? 0,
-                    contentHash: detail.contentHash ?? null,
+        set((state) => {
+            const next = buildResourceReloadUpdate(
+                getResourceHandler("file"),
+                {
+                    tabs: state.tabs,
+                    pendingForceReloads: state._pendingForceFileReloads,
+                    reloadVersions: state._fileReloadVersions,
+                    reloadMetadata: state._fileReloadMetadata,
                 },
-            },
-            tabs: state.tabs.map((t) => {
-                if (!isFileTab(t) || t.relativePath !== relativePath) return t;
-                if (t.content === detail.content && t.title === detail.title) {
-                    return t;
-                }
-                return { ...t, content: detail.content, title: detail.title };
-            }),
-        }));
+                relativePath,
+                detail,
+                { fallbackOrigin: "unknown" },
+            );
+
+            return {
+                tabs: next.tabs,
+                _fileReloadVersions: next.reloadVersions,
+                _fileReloadMetadata: next.reloadMetadata,
+            };
+        });
     },
 
     forceReloadNoteContent: (noteId, detail) => {
         set((state) => {
-            const next = new Set(state._pendingForceReloads);
-            next.add(noteId);
+            const next = buildResourceReloadUpdate(
+                getResourceHandler("note"),
+                {
+                    tabs: state.tabs,
+                    pendingForceReloads: state._pendingForceReloads,
+                    reloadVersions: state._noteReloadVersions,
+                    reloadMetadata: state._noteReloadMetadata,
+                },
+                noteId,
+                detail,
+                { force: true, fallbackOrigin: "system" },
+            );
+
             return {
-                _pendingForceReloads: next,
-                _noteReloadVersions: {
-                    ...state._noteReloadVersions,
-                    [noteId]: (state._noteReloadVersions[noteId] ?? 0) + 1,
-                },
-                _noteReloadMetadata: {
-                    ...state._noteReloadMetadata,
-                    [noteId]: {
-                        origin: detail.origin ?? "system",
-                        opId: detail.opId ?? null,
-                        revision: detail.revision ?? 0,
-                        contentHash: detail.contentHash ?? null,
-                    },
-                },
-                tabs: state.tabs.map((t) => {
-                    if (!isNoteTab(t) || t.noteId !== noteId) return t;
-                    if (
-                        t.content === detail.content &&
-                        t.title === detail.title
-                    ) {
-                        return t;
-                    }
-                    return {
-                        ...t,
-                        content: detail.content,
-                        title: detail.title,
-                    };
-                }),
+                tabs: next.tabs,
+                _pendingForceReloads: next.pendingForceReloads,
+                _noteReloadVersions: next.reloadVersions,
+                _noteReloadMetadata: next.reloadMetadata,
             };
         });
     },
 
     forceReloadFileContent: (relativePath, detail) => {
         set((state) => {
-            const next = new Set(state._pendingForceFileReloads);
-            next.add(relativePath);
+            const next = buildResourceReloadUpdate(
+                getResourceHandler("file"),
+                {
+                    tabs: state.tabs,
+                    pendingForceReloads: state._pendingForceFileReloads,
+                    reloadVersions: state._fileReloadVersions,
+                    reloadMetadata: state._fileReloadMetadata,
+                },
+                relativePath,
+                detail,
+                { force: true, fallbackOrigin: "system" },
+            );
+
             return {
-                _pendingForceFileReloads: next,
-                _fileReloadVersions: {
-                    ...state._fileReloadVersions,
-                    [relativePath]:
-                        (state._fileReloadVersions[relativePath] ?? 0) + 1,
-                },
-                _fileReloadMetadata: {
-                    ...state._fileReloadMetadata,
-                    [relativePath]: {
-                        origin: detail.origin ?? "system",
-                        opId: detail.opId ?? null,
-                        revision: detail.revision ?? 0,
-                        contentHash: detail.contentHash ?? null,
-                    },
-                },
-                tabs: state.tabs.map((t) => {
-                    if (!isFileTab(t) || t.relativePath !== relativePath) {
-                        return t;
-                    }
-                    if (
-                        t.content === detail.content &&
-                        t.title === detail.title
-                    ) {
-                        return t;
-                    }
-                    return {
-                        ...t,
-                        content: detail.content,
-                        title: detail.title,
-                    };
-                }),
+                tabs: next.tabs,
+                _pendingForceFileReloads: next.pendingForceReloads,
+                _fileReloadVersions: next.reloadVersions,
+                _fileReloadMetadata: next.reloadMetadata,
             };
         });
     },
@@ -1143,267 +1121,72 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     handleNoteDeleted: (noteId) => {
         set((state) => {
-            const idsToClose = new Set(
-                state.tabs
-                    .filter((t) => isNoteTab(t) && t.noteId === noteId)
-                    .map((t) => t.id),
+            const next = buildResourceDeleteUpdate(
+                getResourceHandler("note"),
+                {
+                    tabs: state.tabs,
+                    activeTabId: state.activeTabId,
+                    activationHistory: state.activationHistory,
+                    tabNavigationHistory: state.tabNavigationHistory,
+                    tabNavigationIndex: state.tabNavigationIndex,
+                    pendingForceReloads: state._pendingForceReloads,
+                    reloadVersions: state._noteReloadVersions,
+                    reloadMetadata: state._noteReloadMetadata,
+                    externalConflicts: state.noteExternalConflicts,
+                },
+                noteId,
             );
-            const nextPendingForceReloads = new Set(state._pendingForceReloads);
-            const nextNoteExternalConflicts = new Set(
-                state.noteExternalConflicts,
-            );
-            const hadPendingForceReload =
-                nextPendingForceReloads.delete(noteId);
-            const hadExternalConflict =
-                nextNoteExternalConflicts.delete(noteId);
-            const hadReloadVersion = noteId in state._noteReloadVersions;
-            const hadReloadMetadata = noteId in state._noteReloadMetadata;
-            const nextNoteReloadVersions = hadReloadVersion
-                ? Object.fromEntries(
-                      Object.entries(state._noteReloadVersions).filter(
-                          ([key]) => key !== noteId,
-                      ),
-                  )
-                : state._noteReloadVersions;
-            const nextNoteReloadMetadata = hadReloadMetadata
-                ? Object.fromEntries(
-                      Object.entries(state._noteReloadMetadata).filter(
-                          ([key]) => key !== noteId,
-                      ),
-                  )
-                : state._noteReloadMetadata;
-            const didChange = idsToClose.size > 0;
 
-            if (
-                !didChange &&
-                !hadPendingForceReload &&
-                !hadExternalConflict &&
-                !hadReloadVersion &&
-                !hadReloadMetadata
-            ) {
+            if (!next) {
                 return state;
             }
 
-            const tabs = state.tabs.filter((t) => !idsToClose.has(t.id));
-            const activationHistory = state.activationHistory.filter(
-                (id) => !idsToClose.has(id),
-            );
-            const tabNavigationHistory = state.tabNavigationHistory.filter(
-                (id) => !idsToClose.has(id),
-            );
-
-            let activeTabId = state.activeTabId;
-            if (activeTabId && idsToClose.has(activeTabId)) {
-                const closedIdx = state.tabs.findIndex(
-                    (t) => t.id === activeTabId,
-                );
-                activeTabId =
-                    [...activationHistory]
-                        .reverse()
-                        .find((id) => tabs.some((tab) => tab.id === id)) ??
-                    tabs[Math.min(closedIdx, tabs.length - 1)]?.id ??
-                    null;
-            }
-
-            let tabNavigationIndex = Math.min(
-                state.tabNavigationIndex,
-                tabNavigationHistory.length - 1,
-            );
-            if (activeTabId) {
-                const lastActiveIndex =
-                    tabNavigationHistory.lastIndexOf(activeTabId);
-                if (lastActiveIndex === -1) {
-                    const navigation = pushTabToNavigation(
-                        tabNavigationHistory,
-                        tabNavigationIndex,
-                        activeTabId,
-                    );
-                    return {
-                        tabs,
-                        activeTabId,
-                        activationHistory,
-                        tabNavigationHistory: navigation.history,
-                        tabNavigationIndex: navigation.index,
-                        _pendingForceReloads: nextPendingForceReloads,
-                        _noteReloadVersions: nextNoteReloadVersions,
-                        _noteReloadMetadata: nextNoteReloadMetadata,
-                        noteExternalConflicts: nextNoteExternalConflicts,
-                    };
-                }
-                tabNavigationIndex = lastActiveIndex;
-            } else {
-                tabNavigationIndex = -1;
-            }
-
             return {
-                tabs,
-                activeTabId,
-                activationHistory,
-                tabNavigationHistory,
-                tabNavigationIndex,
-                _pendingForceReloads: nextPendingForceReloads,
-                _noteReloadVersions: nextNoteReloadVersions,
-                _noteReloadMetadata: nextNoteReloadMetadata,
-                noteExternalConflicts: nextNoteExternalConflicts,
+                tabs: next.tabs,
+                activeTabId: next.activeTabId,
+                activationHistory: next.activationHistory,
+                tabNavigationHistory: next.tabNavigationHistory,
+                tabNavigationIndex: next.tabNavigationIndex,
+                _pendingForceReloads: next.pendingForceReloads,
+                _noteReloadVersions: next.reloadVersions,
+                _noteReloadMetadata: next.reloadMetadata,
+                noteExternalConflicts: next.externalConflicts,
             };
         });
     },
 
     handleFileDeleted: (relativePath) => {
         set((state) => {
-            let didChange = false;
-            const idsToClose = new Set(
-                state.tabs.flatMap((rawTab) => {
-                    if (!isFileTab(rawTab)) {
-                        return [];
-                    }
-
-                    const tab = ensureFileTabDefaults(rawTab);
-                    const removedEntries = tab.history.filter(
-                        (entry) =>
-                            entry.kind === "file" &&
-                            entry.relativePath === relativePath,
-                    ).length;
-                    if (removedEntries === 0) {
-                        return [];
-                    }
-
-                    didChange = true;
-                    return tab.history.length === removedEntries
-                        ? [tab.id]
-                        : [];
-                }),
+            const next = buildResourceDeleteUpdate(
+                getResourceHandler("file"),
+                {
+                    tabs: state.tabs,
+                    activeTabId: state.activeTabId,
+                    activationHistory: state.activationHistory,
+                    tabNavigationHistory: state.tabNavigationHistory,
+                    tabNavigationIndex: state.tabNavigationIndex,
+                    pendingForceReloads: state._pendingForceFileReloads,
+                    reloadVersions: state._fileReloadVersions,
+                    reloadMetadata: state._fileReloadMetadata,
+                    externalConflicts: state.fileExternalConflicts,
+                },
+                relativePath,
             );
-            const tabs = state.tabs.flatMap((rawTab): Tab[] => {
-                if (!isFileTab(rawTab)) {
-                    return [rawTab];
-                }
 
-                const tab = ensureFileTabDefaults(rawTab);
-                const removedBeforeOrAtCurrent = tab.history
-                    .slice(0, tab.historyIndex + 1)
-                    .filter(
-                        (entry) =>
-                            entry.kind === "file" &&
-                            entry.relativePath === relativePath,
-                    ).length;
-                const history = tab.history.filter(
-                    (entry) =>
-                        entry.kind !== "file" ||
-                        entry.relativePath !== relativePath,
-                );
-
-                if (history.length === tab.history.length) {
-                    return [rawTab];
-                }
-                if (history.length === 0) {
-                    return [];
-                }
-
-                const nextHistoryIndex = Math.min(
-                    Math.max(0, tab.historyIndex - removedBeforeOrAtCurrent),
-                    history.length - 1,
-                );
-                return [buildTabFromHistory(tab.id, history, nextHistoryIndex)];
-            });
-
-            const nextPendingForceFileReloads = new Set(
-                state._pendingForceFileReloads,
-            );
-            const nextFileExternalConflicts = new Set(
-                state.fileExternalConflicts,
-            );
-            const hadPendingForceReload =
-                nextPendingForceFileReloads.delete(relativePath);
-            const hadExternalConflict =
-                nextFileExternalConflicts.delete(relativePath);
-            const hadReloadVersion = relativePath in state._fileReloadVersions;
-            const hadReloadMetadata = relativePath in state._fileReloadMetadata;
-            const nextFileReloadVersions = hadReloadVersion
-                ? Object.fromEntries(
-                      Object.entries(state._fileReloadVersions).filter(
-                          ([key]) => key !== relativePath,
-                      ),
-                  )
-                : state._fileReloadVersions;
-            const nextFileReloadMetadata = hadReloadMetadata
-                ? Object.fromEntries(
-                      Object.entries(state._fileReloadMetadata).filter(
-                          ([key]) => key !== relativePath,
-                      ),
-                  )
-                : state._fileReloadMetadata;
-
-            if (
-                !didChange &&
-                !hadPendingForceReload &&
-                !hadExternalConflict &&
-                !hadReloadVersion &&
-                !hadReloadMetadata
-            ) {
+            if (!next) {
                 return state;
             }
 
-            const activationHistory = state.activationHistory.filter(
-                (id) => !idsToClose.has(id),
-            );
-            const tabNavigationHistory = state.tabNavigationHistory.filter(
-                (id) => !idsToClose.has(id),
-            );
-
-            let activeTabId = state.activeTabId;
-            if (activeTabId && idsToClose.has(activeTabId)) {
-                const closedIdx = state.tabs.findIndex(
-                    (t) => t.id === activeTabId,
-                );
-                activeTabId =
-                    [...activationHistory]
-                        .reverse()
-                        .find((id) => tabs.some((tab) => tab.id === id)) ??
-                    tabs[Math.min(closedIdx, tabs.length - 1)]?.id ??
-                    null;
-            }
-
-            let tabNavigationIndex = Math.min(
-                state.tabNavigationIndex,
-                tabNavigationHistory.length - 1,
-            );
-            if (activeTabId) {
-                const lastActiveIndex =
-                    tabNavigationHistory.lastIndexOf(activeTabId);
-                if (lastActiveIndex === -1) {
-                    const navigation = pushTabToNavigation(
-                        tabNavigationHistory,
-                        tabNavigationIndex,
-                        activeTabId,
-                    );
-                    return {
-                        tabs,
-                        activeTabId,
-                        activationHistory,
-                        tabNavigationHistory: navigation.history,
-                        tabNavigationIndex: navigation.index,
-                        _pendingForceFileReloads: nextPendingForceFileReloads,
-                        _fileReloadVersions: nextFileReloadVersions,
-                        _fileReloadMetadata: nextFileReloadMetadata,
-                        fileExternalConflicts: nextFileExternalConflicts,
-                    };
-                }
-                tabNavigationIndex = lastActiveIndex;
-            } else {
-                tabNavigationIndex = -1;
-            }
-
             return {
-                tabs,
-                activeTabId,
-                activationHistory,
-                tabNavigationHistory,
-                tabNavigationIndex,
-                _pendingForceFileReloads: nextPendingForceFileReloads,
-                _fileReloadVersions: nextFileReloadVersions,
-                _fileReloadMetadata: nextFileReloadMetadata,
-                fileExternalConflicts: nextFileExternalConflicts,
+                tabs: next.tabs,
+                activeTabId: next.activeTabId,
+                activationHistory: next.activationHistory,
+                tabNavigationHistory: next.tabNavigationHistory,
+                tabNavigationIndex: next.tabNavigationIndex,
+                _pendingForceFileReloads: next.pendingForceReloads,
+                _fileReloadVersions: next.reloadVersions,
+                _fileReloadMetadata: next.reloadMetadata,
+                fileExternalConflicts: next.externalConflicts,
             };
         });
     },
@@ -1426,72 +1209,6 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         }));
     },
 }));
-
-// Load content for a history entry that was restored without content (e.g. after session restore)
-async function loadNoteHistoryEntryContent(
-    tabId: string,
-    historyIndex: number,
-    noteId: string,
-) {
-    try {
-        const detail = await vaultInvoke<{ content: string }>("read_note", {
-            noteId,
-        });
-        useEditorStore.setState((state) => ({
-            tabs: state.tabs.map((t) => {
-                if (t.id !== tabId || !isHistoryTab(t) || isMapTab(t)) return t;
-                const tab = normalizeHistoryTab(t);
-                const history = [...tab.history];
-                if (
-                    history[historyIndex]?.kind === "note" &&
-                    history[historyIndex].noteId === noteId
-                ) {
-                    history[historyIndex] = {
-                        ...history[historyIndex],
-                        content: detail.content,
-                    };
-                }
-                return buildTabFromHistory(tab.id, history, tab.historyIndex);
-            }),
-        }));
-    } catch (e) {
-        console.error("Error loading history entry content:", e);
-    }
-}
-
-async function loadFileHistoryEntryContent(
-    tabId: string,
-    historyIndex: number,
-    relativePath: string,
-) {
-    try {
-        const detail = await vaultInvoke<{ content: string }>(
-            "read_vault_file",
-            {
-                relativePath,
-            },
-        );
-        useEditorStore.setState((state) => ({
-            tabs: state.tabs.map((t) => {
-                if (t.id !== tabId || !isHistoryTab(t) || isMapTab(t)) return t;
-                const tab = normalizeHistoryTab(t);
-                const history = [...tab.history];
-                if (
-                    history[historyIndex]?.kind === "file" &&
-                    history[historyIndex].relativePath === relativePath
-                ) {
-                    history[historyIndex] = {
-                        ...history[historyIndex],
-                        content: detail.content,
-                    };
-                }
-                return buildTabFromHistory(tab.id, history, tab.historyIndex);
-            }),
-        }));
-    } catch (e) {
-        console.error("Error loading file history entry content:", e);
-    }
-}
 
 // Debounced session persistence — only write when tab list or active tab changes
 let _sessionTimer: ReturnType<typeof setTimeout> | null = null;

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -45,7 +45,14 @@ import {
     type OpenableHistoryPayload,
     type OpenableHistoryTabKind,
 } from "./editorTabRegistry";
-import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
+import {
+    buildPersistedSession,
+    getEditorSessionSignature,
+    isSessionReady,
+    markSessionReady,
+    readPersistedSession,
+    writePersistedSession,
+} from "./editorSession";
 import { vaultInvoke } from "../utils/vaultInvoke";
 import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
@@ -86,66 +93,9 @@ export type {
     TabInput,
     TransientTab,
 } from "./editorTabs";
+export { markSessionReady, readPersistedSession } from "./editorSession";
 
-const SESSION_KEY = "vaultai.session.tabs";
-const SESSION_KEY_PREFIX = "vaultai.session.tabs:";
 const MAX_RECENTLY_CLOSED_TABS = 20;
-
-interface PersistedSession {
-    tabs?: TabInput[];
-    activeTabId?: string | null;
-    noteIds: Array<{
-        noteId: string;
-        title: string;
-        history?: Array<{ noteId: string; title: string }>;
-        historyIndex?: number;
-    }>;
-    pdfTabs?: Array<{
-        entryId: string;
-        title: string;
-        path: string;
-        page?: number;
-        zoom?: number;
-        viewMode?: PdfViewMode;
-        history?: Array<{
-            entryId: string;
-            title: string;
-            path: string;
-            page?: number;
-            zoom?: number;
-            viewMode?: PdfViewMode;
-        }>;
-        historyIndex?: number;
-    }>;
-    fileTabs?: Array<{
-        relativePath: string;
-        title: string;
-        path: string;
-        mimeType?: string | null;
-        viewer?: FileViewerMode;
-        content?: string;
-        history?: Array<{
-            relativePath: string;
-            title: string;
-            path: string;
-            mimeType?: string | null;
-            viewer?: FileViewerMode;
-        }>;
-        historyIndex?: number;
-    }>;
-    mapTabs?: Array<{
-        relativePath: string;
-        title: string;
-        filePath?: string;
-    }>;
-    hasGraphTab?: boolean;
-    activeNoteId: string | null;
-    activePdfEntryId?: string | null;
-    activeFilePath?: string | null;
-    activeMapRelativePath?: string | null;
-    activeMapFilePath?: string | null;
-    activeGraphTab?: boolean;
-}
 
 function pushTabToActivation(history: string[], tabId: string) {
     return [...history.filter((id) => id !== tabId), tabId];
@@ -312,32 +262,6 @@ function normalizeExternalTab(tab: TabInput): Tab | null {
         return tab;
     }
     return null;
-}
-
-function getSessionKey(vaultPath: string) {
-    return `${SESSION_KEY_PREFIX}${vaultPath}`;
-}
-
-export function readPersistedSession(
-    vaultPath: string | null,
-): PersistedSession | null {
-    try {
-        const raw =
-            (vaultPath ? safeStorageGetItem(getSessionKey(vaultPath)) : null) ??
-            safeStorageGetItem(SESSION_KEY);
-        if (!raw) return null;
-        return JSON.parse(raw) as PersistedSession;
-    } catch {
-        return null;
-    }
-}
-
-// Only start persisting after the session has been restored,
-// to avoid overwriting saved data with the initial empty state.
-let sessionReady = false;
-
-export function markSessionReady() {
-    sessionReady = true;
 }
 function shouldRememberClosedTab(reason: TabCloseReason) {
     return reason === "user" || reason === "bulk-user";
@@ -1575,136 +1499,22 @@ let _lastSessionJson = "";
 let _lastSessionSig = "";
 
 useEditorStore.subscribe((state) => {
-    if (!sessionReady) return;
+    if (!isSessionReady()) return;
 
     const vaultPath = useVaultStore.getState().vaultPath;
     if (!vaultPath) return;
 
-    // Cheap fingerprint: skip expensive serialization on content-only edits
-    let sig = state.activeTabId ?? "";
-    for (const t of state.tabs) {
-        if (isReviewTab(t)) {
-            // Review tabs are transient — skip persistence fingerprint
-            continue;
-        } else if (isNoteTab(t)) {
-            sig += `|note|${t.noteId}|${t.title}|${t.historyIndex}|${t.history.length}`;
-        } else if (isMapTab(t)) {
-            sig += `|map|${t.relativePath}|${t.title}`;
-        } else if (isGraphTab(t)) {
-            sig += `|graph`;
-        } else if (isFileTab(t)) {
-            sig += `|file|${t.relativePath}|${t.title}|${t.mimeType ?? ""}`;
-        } else {
-            const pdfTab = ensurePdfTabDefaults(t);
-            sig += `|pdf|${pdfTab.entryId}|${pdfTab.title}|${pdfTab.historyIndex}|${pdfTab.history.length}`;
-        }
-    }
+    const sig = getEditorSessionSignature(state);
     if (sig === _lastSessionSig) return;
     _lastSessionSig = sig;
 
-    const activeTab = state.tabs.find((t) => t.id === state.activeTabId);
-    const persistedTabs = state.tabs
-        .filter(
-            (tab): tab is NoteTab | PdfTab | FileTab =>
-                isHistoryTab(tab) && !isMapTab(tab),
-        )
-        .map((tab) => normalizeHistoryTab(tab));
-    const noteTabs = persistedTabs.filter((tab): tab is NoteTab =>
-        isNoteTab(tab),
-    );
-    const session: PersistedSession = {
-        activeTabId: activeTab?.id ?? null,
-        noteIds: noteTabs
-            .filter((t) => t.noteId)
-            .map((t) => ({
-                noteId: t.noteId,
-                title: t.title,
-                history: t.history
-                    .filter((h): h is NoteHistoryEntry => h.kind === "note")
-                    .map((h) => ({
-                        noteId: h.noteId,
-                        title: h.title,
-                    })),
-                historyIndex: t.historyIndex,
-            })),
-        pdfTabs: persistedTabs.flatMap((rawTab) => {
-            if (!isPdfTab(rawTab)) return [];
-            const t = ensurePdfTabDefaults(rawTab);
-            return [
-                {
-                    entryId: t.entryId,
-                    title: t.title,
-                    path: t.path,
-                    page: t.page,
-                    zoom: t.zoom,
-                    viewMode: t.viewMode,
-                    history: t.history
-                        .filter(
-                            (entry): entry is PdfHistoryEntry =>
-                                entry.kind === "pdf",
-                        )
-                        .map((entry) => ({
-                            entryId: entry.entryId,
-                            title: entry.title,
-                            path: entry.path,
-                            page: entry.page,
-                            zoom: entry.zoom,
-                            viewMode: entry.viewMode,
-                        })),
-                    historyIndex: t.historyIndex,
-                },
-            ];
-        }),
-        fileTabs: persistedTabs.flatMap((rawTab) => {
-            if (!isFileTab(rawTab)) return [];
-            const t = ensureFileTabHistory(rawTab);
-            return [
-                {
-                    relativePath: t.relativePath,
-                    title: t.title,
-                    path: t.path,
-                    mimeType: t.mimeType,
-                    viewer: t.viewer,
-                    history: t.history
-                        .filter((h): h is FileHistoryEntry => h.kind === "file")
-                        .map((h) => ({
-                            relativePath: h.relativePath,
-                            title: h.title,
-                            path: h.path,
-                            mimeType: h.mimeType,
-                            viewer: h.viewer,
-                        })),
-                    historyIndex: t.historyIndex,
-                },
-            ];
-        }),
-        mapTabs: state.tabs
-            .filter((t): t is MapTab => isMapTab(t))
-            .map((t) => ({
-                relativePath: t.relativePath,
-                title: t.title,
-            })),
-        hasGraphTab: state.tabs.some((t) => isGraphTab(t)),
-        activeNoteId:
-            activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
-        activePdfEntryId:
-            activeTab && isPdfTab(activeTab) ? activeTab.entryId : null,
-        activeFilePath:
-            activeTab && isFileTab(activeTab) ? activeTab.relativePath : null,
-        activeMapRelativePath:
-            activeTab && isMapTab(activeTab) ? activeTab.relativePath : null,
-        activeGraphTab: activeTab ? isGraphTab(activeTab) : false,
-    };
+    const session = buildPersistedSession(state);
     const json = JSON.stringify(session);
     if (json === _lastSessionJson) return;
 
     if (_sessionTimer) clearTimeout(_sessionTimer);
     _sessionTimer = setTimeout(() => {
-        try {
-            safeStorageSetItem(getSessionKey(vaultPath), json);
-            _lastSessionJson = json;
-        } catch (error) {
-            console.warn("Failed to persist editor session", error);
-        }
+        writePersistedSession(vaultPath, session);
+        _lastSessionJson = json;
     }, 500);
 });

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -259,6 +259,55 @@ function normalizeExternalTab(tab: TabInput): Tab | null {
     return null;
 }
 
+function insertNormalizedTab(
+    state: Pick<
+        EditorStore,
+        | "tabs"
+        | "activeTabId"
+        | "activationHistory"
+        | "tabNavigationHistory"
+        | "tabNavigationIndex"
+    >,
+    incoming: Tab,
+    index?: number,
+) {
+    if (isGraphTab(incoming)) {
+        const existing = state.tabs.find((tab) => isGraphTab(tab));
+        if (existing) {
+            const tabs =
+                existing.title === incoming.title
+                    ? state.tabs
+                    : state.tabs.map((tab) =>
+                          tab.id === existing.id
+                              ? { ...tab, title: incoming.title }
+                              : tab,
+                      );
+            return {
+                tabs,
+                ...activateTab(
+                    {
+                        ...state,
+                        tabs,
+                    },
+                    existing.id,
+                ),
+            };
+        }
+    }
+
+    const tabs = state.tabs.filter((existing) => existing.id !== incoming.id);
+    const boundedIndex =
+        index === undefined
+            ? tabs.length
+            : Math.max(0, Math.min(index, tabs.length));
+
+    tabs.splice(boundedIndex, 0, incoming);
+    return {
+        tabs,
+        ...activateTab(state, incoming.id),
+    };
+}
+
 function patchCurrentHistoryEntry(
     tab: HistoryTab,
     patch: (entry: TabHistoryEntry) => TabHistoryEntry,
@@ -892,9 +941,19 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     },
 
     hydrateTabs: (tabs, activeTabId) => {
+        const seenGraph = new Set<string>();
         const hydratedTabs: Tab[] = tabs.flatMap((tab): Tab[] => {
             const normalized = normalizeHydratedTab(tab);
-            return normalized ? [normalized] : [];
+            if (!normalized) {
+                return [];
+            }
+            if (isGraphTab(normalized)) {
+                if (seenGraph.size > 0) {
+                    return [];
+                }
+                seenGraph.add(normalized.id);
+            }
+            return [normalized];
         });
         const nextActiveTabId =
             activeTabId && hydratedTabs.some((tab) => tab.id === activeTabId)
@@ -916,19 +975,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             if (!incoming) {
                 return state;
             }
-            const tabs = state.tabs.filter(
-                (existing) => existing.id !== incoming.id,
-            );
-            const boundedIndex =
-                index === undefined
-                    ? tabs.length
-                    : Math.max(0, Math.min(index, tabs.length));
-
-            tabs.splice(boundedIndex, 0, incoming);
-            return {
-                tabs,
-                ...activateTab(state, incoming.id),
-            };
+            return insertNormalizedTab(state, incoming, index);
         });
     },
 
@@ -1188,17 +1235,28 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     handleNoteRenamed: (oldNoteId, newNoteId, newTitle) => {
         set((state) => ({
             tabs: state.tabs.map((t) => {
-                if (!isNoteTab(t) || t.noteId !== oldNoteId) return t;
-                return {
-                    ...t,
-                    noteId: newNoteId,
-                    title: newTitle,
-                    history: t.history?.map((entry) =>
-                        entry.kind === "note" && entry.noteId === oldNoteId
-                            ? { ...entry, noteId: newNoteId }
-                            : entry,
-                    ),
-                };
+                if (!isNoteTab(t)) {
+                    return t;
+                }
+
+                let didChange = false;
+                const history = t.history.map((entry) => {
+                    if (entry.kind !== "note" || entry.noteId !== oldNoteId) {
+                        return entry;
+                    }
+                    didChange = true;
+                    return {
+                        ...entry,
+                        noteId: newNoteId,
+                        title: newTitle,
+                    };
+                });
+
+                if (!didChange) {
+                    return t;
+                }
+
+                return buildTabFromHistory(t.id, history, t.historyIndex);
             }),
         }));
     },

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -5,12 +5,11 @@ import {
     createGraphTab,
     createMapTab,
     ensureFileTabDefaults,
-    ensureNoteTabHistory,
-    ensurePdfTabDefaults,
     isFileTab,
     isGraphTab,
     isHistoryTab,
     isMapTab,
+    isNavigableHistoryTab,
     isNoteTab,
     isPdfTab,
     isReviewTab,
@@ -22,6 +21,7 @@ import {
     type GraphTab,
     type MapTab,
     type MapTabInput,
+    type NavigableHistoryTab,
     type NoteHistoryEntry,
     type NoteTab,
     type NoteTabInput,
@@ -37,7 +37,7 @@ import {
     type TabCloseReason,
 } from "./editorTabs";
 import {
-    getHistoryTabHandler,
+    createHistorySnapshot,
     getOpenableHistoryTabHandler,
     normalizeHistoryTab,
     type HistoryTabHandler,
@@ -49,6 +49,8 @@ import {
     buildResourceReloadUpdate,
     getResourceHandler,
     loadResourceHistoryEntryContent,
+    type ResourceReloadDetail,
+    type ResourceReloadMetadata,
 } from "./editorResourceRegistry";
 import {
     buildPersistedSession,
@@ -66,6 +68,7 @@ export {
     isGraphTab,
     isHistoryTab,
     isMapTab,
+    isNavigableHistoryTab,
     isNoteTab,
     isPdfTab,
     isResourceBackedTab,
@@ -82,6 +85,7 @@ export type {
     HistoryTabInput,
     MapTab,
     MapTabInput,
+    NavigableHistoryTab,
     NoteHistoryEntry,
     NoteTab,
     NoteTabInput,
@@ -161,25 +165,12 @@ function replaceTab(tabs: Tab[], tabId: string, nextTab: Tab) {
 
 function getReusableHistoryTab(
     state: Pick<EditorStore, "tabs" | "activeTabId">,
-): HistoryTab | null {
+): NavigableHistoryTab | null {
     const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
-    if (!activeTab || !isHistoryTab(activeTab) || isMapTab(activeTab)) {
+    if (!activeTab || !isNavigableHistoryTab(activeTab)) {
         return null;
     }
-    return normalizeHistoryTab(activeTab);
-}
-
-function createHistorySnapshot(tab: HistoryTab): TabHistoryEntry {
-    if (isNoteTab(tab)) {
-        return getHistoryTabHandler("note").entryFromTab(tab);
-    }
-    if (isPdfTab(tab)) {
-        return getHistoryTabHandler("pdf").entryFromTab(tab);
-    }
-    if (isFileTab(tab)) {
-        return getHistoryTabHandler("file").entryFromTab(tab);
-    }
-    return getHistoryTabHandler("map").entryFromTab(tab);
+    return normalizeHistoryTab(activeTab) as NavigableHistoryTab;
 }
 
 function openOrReuseHistoryTab<K extends OpenableHistoryTabKind>(
@@ -267,6 +258,88 @@ function normalizeExternalTab(tab: TabInput): Tab | null {
     }
     return null;
 }
+
+function patchCurrentHistoryEntry(
+    tab: HistoryTab,
+    patch: (entry: TabHistoryEntry) => TabHistoryEntry,
+): HistoryTab {
+    const normalized = normalizeHistoryTab(tab);
+    const currentEntry = normalized.history[normalized.historyIndex];
+
+    if (!currentEntry) {
+        return normalized;
+    }
+
+    const nextEntry = patch(currentEntry);
+    if (nextEntry === currentEntry) {
+        return normalized;
+    }
+
+    const history = [...normalized.history];
+    history[normalized.historyIndex] = nextEntry;
+    return buildTabFromHistory(normalized.id, history, normalized.historyIndex);
+}
+
+function patchHistoryTabById(
+    tabs: Tab[],
+    tabId: string,
+    patch: (tab: HistoryTab) => Tab,
+) {
+    return tabs.map((tab) => {
+        if (tab.id !== tabId || !isHistoryTab(tab)) {
+            return tab;
+        }
+        return patch(tab);
+    });
+}
+
+function updateTabHistoryTitle(tab: HistoryTab, title: string): Tab {
+    if (tab.title === title && !tab.history[tab.historyIndex]) {
+        return tab;
+    }
+
+    if (!tab.history[tab.historyIndex]) {
+        return {
+            ...tab,
+            title,
+        };
+    }
+
+    return patchCurrentHistoryEntry(tab, (entry) =>
+        entry.title === title
+            ? entry
+            : {
+                  ...entry,
+                  title,
+              },
+    );
+}
+
+function loadHistoryEntryContentIfNeeded(
+    tabId: string,
+    historyIndex: number,
+    entry: TabHistoryEntry,
+) {
+    if (entry.kind === "note" && !entry.content) {
+        void loadResourceHistoryEntryContent(
+            getResourceHandler("note"),
+            tabId,
+            historyIndex,
+            entry.noteId,
+            useEditorStore.setState,
+        );
+    }
+
+    if (entry.kind === "file" && !entry.content) {
+        void loadResourceHistoryEntryContent(
+            getResourceHandler("file"),
+            tabId,
+            historyIndex,
+            entry.relativePath,
+            useEditorStore.setState,
+        );
+    }
+}
 function shouldRememberClosedTab(reason: TabCloseReason) {
     return reason === "user" || reason === "bulk-user";
 }
@@ -311,29 +384,12 @@ export interface EditorSelectionContext {
 }
 
 export interface ReloadedDetail {
-    content: string;
-    title: string;
-    origin?: "user" | "agent" | "external" | "system" | "unknown";
-    opId?: string | null;
-    revision?: number;
-    contentHash?: string | null;
-}
-
-type ReloadedNoteDetail = ReloadedDetail;
-type ReloadedFileDetail = ReloadedDetail;
-
-interface NoteReloadMetadata {
-    origin: "user" | "agent" | "external" | "system" | "unknown";
-    opId: string | null;
-    revision: number;
-    contentHash: string | null;
-}
-
-interface FileReloadMetadata {
-    origin: "user" | "agent" | "external" | "system" | "unknown";
-    opId: string | null;
-    revision: number;
-    contentHash: string | null;
+    content: ResourceReloadDetail["content"];
+    title: ResourceReloadDetail["title"];
+    origin?: ResourceReloadDetail["origin"];
+    opId?: ResourceReloadDetail["opId"];
+    revision?: ResourceReloadDetail["revision"];
+    contentHash?: ResourceReloadDetail["contentHash"];
 }
 
 interface EditorStore {
@@ -350,8 +406,8 @@ interface EditorStore {
     _pendingForceFileReloads: Set<string>;
     _noteReloadVersions: Record<string, number>;
     _fileReloadVersions: Record<string, number>;
-    _noteReloadMetadata: Record<string, NoteReloadMetadata | undefined>;
-    _fileReloadMetadata: Record<string, FileReloadMetadata | undefined>;
+    _noteReloadMetadata: Record<string, ResourceReloadMetadata | undefined>;
+    _fileReloadMetadata: Record<string, ResourceReloadMetadata | undefined>;
     noteExternalConflicts: Set<string>;
     fileExternalConflicts: Set<string>;
     openNote: (noteId: string, title: string, content: string) => void;
@@ -396,18 +452,12 @@ interface EditorStore {
     clearPendingSelectionReveal: () => void;
     setCurrentSelection: (selection: EditorSelectionContext) => void;
     clearCurrentSelection: () => void;
-    reloadNoteContent: (noteId: string, detail: ReloadedNoteDetail) => void;
-    reloadFileContent: (
-        relativePath: string,
-        detail: ReloadedFileDetail,
-    ) => void;
-    forceReloadNoteContent: (
-        noteId: string,
-        detail: ReloadedNoteDetail,
-    ) => void;
+    reloadNoteContent: (noteId: string, detail: ReloadedDetail) => void;
+    reloadFileContent: (relativePath: string, detail: ReloadedDetail) => void;
+    forceReloadNoteContent: (noteId: string, detail: ReloadedDetail) => void;
     forceReloadFileContent: (
         relativePath: string,
-        detail: ReloadedFileDetail,
+        detail: ReloadedDetail,
     ) => void;
     forceReloadEditorTarget: (
         target: EditorTarget,
@@ -564,11 +614,9 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     goBack: () => {
         if (getTabOpenBehavior() === "history") {
-            const tab = get().tabs.find((t) => t.id === get().activeTabId);
+            const tab = getReusableHistoryTab(get());
             if (!tab) return;
-            if (isNoteTab(tab) || isFileTab(tab) || isPdfTab(tab)) {
-                get().navigateToHistoryIndex(tab.historyIndex - 1);
-            }
+            get().navigateToHistoryIndex(tab.historyIndex - 1);
             return;
         }
 
@@ -586,11 +634,9 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     goForward: () => {
         if (getTabOpenBehavior() === "history") {
-            const tab = get().tabs.find((t) => t.id === get().activeTabId);
+            const tab = getReusableHistoryTab(get());
             if (!tab) return;
-            if (isNoteTab(tab) || isFileTab(tab) || isPdfTab(tab)) {
-                get().navigateToHistoryIndex(tab.historyIndex + 1);
-            }
+            get().navigateToHistoryIndex(tab.historyIndex + 1);
             return;
         }
 
@@ -615,8 +661,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         const tabIdx = state.tabs.findIndex((t) => t.id === state.activeTabId);
         if (tabIdx === -1) return;
         const raw = state.tabs[tabIdx];
-        if (!isHistoryTab(raw) || isMapTab(raw)) return;
-        const tab = normalizeHistoryTab(raw);
+        if (!isNavigableHistoryTab(raw)) return;
+        const tab = normalizeHistoryTab(raw) as NavigableHistoryTab;
         if (targetIndex < 0 || targetIndex >= tab.history.length) return;
         if (targetIndex === tab.historyIndex) return;
 
@@ -630,25 +676,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         tabs[tabIdx] = buildTabFromHistory(tab.id, history, targetIndex);
         set({ tabs });
 
-        if (entry.kind === "note" && !entry.content) {
-            void loadResourceHistoryEntryContent(
-                getResourceHandler("note"),
-                tab.id,
-                targetIndex,
-                entry.noteId,
-                useEditorStore.setState,
-            );
-        }
-
-        if (entry.kind === "file" && !entry.content) {
-            void loadResourceHistoryEntryContent(
-                getResourceHandler("file"),
-                tab.id,
-                targetIndex,
-                entry.relativePath,
-                useEditorStore.setState,
-            );
-        }
+        loadHistoryEntryContentIfNeeded(tab.id, targetIndex, entry);
     },
 
     closeTab: (tabId, options) => {
@@ -748,34 +776,18 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     updateTabContent: (tabId, content) => {
         set((state) => ({
-            tabs: state.tabs.map((t) => {
-                if (t.id !== tabId) return t;
-                if (isNoteTab(t)) {
-                    const tab = ensureNoteTabHistory(t);
-                    return buildTabFromHistory(
-                        tab.id,
-                        tab.history.map((entry, index) =>
-                            index === tab.historyIndex && entry.kind === "note"
-                                ? { ...entry, content }
-                                : entry,
-                        ),
-                        tab.historyIndex,
-                    );
-                }
-                if (isFileTab(t)) {
-                    const tab = ensureFileTabDefaults(t);
-                    return buildTabFromHistory(
-                        tab.id,
-                        tab.history.map((entry, index) =>
-                            index === tab.historyIndex && entry.kind === "file"
-                                ? { ...entry, content }
-                                : entry,
-                        ),
-                        tab.historyIndex,
-                    );
-                }
-                return t;
-            }),
+            tabs: patchHistoryTabById(state.tabs, tabId, (tab) =>
+                patchCurrentHistoryEntry(tab, (entry) =>
+                    entry.kind === "note" || entry.kind === "file"
+                        ? entry.content === content
+                            ? entry
+                            : {
+                                  ...entry,
+                                  content,
+                              }
+                        : entry,
+                ),
+            ),
         }));
     },
 
@@ -783,19 +795,10 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         set((state) => ({
             tabs: state.tabs.map((t) => {
                 if (t.id !== tabId) return t;
-                if (isReviewTab(t)) return { ...t, title };
-                if (isMapTab(t)) return { ...t, title };
-                if (isGraphTab(t)) return { ...t, title };
-                const tab = normalizeHistoryTab(t);
-                if (!tab.history?.length) return { ...tab, title };
-                const history = [...tab.history];
-                if (history[tab.historyIndex]) {
-                    history[tab.historyIndex] = {
-                        ...history[tab.historyIndex],
-                        title,
-                    };
+                if (!isHistoryTab(t)) {
+                    return t.title === title ? t : { ...t, title };
                 }
-                return buildTabFromHistory(tab.id, history, tab.historyIndex);
+                return updateTabHistoryTitle(t, title);
             }),
         }));
     },
@@ -830,60 +833,51 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     updatePdfPage: (tabId, page) => {
         set((state) => ({
-            tabs: state.tabs.map((t) =>
-                t.id !== tabId || !isPdfTab(t)
-                    ? t
-                    : ((tab) =>
-                          buildTabFromHistory(
-                              tab.id,
-                              tab.history.map((entry, index) =>
-                                  index === tab.historyIndex &&
-                                  entry.kind === "pdf"
-                                      ? { ...entry, page }
-                                      : entry,
-                              ),
-                              tab.historyIndex,
-                          ))(ensurePdfTabDefaults(t)),
+            tabs: patchHistoryTabById(state.tabs, tabId, (tab) =>
+                !isPdfTab(tab)
+                    ? tab
+                    : patchCurrentHistoryEntry(tab, (entry) =>
+                          entry.kind !== "pdf" || entry.page === page
+                              ? entry
+                              : {
+                                    ...entry,
+                                    page,
+                                },
+                      ),
             ),
         }));
     },
 
     updatePdfZoom: (tabId, zoom) => {
         set((state) => ({
-            tabs: state.tabs.map((t) =>
-                t.id !== tabId || !isPdfTab(t)
-                    ? t
-                    : ((tab) =>
-                          buildTabFromHistory(
-                              tab.id,
-                              tab.history.map((entry, index) =>
-                                  index === tab.historyIndex &&
-                                  entry.kind === "pdf"
-                                      ? { ...entry, zoom }
-                                      : entry,
-                              ),
-                              tab.historyIndex,
-                          ))(ensurePdfTabDefaults(t)),
+            tabs: patchHistoryTabById(state.tabs, tabId, (tab) =>
+                !isPdfTab(tab)
+                    ? tab
+                    : patchCurrentHistoryEntry(tab, (entry) =>
+                          entry.kind !== "pdf" || entry.zoom === zoom
+                              ? entry
+                              : {
+                                    ...entry,
+                                    zoom,
+                                },
+                      ),
             ),
         }));
     },
 
     updatePdfViewMode: (tabId, viewMode) => {
         set((state) => ({
-            tabs: state.tabs.map((t) =>
-                t.id !== tabId || !isPdfTab(t)
-                    ? t
-                    : ((tab) =>
-                          buildTabFromHistory(
-                              tab.id,
-                              tab.history.map((entry, index) =>
-                                  index === tab.historyIndex &&
-                                  entry.kind === "pdf"
-                                      ? { ...entry, viewMode }
-                                      : entry,
-                              ),
-                              tab.historyIndex,
-                          ))(ensurePdfTabDefaults(t)),
+            tabs: patchHistoryTabById(state.tabs, tabId, (tab) =>
+                !isPdfTab(tab)
+                    ? tab
+                    : patchCurrentHistoryEntry(tab, (entry) =>
+                          entry.kind !== "pdf" || entry.viewMode === viewMode
+                              ? entry
+                              : {
+                                    ...entry,
+                                    viewMode,
+                                },
+                      ),
             ),
         }));
     },

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -2,18 +2,10 @@ import { create } from "zustand";
 import type { EditorTarget } from "../../features/editor/editorTargetResolver";
 import {
     buildTabFromHistory,
-    createFileHistoryEntry,
-    createFileTab,
     createGraphTab,
-    createHistoryEntryFromTab,
-    createNoteHistoryEntry,
-    createNoteTab,
-    createPdfHistoryEntry,
-    createPdfTab,
     createMapTab,
     ensureFileTabDefaults,
     ensureFileTabHistory,
-    ensureMapTabDefaults,
     ensureNoteTabHistory,
     ensurePdfTabDefaults,
     isFileTab,
@@ -23,11 +15,11 @@ import {
     isNoteTab,
     isPdfTab,
     isReviewTab,
-    normalizeHistoryTab,
     type FileHistoryEntry,
     type FileTab,
     type FileTabInput,
     type FileViewerMode,
+    type HistoryTab,
     type GraphTab,
     type MapTab,
     type MapTabInput,
@@ -45,6 +37,14 @@ import {
     type TabInput,
     type TabCloseReason,
 } from "./editorTabs";
+import {
+    getHistoryTabHandler,
+    getOpenableHistoryTabHandler,
+    normalizeHistoryTab,
+    type HistoryTabHandler,
+    type OpenableHistoryPayload,
+    type OpenableHistoryTabKind,
+} from "./editorTabRegistry";
 import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
 import { vaultInvoke } from "../utils/vaultInvoke";
 import { useSettingsStore } from "./settingsStore";
@@ -199,6 +199,119 @@ function activateTab(
         tabNavigationHistory: navigation.history,
         tabNavigationIndex: navigation.index,
     };
+}
+
+function replaceTab(tabs: Tab[], tabId: string, nextTab: Tab) {
+    return tabs.map((tab) => (tab.id === tabId ? nextTab : tab));
+}
+
+function getReusableHistoryTab(
+    state: Pick<EditorStore, "tabs" | "activeTabId">,
+): HistoryTab | null {
+    const activeTab = state.tabs.find((tab) => tab.id === state.activeTabId);
+    if (!activeTab || !isHistoryTab(activeTab) || isMapTab(activeTab)) {
+        return null;
+    }
+    return normalizeHistoryTab(activeTab);
+}
+
+function createHistorySnapshot(tab: HistoryTab): TabHistoryEntry {
+    if (isNoteTab(tab)) {
+        return getHistoryTabHandler("note").entryFromTab(tab);
+    }
+    if (isPdfTab(tab)) {
+        return getHistoryTabHandler("pdf").entryFromTab(tab);
+    }
+    if (isFileTab(tab)) {
+        return getHistoryTabHandler("file").entryFromTab(tab);
+    }
+    return getHistoryTabHandler("map").entryFromTab(tab);
+}
+
+function openOrReuseHistoryTab<K extends OpenableHistoryTabKind>(
+    state: Pick<
+        EditorStore,
+        | "tabs"
+        | "activeTabId"
+        | "activationHistory"
+        | "tabNavigationHistory"
+        | "tabNavigationIndex"
+    >,
+    payload: Extract<OpenableHistoryPayload, { kind: K }>,
+) {
+    const handler = getOpenableHistoryTabHandler(
+        payload.kind,
+    ) as HistoryTabHandler<K>;
+
+    if (getTabOpenBehavior() === "new_tab") {
+        const newTab = handler.createInitialTab(payload);
+        return {
+            tabs: [...state.tabs, newTab],
+            ...activateTab(state, newTab.id),
+        };
+    }
+
+    const activeTab = getReusableHistoryTab(state);
+    if (!activeTab) {
+        const newTab = handler.createInitialTab(payload);
+        return {
+            tabs: [...state.tabs, newTab],
+            ...activateTab(state, newTab.id),
+        };
+    }
+
+    if (activeTab.kind === payload.kind) {
+        const typedActiveTab = activeTab as Extract<HistoryTab, { kind: K }>;
+        if (handler.matchesOpenTarget(typedActiveTab, payload)) {
+            if (!handler.replaceCurrentEntry) {
+                return state;
+            }
+            const nextTab = handler.replaceCurrentEntry(
+                typedActiveTab,
+                payload,
+            );
+            return {
+                tabs: replaceTab(state.tabs, nextTab.id, nextTab),
+            };
+        }
+    }
+
+    const kept = activeTab.history.slice(0, activeTab.historyIndex);
+    kept.push(
+        createHistorySnapshot(activeTab),
+        handler.createOpenEntry(payload),
+    );
+    const nextTab = handler.buildFromHistory(
+        activeTab.id,
+        kept,
+        kept.length - 1,
+    );
+    return {
+        tabs: replaceTab(state.tabs, activeTab.id, nextTab),
+    };
+}
+
+function normalizeHydratedTab(tab: TabInput): Tab | null {
+    if (isReviewTab(tab)) {
+        return null;
+    }
+    if (isHistoryTab(tab)) {
+        return normalizeHistoryTab(tab);
+    }
+    if (isGraphTab(tab)) {
+        return tab;
+    }
+    return null;
+}
+
+function normalizeExternalTab(tab: TabInput): Tab | null {
+    if (isHistoryTab(tab)) {
+        return normalizeHistoryTab(tab);
+    }
+    if (isReviewTab(tab) || isGraphTab(tab)) {
+        return tab;
+    }
+    return null;
 }
 
 function getSessionKey(vaultPath: string) {
@@ -407,109 +520,25 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     fileExternalConflicts: new Set<string>(),
 
     openNote: (noteId, title, content) => {
-        set((state) => {
-            if (getTabOpenBehavior() === "new_tab") {
-                const newTab = createNoteTab(noteId, title, content);
-                return {
-                    tabs: [...state.tabs, newTab],
-                    ...activateTab(state, newTab.id),
-                };
-            }
-
-            const activeTab = state.tabs.find(
-                (t) => t.id === state.activeTabId,
-            );
-            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
-                const tab = normalizeHistoryTab(activeTab);
-                if (isNoteTab(tab) && tab.noteId === noteId) {
-                    return {
-                        tabs: state.tabs.map((tabItem) =>
-                            tabItem.id === tab.id
-                                ? buildTabFromHistory(
-                                      tab.id,
-                                      tab.history.map((entry, index) =>
-                                          index === tab.historyIndex &&
-                                          entry.kind === "note"
-                                              ? createNoteHistoryEntry(
-                                                    noteId,
-                                                    title,
-                                                    content,
-                                                )
-                                              : entry,
-                                      ),
-                                      tab.historyIndex,
-                                  )
-                                : tabItem,
-                        ),
-                    };
-                }
-                const kept = tab.history.slice(0, tab.historyIndex);
-                kept.push(
-                    createHistoryEntryFromTab(tab),
-                    createNoteHistoryEntry(noteId, title, content),
-                );
-                return {
-                    tabs: state.tabs.map((tabItem) =>
-                        tabItem.id === tab.id
-                            ? buildTabFromHistory(tab.id, kept, kept.length - 1)
-                            : tabItem,
-                    ),
-                };
-            }
-
-            const newTab = createNoteTab(noteId, title, content);
-            return {
-                tabs: [...state.tabs, newTab],
-                ...activateTab(state, newTab.id),
-            };
-        });
+        set((state) =>
+            openOrReuseHistoryTab(state, {
+                kind: "note",
+                noteId,
+                title,
+                content,
+            }),
+        );
     },
 
     openPdf: (entryId, title, path) => {
-        set((state) => {
-            if (getTabOpenBehavior() === "new_tab") {
-                const newTab = createPdfTab(entryId, title, path);
-                return {
-                    tabs: [...state.tabs, newTab],
-                    ...activateTab(state, newTab.id),
-                };
-            }
-
-            const activeTab = state.tabs.find(
-                (t) => t.id === state.activeTabId,
-            );
-            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
-                const tab = normalizeHistoryTab(activeTab);
-                if (isPdfTab(tab) && tab.entryId === entryId) {
-                    return state;
-                }
-                const kept = tab.history.slice(0, tab.historyIndex);
-                kept.push(
-                    createHistoryEntryFromTab(tab),
-                    createPdfHistoryEntry(
-                        entryId,
-                        title,
-                        path,
-                        1,
-                        1,
-                        "continuous",
-                    ),
-                );
-                return {
-                    tabs: state.tabs.map((tabItem) =>
-                        tabItem.id === tab.id
-                            ? buildTabFromHistory(tab.id, kept, kept.length - 1)
-                            : tabItem,
-                    ),
-                };
-            }
-
-            const newTab = createPdfTab(entryId, title, path);
-            return {
-                tabs: [...state.tabs, newTab],
-                ...activateTab(state, newTab.id),
-            };
-        });
+        set((state) =>
+            openOrReuseHistoryTab(state, {
+                kind: "pdf",
+                entryId,
+                title,
+                path,
+            }),
+        );
     },
 
     openMap: (relativePath, title) => {
@@ -543,86 +572,17 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     },
 
     openFile: (relativePath, title, path, content, mimeType, viewer) => {
-        set((state) => {
-            if (getTabOpenBehavior() === "new_tab") {
-                const newTab = createFileTab(
-                    relativePath,
-                    title,
-                    path,
-                    content,
-                    mimeType,
-                    viewer,
-                );
-                return {
-                    tabs: [...state.tabs, newTab],
-                    ...activateTab(state, newTab.id),
-                };
-            }
-
-            const activeTab = state.tabs.find(
-                (t) => t.id === state.activeTabId,
-            );
-            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
-                const tab = normalizeHistoryTab(activeTab);
-                if (isFileTab(tab) && tab.relativePath === relativePath) {
-                    return {
-                        tabs: state.tabs.map((tabItem) =>
-                            tabItem.id !== tab.id
-                                ? tabItem
-                                : buildTabFromHistory(
-                                      tab.id,
-                                      tab.history.map((entry, index) =>
-                                          index === tab.historyIndex &&
-                                          entry.kind === "file"
-                                              ? createFileHistoryEntry(
-                                                    relativePath,
-                                                    title,
-                                                    path,
-                                                    content,
-                                                    mimeType,
-                                                    viewer,
-                                                )
-                                              : entry,
-                                      ),
-                                      tab.historyIndex,
-                                  ),
-                        ),
-                    };
-                }
-                const kept = tab.history.slice(0, tab.historyIndex);
-                kept.push(
-                    createHistoryEntryFromTab(tab),
-                    createFileHistoryEntry(
-                        relativePath,
-                        title,
-                        path,
-                        content,
-                        mimeType,
-                        viewer,
-                    ),
-                );
-                return {
-                    tabs: state.tabs.map((tabItem) =>
-                        tabItem.id === tab.id
-                            ? buildTabFromHistory(tab.id, kept, kept.length - 1)
-                            : tabItem,
-                    ),
-                };
-            }
-
-            const newTab = createFileTab(
+        set((state) =>
+            openOrReuseHistoryTab(state, {
+                kind: "file",
                 relativePath,
                 title,
                 path,
                 content,
                 mimeType,
                 viewer,
-            );
-            return {
-                tabs: [...state.tabs, newTab],
-                ...activateTab(state, newTab.id),
-            };
-        });
+            }),
+        );
     },
 
     openReview: (sessionId, options) => {
@@ -732,7 +692,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         if (targetIndex < 0 || targetIndex >= tab.history.length) return;
         if (targetIndex === tab.historyIndex) return;
 
-        const currentSnapshot = createHistoryEntryFromTab(tab);
+        const currentSnapshot = createHistorySnapshot(tab);
         const history = tab.history.map((h, i) =>
             i === tab.historyIndex ? currentSnapshot : h,
         );
@@ -1002,25 +962,10 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     },
 
     hydrateTabs: (tabs, activeTabId) => {
-        const hydratedTabs: Tab[] = tabs
-            .filter((tab) => !isReviewTab(tab))
-            .flatMap((tab): Tab[] => {
-                if (isHistoryTab(tab)) {
-                    if (isMapTab(tab)) {
-                        const mapTab = ensureMapTabDefaults(tab);
-                        return mapTab.relativePath ? [mapTab] : [];
-                    }
-                    return [normalizeHistoryTab(tab)];
-                }
-                if (isGraphTab(tab)) {
-                    return [tab];
-                }
-                if (isMapTab(tab)) {
-                    const mapTab = ensureMapTabDefaults(tab);
-                    return mapTab.relativePath ? [mapTab] : [];
-                }
-                return [];
-            });
+        const hydratedTabs: Tab[] = tabs.flatMap((tab): Tab[] => {
+            const normalized = normalizeHydratedTab(tab);
+            return normalized ? [normalized] : [];
+        });
         const nextActiveTabId =
             activeTabId && hydratedTabs.some((tab) => tab.id === activeTabId)
                 ? activeTabId
@@ -1037,16 +982,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     insertExternalTab: (tab, index) => {
         set((state) => {
-            const incoming: Tab | null = isHistoryTab(tab)
-                ? isMapTab(tab)
-                    ? (() => {
-                          const mapTab = ensureMapTabDefaults(tab);
-                          return mapTab.relativePath ? mapTab : null;
-                      })()
-                    : normalizeHistoryTab(tab)
-                : isReviewTab(tab) || isGraphTab(tab)
-                  ? tab
-                  : null;
+            const incoming = normalizeExternalTab(tab);
             if (!incoming) {
                 return state;
             }

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -1,10 +1,91 @@
 import { create } from "zustand";
 import type { EditorTarget } from "../../features/editor/editorTargetResolver";
+import {
+    buildTabFromHistory,
+    createFileHistoryEntry,
+    createFileTab,
+    createGraphTab,
+    createHistoryEntryFromTab,
+    createNoteHistoryEntry,
+    createNoteTab,
+    createPdfHistoryEntry,
+    createPdfTab,
+    createMapTab,
+    ensureFileTabDefaults,
+    ensureFileTabHistory,
+    ensureMapTabDefaults,
+    ensureNoteTabHistory,
+    ensurePdfTabDefaults,
+    isFileTab,
+    isGraphTab,
+    isHistoryTab,
+    isMapTab,
+    isNoteTab,
+    isPdfTab,
+    isReviewTab,
+    normalizeHistoryTab,
+    type FileHistoryEntry,
+    type FileTab,
+    type FileTabInput,
+    type FileViewerMode,
+    type GraphTab,
+    type MapTab,
+    type MapTabInput,
+    type NoteHistoryEntry,
+    type NoteTab,
+    type NoteTabInput,
+    type PdfHistoryEntry,
+    type PdfTab,
+    type PdfTabInput,
+    type PdfViewMode,
+    type RecentlyClosedTab,
+    type ReviewTab,
+    type Tab,
+    type TabHistoryEntry,
+    type TabInput,
+    type TabCloseReason,
+} from "./editorTabs";
 import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
-import { toVaultRelativePath } from "../utils/vaultPaths";
 import { vaultInvoke } from "../utils/vaultInvoke";
 import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
+
+export {
+    isFileTab,
+    isGraphTab,
+    isHistoryTab,
+    isMapTab,
+    isNoteTab,
+    isPdfTab,
+    isResourceBackedTab,
+    isReviewTab,
+    isTransientTab,
+} from "./editorTabs";
+export type {
+    FileHistoryEntry,
+    FileTab,
+    FileTabInput,
+    FileViewerMode,
+    GraphTab,
+    HistoryTab,
+    HistoryTabInput,
+    MapTab,
+    MapTabInput,
+    NoteHistoryEntry,
+    NoteTab,
+    NoteTabInput,
+    PdfHistoryEntry,
+    PdfTab,
+    PdfTabInput,
+    PdfViewMode,
+    ResourceBackedTab,
+    ReviewTab,
+    Tab,
+    TabCloseReason,
+    TabHistoryEntry,
+    TabInput,
+    TransientTab,
+} from "./editorTabs";
 
 const SESSION_KEY = "vaultai.session.tabs";
 const SESSION_KEY_PREFIX = "vaultai.session.tabs:";
@@ -145,452 +226,6 @@ let sessionReady = false;
 export function markSessionReady() {
     sessionReady = true;
 }
-
-export interface NoteHistoryEntry {
-    kind: "note";
-    noteId: string;
-    title: string;
-    content: string;
-}
-
-export interface PdfHistoryEntry {
-    kind: "pdf";
-    entryId: string;
-    title: string;
-    path: string;
-    page: number;
-    zoom: number;
-    viewMode: PdfViewMode;
-}
-
-export interface FileHistoryEntry {
-    kind: "file";
-    relativePath: string;
-    title: string;
-    path: string;
-    content: string;
-    mimeType: string | null;
-    viewer: FileViewerMode;
-}
-
-export interface MapHistoryEntry {
-    kind: "map";
-    relativePath: string;
-    title: string;
-    filePath?: string;
-}
-
-export type TabHistoryEntry =
-    | NoteHistoryEntry
-    | PdfHistoryEntry
-    | FileHistoryEntry
-    | MapHistoryEntry;
-
-export type NoteHistoryEntryInput = Omit<NoteHistoryEntry, "kind"> & {
-    kind?: "note";
-};
-
-export type PdfHistoryEntryInput = Omit<PdfHistoryEntry, "kind"> & {
-    kind?: "pdf";
-};
-
-export type FileHistoryEntryInput = Omit<FileHistoryEntry, "kind"> & {
-    kind?: "file";
-};
-
-export type MapHistoryEntryInput = Omit<MapHistoryEntry, "kind"> & {
-    kind?: "map";
-};
-
-export type TabHistoryEntryInput =
-    | NoteHistoryEntryInput
-    | PdfHistoryEntryInput
-    | FileHistoryEntryInput
-    | MapHistoryEntryInput;
-
-export interface NoteTab {
-    id: string;
-    kind?: "note";
-    noteId: string;
-    title: string;
-    content: string;
-    history: TabHistoryEntry[];
-    historyIndex: number;
-}
-
-export interface PdfTab {
-    id: string;
-    kind: "pdf";
-    entryId: string;
-    title: string;
-    path: string;
-    page: number;
-    zoom: number;
-    viewMode: PdfViewMode;
-    history: TabHistoryEntry[];
-    historyIndex: number;
-}
-
-export interface FileTab {
-    id: string;
-    kind: "file";
-    relativePath: string;
-    path: string;
-    title: string;
-    content: string;
-    mimeType: string | null;
-    viewer: FileViewerMode;
-    history: TabHistoryEntry[];
-    historyIndex: number;
-}
-
-export interface ReviewTab {
-    id: string;
-    kind: "ai-review";
-    sessionId: string;
-    title: string;
-}
-
-export interface MapTab {
-    id: string;
-    kind: "map";
-    relativePath: string;
-    title: string;
-    history: TabHistoryEntry[];
-    historyIndex: number;
-}
-
-export interface GraphTab {
-    id: string;
-    kind: "graph";
-    title: string;
-}
-
-export type PdfViewMode = "single" | "continuous";
-export type FileViewerMode = "text" | "image";
-
-export type Tab = NoteTab | PdfTab | FileTab | ReviewTab | MapTab | GraphTab;
-
-export type TabCloseReason =
-    | "user"
-    | "bulk-user"
-    | "delete"
-    | "detach"
-    | "cleanup";
-
-export interface RecentlyClosedTab {
-    tab: Tab;
-    index: number;
-}
-
-export function isNoteTab(tab: Tab | null | undefined): tab is NoteTab;
-export function isNoteTab(
-    tab: TabInput | null | undefined,
-): tab is NoteTabInput;
-export function isNoteTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is NoteTab | NoteTabInput {
-    if (!tab) return false;
-    return (
-        tab.kind !== "pdf" &&
-        tab.kind !== "file" &&
-        tab.kind !== "ai-review" &&
-        tab.kind !== "map" &&
-        tab.kind !== "graph"
-    );
-}
-
-export function isPdfTab(tab: Tab | null | undefined): tab is PdfTab;
-export function isPdfTab(tab: TabInput | null | undefined): tab is PdfTabInput;
-export function isPdfTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is PdfTab | PdfTabInput {
-    if (!tab) return false;
-    return tab.kind === "pdf";
-}
-
-export function isFileTab(tab: Tab | null | undefined): tab is FileTab;
-export function isFileTab(
-    tab: TabInput | null | undefined,
-): tab is FileTabInput;
-export function isFileTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is FileTab | FileTabInput {
-    if (!tab) return false;
-    return tab.kind === "file";
-}
-
-export function isReviewTab(tab: Tab | null | undefined): tab is ReviewTab;
-export function isReviewTab(tab: TabInput | null | undefined): tab is ReviewTab;
-export function isReviewTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is ReviewTab {
-    if (!tab) return false;
-    return tab.kind === "ai-review";
-}
-
-export function isMapTab(tab: Tab | null | undefined): tab is MapTab;
-export function isMapTab(tab: TabInput | null | undefined): tab is MapTabInput;
-export function isMapTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is MapTab | MapTabInput {
-    if (!tab) return false;
-    return tab.kind === "map";
-}
-
-export function isGraphTab(tab: Tab | null | undefined): tab is GraphTab;
-export function isGraphTab(tab: TabInput | null | undefined): tab is GraphTab;
-export function isGraphTab(
-    tab: Tab | TabInput | null | undefined,
-): tab is GraphTab {
-    if (!tab) return false;
-    return tab.kind === "graph";
-}
-
-/** Tab without required history fields — used when creating tabs externally. */
-export type NoteTabInput = Omit<NoteTab, "history" | "historyIndex"> & {
-    history?: TabHistoryEntryInput[];
-    historyIndex?: number;
-};
-
-export type PdfTabInput = Omit<PdfTab, "history" | "historyIndex"> & {
-    history?: TabHistoryEntryInput[];
-    historyIndex?: number;
-};
-
-export type FileTabInput = Omit<FileTab, "history" | "historyIndex"> & {
-    history?: TabHistoryEntryInput[];
-    historyIndex?: number;
-};
-
-export type MapTabInput = Omit<MapTab, "history" | "historyIndex"> & {
-    history?: TabHistoryEntryInput[];
-    historyIndex?: number;
-};
-
-export type TabInput =
-    | NoteTabInput
-    | PdfTabInput
-    | FileTabInput
-    | ReviewTab
-    | MapTabInput
-    | GraphTab;
-
-function createNoteHistoryEntry(
-    noteId: string,
-    title: string,
-    content: string,
-): NoteHistoryEntry {
-    return {
-        kind: "note",
-        noteId,
-        title,
-        content,
-    };
-}
-
-function createPdfHistoryEntry(
-    entryId: string,
-    title: string,
-    path: string,
-    page: number,
-    zoom: number,
-    viewMode: PdfViewMode,
-): PdfHistoryEntry {
-    return {
-        kind: "pdf",
-        entryId,
-        title,
-        path,
-        page,
-        zoom,
-        viewMode,
-    };
-}
-
-function createFileHistoryEntry(
-    relativePath: string,
-    title: string,
-    path: string,
-    content: string,
-    mimeType: string | null,
-    viewer: FileViewerMode,
-): FileHistoryEntry {
-    return {
-        kind: "file",
-        relativePath,
-        title,
-        path,
-        content,
-        mimeType,
-        viewer,
-    };
-}
-
-function createMapHistoryEntry(
-    relativePath: string,
-    title: string,
-): MapHistoryEntry {
-    return {
-        kind: "map",
-        relativePath,
-        title,
-    };
-}
-
-function inferHistoryEntryKind(
-    entry: TabHistoryEntryInput,
-    fallbackKind: "note" | "pdf" | "file" | "map",
-) {
-    if (entry.kind) return entry.kind;
-    if ("noteId" in entry) return "note";
-    if ("entryId" in entry) return "pdf";
-    if (fallbackKind === "map") return "map";
-    if ("relativePath" in entry) return "file";
-    return fallbackKind;
-}
-
-function normalizeHistoryEntry(
-    entry: TabHistoryEntryInput,
-    fallbackKind: "note" | "pdf" | "file" | "map",
-): TabHistoryEntry {
-    const kind = inferHistoryEntryKind(entry, fallbackKind);
-
-    if (kind === "note") {
-        return createNoteHistoryEntry(
-            "noteId" in entry ? entry.noteId : "",
-            entry.title,
-            "content" in entry ? entry.content : "",
-        );
-    }
-
-    if (kind === "pdf") {
-        return createPdfHistoryEntry(
-            "entryId" in entry ? entry.entryId : "",
-            entry.title,
-            "path" in entry ? entry.path : "",
-            "page" in entry ? (entry.page ?? 1) : 1,
-            "zoom" in entry ? (entry.zoom ?? 1) : 1,
-            "viewMode" in entry
-                ? (entry.viewMode ?? "continuous")
-                : "continuous",
-        );
-    }
-
-    if (kind === "map") {
-        return createMapHistoryEntry(
-            "relativePath" in entry ? entry.relativePath : "",
-            entry.title,
-        );
-    }
-
-    const path = "path" in entry ? entry.path : "";
-    const mimeType = "mimeType" in entry ? (entry.mimeType ?? null) : null;
-
-    return createFileHistoryEntry(
-        "relativePath" in entry ? entry.relativePath : "",
-        entry.title,
-        path,
-        "content" in entry ? entry.content : "",
-        mimeType,
-        "viewer" in entry
-            ? (entry.viewer ?? inferFileViewer(path, mimeType))
-            : inferFileViewer(path, mimeType),
-    );
-}
-
-function createHistoryEntryFromTab(
-    tab: NoteTab | PdfTab | FileTab | MapTab,
-): TabHistoryEntry {
-    if (isPdfTab(tab)) {
-        return createPdfHistoryEntry(
-            tab.entryId,
-            tab.title,
-            tab.path,
-            tab.page,
-            tab.zoom,
-            tab.viewMode,
-        );
-    }
-
-    if (isFileTab(tab)) {
-        return createFileHistoryEntry(
-            tab.relativePath,
-            tab.title,
-            tab.path,
-            tab.content,
-            tab.mimeType,
-            tab.viewer,
-        );
-    }
-
-    if (isMapTab(tab)) {
-        return createMapHistoryEntry(tab.relativePath, tab.title);
-    }
-
-    return createNoteHistoryEntry(tab.noteId, tab.title, tab.content);
-}
-
-function buildTabFromHistory(
-    id: string,
-    history: TabHistoryEntry[],
-    historyIndex: number,
-): NoteTab | PdfTab | FileTab | MapTab {
-    const safeIndex = Math.max(0, Math.min(historyIndex, history.length - 1));
-    const entry = history[safeIndex];
-
-    if (entry.kind === "pdf") {
-        return {
-            id,
-            kind: "pdf",
-            entryId: entry.entryId,
-            title: entry.title,
-            path: entry.path,
-            page: entry.page,
-            zoom: entry.zoom,
-            viewMode: entry.viewMode,
-            history,
-            historyIndex: safeIndex,
-        };
-    }
-
-    if (entry.kind === "file") {
-        return {
-            id,
-            kind: "file",
-            relativePath: entry.relativePath,
-            title: entry.title,
-            path: entry.path,
-            content: entry.content,
-            mimeType: entry.mimeType,
-            viewer: entry.viewer,
-            history,
-            historyIndex: safeIndex,
-        };
-    }
-
-    if (entry.kind === "map") {
-        return {
-            id,
-            kind: "map",
-            relativePath: entry.relativePath,
-            title: entry.title,
-            history,
-            historyIndex: safeIndex,
-        };
-    }
-
-    return {
-        id,
-        kind: "note",
-        noteId: entry.noteId,
-        title: entry.title,
-        content: entry.content,
-        history,
-        historyIndex: safeIndex,
-    };
-}
-
 function shouldRememberClosedTab(reason: TabCloseReason) {
     return reason === "user" || reason === "bulk-user";
 }
@@ -608,250 +243,8 @@ function pushRecentlyClosedTab(
     return next.slice(-MAX_RECENTLY_CLOSED_TABS);
 }
 
-function createNoteTab(
-    noteId: string,
-    title: string,
-    content: string,
-): NoteTab {
-    return {
-        id: crypto.randomUUID(),
-        kind: "note",
-        noteId,
-        title,
-        content,
-        history: [createNoteHistoryEntry(noteId, title, content)],
-        historyIndex: 0,
-    };
-}
-
-function createPdfTab(entryId: string, title: string, path: string): PdfTab {
-    return {
-        id: crypto.randomUUID(),
-        kind: "pdf",
-        entryId,
-        title,
-        path,
-        page: 1,
-        zoom: 1,
-        viewMode: "continuous",
-        history: [
-            createPdfHistoryEntry(entryId, title, path, 1, 1, "continuous"),
-        ],
-        historyIndex: 0,
-    };
-}
-
-function createFileTab(
-    relativePath: string,
-    title: string,
-    path: string,
-    content: string,
-    mimeType: string | null,
-    viewer: FileViewerMode,
-): FileTab {
-    return {
-        id: crypto.randomUUID(),
-        kind: "file",
-        relativePath,
-        title,
-        path,
-        content,
-        mimeType,
-        viewer,
-        history: [
-            createFileHistoryEntry(
-                relativePath,
-                title,
-                path,
-                content,
-                mimeType,
-                viewer,
-            ),
-        ],
-        historyIndex: 0,
-    };
-}
-
-function createMapTab(relativePath: string, title: string): MapTab {
-    return {
-        id: crypto.randomUUID(),
-        kind: "map",
-        relativePath,
-        title,
-        history: [],
-        historyIndex: -1,
-    };
-}
-
-function createGraphTab(): GraphTab {
-    return {
-        id: crypto.randomUUID(),
-        kind: "graph",
-        title: "Graph View",
-    };
-}
-
-function ensureMapTabDefaults(tab: MapTabInput): MapTab {
-    const relativePath =
-        tab.relativePath ||
-        ("filePath" in tab && typeof tab.filePath === "string"
-            ? (toVaultRelativePath(
-                  tab.filePath,
-                  useVaultStore.getState().vaultPath,
-              ) ?? "")
-            : "");
-
-    return {
-        id: tab.id,
-        kind: "map",
-        relativePath,
-        title: tab.title,
-        history:
-            tab.history?.map((entry) => normalizeHistoryEntry(entry, "map")) ??
-            [],
-        historyIndex: tab.historyIndex ?? -1,
-    };
-}
-
-function ensurePdfTabDefaults(tab: PdfTabInput): PdfTab {
-    if (tab.history && tab.history.length > 0) {
-        const history = tab.history.map((entry) =>
-            normalizeHistoryEntry(entry, "pdf"),
-        );
-        const historyIndex = Math.max(
-            0,
-            Math.min(
-                tab.historyIndex ?? history.length - 1,
-                history.length - 1,
-            ),
-        );
-        history[historyIndex] = createPdfHistoryEntry(
-            tab.entryId,
-            tab.title,
-            tab.path,
-            tab.page ?? 1,
-            tab.zoom ?? 1,
-            tab.viewMode ?? "continuous",
-        );
-        return buildTabFromHistory(tab.id, history, historyIndex) as PdfTab;
-    }
-
-    const history = [
-        createPdfHistoryEntry(
-            tab.entryId,
-            tab.title,
-            tab.path,
-            tab.page ?? 1,
-            tab.zoom ?? 1,
-            tab.viewMode ?? "continuous",
-        ),
-    ];
-
-    return buildTabFromHistory(tab.id, history, 0) as PdfTab;
-}
-
 function getTabOpenBehavior() {
     return useSettingsStore.getState().tabOpenBehavior;
-}
-
-function ensureFileTabHistory(tab: FileTabInput): FileTab {
-    if (tab.history && tab.history.length > 0) {
-        const history = tab.history.map((entry) =>
-            normalizeHistoryEntry(entry, "file"),
-        );
-        const historyIndex = Math.max(
-            0,
-            Math.min(
-                tab.historyIndex ?? history.length - 1,
-                history.length - 1,
-            ),
-        );
-        history[historyIndex] = createFileHistoryEntry(
-            tab.relativePath,
-            tab.title,
-            tab.path,
-            tab.content,
-            tab.mimeType ?? null,
-            tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
-        );
-        return buildTabFromHistory(tab.id, history, historyIndex) as FileTab;
-    }
-
-    const viewer =
-        tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null);
-
-    return buildTabFromHistory(
-        tab.id,
-        [
-            createFileHistoryEntry(
-                tab.relativePath,
-                tab.title,
-                tab.path,
-                tab.content,
-                tab.mimeType ?? null,
-                viewer,
-            ),
-        ],
-        0,
-    ) as FileTab;
-}
-
-function ensureFileTabDefaults(tab: FileTabInput): FileTab {
-    return {
-        ...ensureFileTabHistory(tab),
-        mimeType: tab.mimeType ?? null,
-        viewer: tab.viewer ?? inferFileViewer(tab.path, tab.mimeType),
-    };
-}
-
-function inferFileViewer(
-    path: string,
-    mimeType: string | null,
-): FileViewerMode {
-    const extension = path.split(".").pop()?.toLowerCase() ?? "";
-    if (mimeType?.startsWith("image/")) return "image";
-    if (
-        extension === "png" ||
-        extension === "jpg" ||
-        extension === "jpeg" ||
-        extension === "jpe" ||
-        extension === "jfif" ||
-        extension === "gif" ||
-        extension === "webp" ||
-        extension === "svg" ||
-        extension === "avif" ||
-        extension === "bmp" ||
-        extension === "ico"
-    ) {
-        return "image";
-    }
-    return "text";
-}
-
-function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {
-    if (tab.history && tab.history.length > 0) {
-        const history = tab.history.map((entry) =>
-            normalizeHistoryEntry(entry, "note"),
-        );
-        const historyIndex = Math.max(
-            0,
-            Math.min(
-                tab.historyIndex ?? history.length - 1,
-                history.length - 1,
-            ),
-        );
-        history[historyIndex] = createNoteHistoryEntry(
-            tab.noteId,
-            tab.title,
-            tab.content,
-        );
-        return buildTabFromHistory(tab.id, history, historyIndex) as NoteTab;
-    }
-    return buildTabFromHistory(
-        tab.id,
-        [createNoteHistoryEntry(tab.noteId, tab.title, tab.content)],
-        0,
-    ) as NoteTab;
 }
 
 export interface PendingReveal {
@@ -1026,17 +419,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             const activeTab = state.tabs.find(
                 (t) => t.id === state.activeTabId,
             );
-            if (
-                activeTab &&
-                !isReviewTab(activeTab) &&
-                !isMapTab(activeTab) &&
-                !isGraphTab(activeTab)
-            ) {
-                const tab = isNoteTab(activeTab)
-                    ? ensureNoteTabHistory(activeTab)
-                    : isPdfTab(activeTab)
-                      ? ensurePdfTabDefaults(activeTab)
-                      : ensureFileTabDefaults(activeTab);
+            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
+                const tab = normalizeHistoryTab(activeTab);
                 if (isNoteTab(tab) && tab.noteId === noteId) {
                     return {
                         tabs: state.tabs.map((tabItem) =>
@@ -1094,17 +478,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             const activeTab = state.tabs.find(
                 (t) => t.id === state.activeTabId,
             );
-            if (
-                activeTab &&
-                !isReviewTab(activeTab) &&
-                !isMapTab(activeTab) &&
-                !isGraphTab(activeTab)
-            ) {
-                const tab = isNoteTab(activeTab)
-                    ? ensureNoteTabHistory(activeTab)
-                    : isPdfTab(activeTab)
-                      ? ensurePdfTabDefaults(activeTab)
-                      : ensureFileTabDefaults(activeTab);
+            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
+                const tab = normalizeHistoryTab(activeTab);
                 if (isPdfTab(tab) && tab.entryId === entryId) {
                     return state;
                 }
@@ -1187,17 +562,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             const activeTab = state.tabs.find(
                 (t) => t.id === state.activeTabId,
             );
-            if (
-                activeTab &&
-                !isReviewTab(activeTab) &&
-                !isMapTab(activeTab) &&
-                !isGraphTab(activeTab)
-            ) {
-                const tab = isNoteTab(activeTab)
-                    ? ensureNoteTabHistory(activeTab)
-                    : isPdfTab(activeTab)
-                      ? ensurePdfTabDefaults(activeTab)
-                      : ensureFileTabDefaults(activeTab);
+            if (activeTab && isHistoryTab(activeTab) && !isMapTab(activeTab)) {
+                const tab = normalizeHistoryTab(activeTab);
                 if (isFileTab(tab) && tab.relativePath === relativePath) {
                     return {
                         tabs: state.tabs.map((tabItem) =>
@@ -1361,15 +727,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         const tabIdx = state.tabs.findIndex((t) => t.id === state.activeTabId);
         if (tabIdx === -1) return;
         const raw = state.tabs[tabIdx];
-        if (isReviewTab(raw)) return;
-        const tab = isNoteTab(raw)
-            ? ensureNoteTabHistory(raw)
-            : isPdfTab(raw)
-              ? ensurePdfTabDefaults(raw)
-              : isFileTab(raw)
-                ? ensureFileTabDefaults(raw)
-                : null;
-        if (!tab) return;
+        if (!isHistoryTab(raw) || isMapTab(raw)) return;
+        const tab = normalizeHistoryTab(raw);
         if (targetIndex < 0 || targetIndex >= tab.history.length) return;
         if (targetIndex === tab.historyIndex) return;
 
@@ -1531,11 +890,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 if (isReviewTab(t)) return { ...t, title };
                 if (isMapTab(t)) return { ...t, title };
                 if (isGraphTab(t)) return { ...t, title };
-                const tab = isNoteTab(t)
-                    ? ensureNoteTabHistory(t)
-                    : isPdfTab(t)
-                      ? ensurePdfTabDefaults(t)
-                      : ensureFileTabDefaults(t);
+                const tab = normalizeHistoryTab(t);
                 if (!tab.history?.length) return { ...tab, title };
                 const history = [...tab.history];
                 if (history[tab.historyIndex]) {
@@ -1648,22 +1003,23 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     hydrateTabs: (tabs, activeTabId) => {
         const hydratedTabs: Tab[] = tabs
-            .filter((tab) => tab.kind !== "ai-review")
+            .filter((tab) => !isReviewTab(tab))
             .flatMap((tab): Tab[] => {
-                if (tab.kind === "pdf") {
-                    return [ensurePdfTabDefaults(tab)];
+                if (isHistoryTab(tab)) {
+                    if (isMapTab(tab)) {
+                        const mapTab = ensureMapTabDefaults(tab);
+                        return mapTab.relativePath ? [mapTab] : [];
+                    }
+                    return [normalizeHistoryTab(tab)];
                 }
-                if (tab.kind === "file") {
-                    return [ensureFileTabDefaults(tab)];
+                if (isGraphTab(tab)) {
+                    return [tab];
                 }
-                if (tab.kind === "map") {
+                if (isMapTab(tab)) {
                     const mapTab = ensureMapTabDefaults(tab);
                     return mapTab.relativePath ? [mapTab] : [];
                 }
-                if (tab.kind === "graph") {
-                    return [tab];
-                }
-                return [ensureNoteTabHistory(tab)];
+                return [];
             });
         const nextActiveTabId =
             activeTabId && hydratedTabs.some((tab) => tab.id === activeTabId)
@@ -1681,21 +1037,16 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     insertExternalTab: (tab, index) => {
         set((state) => {
-            const incoming: Tab | null =
-                tab.kind === "pdf"
-                    ? ensurePdfTabDefaults(tab)
-                    : tab.kind === "file"
-                      ? ensureFileTabDefaults(tab)
-                      : tab.kind === "ai-review"
-                        ? tab
-                        : tab.kind === "map"
-                          ? (() => {
-                                const mapTab = ensureMapTabDefaults(tab);
-                                return mapTab.relativePath ? mapTab : null;
-                            })()
-                          : tab.kind === "graph"
-                            ? tab
-                            : ensureNoteTabHistory(tab);
+            const incoming: Tab | null = isHistoryTab(tab)
+                ? isMapTab(tab)
+                    ? (() => {
+                          const mapTab = ensureMapTabDefaults(tab);
+                          return mapTab.relativePath ? mapTab : null;
+                      })()
+                    : normalizeHistoryTab(tab)
+                : isReviewTab(tab) || isGraphTab(tab)
+                  ? tab
+                  : null;
             if (!incoming) {
                 return state;
             }
@@ -2228,15 +1579,8 @@ async function loadNoteHistoryEntryContent(
         });
         useEditorStore.setState((state) => ({
             tabs: state.tabs.map((t) => {
-                if (t.id !== tabId || isReviewTab(t)) return t;
-                const tab = isNoteTab(t)
-                    ? ensureNoteTabHistory(t)
-                    : isPdfTab(t)
-                      ? ensurePdfTabDefaults(t)
-                      : isFileTab(t)
-                        ? ensureFileTabDefaults(t)
-                        : null;
-                if (!tab) return t;
+                if (t.id !== tabId || !isHistoryTab(t) || isMapTab(t)) return t;
+                const tab = normalizeHistoryTab(t);
                 const history = [...tab.history];
                 if (
                     history[historyIndex]?.kind === "note" &&
@@ -2269,15 +1613,8 @@ async function loadFileHistoryEntryContent(
         );
         useEditorStore.setState((state) => ({
             tabs: state.tabs.map((t) => {
-                if (t.id !== tabId || isReviewTab(t)) return t;
-                const tab = isNoteTab(t)
-                    ? ensureNoteTabHistory(t)
-                    : isPdfTab(t)
-                      ? ensurePdfTabDefaults(t)
-                      : isFileTab(t)
-                        ? ensureFileTabDefaults(t)
-                        : null;
-                if (!tab) return t;
+                if (t.id !== tabId || !isHistoryTab(t) || isMapTab(t)) return t;
+                const tab = normalizeHistoryTab(t);
                 const history = [...tab.history];
                 if (
                     history[historyIndex]?.kind === "file" &&
@@ -2333,15 +1670,9 @@ useEditorStore.subscribe((state) => {
     const persistedTabs = state.tabs
         .filter(
             (tab): tab is NoteTab | PdfTab | FileTab =>
-                !isReviewTab(tab) && !isMapTab(tab) && !isGraphTab(tab),
+                isHistoryTab(tab) && !isMapTab(tab),
         )
-        .map((tab) =>
-            isPdfTab(tab)
-                ? ensurePdfTabDefaults(tab)
-                : isFileTab(tab)
-                  ? ensureFileTabDefaults(tab)
-                  : ensureNoteTabHistory(tab),
-        );
+        .map((tab) => normalizeHistoryTab(tab));
     const noteTabs = persistedTabs.filter((tab): tab is NoteTab =>
         isNoteTab(tab),
     );

--- a/apps/desktop/src/app/store/editorTabRegistry.ts
+++ b/apps/desktop/src/app/store/editorTabRegistry.ts
@@ -1,0 +1,270 @@
+import {
+    buildTabFromHistory,
+    createFileHistoryEntry,
+    createFileTab,
+    createHistoryEntryFromTab,
+    createNoteHistoryEntry,
+    createNoteTab,
+    createPdfHistoryEntry,
+    createPdfTab,
+    ensureFileTabDefaults,
+    ensureMapTabDefaults,
+    ensureNoteTabHistory,
+    ensurePdfTabDefaults,
+    isFileTab,
+    isMapTab,
+    isNoteTab,
+    isPdfTab,
+    type FileHistoryEntry,
+    type FileTab,
+    type FileTabInput,
+    type FileViewerMode,
+    type HistoryTab,
+    type HistoryTabInput,
+    type MapHistoryEntry,
+    type MapTab,
+    type MapTabInput,
+    type NoteHistoryEntry,
+    type NoteTab,
+    type NoteTabInput,
+    type PdfHistoryEntry,
+    type PdfTab,
+    type PdfTabInput,
+    type PdfViewMode,
+    type TabHistoryEntry,
+} from "./editorTabs";
+
+interface HistoryTabByKindMap {
+    note: NoteTab;
+    pdf: PdfTab;
+    file: FileTab;
+    map: MapTab;
+}
+
+interface HistoryTabInputByKindMap {
+    note: NoteTabInput;
+    pdf: PdfTabInput;
+    file: FileTabInput;
+    map: MapTabInput;
+}
+
+interface HistoryEntryByKindMap {
+    note: NoteHistoryEntry;
+    pdf: PdfHistoryEntry;
+    file: FileHistoryEntry;
+    map: MapHistoryEntry;
+}
+
+interface OpenPayloadByKindMap {
+    note: {
+        kind: "note";
+        noteId: string;
+        title: string;
+        content: string;
+    };
+    pdf: {
+        kind: "pdf";
+        entryId: string;
+        title: string;
+        path: string;
+    };
+    file: {
+        kind: "file";
+        relativePath: string;
+        title: string;
+        path: string;
+        content: string;
+        mimeType: string | null;
+        viewer: FileViewerMode;
+    };
+    map: {
+        kind: "map";
+        relativePath: string;
+        title: string;
+    };
+}
+
+export type HistoryTabKind = keyof HistoryTabByKindMap;
+export type OpenableHistoryTabKind = Exclude<HistoryTabKind, "map">;
+export type HistoryTabByKind<K extends HistoryTabKind> = HistoryTabByKindMap[K];
+export type HistoryTabInputByKind<K extends HistoryTabKind> =
+    HistoryTabInputByKindMap[K];
+export type HistoryEntryByKind<K extends HistoryTabKind> =
+    HistoryEntryByKindMap[K];
+export type HistoryOpenPayload<K extends HistoryTabKind> = OpenPayloadByKindMap[K];
+export type OpenableHistoryPayload = HistoryOpenPayload<OpenableHistoryTabKind>;
+
+export interface HistoryTabHandler<K extends HistoryTabKind> {
+    kind: K;
+    normalizeTab: (input: HistoryTabInputByKind<K>) => HistoryTabByKind<K>;
+    createInitialTab: (payload: HistoryOpenPayload<K>) => HistoryTabByKind<K>;
+    createOpenEntry: (payload: HistoryOpenPayload<K>) => HistoryEntryByKind<K>;
+    entryFromTab: (tab: HistoryTabByKind<K>) => HistoryEntryByKind<K>;
+    buildFromHistory: (
+        id: string,
+        history: TabHistoryEntry[],
+        historyIndex: number,
+    ) => HistoryTabByKind<K>;
+    matchesOpenTarget: (
+        tab: HistoryTabByKind<K>,
+        payload: HistoryOpenPayload<K>,
+    ) => boolean;
+    replaceCurrentEntry?: (
+        tab: HistoryTabByKind<K>,
+        payload: HistoryOpenPayload<K>,
+    ) => HistoryTabByKind<K>;
+    isValidTab?: (tab: HistoryTabByKind<K>) => boolean;
+}
+
+const noteTabHandler: HistoryTabHandler<"note"> = {
+    kind: "note",
+    normalizeTab: (input) => ensureNoteTabHistory(input),
+    createInitialTab: (payload) =>
+        createNoteTab(payload.noteId, payload.title, payload.content),
+    createOpenEntry: (payload) =>
+        createNoteHistoryEntry(payload.noteId, payload.title, payload.content),
+    entryFromTab: (tab) => createHistoryEntryFromTab(tab) as NoteHistoryEntry,
+    buildFromHistory: (id, history, historyIndex) =>
+        buildTabFromHistory(id, history, historyIndex) as NoteTab,
+    matchesOpenTarget: (tab, payload) => tab.noteId === payload.noteId,
+    replaceCurrentEntry: (tab, payload) =>
+        buildTabFromHistory(
+            tab.id,
+            tab.history.map((entry, index) =>
+                index === tab.historyIndex && entry.kind === "note"
+                    ? createNoteHistoryEntry(
+                          payload.noteId,
+                          payload.title,
+                          payload.content,
+                      )
+                    : entry,
+            ),
+            tab.historyIndex,
+        ) as NoteTab,
+};
+
+const pdfTabHandler: HistoryTabHandler<"pdf"> = {
+    kind: "pdf",
+    normalizeTab: (input) => ensurePdfTabDefaults(input),
+    createInitialTab: (payload) =>
+        createPdfTab(payload.entryId, payload.title, payload.path),
+    createOpenEntry: (payload) =>
+        createPdfHistoryEntry(
+            payload.entryId,
+            payload.title,
+            payload.path,
+            1,
+            1,
+            "continuous",
+        ),
+    entryFromTab: (tab) => createHistoryEntryFromTab(tab) as PdfHistoryEntry,
+    buildFromHistory: (id, history, historyIndex) =>
+        buildTabFromHistory(id, history, historyIndex) as PdfTab,
+    matchesOpenTarget: (tab, payload) => tab.entryId === payload.entryId,
+};
+
+const fileTabHandler: HistoryTabHandler<"file"> = {
+    kind: "file",
+    normalizeTab: (input) => ensureFileTabDefaults(input),
+    createInitialTab: (payload) =>
+        createFileTab(
+            payload.relativePath,
+            payload.title,
+            payload.path,
+            payload.content,
+            payload.mimeType,
+            payload.viewer,
+        ),
+    createOpenEntry: (payload) =>
+        createFileHistoryEntry(
+            payload.relativePath,
+            payload.title,
+            payload.path,
+            payload.content,
+            payload.mimeType,
+            payload.viewer,
+        ),
+    entryFromTab: (tab) => createHistoryEntryFromTab(tab) as FileHistoryEntry,
+    buildFromHistory: (id, history, historyIndex) =>
+        buildTabFromHistory(id, history, historyIndex) as FileTab,
+    matchesOpenTarget: (tab, payload) =>
+        tab.relativePath === payload.relativePath,
+    replaceCurrentEntry: (tab, payload) =>
+        buildTabFromHistory(
+            tab.id,
+            tab.history.map((entry, index) =>
+                index === tab.historyIndex && entry.kind === "file"
+                    ? createFileHistoryEntry(
+                          payload.relativePath,
+                          payload.title,
+                          payload.path,
+                          payload.content,
+                          payload.mimeType,
+                          payload.viewer,
+                      )
+                    : entry,
+            ),
+            tab.historyIndex,
+        ) as FileTab,
+};
+
+const mapTabHandler: HistoryTabHandler<"map"> = {
+    kind: "map",
+    normalizeTab: (input) => ensureMapTabDefaults(input),
+    createInitialTab: (payload) => ({
+        id: crypto.randomUUID(),
+        kind: "map",
+        relativePath: payload.relativePath,
+        title: payload.title,
+        history: [],
+        historyIndex: -1,
+    }),
+    createOpenEntry: (payload) => ({
+        kind: "map",
+        relativePath: payload.relativePath,
+        title: payload.title,
+    }),
+    entryFromTab: (tab) => createHistoryEntryFromTab(tab) as MapHistoryEntry,
+    buildFromHistory: (id, history, historyIndex) =>
+        buildTabFromHistory(id, history, historyIndex) as MapTab,
+    matchesOpenTarget: (tab, payload) =>
+        tab.relativePath === payload.relativePath,
+    isValidTab: (tab) => tab.relativePath.length > 0,
+};
+
+export const historyTabHandlers: {
+    [K in HistoryTabKind]: HistoryTabHandler<K>;
+} = {
+    note: noteTabHandler,
+    pdf: pdfTabHandler,
+    file: fileTabHandler,
+    map: mapTabHandler,
+};
+
+export function getHistoryTabHandler<K extends HistoryTabKind>(kind: K) {
+    return historyTabHandlers[kind];
+}
+
+export function getHistoryTabKind(tab: HistoryTabInput): HistoryTabKind {
+    if (isNoteTab(tab)) return "note";
+    if (isPdfTab(tab)) return "pdf";
+    if (isFileTab(tab)) return "file";
+    return "map";
+}
+
+export function normalizeHistoryTab(tab: HistoryTabInput): HistoryTab | null {
+    const kind = getHistoryTabKind(tab);
+    const handler = getHistoryTabHandler(kind);
+    const normalized = handler.normalizeTab(
+        tab as HistoryTabInputByKind<typeof kind>,
+    );
+    return handler.isValidTab && !handler.isValidTab(normalized)
+        ? null
+        : normalized;
+}
+
+export function getOpenableHistoryTabHandler<K extends OpenableHistoryTabKind>(
+    kind: K,
+) {
+    return getHistoryTabHandler(kind);
+}

--- a/apps/desktop/src/app/store/editorTabRegistry.ts
+++ b/apps/desktop/src/app/store/editorTabRegistry.ts
@@ -91,7 +91,8 @@ export type HistoryTabInputByKind<K extends HistoryTabKind> =
     HistoryTabInputByKindMap[K];
 export type HistoryEntryByKind<K extends HistoryTabKind> =
     HistoryEntryByKindMap[K];
-export type HistoryOpenPayload<K extends HistoryTabKind> = OpenPayloadByKindMap[K];
+export type HistoryOpenPayload<K extends HistoryTabKind> =
+    OpenPayloadByKindMap[K];
 export type OpenableHistoryPayload = HistoryOpenPayload<OpenableHistoryTabKind>;
 
 export interface HistoryTabHandler<K extends HistoryTabKind> {
@@ -113,6 +114,8 @@ export interface HistoryTabHandler<K extends HistoryTabKind> {
         tab: HistoryTabByKind<K>,
         payload: HistoryOpenPayload<K>,
     ) => HistoryTabByKind<K>;
+    fingerprint: (tab: HistoryTabByKind<K>) => string;
+    serializeForSession: (tab: HistoryTabByKind<K>) => unknown;
     isValidTab?: (tab: HistoryTabByKind<K>) => boolean;
 }
 
@@ -141,6 +144,19 @@ const noteTabHandler: HistoryTabHandler<"note"> = {
             ),
             tab.historyIndex,
         ) as NoteTab,
+    fingerprint: (tab) =>
+        `|note|${tab.noteId}|${tab.title}|${tab.historyIndex}|${tab.history.length}`,
+    serializeForSession: (tab) => ({
+        noteId: tab.noteId,
+        title: tab.title,
+        history: tab.history
+            .filter((entry): entry is NoteHistoryEntry => entry.kind === "note")
+            .map((entry) => ({
+                noteId: entry.noteId,
+                title: entry.title,
+            })),
+        historyIndex: tab.historyIndex,
+    }),
 };
 
 const pdfTabHandler: HistoryTabHandler<"pdf"> = {
@@ -161,6 +177,27 @@ const pdfTabHandler: HistoryTabHandler<"pdf"> = {
     buildFromHistory: (id, history, historyIndex) =>
         buildTabFromHistory(id, history, historyIndex) as PdfTab,
     matchesOpenTarget: (tab, payload) => tab.entryId === payload.entryId,
+    fingerprint: (tab) =>
+        `|pdf|${tab.entryId}|${tab.title}|${tab.historyIndex}|${tab.history.length}`,
+    serializeForSession: (tab) => ({
+        entryId: tab.entryId,
+        title: tab.title,
+        path: tab.path,
+        page: tab.page,
+        zoom: tab.zoom,
+        viewMode: tab.viewMode,
+        history: tab.history
+            .filter((entry): entry is PdfHistoryEntry => entry.kind === "pdf")
+            .map((entry) => ({
+                entryId: entry.entryId,
+                title: entry.title,
+                path: entry.path,
+                page: entry.page,
+                zoom: entry.zoom,
+                viewMode: entry.viewMode,
+            })),
+        historyIndex: tab.historyIndex,
+    }),
 };
 
 const fileTabHandler: HistoryTabHandler<"file"> = {
@@ -206,6 +243,25 @@ const fileTabHandler: HistoryTabHandler<"file"> = {
             ),
             tab.historyIndex,
         ) as FileTab,
+    fingerprint: (tab) =>
+        `|file|${tab.relativePath}|${tab.title}|${tab.mimeType ?? ""}`,
+    serializeForSession: (tab) => ({
+        relativePath: tab.relativePath,
+        title: tab.title,
+        path: tab.path,
+        mimeType: tab.mimeType,
+        viewer: tab.viewer,
+        history: tab.history
+            .filter((entry): entry is FileHistoryEntry => entry.kind === "file")
+            .map((entry) => ({
+                relativePath: entry.relativePath,
+                title: entry.title,
+                path: entry.path,
+                mimeType: entry.mimeType,
+                viewer: entry.viewer,
+            })),
+        historyIndex: tab.historyIndex,
+    }),
 };
 
 const mapTabHandler: HistoryTabHandler<"map"> = {
@@ -229,6 +285,11 @@ const mapTabHandler: HistoryTabHandler<"map"> = {
         buildTabFromHistory(id, history, historyIndex) as MapTab,
     matchesOpenTarget: (tab, payload) =>
         tab.relativePath === payload.relativePath,
+    fingerprint: (tab) => `|map|${tab.relativePath}|${tab.title}`,
+    serializeForSession: (tab) => ({
+        relativePath: tab.relativePath,
+        title: tab.title,
+    }),
     isValidTab: (tab) => tab.relativePath.length > 0,
 };
 

--- a/apps/desktop/src/app/store/editorTabRegistry.ts
+++ b/apps/desktop/src/app/store/editorTabRegistry.ts
@@ -119,6 +119,73 @@ export interface HistoryTabHandler<K extends HistoryTabKind> {
     isValidTab?: (tab: HistoryTabByKind<K>) => boolean;
 }
 
+function serializeNoteTabForSession(tab: NoteTab) {
+    return {
+        noteId: tab.noteId,
+        title: tab.title,
+        history: tab.history
+            .filter((entry): entry is NoteHistoryEntry => entry.kind === "note")
+            .map((entry) => ({
+                noteId: entry.noteId,
+                title: entry.title,
+            })),
+        historyIndex: tab.historyIndex,
+    };
+}
+
+function serializePdfTabForSession(tab: PdfTab) {
+    return {
+        entryId: tab.entryId,
+        title: tab.title,
+        path: tab.path,
+        page: tab.page,
+        zoom: tab.zoom,
+        viewMode: tab.viewMode,
+        history: tab.history
+            .filter((entry): entry is PdfHistoryEntry => entry.kind === "pdf")
+            .map((entry) => ({
+                entryId: entry.entryId,
+                title: entry.title,
+                path: entry.path,
+                page: entry.page,
+                zoom: entry.zoom,
+                viewMode: entry.viewMode,
+            })),
+        historyIndex: tab.historyIndex,
+    };
+}
+
+function serializeFileTabForSession(tab: FileTab) {
+    return {
+        relativePath: tab.relativePath,
+        title: tab.title,
+        path: tab.path,
+        mimeType: tab.mimeType,
+        viewer: tab.viewer,
+        history: tab.history
+            .filter((entry): entry is FileHistoryEntry => entry.kind === "file")
+            .map((entry) => ({
+                relativePath: entry.relativePath,
+                title: entry.title,
+                path: entry.path,
+                mimeType: entry.mimeType,
+                viewer: entry.viewer,
+            })),
+        historyIndex: tab.historyIndex,
+    };
+}
+
+function serializeMapTabForSession(tab: MapTab) {
+    return {
+        relativePath: tab.relativePath,
+        title: tab.title,
+    };
+}
+
+function createSessionFingerprint(kind: HistoryTabKind, payload: unknown) {
+    return `|${kind}|${JSON.stringify(payload)}`;
+}
+
 // Invariants:
 // - Only note/pdf/file/map belong to the history-tab capability model.
 // - Special tabs like graph/review stay outside this registry on purpose.
@@ -151,18 +218,8 @@ const noteTabHandler: HistoryTabHandler<"note"> = {
             tab.historyIndex,
         ) as NoteTab,
     fingerprint: (tab) =>
-        `|note|${tab.noteId}|${tab.title}|${tab.historyIndex}|${tab.history.length}`,
-    serializeForSession: (tab) => ({
-        noteId: tab.noteId,
-        title: tab.title,
-        history: tab.history
-            .filter((entry): entry is NoteHistoryEntry => entry.kind === "note")
-            .map((entry) => ({
-                noteId: entry.noteId,
-                title: entry.title,
-            })),
-        historyIndex: tab.historyIndex,
-    }),
+        createSessionFingerprint("note", serializeNoteTabForSession(tab)),
+    serializeForSession: serializeNoteTabForSession,
 };
 
 const pdfTabHandler: HistoryTabHandler<"pdf"> = {
@@ -184,26 +241,8 @@ const pdfTabHandler: HistoryTabHandler<"pdf"> = {
         buildTabFromHistory(id, history, historyIndex) as PdfTab,
     matchesOpenTarget: (tab, payload) => tab.entryId === payload.entryId,
     fingerprint: (tab) =>
-        `|pdf|${tab.entryId}|${tab.title}|${tab.historyIndex}|${tab.history.length}`,
-    serializeForSession: (tab) => ({
-        entryId: tab.entryId,
-        title: tab.title,
-        path: tab.path,
-        page: tab.page,
-        zoom: tab.zoom,
-        viewMode: tab.viewMode,
-        history: tab.history
-            .filter((entry): entry is PdfHistoryEntry => entry.kind === "pdf")
-            .map((entry) => ({
-                entryId: entry.entryId,
-                title: entry.title,
-                path: entry.path,
-                page: entry.page,
-                zoom: entry.zoom,
-                viewMode: entry.viewMode,
-            })),
-        historyIndex: tab.historyIndex,
-    }),
+        createSessionFingerprint("pdf", serializePdfTabForSession(tab)),
+    serializeForSession: serializePdfTabForSession,
 };
 
 const fileTabHandler: HistoryTabHandler<"file"> = {
@@ -250,24 +289,8 @@ const fileTabHandler: HistoryTabHandler<"file"> = {
             tab.historyIndex,
         ) as FileTab,
     fingerprint: (tab) =>
-        `|file|${tab.relativePath}|${tab.title}|${tab.mimeType ?? ""}`,
-    serializeForSession: (tab) => ({
-        relativePath: tab.relativePath,
-        title: tab.title,
-        path: tab.path,
-        mimeType: tab.mimeType,
-        viewer: tab.viewer,
-        history: tab.history
-            .filter((entry): entry is FileHistoryEntry => entry.kind === "file")
-            .map((entry) => ({
-                relativePath: entry.relativePath,
-                title: entry.title,
-                path: entry.path,
-                mimeType: entry.mimeType,
-                viewer: entry.viewer,
-            })),
-        historyIndex: tab.historyIndex,
-    }),
+        createSessionFingerprint("file", serializeFileTabForSession(tab)),
+    serializeForSession: serializeFileTabForSession,
 };
 
 const mapTabHandler: HistoryTabHandler<"map"> = {
@@ -291,11 +314,9 @@ const mapTabHandler: HistoryTabHandler<"map"> = {
         buildTabFromHistory(id, history, historyIndex) as MapTab,
     matchesOpenTarget: (tab, payload) =>
         tab.relativePath === payload.relativePath,
-    fingerprint: (tab) => `|map|${tab.relativePath}|${tab.title}`,
-    serializeForSession: (tab) => ({
-        relativePath: tab.relativePath,
-        title: tab.title,
-    }),
+    fingerprint: (tab) =>
+        createSessionFingerprint("map", serializeMapTabForSession(tab)),
+    serializeForSession: serializeMapTabForSession,
     isValidTab: (tab) => tab.relativePath.length > 0,
 };
 

--- a/apps/desktop/src/app/store/editorTabRegistry.ts
+++ b/apps/desktop/src/app/store/editorTabRegistry.ts
@@ -119,6 +119,12 @@ export interface HistoryTabHandler<K extends HistoryTabKind> {
     isValidTab?: (tab: HistoryTabByKind<K>) => boolean;
 }
 
+// Invariants:
+// - Only note/pdf/file/map belong to the history-tab capability model.
+// - Special tabs like graph/review stay outside this registry on purpose.
+// - The store should delegate history mechanics to these handlers instead of
+//   branching on kind for normalize/open/persist/restore behavior.
+
 const noteTabHandler: HistoryTabHandler<"note"> = {
     kind: "note",
     normalizeTab: (input) => ensureNoteTabHistory(input),
@@ -328,4 +334,10 @@ export function getOpenableHistoryTabHandler<K extends OpenableHistoryTabKind>(
     kind: K,
 ) {
     return getHistoryTabHandler(kind);
+}
+
+export function createHistorySnapshot(tab: HistoryTab): TabHistoryEntry {
+    return getHistoryTabHandler(tab.kind).entryFromTab(
+        tab as HistoryTabByKind<typeof tab.kind>,
+    );
 }

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -1,0 +1,757 @@
+import { toVaultRelativePath } from "../utils/vaultPaths";
+import { useVaultStore } from "./vaultStore";
+
+export type PdfViewMode = "single" | "continuous";
+export type FileViewerMode = "text" | "image";
+
+export interface NoteHistoryEntry {
+    kind: "note";
+    noteId: string;
+    title: string;
+    content: string;
+}
+
+export interface PdfHistoryEntry {
+    kind: "pdf";
+    entryId: string;
+    title: string;
+    path: string;
+    page: number;
+    zoom: number;
+    viewMode: PdfViewMode;
+}
+
+export interface FileHistoryEntry {
+    kind: "file";
+    relativePath: string;
+    title: string;
+    path: string;
+    content: string;
+    mimeType: string | null;
+    viewer: FileViewerMode;
+}
+
+export interface MapHistoryEntry {
+    kind: "map";
+    relativePath: string;
+    title: string;
+    filePath?: string;
+}
+
+export type TabHistoryEntry =
+    | NoteHistoryEntry
+    | PdfHistoryEntry
+    | FileHistoryEntry
+    | MapHistoryEntry;
+
+export type NoteHistoryEntryInput = Omit<NoteHistoryEntry, "kind"> & {
+    kind?: "note";
+};
+
+export type PdfHistoryEntryInput = Omit<PdfHistoryEntry, "kind"> & {
+    kind?: "pdf";
+};
+
+export type FileHistoryEntryInput = Omit<FileHistoryEntry, "kind"> & {
+    kind?: "file";
+};
+
+export type MapHistoryEntryInput = Omit<MapHistoryEntry, "kind"> & {
+    kind?: "map";
+};
+
+export type TabHistoryEntryInput =
+    | NoteHistoryEntryInput
+    | PdfHistoryEntryInput
+    | FileHistoryEntryInput
+    | MapHistoryEntryInput;
+
+export interface NoteTab {
+    id: string;
+    kind: "note";
+    noteId: string;
+    title: string;
+    content: string;
+    history: TabHistoryEntry[];
+    historyIndex: number;
+}
+
+export interface PdfTab {
+    id: string;
+    kind: "pdf";
+    entryId: string;
+    title: string;
+    path: string;
+    page: number;
+    zoom: number;
+    viewMode: PdfViewMode;
+    history: TabHistoryEntry[];
+    historyIndex: number;
+}
+
+export interface FileTab {
+    id: string;
+    kind: "file";
+    relativePath: string;
+    path: string;
+    title: string;
+    content: string;
+    mimeType: string | null;
+    viewer: FileViewerMode;
+    history: TabHistoryEntry[];
+    historyIndex: number;
+}
+
+export interface ReviewTab {
+    id: string;
+    kind: "ai-review";
+    sessionId: string;
+    title: string;
+}
+
+export interface MapTab {
+    id: string;
+    kind: "map";
+    relativePath: string;
+    title: string;
+    history: TabHistoryEntry[];
+    historyIndex: number;
+}
+
+export interface GraphTab {
+    id: string;
+    kind: "graph";
+    title: string;
+}
+
+export type Tab = NoteTab | PdfTab | FileTab | ReviewTab | MapTab | GraphTab;
+
+export type NoteTabInput = Omit<
+    NoteTab,
+    "kind" | "history" | "historyIndex"
+> & {
+    kind?: "note";
+    history?: TabHistoryEntryInput[];
+    historyIndex?: number;
+};
+
+export type PdfTabInput = Omit<PdfTab, "history" | "historyIndex"> & {
+    history?: TabHistoryEntryInput[];
+    historyIndex?: number;
+};
+
+export type FileTabInput = Omit<FileTab, "history" | "historyIndex"> & {
+    history?: TabHistoryEntryInput[];
+    historyIndex?: number;
+};
+
+export type MapTabInput = Omit<MapTab, "history" | "historyIndex"> & {
+    history?: TabHistoryEntryInput[];
+    historyIndex?: number;
+};
+
+export type TabInput =
+    | NoteTabInput
+    | PdfTabInput
+    | FileTabInput
+    | ReviewTab
+    | MapTabInput
+    | GraphTab;
+
+export type HistoryTab = NoteTab | PdfTab | FileTab | MapTab;
+export type HistoryTabInput =
+    | NoteTabInput
+    | PdfTabInput
+    | FileTabInput
+    | MapTabInput;
+export type TransientTab = ReviewTab | GraphTab;
+export type ResourceBackedTab = NoteTab | FileTab;
+
+type AnyTabLike = Tab | TabInput;
+
+function inferTabKind(tab: AnyTabLike | null | undefined): Tab["kind"] | null {
+    if (!tab) return null;
+    if ("kind" in tab && typeof tab.kind === "string") {
+        return tab.kind;
+    }
+    if ("noteId" in tab) return "note";
+    if ("entryId" in tab) return "pdf";
+    if ("sessionId" in tab) return "ai-review";
+    if (
+        "path" in tab ||
+        "mimeType" in tab ||
+        "viewer" in tab ||
+        "content" in tab
+    ) {
+        return "file";
+    }
+    if ("relativePath" in tab || "filePath" in tab) {
+        return "map";
+    }
+    return null;
+}
+
+export function isNoteTab(tab: Tab | null | undefined): tab is NoteTab;
+export function isNoteTab(
+    tab: TabInput | null | undefined,
+): tab is NoteTabInput;
+export function isNoteTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is NoteTab | NoteTabInput {
+    return inferTabKind(tab) === "note";
+}
+
+export function isPdfTab(tab: Tab | null | undefined): tab is PdfTab;
+export function isPdfTab(tab: TabInput | null | undefined): tab is PdfTabInput;
+export function isPdfTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is PdfTab | PdfTabInput {
+    return inferTabKind(tab) === "pdf";
+}
+
+export function isFileTab(tab: Tab | null | undefined): tab is FileTab;
+export function isFileTab(
+    tab: TabInput | null | undefined,
+): tab is FileTabInput;
+export function isFileTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is FileTab | FileTabInput {
+    return inferTabKind(tab) === "file";
+}
+
+export function isReviewTab(tab: Tab | null | undefined): tab is ReviewTab;
+export function isReviewTab(tab: TabInput | null | undefined): tab is ReviewTab;
+export function isReviewTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is ReviewTab {
+    return inferTabKind(tab) === "ai-review";
+}
+
+export function isMapTab(tab: Tab | null | undefined): tab is MapTab;
+export function isMapTab(tab: TabInput | null | undefined): tab is MapTabInput;
+export function isMapTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is MapTab | MapTabInput {
+    return inferTabKind(tab) === "map";
+}
+
+export function isGraphTab(tab: Tab | null | undefined): tab is GraphTab;
+export function isGraphTab(tab: TabInput | null | undefined): tab is GraphTab;
+export function isGraphTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is GraphTab {
+    return inferTabKind(tab) === "graph";
+}
+
+export function isHistoryTab(tab: Tab | null | undefined): tab is HistoryTab;
+export function isHistoryTab(
+    tab: TabInput | null | undefined,
+): tab is HistoryTabInput;
+export function isHistoryTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is HistoryTab | HistoryTabInput {
+    const kind = inferTabKind(tab);
+    return (
+        kind === "note" || kind === "pdf" || kind === "file" || kind === "map"
+    );
+}
+
+export function isTransientTab(
+    tab: Tab | null | undefined,
+): tab is TransientTab;
+export function isTransientTab(
+    tab: TabInput | null | undefined,
+): tab is TransientTab;
+export function isTransientTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is TransientTab {
+    const kind = inferTabKind(tab);
+    return kind === "ai-review" || kind === "graph";
+}
+
+export function isResourceBackedTab(
+    tab: Tab | null | undefined,
+): tab is ResourceBackedTab;
+export function isResourceBackedTab(
+    tab: TabInput | null | undefined,
+): tab is NoteTabInput | FileTabInput;
+export function isResourceBackedTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is ResourceBackedTab | NoteTabInput | FileTabInput {
+    const kind = inferTabKind(tab);
+    return kind === "note" || kind === "file";
+}
+
+export function createNoteHistoryEntry(
+    noteId: string,
+    title: string,
+    content: string,
+): NoteHistoryEntry {
+    return {
+        kind: "note",
+        noteId,
+        title,
+        content,
+    };
+}
+
+export function createPdfHistoryEntry(
+    entryId: string,
+    title: string,
+    path: string,
+    page: number,
+    zoom: number,
+    viewMode: PdfViewMode,
+): PdfHistoryEntry {
+    return {
+        kind: "pdf",
+        entryId,
+        title,
+        path,
+        page,
+        zoom,
+        viewMode,
+    };
+}
+
+export function createFileHistoryEntry(
+    relativePath: string,
+    title: string,
+    path: string,
+    content: string,
+    mimeType: string | null,
+    viewer: FileViewerMode,
+): FileHistoryEntry {
+    return {
+        kind: "file",
+        relativePath,
+        title,
+        path,
+        content,
+        mimeType,
+        viewer,
+    };
+}
+
+export function createMapHistoryEntry(
+    relativePath: string,
+    title: string,
+): MapHistoryEntry {
+    return {
+        kind: "map",
+        relativePath,
+        title,
+    };
+}
+
+function inferHistoryEntryKind(
+    entry: TabHistoryEntryInput,
+    fallbackKind: "note" | "pdf" | "file" | "map",
+) {
+    if (entry.kind) return entry.kind;
+    if ("noteId" in entry) return "note";
+    if ("entryId" in entry) return "pdf";
+    if (fallbackKind === "map") return "map";
+    if ("relativePath" in entry) return "file";
+    return fallbackKind;
+}
+
+export function normalizeHistoryEntry(
+    entry: TabHistoryEntryInput,
+    fallbackKind: "note" | "pdf" | "file" | "map",
+): TabHistoryEntry {
+    const kind = inferHistoryEntryKind(entry, fallbackKind);
+
+    if (kind === "note") {
+        return createNoteHistoryEntry(
+            "noteId" in entry ? entry.noteId : "",
+            entry.title,
+            "content" in entry ? entry.content : "",
+        );
+    }
+
+    if (kind === "pdf") {
+        return createPdfHistoryEntry(
+            "entryId" in entry ? entry.entryId : "",
+            entry.title,
+            "path" in entry ? entry.path : "",
+            "page" in entry ? (entry.page ?? 1) : 1,
+            "zoom" in entry ? (entry.zoom ?? 1) : 1,
+            "viewMode" in entry
+                ? (entry.viewMode ?? "continuous")
+                : "continuous",
+        );
+    }
+
+    if (kind === "map") {
+        return createMapHistoryEntry(
+            "relativePath" in entry ? entry.relativePath : "",
+            entry.title,
+        );
+    }
+
+    const path = "path" in entry ? entry.path : "";
+    const mimeType = "mimeType" in entry ? (entry.mimeType ?? null) : null;
+
+    return createFileHistoryEntry(
+        "relativePath" in entry ? entry.relativePath : "",
+        entry.title,
+        path,
+        "content" in entry ? entry.content : "",
+        mimeType,
+        "viewer" in entry
+            ? (entry.viewer ?? inferFileViewer(path, mimeType))
+            : inferFileViewer(path, mimeType),
+    );
+}
+
+export function createHistoryEntryFromTab(tab: HistoryTab): TabHistoryEntry {
+    if (isPdfTab(tab)) {
+        return createPdfHistoryEntry(
+            tab.entryId,
+            tab.title,
+            tab.path,
+            tab.page,
+            tab.zoom,
+            tab.viewMode,
+        );
+    }
+
+    if (isFileTab(tab)) {
+        return createFileHistoryEntry(
+            tab.relativePath,
+            tab.title,
+            tab.path,
+            tab.content,
+            tab.mimeType,
+            tab.viewer,
+        );
+    }
+
+    if (isMapTab(tab)) {
+        return createMapHistoryEntry(tab.relativePath, tab.title);
+    }
+
+    return createNoteHistoryEntry(tab.noteId, tab.title, tab.content);
+}
+
+export function buildTabFromHistory(
+    id: string,
+    history: TabHistoryEntry[],
+    historyIndex: number,
+): HistoryTab {
+    const safeIndex = Math.max(0, Math.min(historyIndex, history.length - 1));
+    const entry = history[safeIndex];
+
+    if (entry.kind === "pdf") {
+        return {
+            id,
+            kind: "pdf",
+            entryId: entry.entryId,
+            title: entry.title,
+            path: entry.path,
+            page: entry.page,
+            zoom: entry.zoom,
+            viewMode: entry.viewMode,
+            history,
+            historyIndex: safeIndex,
+        };
+    }
+
+    if (entry.kind === "file") {
+        return {
+            id,
+            kind: "file",
+            relativePath: entry.relativePath,
+            title: entry.title,
+            path: entry.path,
+            content: entry.content,
+            mimeType: entry.mimeType,
+            viewer: entry.viewer,
+            history,
+            historyIndex: safeIndex,
+        };
+    }
+
+    if (entry.kind === "map") {
+        return {
+            id,
+            kind: "map",
+            relativePath: entry.relativePath,
+            title: entry.title,
+            history,
+            historyIndex: safeIndex,
+        };
+    }
+
+    return {
+        id,
+        kind: "note",
+        noteId: entry.noteId,
+        title: entry.title,
+        content: entry.content,
+        history,
+        historyIndex: safeIndex,
+    };
+}
+
+export function createNoteTab(
+    noteId: string,
+    title: string,
+    content: string,
+): NoteTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "note",
+        noteId,
+        title,
+        content,
+        history: [createNoteHistoryEntry(noteId, title, content)],
+        historyIndex: 0,
+    };
+}
+
+export function createPdfTab(
+    entryId: string,
+    title: string,
+    path: string,
+): PdfTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "pdf",
+        entryId,
+        title,
+        path,
+        page: 1,
+        zoom: 1,
+        viewMode: "continuous",
+        history: [
+            createPdfHistoryEntry(entryId, title, path, 1, 1, "continuous"),
+        ],
+        historyIndex: 0,
+    };
+}
+
+export function createFileTab(
+    relativePath: string,
+    title: string,
+    path: string,
+    content: string,
+    mimeType: string | null,
+    viewer: FileViewerMode,
+): FileTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "file",
+        relativePath,
+        title,
+        path,
+        content,
+        mimeType,
+        viewer,
+        history: [
+            createFileHistoryEntry(
+                relativePath,
+                title,
+                path,
+                content,
+                mimeType,
+                viewer,
+            ),
+        ],
+        historyIndex: 0,
+    };
+}
+
+export function createMapTab(relativePath: string, title: string): MapTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "map",
+        relativePath,
+        title,
+        history: [],
+        historyIndex: -1,
+    };
+}
+
+export function createGraphTab(): GraphTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "graph",
+        title: "Graph View",
+    };
+}
+
+export function ensureMapTabDefaults(tab: MapTabInput): MapTab {
+    const relativePath =
+        tab.relativePath ||
+        ("filePath" in tab && typeof tab.filePath === "string"
+            ? (toVaultRelativePath(
+                  tab.filePath,
+                  useVaultStore.getState().vaultPath,
+              ) ?? "")
+            : "");
+
+    return {
+        id: tab.id,
+        kind: "map",
+        relativePath,
+        title: tab.title,
+        history:
+            tab.history?.map((entry) => normalizeHistoryEntry(entry, "map")) ??
+            [],
+        historyIndex: tab.historyIndex ?? -1,
+    };
+}
+
+export function ensurePdfTabDefaults(tab: PdfTabInput): PdfTab {
+    if (tab.history && tab.history.length > 0) {
+        const history = tab.history.map((entry) =>
+            normalizeHistoryEntry(entry, "pdf"),
+        );
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createPdfHistoryEntry(
+            tab.entryId,
+            tab.title,
+            tab.path,
+            tab.page ?? 1,
+            tab.zoom ?? 1,
+            tab.viewMode ?? "continuous",
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as PdfTab;
+    }
+
+    return buildTabFromHistory(
+        tab.id,
+        [
+            createPdfHistoryEntry(
+                tab.entryId,
+                tab.title,
+                tab.path,
+                tab.page ?? 1,
+                tab.zoom ?? 1,
+                tab.viewMode ?? "continuous",
+            ),
+        ],
+        0,
+    ) as PdfTab;
+}
+
+export function ensureFileTabHistory(tab: FileTabInput): FileTab {
+    if (tab.history && tab.history.length > 0) {
+        const history = tab.history.map((entry) =>
+            normalizeHistoryEntry(entry, "file"),
+        );
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createFileHistoryEntry(
+            tab.relativePath,
+            tab.title,
+            tab.path,
+            tab.content,
+            tab.mimeType ?? null,
+            tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as FileTab;
+    }
+
+    const viewer =
+        tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null);
+
+    return buildTabFromHistory(
+        tab.id,
+        [
+            createFileHistoryEntry(
+                tab.relativePath,
+                tab.title,
+                tab.path,
+                tab.content,
+                tab.mimeType ?? null,
+                viewer,
+            ),
+        ],
+        0,
+    ) as FileTab;
+}
+
+export function ensureFileTabDefaults(tab: FileTabInput): FileTab {
+    return {
+        ...ensureFileTabHistory(tab),
+        mimeType: tab.mimeType ?? null,
+        viewer: tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
+    };
+}
+
+export function inferFileViewer(
+    path: string,
+    mimeType: string | null,
+): FileViewerMode {
+    const extension = path.split(".").pop()?.toLowerCase() ?? "";
+    if (mimeType?.startsWith("image/")) return "image";
+    if (
+        extension === "png" ||
+        extension === "jpg" ||
+        extension === "jpeg" ||
+        extension === "jpe" ||
+        extension === "jfif" ||
+        extension === "gif" ||
+        extension === "webp" ||
+        extension === "svg" ||
+        extension === "avif" ||
+        extension === "bmp" ||
+        extension === "ico"
+    ) {
+        return "image";
+    }
+    return "text";
+}
+
+export function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {
+    if (tab.history && tab.history.length > 0) {
+        const history = tab.history.map((entry) =>
+            normalizeHistoryEntry(entry, "note"),
+        );
+        const historyIndex = Math.max(
+            0,
+            Math.min(
+                tab.historyIndex ?? history.length - 1,
+                history.length - 1,
+            ),
+        );
+        history[historyIndex] = createNoteHistoryEntry(
+            tab.noteId,
+            tab.title,
+            tab.content,
+        );
+        return buildTabFromHistory(tab.id, history, historyIndex) as NoteTab;
+    }
+    return buildTabFromHistory(
+        tab.id,
+        [createNoteHistoryEntry(tab.noteId, tab.title, tab.content)],
+        0,
+    ) as NoteTab;
+}
+
+export function normalizeHistoryTab(tab: HistoryTabInput): HistoryTab {
+    if (isNoteTab(tab)) {
+        return ensureNoteTabHistory(tab);
+    }
+    if (isPdfTab(tab)) {
+        return ensurePdfTabDefaults(tab);
+    }
+    if (isFileTab(tab)) {
+        return ensureFileTabDefaults(tab);
+    }
+    return ensureMapTabDefaults(tab);
+}

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -159,11 +159,16 @@ export type TabInput =
     | GraphTab;
 
 export type HistoryTab = NoteTab | PdfTab | FileTab | MapTab;
+export type NavigableHistoryTab = NoteTab | PdfTab | FileTab;
 export type HistoryTabInput =
     | NoteTabInput
     | PdfTabInput
     | FileTabInput
     | MapTabInput;
+export type NavigableHistoryTabInput =
+    | NoteTabInput
+    | PdfTabInput
+    | FileTabInput;
 export type TransientTab = ReviewTab | GraphTab;
 export type ResourceBackedTab = NoteTab | FileTab;
 
@@ -254,6 +259,19 @@ export function isHistoryTab(
     return (
         kind === "note" || kind === "pdf" || kind === "file" || kind === "map"
     );
+}
+
+export function isNavigableHistoryTab(
+    tab: Tab | null | undefined,
+): tab is NavigableHistoryTab;
+export function isNavigableHistoryTab(
+    tab: TabInput | null | undefined,
+): tab is NavigableHistoryTabInput;
+export function isNavigableHistoryTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is NavigableHistoryTab | NavigableHistoryTabInput {
+    const kind = inferTabKind(tab);
+    return kind === "note" || kind === "pdf" || kind === "file";
 }
 
 export function isTransientTab(

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -742,16 +742,3 @@ export function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {
         0,
     ) as NoteTab;
 }
-
-export function normalizeHistoryTab(tab: HistoryTabInput): HistoryTab {
-    if (isNoteTab(tab)) {
-        return ensureNoteTabHistory(tab);
-    }
-    if (isPdfTab(tab)) {
-        return ensurePdfTabDefaults(tab);
-    }
-    if (isFileTab(tab)) {
-        return ensureFileTabDefaults(tab);
-    }
-    return ensureMapTabDefaults(tab);
-}


### PR DESCRIPTION
## Summary

This PR refactors the desktop editor tab subsystem so `editorStore` stops owning tab-type branching directly and instead orchestrates common mechanics through capability registries.

The change is intentionally bounded to the editor tab/session subsystem. It preserves the public store API while moving variation into focused modules for:
- tab model and guards
- history-tab normalization/opening
- session persistence/restore
- editable resource reload/delete behavior

## What changed

- extracted the tab model and positive guards to `editorTabs.ts`
- introduced a history-tab registry in `editorTabRegistry.ts`
- centralized editor session persistence/restore in `editorSession.ts`
- centralized note/file reload, force reload, delete and lazy history content loading in `editorResourceRegistry.ts`
- simplified `editorStore.ts` so it orchestrates shared behavior instead of branching per tab kind
- removed manual session reconstruction from `App.tsx`
- hardened invariants around:
  - explicit `note` runtime kind
  - graph singleton behavior
  - review tabs staying transient
  - map staying outside navigable history
  - mixed note/pdf/file history navigation
  - cleanup of reload/conflict state after external deletes

## Why this refactor was necessary

The previous model already had some shared history helpers, but ownership was still split across `editorStore.ts` and `App.tsx`, with duplicated note/file flows and manual dispatch by tab kind in open, hydrate, persist, restore, reload and delete paths.

That made the subsystem harder to verify and increased regression risk in review flows and session restore. This refactor creates a cleaner ownership boundary without broadening scope outside the editor tab subsystem.

## Validation

Executed:

- `npm --prefix apps/desktop run test -- src/app/store/editorStore.test.ts src/app/store/editorSession.test.ts src/features/editor/Editor.test.tsx src/features/editor/FileTabView.test.tsx src/features/editor/UnifiedBar.test.tsx src/features/ai/components/AIReviewView.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx`

Result:

- `141/141` tests passing

Notes:

- existing stderr warnings in `Editor.test.tsx` and `FileTabView.test.tsx` remain, but they are pre-existing and not introduced by this PR
