### PR TITLE
feat(desktop): add editable CSV file viewer

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -41,9 +41,11 @@
                 "@xterm/addon-web-links": "^0.12.0",
                 "@xterm/xterm": "^6.0.0",
                 "katex": "^0.16.38",
+                "papaparse": "^5.5.3",
                 "pdfjs-dist": "5.5.207",
-                "react": "^19.2.0",
-                "react-dom": "^19.2.0",
+                "react": "19.2.5",
+                "react-datasheet-grid": "^4.11.6",
+                "react-dom": "19.2.5",
                 "react-force-graph-2d": "^1.29.1",
                 "react-force-graph-3d": "^1.29.1",
                 "tailwindcss": "^4.2.1",
@@ -56,6 +58,7 @@
                 "@testing-library/user-event": "^14.6.1",
                 "@types/katex": "^0.16.8",
                 "@types/node": "^24.10.1",
+                "@types/papaparse": "^5.5.2",
                 "@types/react": "^19.2.7",
                 "@types/react-dom": "^19.2.3",
                 "@types/three": "^0.183.1",
@@ -3347,6 +3350,16 @@
                 "vite": "^5.2.0 || ^6 || ^7"
             }
         },
+        "node_modules/@tanstack/virtual-core": {
+            "version": "3.13.23",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+            "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            }
+        },
         "node_modules/@tauri-apps/api": {
             "version": "2.10.1",
             "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -3829,6 +3842,16 @@
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~7.16.0"
+            }
+        },
+        "node_modules/@types/papaparse": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+            "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
             }
         },
         "node_modules/@types/react": {
@@ -4743,6 +4766,12 @@
                 "node": ">= 16"
             }
         },
+        "node_modules/classnames": {
+            "version": "2.5.1",
+            "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+            "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+            "license": "MIT"
+        },
         "node_modules/clsx": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
@@ -5576,6 +5605,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/es-toolkit": {
+            "version": "1.45.1",
+            "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+            "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+            "license": "MIT",
+            "workspaces": [
+                "docs",
+                "benchmarks"
+            ]
+        },
         "node_modules/es6-promise-pool": {
             "version": "2.5.0",
             "resolved": "https://registry.npmjs.org/es6-promise-pool/-/es6-promise-pool-2.5.0.tgz",
@@ -5857,7 +5896,6 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/fast-json-stable-stringify": {
@@ -7608,6 +7646,12 @@
             "integrity": "sha512-WjR1hOeg+kki3ZIOjaf4b5WVcay1jaliKSYiEaB1XzwhMQZJxRdQRv0V31EKBYlxb4T7SK3hjfc/jxyU64BoSw==",
             "license": "(MIT AND Zlib)"
         },
+        "node_modules/papaparse": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+            "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+            "license": "MIT"
+        },
         "node_modules/parent-module": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7897,24 +7941,57 @@
             "license": "Apache-2.0"
         },
         "node_modules/react": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+            "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-datasheet-grid": {
+            "version": "4.11.6",
+            "resolved": "https://registry.npmjs.org/react-datasheet-grid/-/react-datasheet-grid-4.11.6.tgz",
+            "integrity": "sha512-+MjrIlrdRi5xSHfJSRPZfOp+jTBSZurvPdTrX1BibnTmGi+fWzzRlpXvNz0AB8aAo5ZMN/XilrGzcgOvVLKs4Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/react-virtual": "^3.0.0-beta.18",
+                "classnames": "^2.3.1",
+                "fast-deep-equal": "^3.1.3",
+                "react-resize-detector": "^7.1.2",
+                "throttle-debounce": "^3.0.1"
+            },
+            "peerDependencies": {
+                "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
+        "node_modules/react-datasheet-grid/node_modules/@tanstack/react-virtual": {
+            "version": "3.13.23",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+            "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@tanstack/virtual-core": "3.13.23"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/tannerlinsley"
+            },
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+                "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/react-dom": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
-            "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
+            "version": "19.2.5",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+            "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^19.2.4"
+                "react": "^19.2.5"
             }
         },
         "node_modules/react-force-graph-2d": {
@@ -8029,6 +8106,18 @@
                 "@types/react": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/react-resize-detector": {
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/react-resize-detector/-/react-resize-detector-12.3.0.tgz",
+            "integrity": "sha512-mIDOVrTHKGnKe6qEUWi8dFdfHM5CPyTOpqoHctdMQf89Ljm/0qqDIzkP3vTRZZJi9/raaMiRxDEOqO4you5x+A==",
+            "license": "MIT",
+            "dependencies": {
+                "es-toolkit": "^1.39.6"
+            },
+            "peerDependencies": {
+                "react": "^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/react-style-singleton": {
@@ -8406,6 +8495,15 @@
             },
             "peerDependencies": {
                 "three": ">=0.168"
+            }
+        },
+        "node_modules/throttle-debounce": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz",
+            "integrity": "sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/tinybench": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -46,9 +46,11 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
         "katex": "^0.16.38",
+        "papaparse": "^5.5.3",
         "pdfjs-dist": "5.5.207",
-        "react": "^19.2.0",
-        "react-dom": "^19.2.0",
+        "react": "19.2.5",
+        "react-datasheet-grid": "^4.11.6",
+        "react-dom": "19.2.5",
         "react-force-graph-2d": "^1.29.1",
         "react-force-graph-3d": "^1.29.1",
         "tailwindcss": "^4.2.1",
@@ -61,6 +63,7 @@
         "@testing-library/user-event": "^14.6.1",
         "@types/katex": "^0.16.8",
         "@types/node": "^24.10.1",
+        "@types/papaparse": "^5.5.2",
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/three": "^0.183.1",
@@ -74,5 +77,10 @@
         "typescript-eslint": "^8.48.0",
         "vite": "^7.3.1",
         "vitest": "^3.2.4"
+    },
+    "overrides": {
+        "react": "$react",
+        "react-dom": "$react-dom",
+        "react-resize-detector": "12.3.0"
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2821,6 +2821,8 @@ struct VaultFileDetail {
     file_name: String,
     mime_type: Option<String>,
     content: String,
+    size_bytes: u64,
+    content_truncated: bool,
 }
 
 fn build_vault_file_detail(
@@ -2835,6 +2837,9 @@ fn build_vault_file_detail(
         .file_name()
         .map(|value| value.to_string_lossy().to_string())
         .unwrap_or_else(|| relative_path.clone());
+    let size_bytes = std::fs::metadata(&path)
+        .map(|metadata| metadata.len())
+        .map_err(|error| error.to_string())?;
 
     let mime_type = vault
         .discover_vault_entries()
@@ -2849,6 +2854,8 @@ fn build_vault_file_detail(
         file_name,
         mime_type,
         content,
+        size_bytes,
+        content_truncated: false,
     })
 }
 
@@ -2903,6 +2910,8 @@ fn save_vault_file(
             file_name: entry.file_name.clone(),
             mime_type: entry.mime_type.clone(),
             content,
+            size_bytes: entry.size,
+            content_truncated: false,
         };
 
         let revision =

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -59,6 +59,7 @@ import {
     writeWindowSessionEntry,
 } from "./app/windowSession";
 import {
+    fileViewerNeedsTextContent,
     useEditorStore,
     isFileTab,
     isGraphTab,
@@ -1590,7 +1591,7 @@ export default function App() {
                         .tabs.find(
                             (t) =>
                                 isFileTab(t) &&
-                                t.viewer === "text" &&
+                                fileViewerNeedsTextContent(t.viewer) &&
                                 t.relativePath === relativePath,
                         );
                     if (openTab) {
@@ -1610,6 +1611,8 @@ export default function App() {
                             void vaultInvoke<{
                                 file_name: string;
                                 content: string;
+                                size_bytes?: number | null;
+                                content_truncated?: boolean;
                             }>("read_vault_file", {
                                 relativePath,
                             }).then((detail) => {
@@ -1624,6 +1627,10 @@ export default function App() {
                                     .reloadFileContent(relativePath, {
                                         title: detail.file_name,
                                         content: detail.content,
+                                        sizeBytes: detail.size_bytes ?? null,
+                                        contentTruncated: Boolean(
+                                            detail.content_truncated,
+                                        ),
                                         origin: change.origin,
                                         opId: change.op_id,
                                         revision: change.revision,

--- a/apps/desktop/src/app/store/editorResourceRegistry.ts
+++ b/apps/desktop/src/app/store/editorResourceRegistry.ts
@@ -19,6 +19,8 @@ export type ResourceKind = "note" | "file";
 export interface ResourceReloadDetail {
     content: string;
     title: string;
+    sizeBytes?: number | null;
+    contentTruncated?: boolean;
     origin?: "user" | "agent" | "external" | "system" | "unknown";
     opId?: string | null;
     revision?: number;
@@ -182,13 +184,23 @@ const noteResourceHandler: ResourceHandler<"note"> = {
 const fileResourceHandler: ResourceHandler<"file"> = {
     kind: "file",
     updateOpenTab: (tab, detail) => {
-        if (tab.content === detail.content && tab.title === detail.title) {
+        const nextSizeBytes = detail.sizeBytes ?? tab.sizeBytes;
+        const nextContentTruncated =
+            detail.contentTruncated ?? tab.contentTruncated;
+        if (
+            tab.content === detail.content &&
+            tab.title === detail.title &&
+            tab.sizeBytes === nextSizeBytes &&
+            tab.contentTruncated === nextContentTruncated
+        ) {
             return tab;
         }
         return {
             ...tab,
             content: detail.content,
             title: detail.title,
+            sizeBytes: nextSizeBytes,
+            contentTruncated: nextContentTruncated,
         };
     },
     removeFromTabs: (tabs, relativePath) => {

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -5,6 +5,7 @@ import {
     getEditorSessionKey,
     restorePersistedSession,
 } from "./editorSession";
+import { normalizeHistoryTab } from "./editorTabRegistry";
 import { safeStorageClear } from "../utils/safeStorage";
 import { useVaultStore } from "./vaultStore";
 
@@ -170,6 +171,90 @@ describe("editorSession", () => {
         expect(session.activeTabId).toBe("file-1");
     });
 
+    it("normalizes csv file tabs with the csv viewer by default", () => {
+        const normalized = normalizeHistoryTab({
+            id: "file-csv",
+            kind: "file",
+            relativePath: "data/report.csv",
+            title: "report.csv",
+            path: "/vault/data/report.csv",
+            content: "name,amount\nAlice,10",
+            mimeType: "text/csv",
+        });
+
+        expect(normalized).toMatchObject({
+            kind: "file",
+            relativePath: "data/report.csv",
+            viewer: "csv",
+            historyIndex: 0,
+        });
+        expect(normalized?.history).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                viewer: "csv",
+            }),
+        ]);
+    });
+
+    it("serializes csv file tabs preserving the csv viewer metadata", () => {
+        const session = buildPersistedSession({
+            tabs: [
+                {
+                    id: "file-csv",
+                    kind: "file",
+                    relativePath: "data/report.csv",
+                    title: "report.csv",
+                    path: "/vault/data/report.csv",
+                    content: "name,amount\nAlice,10",
+                    mimeType: "text/csv",
+                    viewer: "csv",
+                    sizeBytes: 2048,
+                    contentTruncated: true,
+                    history: [
+                        {
+                            kind: "file",
+                            relativePath: "data/report.csv",
+                            title: "report.csv",
+                            path: "/vault/data/report.csv",
+                            content: "name,amount\nAlice,10",
+                            mimeType: "text/csv",
+                            viewer: "csv",
+                            sizeBytes: 2048,
+                            contentTruncated: true,
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "file-csv",
+        });
+
+        expect(session.fileTabs).toEqual([
+            {
+                relativePath: "data/report.csv",
+                title: "report.csv",
+                path: "/vault/data/report.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                sizeBytes: 2048,
+                contentTruncated: true,
+                history: [
+                    {
+                        relativePath: "data/report.csv",
+                        title: "report.csv",
+                        path: "/vault/data/report.csv",
+                        mimeType: "text/csv",
+                        viewer: "csv",
+                        sizeBytes: 2048,
+                        contentTruncated: true,
+                    },
+                ],
+                historyIndex: 0,
+            },
+        ]);
+        expect(session.activeFilePath).toBe("data/report.csv");
+    });
+
     it("restores legacy persisted sessions through the session module", async () => {
         localStorage.setItem(
             getEditorSessionKey("/vaults/project-alpha"),
@@ -233,9 +318,12 @@ describe("editorSession", () => {
             throw new Error(`Unexpected command: ${command}`);
         });
 
-        const restored = await restorePersistedSession("/vaults/project-alpha", {
-            includeMaps: true,
-        });
+        const restored = await restorePersistedSession(
+            "/vaults/project-alpha",
+            {
+                includeMaps: true,
+            },
+        );
 
         expect(restored).not.toBeNull();
         expect(restored?.tabs.map((tab) => tab.kind ?? "note")).toEqual([
@@ -271,5 +359,121 @@ describe("editorSession", () => {
             title: "Graph View",
         });
         expect(restored?.activeTabId).toBe(restored?.tabs[3]?.id ?? null);
+    });
+
+    it("restores legacy csv file tabs with inferred viewer and file content", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                noteIds: [],
+                fileTabs: [
+                    {
+                        relativePath: "data/report.csv",
+                        title: "report.csv",
+                        path: "/vault/data/report.csv",
+                        mimeType: "text/csv",
+                    },
+                ],
+                activeNoteId: null,
+                activeFilePath: "data/report.csv",
+            }),
+        );
+
+        vi.mocked(invoke).mockImplementation(async (command, args) => {
+            if (command === "read_vault_file") {
+                expect(args).toMatchObject({
+                    relativePath: "data/report.csv",
+                    vaultPath: "/vaults/project-alpha",
+                });
+                return { content: "name,amount\nAlice,10" };
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored).not.toBeNull();
+        expect(restored?.tabs).toHaveLength(1);
+        expect(restored?.tabs[0]).toMatchObject({
+            kind: "file",
+            relativePath: "data/report.csv",
+            viewer: "csv",
+            content: "name,amount\nAlice,10",
+        });
+        expect(restored?.activeTabId).toBe(restored?.tabs[0]?.id ?? null);
+    });
+
+    it("restores legacy csv file tabs preserving explicit viewer metadata", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                noteIds: [],
+                fileTabs: [
+                    {
+                        relativePath: "data/report.csv",
+                        title: "report.csv",
+                        path: "/vault/data/report.csv",
+                        mimeType: "text/csv",
+                        viewer: "csv",
+                        sizeBytes: 2048,
+                        contentTruncated: true,
+                        history: [
+                            {
+                                relativePath: "data/report.csv",
+                                title: "report.csv",
+                                path: "/vault/data/report.csv",
+                                mimeType: "text/csv",
+                                viewer: "csv",
+                                sizeBytes: 2048,
+                                contentTruncated: true,
+                            },
+                        ],
+                        historyIndex: 0,
+                    },
+                ],
+                activeNoteId: null,
+                activeFilePath: "data/report.csv",
+            }),
+        );
+
+        vi.mocked(invoke).mockImplementation(async (command, args) => {
+            if (command === "read_vault_file") {
+                expect(args).toMatchObject({
+                    relativePath: "data/report.csv",
+                    vaultPath: "/vaults/project-alpha",
+                });
+                return {
+                    content: "name,amount\nAlice,10",
+                    size_bytes: 2048,
+                    content_truncated: true,
+                };
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored).not.toBeNull();
+        expect(restored?.tabs).toHaveLength(1);
+        expect(restored?.tabs[0]).toMatchObject({
+            kind: "file",
+            relativePath: "data/report.csv",
+            viewer: "csv",
+            content: "name,amount\nAlice,10",
+            sizeBytes: 2048,
+            contentTruncated: true,
+            historyIndex: 0,
+        });
+        expect(restored?.tabs[0]).toMatchObject({
+            history: [
+                expect.objectContaining({
+                    viewer: "csv",
+                    content: "name,amount\nAlice,10",
+                    sizeBytes: 2048,
+                    contentTruncated: true,
+                }),
+            ],
+        });
+        expect(restored?.activeTabId).toBe(restored?.tabs[0]?.id ?? null);
     });
 });

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -1,9 +1,11 @@
 import {
+    fileViewerNeedsTextContent,
     isFileTab,
     isGraphTab,
     isHistoryTab,
     isMapTab,
     isNoteTab,
+    normalizeFileViewer,
     isPdfTab,
     isReviewTab,
     type FileViewerMode,
@@ -51,6 +53,8 @@ export interface PersistedSession {
         path: string;
         mimeType?: string | null;
         viewer?: FileViewerMode;
+        sizeBytes?: number | null;
+        contentTruncated?: boolean;
         content?: string;
         history?: Array<{
             relativePath: string;
@@ -58,6 +62,8 @@ export interface PersistedSession {
             path: string;
             mimeType?: string | null;
             viewer?: FileViewerMode;
+            sizeBytes?: number | null;
+            contentTruncated?: boolean;
         }>;
         historyIndex?: number;
     }>;
@@ -302,17 +308,24 @@ async function restoreLegacyFileTabs(session: PersistedSession) {
     const restoredTabs: TabInput[] = [];
     for (const entry of session.fileTabs ?? []) {
         let content = entry.content ?? "";
-        const viewer =
-            entry.viewer ??
-            (entry.mimeType?.startsWith("image/") ? "image" : "text");
+        const viewer = normalizeFileViewer(
+            entry.viewer,
+            entry.path,
+            entry.mimeType ?? null,
+        );
 
-        if (!content && viewer === "text") {
+        if (!content && fileViewerNeedsTextContent(viewer)) {
             try {
-                const detail = await vaultInvoke<{ content: string }>(
-                    "read_vault_file",
-                    { relativePath: entry.relativePath },
-                );
+                const detail = await vaultInvoke<{
+                    content: string;
+                    size_bytes?: number | null;
+                    content_truncated?: boolean;
+                }>("read_vault_file", {
+                    relativePath: entry.relativePath,
+                });
                 content = detail.content;
+                entry.sizeBytes = detail.size_bytes ?? null;
+                entry.contentTruncated = Boolean(detail.content_truncated);
             } catch {
                 content = "";
             }
@@ -326,6 +339,11 @@ async function restoreLegacyFileTabs(session: PersistedSession) {
                     path: entry.path,
                     mimeType: entry.mimeType ?? null,
                     viewer,
+                    sizeBytes:
+                        typeof entry.sizeBytes === "number"
+                            ? entry.sizeBytes
+                            : null,
+                    contentTruncated: Boolean(entry.contentTruncated),
                 },
             ]
         ).map((historyEntry) => ({
@@ -333,11 +351,16 @@ async function restoreLegacyFileTabs(session: PersistedSession) {
             title: historyEntry.title,
             path: historyEntry.path,
             mimeType: historyEntry.mimeType ?? null,
-            viewer:
-                historyEntry.viewer ??
-                (historyEntry.mimeType?.startsWith("image/")
-                    ? "image"
-                    : "text"),
+            viewer: normalizeFileViewer(
+                historyEntry.viewer,
+                historyEntry.path,
+                historyEntry.mimeType ?? null,
+            ),
+            sizeBytes:
+                typeof historyEntry.sizeBytes === "number"
+                    ? historyEntry.sizeBytes
+                    : null,
+            contentTruncated: Boolean(historyEntry.contentTruncated),
             content: "",
         }));
         const historyIndex = Math.min(
@@ -357,6 +380,9 @@ async function restoreLegacyFileTabs(session: PersistedSession) {
             mimeType: entry.mimeType ?? null,
             viewer,
             content,
+            sizeBytes:
+                typeof entry.sizeBytes === "number" ? entry.sizeBytes : null,
+            contentTruncated: Boolean(entry.contentTruncated),
             history,
             historyIndex,
         });

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    type FileViewerMode,
     isFileTab,
     isGraphTab,
     isMapTab,
@@ -44,7 +45,7 @@ function makeFileTab(overrides: {
     path: string;
     content: string;
     mimeType: string | null;
-    viewer: "text" | "image";
+    viewer: FileViewerMode;
 }) {
     return {
         ...overrides,
@@ -225,6 +226,38 @@ describe("editorStore session persistence", () => {
             viewer: "image",
         });
         expect(session?.activeFilePath).toBe("assets/cover.avif");
+        expect(session?.tabs).toBeUndefined();
+        expect(session?.fileTabs?.[0]).not.toHaveProperty("content");
+    });
+
+    it("persists csv file viewer mode per vault path", async () => {
+        markSessionReady();
+        useVaultStore.setState({ vaultPath: "/vaults/data-2026" });
+
+        useEditorStore.setState({
+            tabs: [
+                makeFileTab({
+                    id: "file-tab-csv",
+                    relativePath: "data/report.csv",
+                    title: "report.csv",
+                    path: "/vaults/data-2026/data/report.csv",
+                    mimeType: "text/csv",
+                    viewer: "csv",
+                    content: "name,amount\nAlice,10",
+                }),
+            ],
+            activeTabId: "file-tab-csv",
+        });
+
+        await new Promise((resolve) => setTimeout(resolve, 600));
+
+        const session = readPersistedSession("/vaults/data-2026");
+        expect(session?.fileTabs?.[0]).toMatchObject({
+            relativePath: "data/report.csv",
+            viewer: "csv",
+            mimeType: "text/csv",
+        });
+        expect(session?.activeFilePath).toBe("data/report.csv");
         expect(session?.tabs).toBeUndefined();
         expect(session?.fileTabs?.[0]).not.toHaveProperty("content");
     });

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -48,6 +48,7 @@ import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
 
 export {
+    fileViewerNeedsTextContent,
     isFileTab,
     isGraphTab,
     isHistoryTab,
@@ -420,6 +421,8 @@ export interface EditorSelectionContext {
 export interface ReloadedDetail {
     content: ResourceReloadDetail["content"];
     title: ResourceReloadDetail["title"];
+    sizeBytes?: ResourceReloadDetail["sizeBytes"];
+    contentTruncated?: ResourceReloadDetail["contentTruncated"];
     origin?: ResourceReloadDetail["origin"];
     opId?: ResourceReloadDetail["opId"];
     revision?: ResourceReloadDetail["revision"];
@@ -454,6 +457,10 @@ interface EditorStore {
         content: string,
         mimeType: string | null,
         viewer: FileViewerMode,
+        options?: {
+            sizeBytes?: number | null;
+            contentTruncated?: boolean;
+        },
     ) => void;
     openMap: (relativePath: string, title: string) => void;
     openGraph: () => void;
@@ -586,7 +593,15 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         });
     },
 
-    openFile: (relativePath, title, path, content, mimeType, viewer) => {
+    openFile: (
+        relativePath,
+        title,
+        path,
+        content,
+        mimeType,
+        viewer,
+        options,
+    ) => {
         set((state) =>
             openOrReuseHistoryTab(state, {
                 kind: "file",
@@ -596,6 +611,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 content,
                 mimeType,
                 viewer,
+                sizeBytes: options?.sizeBytes ?? null,
+                contentTruncated: options?.contentTruncated ?? false,
             }),
         );
     },

--- a/apps/desktop/src/app/store/editorTabRegistry.ts
+++ b/apps/desktop/src/app/store/editorTabRegistry.ts
@@ -74,6 +74,8 @@ interface OpenPayloadByKindMap {
         content: string;
         mimeType: string | null;
         viewer: FileViewerMode;
+        sizeBytes?: number | null;
+        contentTruncated?: boolean;
     };
     map: {
         kind: "map";
@@ -160,6 +162,10 @@ function serializeFileTabForSession(tab: FileTab) {
         path: tab.path,
         mimeType: tab.mimeType,
         viewer: tab.viewer,
+        ...(typeof tab.sizeBytes === "number"
+            ? { sizeBytes: tab.sizeBytes }
+            : {}),
+        ...(tab.contentTruncated ? { contentTruncated: true } : {}),
         history: tab.history
             .filter((entry): entry is FileHistoryEntry => entry.kind === "file")
             .map((entry) => ({
@@ -168,6 +174,10 @@ function serializeFileTabForSession(tab: FileTab) {
                 path: entry.path,
                 mimeType: entry.mimeType,
                 viewer: entry.viewer,
+                ...(typeof entry.sizeBytes === "number"
+                    ? { sizeBytes: entry.sizeBytes }
+                    : {}),
+                ...(entry.contentTruncated ? { contentTruncated: true } : {}),
             })),
         historyIndex: tab.historyIndex,
     };
@@ -254,6 +264,10 @@ const fileTabHandler: HistoryTabHandler<"file"> = {
             payload.content,
             payload.mimeType,
             payload.viewer,
+            {
+                sizeBytes: payload.sizeBytes,
+                contentTruncated: payload.contentTruncated,
+            },
         ),
     createOpenEntry: (payload) =>
         createFileHistoryEntry(
@@ -263,6 +277,10 @@ const fileTabHandler: HistoryTabHandler<"file"> = {
             payload.content,
             payload.mimeType,
             payload.viewer,
+            {
+                sizeBytes: payload.sizeBytes,
+                contentTruncated: payload.contentTruncated,
+            },
         ),
     entryFromTab: (tab) => createHistoryEntryFromTab(tab) as FileHistoryEntry,
     buildFromHistory: (id, history, historyIndex) =>
@@ -281,6 +299,10 @@ const fileTabHandler: HistoryTabHandler<"file"> = {
                           payload.content,
                           payload.mimeType,
                           payload.viewer,
+                          {
+                              sizeBytes: payload.sizeBytes,
+                              contentTruncated: payload.contentTruncated,
+                          },
                       )
                     : entry,
             ),

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -2,7 +2,23 @@ import { toVaultRelativePath } from "../utils/vaultPaths";
 import { useVaultStore } from "./vaultStore";
 
 export type PdfViewMode = "single" | "continuous";
-export type FileViewerMode = "text" | "image";
+export type FileViewerMode = "text" | "image" | "csv";
+
+const IMAGE_FILE_EXTENSIONS = new Set([
+    "png",
+    "jpg",
+    "jpeg",
+    "jpe",
+    "jfif",
+    "gif",
+    "webp",
+    "svg",
+    "avif",
+    "bmp",
+    "ico",
+]);
+
+const CSV_FILE_EXTENSIONS = new Set(["csv"]);
 
 export interface NoteHistoryEntry {
     kind: "note";
@@ -29,6 +45,8 @@ export interface FileHistoryEntry {
     content: string;
     mimeType: string | null;
     viewer: FileViewerMode;
+    sizeBytes?: number | null;
+    contentTruncated?: boolean;
 }
 
 export interface MapHistoryEntry {
@@ -64,12 +82,19 @@ export type PdfHistoryEntryInput = Omit<
 
 export type FileHistoryEntryInput = Omit<
     FileHistoryEntry,
-    "kind" | "content" | "mimeType" | "viewer"
+    | "kind"
+    | "content"
+    | "mimeType"
+    | "viewer"
+    | "sizeBytes"
+    | "contentTruncated"
 > & {
     kind?: "file";
     content?: string;
     mimeType?: string | null;
     viewer?: FileViewerMode;
+    sizeBytes?: number | null;
+    contentTruncated?: boolean;
 };
 
 export type MapHistoryEntryInput = Omit<MapHistoryEntry, "kind"> & {
@@ -114,6 +139,8 @@ export interface FileTab {
     content: string;
     mimeType: string | null;
     viewer: FileViewerMode;
+    sizeBytes?: number | null;
+    contentTruncated?: boolean;
     history: TabHistoryEntry[];
     historyIndex: number;
 }
@@ -165,13 +192,21 @@ export type PdfTabInput = Omit<
 
 export type FileTabInput = Omit<
     FileTab,
-    "kind" | "history" | "historyIndex" | "mimeType" | "viewer"
+    | "kind"
+    | "history"
+    | "historyIndex"
+    | "mimeType"
+    | "viewer"
+    | "sizeBytes"
+    | "contentTruncated"
 > & {
     kind?: "file";
     mimeType?: string | null;
     viewer?: FileViewerMode;
     history?: TabHistoryEntryInput[];
     historyIndex?: number;
+    sizeBytes?: number | null;
+    contentTruncated?: boolean;
 };
 
 export type MapTabInput = Omit<MapTab, "kind" | "history" | "historyIndex"> & {
@@ -382,6 +417,10 @@ export function createFileHistoryEntry(
     content: string,
     mimeType: string | null,
     viewer: FileViewerMode,
+    options?: {
+        sizeBytes?: number | null;
+        contentTruncated?: boolean;
+    },
 ): FileHistoryEntry {
     return {
         kind: "file",
@@ -391,6 +430,10 @@ export function createFileHistoryEntry(
         content,
         mimeType,
         viewer,
+        ...(typeof options?.sizeBytes === "number"
+            ? { sizeBytes: options.sizeBytes }
+            : {}),
+        ...(options?.contentTruncated ? { contentTruncated: true } : {}),
     };
 }
 
@@ -460,9 +503,21 @@ export function normalizeHistoryEntry(
         path,
         "content" in entry ? (entry.content ?? "") : "",
         mimeType,
-        "viewer" in entry
-            ? (entry.viewer ?? inferFileViewer(path, mimeType))
-            : inferFileViewer(path, mimeType),
+        normalizeFileViewer(
+            "viewer" in entry ? entry.viewer : undefined,
+            path,
+            mimeType,
+        ),
+        {
+            sizeBytes:
+                "sizeBytes" in entry && typeof entry.sizeBytes === "number"
+                    ? entry.sizeBytes
+                    : null,
+            contentTruncated:
+                "contentTruncated" in entry
+                    ? Boolean(entry.contentTruncated)
+                    : false,
+        },
     );
 }
 
@@ -486,6 +541,10 @@ export function createHistoryEntryFromTab(tab: HistoryTab): TabHistoryEntry {
             tab.content,
             tab.mimeType,
             tab.viewer,
+            {
+                sizeBytes: tab.sizeBytes,
+                contentTruncated: tab.contentTruncated,
+            },
         );
     }
 
@@ -529,6 +588,10 @@ export function buildTabFromHistory(
             content: entry.content,
             mimeType: entry.mimeType,
             viewer: entry.viewer,
+            ...(typeof entry.sizeBytes === "number"
+                ? { sizeBytes: entry.sizeBytes }
+                : {}),
+            ...(entry.contentTruncated ? { contentTruncated: true } : {}),
             history,
             historyIndex: safeIndex,
         };
@@ -600,6 +663,10 @@ export function createFileTab(
     content: string,
     mimeType: string | null,
     viewer: FileViewerMode,
+    options?: {
+        sizeBytes?: number | null;
+        contentTruncated?: boolean;
+    },
 ): FileTab {
     return {
         id: crypto.randomUUID(),
@@ -610,6 +677,10 @@ export function createFileTab(
         content,
         mimeType,
         viewer,
+        ...(typeof options?.sizeBytes === "number"
+            ? { sizeBytes: options.sizeBytes }
+            : {}),
+        ...(options?.contentTruncated ? { contentTruncated: true } : {}),
         history: [
             createFileHistoryEntry(
                 relativePath,
@@ -618,6 +689,7 @@ export function createFileTab(
                 content,
                 mimeType,
                 viewer,
+                options,
             ),
         ],
         historyIndex: 0,
@@ -722,13 +794,21 @@ export function ensureFileTabHistory(tab: FileTabInput): FileTab {
             tab.path,
             tab.content,
             tab.mimeType ?? null,
-            tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
+            normalizeFileViewer(tab.viewer, tab.path, tab.mimeType ?? null),
+            {
+                sizeBytes:
+                    typeof tab.sizeBytes === "number" ? tab.sizeBytes : null,
+                contentTruncated: Boolean(tab.contentTruncated),
+            },
         );
         return buildTabFromHistory(tab.id, history, historyIndex) as FileTab;
     }
 
-    const viewer =
-        tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null);
+    const viewer = normalizeFileViewer(
+        tab.viewer,
+        tab.path,
+        tab.mimeType ?? null,
+    );
 
     return buildTabFromHistory(
         tab.id,
@@ -740,6 +820,13 @@ export function ensureFileTabHistory(tab: FileTabInput): FileTab {
                 tab.content,
                 tab.mimeType ?? null,
                 viewer,
+                {
+                    sizeBytes:
+                        typeof tab.sizeBytes === "number"
+                            ? tab.sizeBytes
+                            : null,
+                    contentTruncated: Boolean(tab.contentTruncated),
+                },
             ),
         ],
         0,
@@ -750,8 +837,16 @@ export function ensureFileTabDefaults(tab: FileTabInput): FileTab {
     return {
         ...ensureFileTabHistory(tab),
         mimeType: tab.mimeType ?? null,
-        viewer: tab.viewer ?? inferFileViewer(tab.path, tab.mimeType ?? null),
+        viewer: normalizeFileViewer(tab.viewer, tab.path, tab.mimeType ?? null),
+        ...(typeof tab.sizeBytes === "number"
+            ? { sizeBytes: tab.sizeBytes }
+            : {}),
+        ...(tab.contentTruncated ? { contentTruncated: true } : {}),
     };
+}
+
+export function isFileViewerMode(value: unknown): value is FileViewerMode {
+    return value === "text" || value === "image" || value === "csv";
 }
 
 export function inferFileViewer(
@@ -760,22 +855,24 @@ export function inferFileViewer(
 ): FileViewerMode {
     const extension = path.split(".").pop()?.toLowerCase() ?? "";
     if (mimeType?.startsWith("image/")) return "image";
-    if (
-        extension === "png" ||
-        extension === "jpg" ||
-        extension === "jpeg" ||
-        extension === "jpe" ||
-        extension === "jfif" ||
-        extension === "gif" ||
-        extension === "webp" ||
-        extension === "svg" ||
-        extension === "avif" ||
-        extension === "bmp" ||
-        extension === "ico"
-    ) {
+    if (mimeType?.startsWith("text/csv")) return "csv";
+    if (CSV_FILE_EXTENSIONS.has(extension)) return "csv";
+    if (IMAGE_FILE_EXTENSIONS.has(extension)) {
         return "image";
     }
     return "text";
+}
+
+export function normalizeFileViewer(
+    viewer: unknown,
+    path: string,
+    mimeType: string | null,
+): FileViewerMode {
+    return isFileViewerMode(viewer) ? viewer : inferFileViewer(path, mimeType);
+}
+
+export function fileViewerNeedsTextContent(viewer: FileViewerMode) {
+    return viewer !== "image";
 }
 
 export function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {

--- a/apps/desktop/src/app/utils/vaultEntries.test.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.test.ts
@@ -1,10 +1,32 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@tauri-apps/api/core";
+import { useEditorStore } from "../store/editorStore";
+import { useVaultStore } from "../store/vaultStore";
 import {
     getVaultEntryDisplayName,
     isTextLikeVaultEntry,
+    openVaultFileEntry,
 } from "./vaultEntries";
+import { setEditorTabs } from "../../test/test-utils";
+
+vi.mock("@tauri-apps/api/core", () => ({
+    invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+    openPath: vi.fn(),
+}));
 
 describe("vaultEntries", () => {
+    beforeEach(() => {
+        setEditorTabs([]);
+        useVaultStore.setState({ vaultPath: "/vault" });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it("treats common config files without standard extensions as text", () => {
         expect(
             isTextLikeVaultEntry({
@@ -68,5 +90,102 @@ describe("vaultEntries", () => {
                 false,
             ),
         ).toBe(".gitignore");
+    });
+
+    it("opens csv entries with the csv viewer", async () => {
+        vi.mocked(invoke).mockResolvedValueOnce({
+            path: "/vault/data/report.csv",
+            relative_path: "data/report.csv",
+            file_name: "report.csv",
+            mime_type: "text/csv",
+            content: "name,amount\nAlice,10",
+        });
+
+        await openVaultFileEntry({
+            id: "csv-entry",
+            kind: "file",
+            path: "/vault/data/report.csv",
+            relative_path: "data/report.csv",
+            title: "report.csv",
+            file_name: "report.csv",
+            extension: "csv",
+            modified_at: 0,
+            created_at: 0,
+            size: 22,
+            mime_type: "text/csv",
+        });
+
+        const activeTab = useEditorStore
+            .getState()
+            .tabs.find(
+                (tab) => tab.id === useEditorStore.getState().activeTabId,
+            );
+
+        expect(activeTab).toMatchObject({
+            kind: "file",
+            relativePath: "data/report.csv",
+            viewer: "csv",
+            content: "name,amount\nAlice,10",
+        });
+        expect(vi.mocked(invoke)).toHaveBeenCalledWith("read_vault_file", {
+            relativePath: "data/report.csv",
+            vaultPath: "/vault",
+        });
+    });
+
+    it("inserts csv entries in a new tab with the csv viewer", async () => {
+        setEditorTabs([
+            {
+                id: "existing-text-tab",
+                kind: "file",
+                relativePath: "notes/todo.txt",
+                title: "todo.txt",
+                path: "/vault/notes/todo.txt",
+                mimeType: "text/plain",
+                viewer: "text",
+                content: "todo",
+            },
+        ]);
+
+        vi.mocked(invoke).mockResolvedValueOnce({
+            path: "/vault/data/report.csv",
+            relative_path: "data/report.csv",
+            file_name: "report.csv",
+            mime_type: "text/csv",
+            content: "name,amount\nAlice,10",
+        });
+
+        await openVaultFileEntry(
+            {
+                id: "csv-entry",
+                kind: "file",
+                path: "/vault/data/report.csv",
+                relative_path: "data/report.csv",
+                title: "report.csv",
+                file_name: "report.csv",
+                extension: "csv",
+                modified_at: 0,
+                created_at: 0,
+                size: 22,
+                mime_type: "text/csv",
+            },
+            { newTab: true },
+        );
+
+        const csvTab = useEditorStore
+            .getState()
+            .tabs.find(
+                (tab) =>
+                    tab.kind === "file" &&
+                    tab.relativePath === "data/report.csv",
+            );
+
+        expect(useEditorStore.getState().tabs).toHaveLength(2);
+        expect(csvTab).toMatchObject({
+            kind: "file",
+            viewer: "csv",
+            content: "name,amount\nAlice,10",
+        });
+        expect(useEditorStore.getState().activeTabId).toBe(csvTab?.id);
     });
 });

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -6,6 +6,7 @@ import {
     isPdfTab,
     type TabInput,
 } from "../store/editorStore";
+import { inferFileViewer } from "../store/editorTabs";
 import { useVaultStore, type VaultEntryDto } from "../store/vaultStore";
 import { toVaultRelativePath } from "./vaultPaths";
 import { vaultInvoke } from "./vaultInvoke";
@@ -288,6 +289,8 @@ type VaultFileReadDetail = {
     file_name: string;
     mime_type: string | null;
     content: string;
+    size_bytes?: number | null;
+    content_truncated?: boolean;
 };
 
 async function buildVaultEntryTab(
@@ -334,6 +337,8 @@ async function buildVaultEntryTab(
             mimeType: entry.mime_type,
             viewer: "image",
             content: "",
+            sizeBytes: entry.size,
+            contentTruncated: false,
         };
     }
 
@@ -352,8 +357,10 @@ async function buildVaultEntryTab(
         title: detail.file_name,
         path: detail.path,
         mimeType: detail.mime_type,
-        viewer: "text",
+        viewer: inferFileViewer(detail.path, detail.mime_type),
         content: detail.content,
+        sizeBytes: detail.size_bytes ?? null,
+        contentTruncated: Boolean(detail.content_truncated),
     };
 }
 
@@ -409,6 +416,10 @@ export async function openVaultFileEntry(
                 "",
                 entry.mime_type,
                 "image",
+                {
+                    sizeBytes: entry.size,
+                    contentTruncated: false,
+                },
             );
         return;
     }
@@ -434,7 +445,11 @@ export async function openVaultFileEntry(
             detail.path,
             detail.content,
             detail.mime_type,
-            "text",
+            inferFileViewer(detail.path, detail.mime_type),
+            {
+                sizeBytes: detail.size_bytes ?? null,
+                contentTruncated: Boolean(detail.content_truncated),
+            },
         );
 }
 

--- a/apps/desktop/src/features/editor/CsvFileTabView.test.tsx
+++ b/apps/desktop/src/features/editor/CsvFileTabView.test.tsx
@@ -1,0 +1,381 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CsvFileTabView } from "./CsvFileTabView";
+import {
+    mockInvoke,
+    renderComponent,
+    setEditorTabs,
+    setVaultEntries,
+} from "../../test/test-utils";
+
+function configureCsvSaveEcho() {
+    mockInvoke().mockImplementation(async (command, rawPayload) => {
+        if (command !== "save_vault_file") {
+            throw new Error(`Unexpected command: ${command}`);
+        }
+
+        const payload = rawPayload as Record<string, string>;
+        return {
+            relative_path: payload.relativePath,
+            file_name: payload.relativePath.split("/").pop(),
+            content: payload.content,
+        };
+    });
+}
+
+function getLastSavePayload() {
+    const saveCalls = mockInvoke().mock.calls.filter(
+        ([command]) => command === "save_vault_file",
+    );
+    const lastCall = saveCalls.at(-1);
+    expect(lastCall).toBeDefined();
+    return lastCall?.[1] as Record<string, string>;
+}
+
+function getGridInputs(container: HTMLElement) {
+    return Array.from(
+        container.querySelectorAll(".dsg-row:not(.dsg-row-header) input"),
+    ) as HTMLInputElement[];
+}
+
+describe("CsvFileTabView", () => {
+    beforeEach(() => {
+        setVaultEntries([], "/vault");
+    });
+
+    it("edits a cell and autosaves the updated csv content", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/report.csv",
+                title: "report.csv",
+                path: "/vault/data/report.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        fireEvent.change(screen.getByDisplayValue("Alice"), {
+            target: { value: "Bob" },
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("10")).toBeInTheDocument();
+        expect(getLastSavePayload()).toMatchObject({
+            vaultPath: "/vault",
+            relativePath: "data/report.csv",
+            content: "name,amount\nBob,10",
+            opId: expect.any(String),
+        });
+    });
+
+    it("adds and deletes rows while keeping the serialized csv in sync", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/report.csv",
+                title: "report.csv",
+                path: "/vault/data/report.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+            },
+        ]);
+
+        const { container } = renderComponent(<CsvFileTabView />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Row" }));
+        const inputsAfterAdd = getGridInputs(container);
+        expect(inputsAfterAdd).toHaveLength(4);
+
+        fireEvent.change(inputsAfterAdd[2], {
+            target: { value: "Bob" },
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(screen.getByDisplayValue("Alice")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
+        expect(getLastSavePayload()).toMatchObject({
+            content: "name,amount\nAlice,10\nBob,",
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Delete row 1" }));
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(screen.queryByDisplayValue("Alice")).not.toBeInTheDocument();
+        expect(screen.getByDisplayValue("Bob")).toBeInTheDocument();
+        expect(getLastSavePayload()).toMatchObject({
+            content: "name,amount\nBob,",
+        });
+    });
+
+    it("adds and deletes columns while keeping the serialized csv in sync", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/report.csv",
+                title: "report.csv",
+                path: "/vault/data/report.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+            },
+        ]);
+
+        const { container } = renderComponent(<CsvFileTabView />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Add Column" }));
+        const columnNameInput = screen.getByLabelText("Column 3 name");
+        expect(columnNameInput).toBeInTheDocument();
+
+        const inputsAfterAdd = getGridInputs(container);
+        expect(inputsAfterAdd).toHaveLength(3);
+
+        fireEvent.change(inputsAfterAdd[2], {
+            target: { value: "notes" },
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(screen.getByLabelText("Column 3 name")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("notes")).toBeInTheDocument();
+        expect(getLastSavePayload()).toMatchObject({
+            content: "name,amount,Column 3\nAlice,10,notes",
+        });
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Delete Column 3" }),
+        );
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(
+            screen.queryByRole("button", { name: "Delete Column 3" }),
+        ).not.toBeInTheDocument();
+        expect(screen.queryByDisplayValue("notes")).not.toBeInTheDocument();
+        expect(getLastSavePayload()).toMatchObject({
+            content: "name,amount\nAlice,10",
+        });
+    });
+
+    it("falls back to raw mode when the csv cannot be parsed safely", () => {
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/broken.csv",
+                title: "broken.csv",
+                path: "/vault/data/broken.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: 'name,amount\n"Alice,10',
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        expect(screen.getByRole("button", { name: "Table" })).toBeDisabled();
+        expect(screen.getByRole("button", { name: "Raw" })).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "This CSV could not be parsed. Showing raw content instead.",
+            ),
+        ).toBeInTheDocument();
+        expect(screen.getByLabelText("Raw CSV content")).toHaveValue(
+            'name,amount\n"Alice,10',
+        );
+    });
+
+    it("disables table editing for large csv files", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/large.csv",
+                title: "large.csv",
+                path: "/vault/data/large.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+                sizeBytes: 2 * 1024 * 1024 + 1,
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        expect(screen.getByRole("button", { name: "Table" })).toBeDisabled();
+        expect(
+            screen.getByText(
+                /Table editing is disabled for CSV files larger than/i,
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("Table editing unavailable · 2.0 MB"),
+        ).toBeInTheDocument();
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(
+            mockInvoke().mock.calls.filter(
+                ([command]) => command === "save_vault_file",
+            ),
+        ).toHaveLength(0);
+    });
+
+    it("keeps table editing enabled at the 2 MB limit", () => {
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/exact-limit.csv",
+                title: "exact-limit.csv",
+                path: "/vault/data/exact-limit.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+                sizeBytes: 2 * 1024 * 1024,
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        expect(screen.getByRole("button", { name: "Table" })).toBeEnabled();
+        expect(
+            screen.queryByText(
+                /Table editing is disabled for CSV files larger than/i,
+            ),
+        ).not.toBeInTheDocument();
+        expect(screen.getByDisplayValue("Alice")).toBeInTheDocument();
+    });
+
+    it("shows a read-only table preview when the csv exceeds 500 data rows", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        const content = [
+            "name,amount",
+            ...Array.from(
+                { length: 501 },
+                (_, index) => `row${index},${index}`,
+            ),
+        ].join("\n");
+
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/preview.csv",
+                title: "preview.csv",
+                path: "/vault/data/preview.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content,
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        expect(screen.getByRole("button", { name: "Table" })).toBeEnabled();
+        expect(screen.getByRole("button", { name: "Add Row" })).toBeDisabled();
+        expect(
+            screen.getByRole("button", { name: "Add Column" }),
+        ).toBeDisabled();
+        expect(
+            screen.getByText(
+                "Preview limited to first 500 rows. Editing disabled for large files.",
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("Rows: 500 of 501 · Columns: 2"),
+        ).toBeInTheDocument();
+        expect(screen.getByText("row499")).toBeInTheDocument();
+        expect(screen.queryByText("row500")).not.toBeInTheDocument();
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(
+            mockInvoke().mock.calls.filter(
+                ([command]) => command === "save_vault_file",
+            ),
+        ).toHaveLength(0);
+    });
+
+    it("disables editing when the tab only contains a partial csv preview", async () => {
+        vi.useFakeTimers();
+        configureCsvSaveEcho();
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/partial.csv",
+                title: "partial.csv",
+                path: "/vault/data/partial.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+                contentTruncated: true,
+            },
+        ]);
+
+        renderComponent(<CsvFileTabView />);
+
+        expect(screen.getByRole("button", { name: "Table" })).toBeDisabled();
+        expect(
+            screen.getByText(
+                "This tab only has a partial CSV preview. Reload the full file to edit it safely.",
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText("Partial preview · table editing unavailable"),
+        ).toBeInTheDocument();
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        expect(
+            mockInvoke().mock.calls.filter(
+                ([command]) => command === "save_vault_file",
+            ),
+        ).toHaveLength(0);
+    });
+});

--- a/apps/desktop/src/features/editor/CsvFileTabView.tsx
+++ b/apps/desktop/src/features/editor/CsvFileTabView.tsx
@@ -83,17 +83,12 @@ const csvTextColumn = createTextColumn<string>({
 });
 
 export function CsvFileTabView() {
-    const contentRef = useRef("");
-    const editorStateRef = useRef<CsvEditorState>(
-        buildCsvEditorState("", null),
-    );
+    const initialEditorState = buildCsvEditorState("", null);
+    const contentRef = useRef(initialEditorState.rawContent);
+    const editorStateRef = useRef<CsvEditorState>(initialEditorState);
     const gridViewportRef = useRef<HTMLDivElement>(null);
-    const [editorState, setEditorState] = useState<CsvEditorState>(() => {
-        const initialState = buildCsvEditorState("", null);
-        contentRef.current = initialState.rawContent;
-        editorStateRef.current = initialState;
-        return initialState;
-    });
+    const [editorState, setEditorState] =
+        useState<CsvEditorState>(initialEditorState);
     const [viewMode, setViewMode] = useState<CsvViewMode>("table");
     const [gridHeight, setGridHeight] = useState(420);
 

--- a/apps/desktop/src/features/editor/CsvFileTabView.tsx
+++ b/apps/desktop/src/features/editor/CsvFileTabView.tsx
@@ -1,0 +1,1008 @@
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type MouseEvent,
+    type ReactNode,
+} from "react";
+import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
+import {
+    DataSheetGrid,
+    createTextColumn,
+    keyColumn,
+    type CellProps,
+    type SimpleColumn,
+} from "react-datasheet-grid";
+import Papa, { type ParseError } from "papaparse";
+import {
+    isFileTab,
+    useEditorStore,
+    type FileTab,
+} from "../../app/store/editorStore";
+import { useEditableFileResource } from "./useEditableFileResource";
+
+type CsvFormat = {
+    delimiter: string;
+    linebreak: string;
+};
+
+type CsvColumn = {
+    id: string;
+    name: string;
+};
+
+type CsvGridRow = Record<string, string>;
+
+type CsvEditorState = {
+    rawContent: string;
+    columns: CsvColumn[];
+    rows: CsvGridRow[];
+    format: CsvFormat;
+    isTableAvailable: boolean;
+    isTableEditable: boolean;
+    rawModeReason:
+        | "parse_failed"
+        | "too_large"
+        | "truncated"
+        | "preview_limited"
+        | null;
+    statusMessage: string | null;
+    sizeBytes: number;
+    totalDataRowCount: number;
+};
+
+type CsvViewMode = "table" | "raw";
+
+type CsvIdentitySnapshot = {
+    columns: CsvColumn[];
+    rows: CsvGridRow[];
+};
+
+const DEFAULT_CSV_FORMAT: CsvFormat = {
+    delimiter: ",",
+    linebreak: "\n",
+};
+const CSV_ROW_ID_KEY = "__csv_row_id";
+const CSV_MAX_EDITABLE_BYTES = 2 * 1024 * 1024; // 2 MB
+const CSV_MAX_PREVIEW_ROWS = 500;
+
+const CSV_PARSE_FALLBACK_MESSAGE =
+    "This CSV could not be parsed. Showing raw content instead.";
+const CSV_TRUNCATED_FALLBACK_MESSAGE =
+    "This tab only has a partial CSV preview. Reload the full file to edit it safely.";
+const CSV_PREVIEW_LIMIT_MESSAGE =
+    "Preview limited to first 500 rows. Editing disabled for large files.";
+
+const csvTextColumn = createTextColumn<string>({
+    parseUserInput: (value) => value,
+    formatBlurredInput: (value) => value ?? "",
+    formatInputOnFocus: (value) => value ?? "",
+    deletedValue: "",
+});
+
+export function CsvFileTabView() {
+    const contentRef = useRef("");
+    const editorStateRef = useRef<CsvEditorState>(
+        buildCsvEditorState("", null),
+    );
+    const gridViewportRef = useRef<HTMLDivElement>(null);
+    const [editorState, setEditorState] = useState<CsvEditorState>(() => {
+        const initialState = buildCsvEditorState("", null);
+        contentRef.current = initialState.rawContent;
+        editorStateRef.current = initialState;
+        return initialState;
+    });
+    const [viewMode, setViewMode] = useState<CsvViewMode>("table");
+    const [gridHeight, setGridHeight] = useState(420);
+
+    const getCurrentContent = useCallback(() => contentRef.current, []);
+    const applyIncomingContent = useCallback((nextContent: string) => {
+        const nextState = buildCsvEditorState(
+            nextContent,
+            getActiveCsvTabMetadata(),
+            getCsvIdentitySnapshot(editorStateRef.current),
+        );
+        contentRef.current = nextState.rawContent;
+        editorStateRef.current = nextState;
+        setEditorState(nextState);
+        setViewMode((currentMode) =>
+            nextState.isTableAvailable ? currentMode : "raw",
+        );
+    }, []);
+
+    const {
+        tab,
+        hasExternalConflict,
+        handleLocalContentChange,
+        reloadFileFromDisk,
+        keepLocalFileVersion,
+    } = useEditableFileResource({
+        getCurrentContent,
+        applyIncomingContent,
+        acceptTab: (candidate) => candidate.viewer === "csv",
+    });
+
+    const isDirty = useEditorStore((state) =>
+        tab ? state.dirtyTabIds.has(tab.id) : false,
+    );
+
+    useEffect(() => {
+        const node = gridViewportRef.current;
+        if (!node) return;
+
+        const syncHeight = (nextHeight: number) => {
+            if (!Number.isFinite(nextHeight) || nextHeight <= 0) return;
+            setGridHeight(Math.max(220, Math.floor(nextHeight)));
+        };
+
+        syncHeight(node.getBoundingClientRect().height);
+        const observer = new ResizeObserver((entries) => {
+            const entry = entries[0];
+            syncHeight(entry?.contentRect.height ?? 0);
+        });
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, [editorState.isTableAvailable, viewMode]);
+
+    const commitTableChange = useCallback(
+        (nextColumns: CsvColumn[], nextRows: CsvGridRow[]) => {
+            const normalizedRows =
+                nextColumns.length === 0
+                    ? []
+                    : nextRows.map((row) => ({
+                          ...row,
+                          ...Object.fromEntries(
+                              nextColumns.map((column) => [
+                                  column.id,
+                                  row[column.id] ?? "",
+                              ]),
+                          ),
+                      }));
+            const nextFormat = editorStateRef.current.format;
+            const nextRawContent = serializeCsvTable(
+                nextColumns,
+                normalizedRows,
+                nextFormat,
+            );
+            const nextState = buildCsvEditorState(
+                nextRawContent,
+                {
+                    ...getActiveCsvTabMetadata(),
+                    sizeBytes: getContentByteLength(nextRawContent),
+                    contentTruncated: false,
+                },
+                {
+                    columns: nextColumns,
+                    rows: normalizedRows,
+                },
+            );
+
+            contentRef.current = nextRawContent;
+            editorStateRef.current = nextState;
+            setEditorState(nextState);
+            handleLocalContentChange(nextRawContent);
+        },
+        [handleLocalContentChange],
+    );
+
+    const handleGridChange = useCallback(
+        (nextRows: CsvGridRow[]) => {
+            const currentState = editorStateRef.current;
+            if (!currentState.isTableEditable) return;
+            commitTableChange(currentState.columns, nextRows);
+        },
+        [commitTableChange],
+    );
+
+    const handleAddRow = useCallback(() => {
+        const currentState = editorStateRef.current;
+        if (
+            !currentState.isTableEditable ||
+            currentState.columns.length === 0
+        ) {
+            return;
+        }
+        commitTableChange(currentState.columns, [
+            ...currentState.rows,
+            createEmptyCsvRow(currentState.columns),
+        ]);
+    }, [commitTableChange]);
+
+    const handleAddColumn = useCallback(() => {
+        const currentState = editorStateRef.current;
+        if (!currentState.isTableEditable) return;
+
+        const nextIndex = currentState.columns.length + 1;
+        const nextColumn: CsvColumn = {
+            id: createCsvEntityId("column"),
+            name: `Column ${nextIndex}`,
+        };
+        const nextColumns = [...currentState.columns, nextColumn];
+        const nextRows =
+            currentState.rows.length === 0
+                ? currentState.rows
+                : currentState.rows.map((row) => ({
+                      ...row,
+                      [nextColumn.id]: "",
+                  }));
+
+        commitTableChange(nextColumns, nextRows);
+    }, [commitTableChange]);
+
+    const handleRenameColumn = useCallback(
+        (columnId: string, nextName: string) => {
+            const currentState = editorStateRef.current;
+            if (!currentState.isTableEditable) return;
+            commitTableChange(
+                currentState.columns.map((column) =>
+                    column.id === columnId
+                        ? {
+                              ...column,
+                              name: nextName,
+                          }
+                        : column,
+                ),
+                currentState.rows,
+            );
+        },
+        [commitTableChange],
+    );
+
+    const handleDeleteColumn = useCallback(
+        (columnId: string) => {
+            const currentState = editorStateRef.current;
+            if (!currentState.isTableEditable) return;
+
+            const nextColumns = currentState.columns.filter(
+                (column) => column.id !== columnId,
+            );
+            const nextRows =
+                nextColumns.length === 0
+                    ? []
+                    : currentState.rows.map((row) => {
+                          const nextRow = { ...row };
+                          delete nextRow[columnId];
+                          return nextRow;
+                      });
+
+            commitTableChange(nextColumns, nextRows);
+        },
+        [commitTableChange],
+    );
+
+    const rowActionsColumn = useMemo<SimpleColumn<CsvGridRow, null>>(
+        () => ({
+            title: null,
+            basis: 40,
+            minWidth: 40,
+            grow: 0,
+            shrink: 0,
+            component: DeleteRowCell,
+            columnData: null,
+        }),
+        [],
+    );
+
+    const gridColumns = useMemo(
+        () =>
+            editorState.columns.map((column, index) => ({
+                ...keyColumn(column.id, csvTextColumn),
+                title: (
+                    <CsvColumnHeader
+                        column={column}
+                        index={index}
+                        onRename={handleRenameColumn}
+                        onDelete={handleDeleteColumn}
+                    />
+                ),
+                basis: 180,
+                minWidth: 160,
+                grow: 1,
+                shrink: 0,
+            })),
+        [editorState.columns, handleDeleteColumn, handleRenameColumn],
+    );
+
+    const gridStructureKey = useMemo(
+        () =>
+            JSON.stringify({
+                columns: editorState.columns.map((column) => ({
+                    id: column.id,
+                    name: column.name,
+                })),
+                rowCount: editorState.rows.length,
+                editable: editorState.isTableEditable,
+            }),
+        [
+            editorState.columns,
+            editorState.rows.length,
+            editorState.isTableEditable,
+        ],
+    );
+
+    const createRow = useCallback(() => {
+        const currentState = editorStateRef.current;
+        return createEmptyCsvRow(currentState.columns);
+    }, []);
+
+    const duplicateRow = useCallback(
+        ({ rowData }: { rowData: CsvGridRow }) => ({
+            ...rowData,
+            [CSV_ROW_ID_KEY]: createCsvEntityId("row"),
+        }),
+        [],
+    );
+
+    if (!tab) {
+        return (
+            <div
+                className="h-full flex items-center justify-center"
+                style={{ color: "var(--text-secondary)" }}
+            >
+                No CSV file tab active
+            </div>
+        );
+    }
+
+    const canShowTable = editorState.isTableAvailable;
+    const canEditTable = editorState.isTableEditable;
+    const showTable = viewMode === "table" && canShowTable;
+    const tableSummary = canShowTable
+        ? buildCsvTableSummary(editorState)
+        : buildCsvUnavailableSummary(editorState);
+
+    return (
+        <div className="h-full flex flex-col overflow-hidden">
+            {hasExternalConflict && (
+                <div
+                    className="shrink-0 px-3 py-2 flex items-center justify-between gap-3"
+                    style={{
+                        borderBottom:
+                            "1px solid color-mix(in srgb, #f59e0b 35%, var(--border))",
+                        background:
+                            "color-mix(in srgb, #f59e0b 12%, var(--bg-secondary))",
+                    }}
+                >
+                    <div
+                        className="min-w-0 text-[12px]"
+                        style={{ color: "var(--text-primary)" }}
+                    >
+                        This file changed on disk while you still have unsaved
+                        edits.
+                    </div>
+                    <div className="shrink-0 flex items-center gap-2">
+                        <button
+                            type="button"
+                            onClick={() => void reloadFileFromDisk()}
+                            className="rounded-md px-2.5 py-1 text-[11px]"
+                            style={{
+                                border: "1px solid color-mix(in srgb, #f59e0b 45%, var(--border))",
+                                backgroundColor: "var(--bg-primary)",
+                                color: "var(--text-primary)",
+                            }}
+                        >
+                            Reload from Disk
+                        </button>
+                        <button
+                            type="button"
+                            onClick={keepLocalFileVersion}
+                            className="rounded-md px-2.5 py-1 text-[11px]"
+                            style={{
+                                border: "1px solid transparent",
+                                backgroundColor: "transparent",
+                                color: "var(--text-secondary)",
+                            }}
+                        >
+                            Keep Local
+                        </button>
+                    </div>
+                </div>
+            )}
+
+            <div
+                className="flex items-center justify-between gap-2 px-3 shrink-0"
+                style={{
+                    height: 34,
+                    borderBottom: "1px solid var(--border)",
+                    backgroundColor: "var(--bg-secondary)",
+                }}
+            >
+                <div
+                    className="min-w-0 truncate text-[11px]"
+                    title={tab.relativePath}
+                >
+                    <span
+                        className="font-medium"
+                        style={{ color: "var(--text-primary)" }}
+                    >
+                        {tab.title}
+                    </span>
+                    <span
+                        className="ml-1.5"
+                        style={{ color: "var(--text-secondary)" }}
+                    >
+                        {tab.relativePath}
+                    </span>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                    <span
+                        className="rounded-full px-2 py-0.5 text-[10px] font-medium"
+                        style={
+                            isDirty
+                                ? dirtyStatusBadgeStyle
+                                : savedStatusBadgeStyle
+                        }
+                    >
+                        {isDirty ? "Unsaved changes" : "Saved"}
+                    </span>
+                    <button
+                        type="button"
+                        onClick={() => setViewMode("table")}
+                        disabled={!canShowTable}
+                        className="inline-flex items-center rounded px-1.5 text-[10px] disabled:opacity-50"
+                        style={
+                            showTable
+                                ? activeHeaderButtonStyle
+                                : headerButtonStyle
+                        }
+                    >
+                        Table
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => setViewMode("raw")}
+                        className="inline-flex items-center rounded px-1.5 text-[10px]"
+                        style={
+                            !showTable
+                                ? activeHeaderButtonStyle
+                                : headerButtonStyle
+                        }
+                    >
+                        Raw
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void openPath(tab.path)}
+                        className="inline-flex items-center rounded px-1.5 text-[10px]"
+                        style={headerButtonStyle}
+                    >
+                        Open Externally
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void revealItemInDir(tab.path)}
+                        className="inline-flex items-center rounded px-1.5 text-[10px]"
+                        style={headerButtonStyle}
+                    >
+                        Reveal in Finder
+                    </button>
+                </div>
+            </div>
+
+            <div
+                className="flex items-center justify-between gap-3 px-3 py-2 shrink-0"
+                style={{
+                    borderBottom: "1px solid var(--border)",
+                    backgroundColor:
+                        "color-mix(in srgb, var(--bg-secondary) 45%, var(--bg-primary))",
+                }}
+            >
+                <div
+                    className="text-[11px] tabular-nums"
+                    style={{ color: "var(--text-secondary)" }}
+                >
+                    {tableSummary}
+                </div>
+                <div className="flex items-center gap-2">
+                    <button
+                        type="button"
+                        onClick={handleAddRow}
+                        disabled={
+                            !canEditTable || editorState.columns.length === 0
+                        }
+                        className="rounded px-2 py-1 text-[11px] disabled:opacity-50"
+                        style={secondaryActionButtonStyle}
+                    >
+                        Add Row
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleAddColumn}
+                        disabled={!canEditTable}
+                        className="rounded px-2 py-1 text-[11px] disabled:opacity-50"
+                        style={secondaryActionButtonStyle}
+                    >
+                        Add Column
+                    </button>
+                </div>
+            </div>
+
+            <div
+                ref={gridViewportRef}
+                className="min-h-0 flex-1 overflow-hidden"
+            >
+                {editorState.statusMessage && (
+                    <div
+                        className="px-3 py-2 text-[12px] shrink-0"
+                        style={{
+                            borderBottom:
+                                "1px solid color-mix(in srgb, #f59e0b 35%, var(--border))",
+                            background:
+                                "color-mix(in srgb, #f59e0b 10%, var(--bg-secondary))",
+                            color: "var(--text-primary)",
+                        }}
+                    >
+                        {editorState.statusMessage}
+                    </div>
+                )}
+                {showTable ? (
+                    editorState.columns.length > 0 ? (
+                        canEditTable ? (
+                            <DataSheetGrid<CsvGridRow>
+                                key={gridStructureKey}
+                                value={editorState.rows}
+                                onChange={handleGridChange}
+                                columns={gridColumns}
+                                rowKey={CSV_ROW_ID_KEY}
+                                createRow={createRow}
+                                duplicateRow={duplicateRow}
+                                addRowsComponent={false}
+                                stickyRightColumn={rowActionsColumn}
+                                className="csv-file-grid"
+                                height={gridHeight}
+                            />
+                        ) : (
+                            <CsvTablePreview
+                                columns={editorState.columns}
+                                rows={editorState.rows}
+                            />
+                        )
+                    ) : (
+                        <EmptyCsvTableState>
+                            Add a column to start editing this CSV as a table.
+                        </EmptyCsvTableState>
+                    )
+                ) : (
+                    <div className="h-full flex flex-col">
+                        <div className="min-h-0 flex-1 p-3">
+                            <textarea
+                                aria-label="Raw CSV content"
+                                readOnly
+                                value={editorState.rawContent}
+                                className="csv-file-raw"
+                            />
+                        </div>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+function CsvColumnHeader({
+    column,
+    index,
+    onRename,
+    onDelete,
+}: {
+    column: CsvColumn;
+    index: number;
+    onRename: (columnId: string, nextName: string) => void;
+    onDelete: (columnId: string) => void;
+}) {
+    const columnLabel = getCsvColumnLabel(column, index);
+
+    return (
+        <div
+            className="csv-file-column-header"
+            onMouseDown={(event) => event.stopPropagation()}
+        >
+            <input
+                aria-label={`${columnLabel} name`}
+                value={column.name}
+                placeholder={columnLabel}
+                onChange={(event) => onRename(column.id, event.target.value)}
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={(event) => event.stopPropagation()}
+                className="csv-file-column-input"
+            />
+            <button
+                type="button"
+                aria-label={`Delete ${columnLabel}`}
+                onMouseDown={(event) => stopHeaderButtonEvent(event)}
+                onClick={(event) => {
+                    stopHeaderButtonEvent(event);
+                    onDelete(column.id);
+                }}
+                className="csv-file-column-delete"
+            >
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="M2 4h12M5.33 4V2.67a1.33 1.33 0 0 1 1.34-1.34h2.66a1.33 1.33 0 0 1 1.34 1.34V4M6.67 7.33v4M9.33 7.33v4M12.67 4v9.33a1.33 1.33 0 0 1-1.34 1.34H4.67a1.33 1.33 0 0 1-1.34-1.34V4" />
+                </svg>
+            </button>
+        </div>
+    );
+}
+
+function DeleteRowCell({ rowIndex, deleteRow }: CellProps<CsvGridRow, null>) {
+    return (
+        <div className="w-full flex items-center justify-center">
+            <button
+                type="button"
+                aria-label={`Delete row ${rowIndex + 1}`}
+                onMouseDown={(event) => stopHeaderButtonEvent(event)}
+                onClick={(event) => {
+                    stopHeaderButtonEvent(event);
+                    deleteRow();
+                }}
+                className="csv-file-row-delete"
+            >
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="M2 4h12M5.33 4V2.67a1.33 1.33 0 0 1 1.34-1.34h2.66a1.33 1.33 0 0 1 1.34 1.34V4M6.67 7.33v4M9.33 7.33v4M12.67 4v9.33a1.33 1.33 0 0 1-1.34 1.34H4.67a1.33 1.33 0 0 1-1.34-1.34V4" />
+                </svg>
+            </button>
+        </div>
+    );
+}
+
+function EmptyCsvTableState({ children }: { children: ReactNode }) {
+    return (
+        <div
+            className="h-full flex items-center justify-center px-6 text-center text-[13px]"
+            style={{ color: "var(--text-secondary)" }}
+        >
+            {children}
+        </div>
+    );
+}
+
+function CsvTablePreview({
+    columns,
+    rows,
+}: {
+    columns: CsvColumn[];
+    rows: CsvGridRow[];
+}) {
+    return (
+        <div className="h-full overflow-auto">
+            <table className="csv-file-preview-table">
+                <thead>
+                    <tr>
+                        {columns.map((column, index) => (
+                            <th key={column.id} scope="col">
+                                {getCsvColumnLabel(column, index)}
+                            </th>
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {rows.map((row) => (
+                        <tr key={row[CSV_ROW_ID_KEY]}>
+                            {columns.map((column) => (
+                                <td key={column.id}>{row[column.id] ?? ""}</td>
+                            ))}
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    );
+}
+
+function buildCsvEditorState(
+    content: string,
+    metadata: Pick<FileTab, "sizeBytes" | "contentTruncated"> | null,
+    identitySnapshot: CsvIdentitySnapshot | null = null,
+): CsvEditorState {
+    const format = {
+        ...DEFAULT_CSV_FORMAT,
+        linebreak: detectCsvLinebreak(content),
+    };
+    const sizeBytes = Math.max(
+        metadata?.sizeBytes ?? 0,
+        getContentByteLength(content),
+    );
+
+    if (metadata?.contentTruncated) {
+        return {
+            rawContent: content,
+            columns: [],
+            rows: [],
+            format,
+            isTableAvailable: false,
+            isTableEditable: false,
+            rawModeReason: "truncated",
+            statusMessage: CSV_TRUNCATED_FALLBACK_MESSAGE,
+            sizeBytes,
+            totalDataRowCount: 0,
+        };
+    }
+
+    if (sizeBytes > CSV_MAX_EDITABLE_BYTES) {
+        return {
+            rawContent: content,
+            columns: [],
+            rows: [],
+            format,
+            isTableAvailable: false,
+            isTableEditable: false,
+            rawModeReason: "too_large",
+            statusMessage: `Table editing is disabled for CSV files larger than ${formatByteCount(CSV_MAX_EDITABLE_BYTES)}. Showing raw content instead.`,
+            sizeBytes,
+            totalDataRowCount: 0,
+        };
+    }
+
+    const parsed = Papa.parse<string[]>(content, {
+        skipEmptyLines: false,
+    });
+    const blockingErrors = parsed.errors.filter(isBlockingCsvParseError);
+
+    if (
+        blockingErrors.length > 0 ||
+        parsed.meta.aborted ||
+        parsed.meta.truncated
+    ) {
+        return {
+            rawContent: content,
+            columns: [],
+            rows: [],
+            format,
+            isTableAvailable: false,
+            isTableEditable: false,
+            rawModeReason: "parse_failed",
+            statusMessage: CSV_PARSE_FALLBACK_MESSAGE,
+            sizeBytes,
+            totalDataRowCount: 0,
+        };
+    }
+
+    const parsedRows = normalizeParsedRows(parsed.data, content);
+    const width = parsedRows.reduce(
+        (maxWidth, row) => Math.max(maxWidth, row.length),
+        0,
+    );
+    const headerValues =
+        width === 0 ? [] : normalizeCsvRowWidth(parsedRows[0] ?? [], width);
+    const bodyValues =
+        width === 0
+            ? []
+            : parsedRows
+                  .slice(1)
+                  .map((row) => normalizeCsvRowWidth(row, width));
+    const columns = headerValues.map((name, index) => ({
+        id: identitySnapshot?.columns[index]?.id ?? createCsvEntityId("column"),
+        name,
+    }));
+    const allRows = bodyValues.map((values, index) =>
+        createCsvRow(
+            columns,
+            values,
+            identitySnapshot?.rows[index]?.[CSV_ROW_ID_KEY],
+        ),
+    );
+    const exceedsPreviewLimit = allRows.length > CSV_MAX_PREVIEW_ROWS;
+    const rows = exceedsPreviewLimit
+        ? allRows.slice(0, CSV_MAX_PREVIEW_ROWS)
+        : allRows;
+
+    return {
+        rawContent: content,
+        columns,
+        rows,
+        format: {
+            delimiter: parsed.meta.delimiter || DEFAULT_CSV_FORMAT.delimiter,
+            linebreak: parsed.meta.linebreak || format.linebreak,
+        },
+        isTableAvailable: true,
+        isTableEditable: !exceedsPreviewLimit,
+        rawModeReason: exceedsPreviewLimit ? "preview_limited" : null,
+        statusMessage: exceedsPreviewLimit ? CSV_PREVIEW_LIMIT_MESSAGE : null,
+        sizeBytes,
+        totalDataRowCount: allRows.length,
+    };
+}
+
+function serializeCsvTable(
+    columns: CsvColumn[],
+    rows: CsvGridRow[],
+    format: CsvFormat,
+) {
+    if (columns.length === 0) {
+        return "";
+    }
+
+    return Papa.unparse(
+        {
+            fields: columns.map((column) => column.name),
+            data: rows.map((row) =>
+                columns.map((column) => row[column.id] ?? ""),
+            ),
+        },
+        {
+            delimiter: format.delimiter,
+            newline: format.linebreak,
+        },
+    );
+}
+
+function normalizeParsedRows(data: string[][], originalContent: string) {
+    const rows = data.map((row) => row.map((value) => value ?? ""));
+    if (
+        rows.length > 0 &&
+        hasTrailingCsvLinebreak(originalContent) &&
+        rows.at(-1)?.every((cell) => cell === "")
+    ) {
+        rows.pop();
+    }
+    return rows;
+}
+
+function normalizeCsvRowWidth(row: string[], width: number) {
+    const nextRow = row.slice(0, width);
+    while (nextRow.length < width) {
+        nextRow.push("");
+    }
+    return nextRow;
+}
+
+function createCsvRow(
+    columns: CsvColumn[],
+    values: string[],
+    rowId: string | undefined = undefined,
+): CsvGridRow {
+    return {
+        [CSV_ROW_ID_KEY]: rowId ?? createCsvEntityId("row"),
+        ...Object.fromEntries(
+            columns.map((column, index) => [column.id, values[index] ?? ""]),
+        ),
+    };
+}
+
+function createEmptyCsvRow(columns: CsvColumn[]): CsvGridRow {
+    return createCsvRow(
+        columns,
+        columns.map(() => ""),
+    );
+}
+
+function createCsvEntityId(prefix: "column" | "row") {
+    if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return `${prefix}-${crypto.randomUUID()}`;
+    }
+    return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function getActiveCsvTabMetadata() {
+    const state = useEditorStore.getState();
+    const activeTab = state.tabs.find(
+        (candidate) => candidate.id === state.activeTabId,
+    );
+    if (!activeTab || !isFileTab(activeTab) || activeTab.viewer !== "csv") {
+        return null;
+    }
+    return {
+        sizeBytes: activeTab.sizeBytes,
+        contentTruncated: activeTab.contentTruncated,
+    };
+}
+
+function getCsvIdentitySnapshot(
+    state: CsvEditorState | null,
+): CsvIdentitySnapshot | null {
+    if (!state || !state.isTableAvailable) {
+        return null;
+    }
+
+    return {
+        columns: state.columns,
+        rows: state.rows,
+    };
+}
+
+function getContentByteLength(content: string) {
+    return new TextEncoder().encode(content).length;
+}
+
+function detectCsvLinebreak(content: string) {
+    return content.includes("\r\n") ? "\r\n" : DEFAULT_CSV_FORMAT.linebreak;
+}
+
+function hasTrailingCsvLinebreak(content: string) {
+    return content.endsWith("\n") || content.endsWith("\r\n");
+}
+
+function isBlockingCsvParseError(error: ParseError) {
+    // Papa reports undetectable delimiter warnings for tiny or trailing-newline
+    // inputs even when the parsed table is otherwise perfectly usable.
+    return !(
+        error.type === "Delimiter" && error.code === "UndetectableDelimiter"
+    );
+}
+
+function getCsvColumnLabel(column: CsvColumn, index: number) {
+    return column.name.trim() || `Column ${index + 1}`;
+}
+
+function buildCsvUnavailableSummary(state: CsvEditorState) {
+    if (state.rawModeReason === "too_large") {
+        return `Table editing unavailable · ${formatByteCount(state.sizeBytes)}`;
+    }
+    if (state.rawModeReason === "truncated") {
+        return "Partial preview · table editing unavailable";
+    }
+    return "Raw fallback · table editing unavailable";
+}
+
+function buildCsvTableSummary(state: CsvEditorState) {
+    if (state.rawModeReason === "preview_limited") {
+        return `Rows: ${state.rows.length} of ${state.totalDataRowCount} · Columns: ${state.columns.length}`;
+    }
+    return `Rows: ${state.rows.length} · Columns: ${state.columns.length}`;
+}
+
+function formatByteCount(sizeBytes: number) {
+    if (sizeBytes >= 1024 * 1024) {
+        return `${(sizeBytes / (1024 * 1024)).toFixed(1)} MB`;
+    }
+    if (sizeBytes >= 1024) {
+        return `${Math.round(sizeBytes / 1024)} KB`;
+    }
+    return `${sizeBytes} B`;
+}
+
+function stopHeaderButtonEvent(event: MouseEvent<HTMLElement>) {
+    event.preventDefault();
+    event.stopPropagation();
+}
+
+const headerButtonStyle = {
+    height: 22,
+    border: "1px solid var(--border)",
+    backgroundColor: "var(--bg-primary)",
+    color: "var(--text-primary)",
+} as const;
+
+const activeHeaderButtonStyle = {
+    ...headerButtonStyle,
+    border: "1px solid color-mix(in srgb, var(--accent) 24%, var(--border))",
+    backgroundColor: "color-mix(in srgb, var(--accent) 12%, var(--bg-primary))",
+} as const;
+
+const secondaryActionButtonStyle = {
+    border: "1px solid var(--border)",
+    backgroundColor: "var(--bg-primary)",
+    color: "var(--text-primary)",
+} as const;
+
+const savedStatusBadgeStyle = {
+    border: "1px solid color-mix(in srgb, #16a34a 32%, var(--border))",
+    backgroundColor: "color-mix(in srgb, #16a34a 10%, var(--bg-primary))",
+    color: "var(--text-primary)",
+} as const;
+
+const dirtyStatusBadgeStyle = {
+    border: "1px solid color-mix(in srgb, #f59e0b 38%, var(--border))",
+    backgroundColor: "color-mix(in srgb, #f59e0b 12%, var(--bg-primary))",
+    color: "var(--text-primary)",
+} as const;

--- a/apps/desktop/src/features/editor/EmbedContextMenu.tsx
+++ b/apps/desktop/src/features/editor/EmbedContextMenu.tsx
@@ -4,8 +4,10 @@ import {
     ContextMenu,
     type ContextMenuEntry,
 } from "../../components/context-menu/ContextMenu";
-import { useVaultStore } from "../../app/store/vaultStore";
-import { useEditorStore } from "../../app/store/editorStore";
+import {
+    getVaultEmbedAbsolutePath,
+    openVaultEmbedTarget,
+} from "./embedNavigation";
 
 export interface EmbedContextMenuState {
     x: number;
@@ -23,82 +25,18 @@ export function EmbedContextMenu({
     menu: EmbedContextMenuState;
     onClose: () => void;
 }) {
-    const vaultPath = useVaultStore((s) => s.vaultPath);
-    const entries = useVaultStore((s) => s.entries);
-    const { openPdf, openFile, insertExternalTab } = useEditorStore();
-
-    const absolutePath = useMemo(() => {
-        if (!vaultPath) return null;
-        const rel = menu.target.startsWith("/")
-            ? menu.target.slice(1)
-            : menu.target;
-        const sep =
-            vaultPath.endsWith("/") || vaultPath.endsWith("\\") ? "" : "/";
-        return `${vaultPath}${sep}${rel}`;
-    }, [vaultPath, menu.target]);
-
-    const vaultEntry = useMemo(() => {
-        const rel = menu.target.startsWith("/")
-            ? menu.target.slice(1)
-            : menu.target;
-        return entries.find((e) => e.relative_path === rel) ?? null;
-    }, [entries, menu.target]);
-
-    const fileName = menu.target.split("/").pop() ?? menu.target;
+    const absolutePath = useMemo(
+        () => getVaultEmbedAbsolutePath(menu.target),
+        [menu.target],
+    );
 
     const handleOpen = useCallback(() => {
-        if (vaultEntry) {
-            if (menu.kind === "pdf") {
-                openPdf(vaultEntry.id, vaultEntry.title, vaultEntry.path);
-            } else {
-                openFile(
-                    vaultEntry.relative_path,
-                    vaultEntry.title,
-                    vaultEntry.path,
-                    "",
-                    vaultEntry.mime_type,
-                    "image",
-                );
-            }
-        } else if (absolutePath) {
-            void openPath(absolutePath);
-        }
-    }, [vaultEntry, absolutePath, menu.kind, openPdf, openFile]);
+        void openVaultEmbedTarget(menu.target, menu.kind);
+    }, [menu.target, menu.kind]);
 
     const handleOpenNewTab = useCallback(() => {
-        if (menu.kind === "pdf") {
-            insertExternalTab({
-                id: crypto.randomUUID(),
-                kind: "pdf",
-                entryId: vaultEntry?.id ?? menu.target,
-                title: vaultEntry?.title ?? fileName,
-                path: absolutePath ?? "",
-                page: 1,
-                zoom: 1,
-                viewMode: "continuous",
-            });
-        } else if (vaultEntry) {
-            insertExternalTab({
-                id: crypto.randomUUID(),
-                kind: "file",
-                relativePath: vaultEntry.relative_path,
-                title: vaultEntry.title,
-                path: vaultEntry.path,
-                content: "",
-                mimeType: vaultEntry.mime_type,
-                viewer: "image",
-            });
-        } else if (absolutePath) {
-            void openPath(absolutePath);
-        }
-    }, [
-        menu.kind,
-        menu.target,
-        vaultEntry,
-        absolutePath,
-        fileName,
-        insertExternalTab,
-    ]);
+        void openVaultEmbedTarget(menu.target, menu.kind, { newTab: true });
+    }, [menu.target, menu.kind]);
 
     const menuEntries: ContextMenuEntry[] = useMemo(() => {
         const items: ContextMenuEntry[] = [

--- a/apps/desktop/src/features/editor/FileTabView.test.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.test.tsx
@@ -109,7 +109,7 @@ describe("FileTabView", () => {
         );
     });
 
-    it("supports Command + wheel zoom from fit mode", () => {
+    it("supports Command + wheel zoom from fit mode", async () => {
         setEditorTabs([
             {
                 id: "image-tab",
@@ -132,14 +132,17 @@ describe("FileTabView", () => {
         expect(scrollSurface?.style.touchAction).toBe("pan-x pan-y pinch-zoom");
         expect(image.style.touchAction).toBe("pan-x pan-y pinch-zoom");
 
-        fireEvent.keyDown(window, { key: "Meta" });
-        fireEvent.wheel(scrollSurface!, { deltaY: -10 });
-        fireEvent.keyUp(window, { key: "Meta" });
+        await act(async () => {
+            fireEvent.keyDown(window, { key: "Meta" });
+            fireEvent.wheel(scrollSurface!, { deltaY: -10 });
+            fireEvent.keyUp(window, { key: "Meta" });
+            await Promise.resolve();
+        });
 
         expect(screen.getByText("102.5%")).toBeInTheDocument();
     });
 
-    it("anchors image wheel zoom to the pointer by adjusting scroll offsets", () => {
+    it("anchors image wheel zoom to the pointer by adjusting scroll offsets", async () => {
         setEditorTabs([
             {
                 id: "image-tab",
@@ -183,13 +186,16 @@ describe("FileTabView", () => {
                 toJSON: () => ({}),
             }) as DOMRect;
 
-        fireEvent.keyDown(window, { key: "Meta" });
-        fireEvent.wheel(scrollSurface!, {
-            clientX: 180,
-            clientY: 200,
-            deltaY: -100,
+        await act(async () => {
+            fireEvent.keyDown(window, { key: "Meta" });
+            fireEvent.wheel(scrollSurface!, {
+                clientX: 180,
+                clientY: 200,
+                deltaY: -100,
+            });
+            fireEvent.keyUp(window, { key: "Meta" });
+            await Promise.resolve();
         });
-        fireEvent.keyUp(window, { key: "Meta" });
 
         expect(scrollSurface!.scrollTop).toBeCloseTo(425);
         expect(scrollSurface!.scrollLeft).toBeCloseTo(95);
@@ -252,6 +258,34 @@ describe("FileTabView", () => {
             content: 'name = "NeverWrite"\nversion = "1.0.0"',
             opId: expect.any(String),
         });
+    });
+
+    it("renders csv files in the dedicated table viewer", async () => {
+        setEditorTabs([
+            {
+                id: "csv-tab",
+                kind: "file",
+                relativePath: "data/report.csv",
+                title: "report.csv",
+                path: "/vault/data/report.csv",
+                mimeType: "text/csv",
+                viewer: "csv",
+                content: "name,amount\nAlice,10",
+            },
+        ]);
+
+        await act(async () => {
+            renderComponent(<FileTabView />);
+            await Promise.resolve();
+        });
+
+        expect(document.querySelector(".cm-editor")).toBeNull();
+        expect(
+            screen.getByRole("button", { name: "Table" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Raw" })).toBeInTheDocument();
+        expect(screen.getByText("Rows: 1 · Columns: 2")).toBeInTheDocument();
+        expect(screen.getByDisplayValue("Alice")).toBeInTheDocument();
     });
 
     it("switches text files in history mode without writing the next file or showing a false conflict", async () => {

--- a/apps/desktop/src/features/editor/FileTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
 import {
+    fileViewerNeedsTextContent,
     useEditorStore,
     isFileTab,
     type FileTab,
@@ -20,6 +21,7 @@ import { useVaultStore } from "../../app/store/vaultStore";
 import { buildVaultPreviewUrlFromAbsolutePath } from "../../app/utils/filePreviewUrl";
 import { formatZoomPercentage } from "../../app/utils/zoom";
 import { FileTextTabView } from "./FileTextTabView";
+import { CsvFileTabView } from "./CsvFileTabView";
 
 const IMG_MIN_ZOOM = 0.1;
 const IMG_MAX_ZOOM = 10;
@@ -49,10 +51,25 @@ export function FileTabView() {
         );
     }
 
-    return tab.viewer === "image" ? (
-        <ImageFileViewer key={tab.path} tab={tab} />
-    ) : (
-        <FileTextTabView key={tab.id} />
+    if (tab.viewer === "image") {
+        return <ImageFileViewer key={tab.path} tab={tab} />;
+    }
+
+    if (tab.viewer === "csv") {
+        return <CsvFileTabView key={tab.id} />;
+    }
+
+    if (fileViewerNeedsTextContent(tab.viewer)) {
+        return <FileTextTabView key={tab.id} />;
+    }
+
+    return (
+        <div
+            className="h-full flex items-center justify-center"
+            style={{ color: "var(--text-secondary)" }}
+        >
+            Unsupported file viewer
+        </div>
     );
 }
 

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -25,12 +25,7 @@ import {
     ContextMenu,
     type ContextMenuState,
 } from "../../components/context-menu/ContextMenu";
-import {
-    useEditorStore,
-    isFileTab,
-    type Tab,
-    type FileTab,
-} from "../../app/store/editorStore";
+import { useEditorStore } from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useThemeStore } from "../../app/store/themeStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -44,33 +39,14 @@ import {
 import { mergeViewCompartment } from "./extensions/mergeViewDiff";
 import { syncMergeViewForPaths } from "./mergeViewSync";
 import { useChatStore } from "../ai/store/chatStore";
-import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import { loadCodeLanguage } from "./codeLanguage";
 import { searchTheme } from "./extensions/searchTheme";
 import { resolveTrackedFileMatchForPaths } from "./trackedFileMatch";
 import { resolveEditorTargetForOpenTab } from "./editorTargetResolver";
 import { subscribeEditorReviewSync } from "./editorReviewSync";
 import { shouldEnableInlineReviewMergeView } from "./editorReviewGate";
-import {
-    buildLiveFilePathCacheKey,
-    clearFilePathStateCaches,
-    pruneFilePathStateCaches,
-    type FilePathStateCacheCollection,
-} from "./filePathStateCache";
+import { useEditableFileResource } from "./useEditableFileResource";
 import { logError } from "../../app/utils/runtimeLog";
-
-type SavedVaultFileDetail = {
-    relative_path: string;
-    file_name: string;
-    content: string;
-};
-
-type FileReloadMetadata = {
-    origin?: "user" | "agent" | "external" | "system" | "unknown";
-    opId?: string | null;
-    revision?: number;
-    contentHash?: string | null;
-};
 
 export function FileTextTabView() {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -79,28 +55,11 @@ export function FileTextTabView() {
     const wrappingCompartmentRef = useRef(new Compartment());
     const languageCompartmentRef = useRef(new Compartment());
     const loadRequestRef = useRef(0);
-    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const tabRef = useRef<FileTab | null>(null);
-    const previousTabRef = useRef<FileTab | null>(null);
     const contextMenuCleanupRef = useRef<(() => void) | null>(null);
     const applyingExternalUpdateRef = useRef(false);
-    const lastSavedContentByPathRef = useRef(new Map<string, string>());
-    const lastAckRevisionByPathRef = useRef(new Map<string, number>());
-    const pendingLocalOpIdByPathRef = useRef(new Map<string, string>());
-    const saveRequestIdByPathRef = useRef(new Map<string, number>());
     const [, setEditorView] = useState<EditorView | null>(null);
     const [editorContextMenu, setEditorContextMenu] =
         useState<ContextMenuState<{ hasSelection: boolean }> | null>(null);
-
-    const tab = useEditorStore((state) => {
-        return getActiveFileTab(state);
-    });
-    const hasExternalConflict = useEditorStore((state) => {
-        const relativePath = tab?.relativePath;
-        return relativePath
-            ? state.fileExternalConflicts.has(relativePath)
-            : false;
-    });
     const isDark = useThemeStore((s) => s.isDark);
     const editorFontSize = useSettingsStore((s) => s.editorFontSize);
     const editorFontFamily = useSettingsStore((s) => s.editorFontFamily);
@@ -110,8 +69,49 @@ export function FileTextTabView() {
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const sessionsById = useChatStore((state) => state.sessionsById);
-    const lastLiveFilePathCacheKeyRef = useRef<string | null>(null);
-    const lastVaultPathRef = useRef<string | null>(vaultPath);
+    const getCurrentContent = useCallback(
+        () => viewRef.current?.state.doc.toString() ?? null,
+        [],
+    );
+    const replaceEditorDocument = useCallback((nextContent: string) => {
+        const view = viewRef.current;
+        if (!view) {
+            return;
+        }
+
+        const currentContent = view.state.doc.toString();
+        if (currentContent === nextContent) {
+            return;
+        }
+
+        const selection = view.state.selection.main;
+        applyingExternalUpdateRef.current = true;
+        view.dispatch({
+            changes: {
+                from: 0,
+                to: currentContent.length,
+                insert: nextContent,
+            },
+            selection: {
+                anchor: Math.min(selection.anchor, nextContent.length),
+                head: Math.min(selection.head, nextContent.length),
+            },
+        });
+        applyingExternalUpdateRef.current = false;
+    }, []);
+
+    const {
+        tab,
+        tabRef,
+        hasExternalConflict,
+        handleLocalContentChange,
+        reloadFileFromDisk,
+        keepLocalFileVersion,
+        flushCurrentSave,
+    } = useEditableFileResource({
+        getCurrentContent,
+        applyIncomingContent: replaceEditorDocument,
+    });
     const languagePath = tab?.path ?? null;
     const languageMimeType = tab?.mimeType ?? null;
     const trackedFileMatch = tab
@@ -123,49 +123,6 @@ export function FileTextTabView() {
               },
           ).match
         : null;
-
-    useEffect(() => {
-        tabRef.current = tab;
-    }, [tab]);
-
-    const getFilePathStateCaches = useCallback(
-        (): FilePathStateCacheCollection => ({
-            lastSavedContentByPath: lastSavedContentByPathRef.current,
-            lastAckRevisionByPath: lastAckRevisionByPathRef.current,
-            pendingLocalOpIdByPath: pendingLocalOpIdByPathRef.current,
-            saveRequestIdByPath: saveRequestIdByPathRef.current,
-        }),
-        [],
-    );
-
-    const pruneFilePathStateForOpenTabs = useCallback(
-        (tabs: readonly Tab[]) => {
-            pruneFilePathStateCaches(tabs, getFilePathStateCaches());
-        },
-        [getFilePathStateCaches],
-    );
-
-    useEffect(() => {
-        if (lastVaultPathRef.current === vaultPath) return;
-        lastVaultPathRef.current = vaultPath;
-        lastLiveFilePathCacheKeyRef.current = null;
-        clearFilePathStateCaches(getFilePathStateCaches());
-    }, [getFilePathStateCaches, vaultPath]);
-
-    useEffect(() => {
-        const syncLiveFilePathState = (tabs: readonly Tab[]) => {
-            const nextKey = buildLiveFilePathCacheKey(tabs);
-            if (lastLiveFilePathCacheKeyRef.current === nextKey) return;
-            lastLiveFilePathCacheKeyRef.current = nextKey;
-            pruneFilePathStateForOpenTabs(tabs);
-        };
-
-        syncLiveFilePathState(useEditorStore.getState().tabs);
-        const unsubscribe = useEditorStore.subscribe((state) => {
-            syncLiveFilePathState(state.tabs);
-        });
-        return unsubscribe;
-    }, [pruneFilePathStateForOpenTabs]);
 
     useEffect(() => {
         const handler = (event: KeyboardEvent) => {
@@ -325,117 +282,6 @@ export function FileTextTabView() {
         });
     }, []);
 
-    const saveFile = useCallback(
-        async (
-            targetTab: NonNullable<ReturnType<typeof getActiveFileTab>>,
-            content: string,
-        ) => {
-            const lastSaved = lastSavedContentByPathRef.current.get(
-                targetTab.relativePath,
-            );
-            if (lastSaved === content) {
-                return;
-            }
-
-            const requestId =
-                (saveRequestIdByPathRef.current.get(targetTab.relativePath) ??
-                    0) + 1;
-            saveRequestIdByPathRef.current.set(
-                targetTab.relativePath,
-                requestId,
-            );
-            const localOpId =
-                typeof crypto !== "undefined" &&
-                typeof crypto.randomUUID === "function"
-                    ? crypto.randomUUID()
-                    : `local-file-save-${Date.now()}-${Math.random()}`;
-            pendingLocalOpIdByPathRef.current.set(
-                targetTab.relativePath,
-                localOpId,
-            );
-
-            try {
-                const detail = await vaultInvoke<SavedVaultFileDetail>(
-                    "save_vault_file",
-                    {
-                        relativePath: targetTab.relativePath,
-                        content,
-                        opId: localOpId,
-                    },
-                );
-                if (
-                    saveRequestIdByPathRef.current.get(
-                        targetTab.relativePath,
-                    ) !== requestId
-                ) {
-                    return;
-                }
-                lastSavedContentByPathRef.current.set(
-                    targetTab.relativePath,
-                    detail.content,
-                );
-                const store = useEditorStore.getState();
-                store.setTabDirty(targetTab.id, false);
-                store.updateFileHistoryTitle(
-                    targetTab.id,
-                    targetTab.relativePath,
-                    detail.file_name,
-                );
-                store.clearFileExternalConflict(targetTab.relativePath);
-            } catch (error) {
-                pendingLocalOpIdByPathRef.current.delete(
-                    targetTab.relativePath,
-                );
-                logError("file-editor", "Failed to save vault file", error);
-            }
-        },
-        [],
-    );
-
-    const scheduleSave = useCallback(
-        (
-            targetTab: NonNullable<ReturnType<typeof getActiveFileTab>>,
-            content: string,
-        ) => {
-            if (saveTimerRef.current) {
-                clearTimeout(saveTimerRef.current);
-            }
-
-            saveTimerRef.current = setTimeout(() => {
-                saveTimerRef.current = null;
-                void saveFile(targetTab, content);
-            }, 300);
-        },
-        [saveFile],
-    );
-
-    const replaceEditorDocument = useCallback((nextContent: string) => {
-        const view = viewRef.current;
-        if (!view) {
-            return;
-        }
-
-        const currentContent = view.state.doc.toString();
-        if (currentContent === nextContent) {
-            return;
-        }
-
-        const selection = view.state.selection.main;
-        applyingExternalUpdateRef.current = true;
-        view.dispatch({
-            changes: {
-                from: 0,
-                to: currentContent.length,
-                insert: nextContent,
-            },
-            selection: {
-                anchor: Math.min(selection.anchor, nextContent.length),
-                head: Math.min(selection.head, nextContent.length),
-            },
-        });
-        applyingExternalUpdateRef.current = false;
-    }, []);
-
     useEffect(() => {
         const container = containerRef.current;
         if (!container || !tab) {
@@ -505,18 +351,7 @@ export function FileTextTabView() {
                             return;
                         }
 
-                        const content = update.state.doc.toString();
-                        const lastSaved =
-                            lastSavedContentByPathRef.current.get(
-                                currentTab.relativePath,
-                            ) ?? currentTab.content;
-                        useEditorStore
-                            .getState()
-                            .updateTabContent(currentTab.id, content);
-                        useEditorStore
-                            .getState()
-                            .setTabDirty(currentTab.id, content !== lastSaved);
-                        scheduleSave(currentTab, content);
+                        handleLocalContentChange(update.state.doc.toString());
                     }),
                     syntaxCompartmentRef.current.of(getSyntaxExtension(isDark)),
                     languageCompartmentRef.current.of([]),
@@ -546,197 +381,14 @@ export function FileTextTabView() {
             setEditorView(nextView);
         });
     }, [
+        handleLocalContentChange,
         handleEditorContextMenu,
         isDark,
         lineWrapping,
-        scheduleSave,
         syncCurrentSelection,
         tab,
         trackedFileMatch?.trackedFile.diffBase,
     ]);
-
-    useEffect(() => {
-        const view = viewRef.current;
-        const previousTab = previousTabRef.current;
-        const currentTab = tabRef.current;
-
-        if (previousTab && view) {
-            if (saveTimerRef.current) {
-                clearTimeout(saveTimerRef.current);
-                saveTimerRef.current = null;
-            }
-
-            const previousContent = view.state.doc.toString();
-            const previousLastSaved =
-                lastSavedContentByPathRef.current.get(
-                    previousTab.relativePath,
-                ) ?? previousTab.content;
-            if (previousContent !== previousLastSaved) {
-                void saveFile(previousTab, previousContent);
-            }
-        }
-
-        previousTabRef.current = currentTab;
-
-        if (!currentTab || !view) {
-            return;
-        }
-
-        replaceEditorDocument(currentTab.content);
-        lastSavedContentByPathRef.current.set(
-            currentTab.relativePath,
-            currentTab.content,
-        );
-        const store = useEditorStore.getState();
-        store.setTabDirty(currentTab.id, false);
-        store.clearCurrentSelection();
-    }, [replaceEditorDocument, saveFile, tab?.id, tab?.relativePath]);
-
-    useEffect(() => {
-        const currentTab = tabRef.current;
-        if (!currentTab) {
-            return;
-        }
-
-        if (!lastSavedContentByPathRef.current.has(currentTab.relativePath)) {
-            lastSavedContentByPathRef.current.set(
-                currentTab.relativePath,
-                currentTab.content,
-            );
-            useEditorStore.getState().setTabDirty(currentTab.id, false);
-        }
-    }, [tab?.content, tab?.relativePath]);
-
-    useEffect(() => {
-        const unsubscribe = useEditorStore.subscribe((state, prev) => {
-            const view = viewRef.current;
-            if (!view) return;
-
-            const activeTabId = state.activeTabId;
-            if (!activeTabId) return;
-
-            const currentTab = state.tabs.find(
-                (candidate) => candidate.id === activeTabId,
-            );
-            const previousTab = prev.tabs.find(
-                (candidate) => candidate.id === activeTabId,
-            );
-            if (!currentTab || !previousTab) return;
-            if (!isFileTab(currentTab) || !isFileTab(previousTab)) return;
-            if (currentTab.viewer !== "text" || previousTab.viewer !== "text") {
-                return;
-            }
-
-            if (currentTab.relativePath !== previousTab.relativePath) {
-                return;
-            }
-
-            const relativePath = currentTab.relativePath;
-            const reloadVersion =
-                state._fileReloadVersions?.[relativePath] ?? 0;
-            const previousReloadVersion =
-                prev._fileReloadVersions?.[relativePath] ?? 0;
-            const isForced =
-                state._pendingForceFileReloads?.has(relativePath) ?? false;
-
-            if (reloadVersion === previousReloadVersion && !isForced) {
-                return;
-            }
-
-            const currentContent = view.state.doc.toString();
-            const lastSaved =
-                lastSavedContentByPathRef.current.get(relativePath) ?? null;
-            const hasLocalUnsavedChanges =
-                lastSaved !== null && currentContent !== lastSaved;
-            const incomingContent = currentTab.content;
-            const reloadMeta = (state._fileReloadMetadata?.[relativePath] ??
-                null) as FileReloadMetadata | null;
-            const incomingOrigin = reloadMeta?.origin ?? "unknown";
-            const incomingOpId = reloadMeta?.opId ?? null;
-            const incomingRevision = reloadMeta?.revision ?? 0;
-            const lastAckRevision =
-                lastAckRevisionByPathRef.current.get(relativePath) ?? 0;
-            const pendingLocalOpId =
-                pendingLocalOpIdByPathRef.current.get(relativePath) ?? null;
-            const isPendingLocalSaveAck =
-                !isForced &&
-                incomingOrigin === "user" &&
-                incomingOpId !== null &&
-                incomingOpId === pendingLocalOpId;
-            const isStaleRevision =
-                !isForced &&
-                incomingRevision > 0 &&
-                incomingRevision <= lastAckRevision &&
-                !isPendingLocalSaveAck;
-            const acknowledgeIncomingRevision = () => {
-                if (incomingRevision <= 0) return;
-                lastAckRevisionByPathRef.current.set(
-                    relativePath,
-                    Math.max(lastAckRevision, incomingRevision),
-                );
-            };
-            const clearPendingLocalAck = () => {
-                if (isPendingLocalSaveAck) {
-                    pendingLocalOpIdByPathRef.current.delete(relativePath);
-                }
-            };
-
-            if (isStaleRevision) {
-                clearPendingLocalAck();
-                return;
-            }
-
-            if (!isForced && incomingContent === currentContent) {
-                acknowledgeIncomingRevision();
-                clearPendingLocalAck();
-                if (lastSaved !== incomingContent) {
-                    lastSavedContentByPathRef.current.set(
-                        relativePath,
-                        incomingContent,
-                    );
-                }
-                const store = useEditorStore.getState();
-                store.setTabDirty(currentTab.id, false);
-                store.clearFileExternalConflict(relativePath);
-                return;
-            }
-
-            if (hasLocalUnsavedChanges && !isForced) {
-                if (isPendingLocalSaveAck) {
-                    acknowledgeIncomingRevision();
-                    clearPendingLocalAck();
-                    lastSavedContentByPathRef.current.set(
-                        relativePath,
-                        incomingContent,
-                    );
-                    const store = useEditorStore.getState();
-                    store.setTabDirty(currentTab.id, false);
-                    store.clearFileExternalConflict(relativePath);
-                    return;
-                }
-                useEditorStore
-                    .getState()
-                    .markFileExternalConflict(relativePath);
-                return;
-            }
-
-            if (isForced) {
-                useEditorStore.getState().clearForceFileReload(relativePath);
-            }
-            acknowledgeIncomingRevision();
-            clearPendingLocalAck();
-            const store = useEditorStore.getState();
-            store.setTabDirty(currentTab.id, false);
-            store.clearFileExternalConflict(relativePath);
-            lastSavedContentByPathRef.current.set(
-                relativePath,
-                incomingContent,
-            );
-            replaceEditorDocument(incomingContent);
-        });
-
-        return unsubscribe;
-    }, [replaceEditorDocument]);
 
     useEffect(() => {
         const view = viewRef.current;
@@ -843,15 +495,7 @@ export function FileTextTabView() {
 
     useEffect(() => {
         return () => {
-            const currentTab = tabRef.current;
-            const view = viewRef.current;
-            if (saveTimerRef.current) {
-                clearTimeout(saveTimerRef.current);
-                saveTimerRef.current = null;
-            }
-            if (currentTab && view) {
-                void saveFile(currentTab, view.state.doc.toString());
-            }
+            flushCurrentSave();
             contextMenuCleanupRef.current?.();
             contextMenuCleanupRef.current = null;
             loadRequestRef.current += 1;
@@ -861,7 +505,7 @@ export function FileTextTabView() {
             setEditorContextMenu(null);
             setEditorView(null);
         };
-    }, [saveFile]);
+    }, [flushCurrentSave]);
 
     const editorShellStyle = {
         "--editor-font-size": `${editorFontSize}px`,
@@ -870,33 +514,6 @@ export function FileTextTabView() {
         "--editor-content-width": `${editorContentWidth}px`,
         "--editor-horizontal-inset": getEditorHorizontalInset(lineWrapping),
     } as CSSProperties;
-
-    const reloadFileFromDisk = useCallback(async () => {
-        if (!tab) return;
-
-        try {
-            const detail = await vaultInvoke<SavedVaultFileDetail>(
-                "read_vault_file",
-                {
-                    relativePath: tab.relativePath,
-                },
-            );
-            useEditorStore.getState().forceReloadFileContent(tab.relativePath, {
-                title: detail.file_name,
-                content: detail.content,
-            });
-            useEditorStore
-                .getState()
-                .clearFileExternalConflict(tab.relativePath);
-        } catch (error) {
-            logError("file-editor", "Failed to reload vault file", error);
-        }
-    }, [tab]);
-
-    const keepLocalFileVersion = useCallback(() => {
-        if (!tab) return;
-        useEditorStore.getState().clearFileExternalConflict(tab.relativePath);
-    }, [tab]);
 
     if (!tab) {
         return (
@@ -1070,13 +687,4 @@ export function FileTextTabView() {
             )}
         </div>
     );
-}
-
-function getActiveFileTab(state: ReturnType<typeof useEditorStore.getState>) {
-    const current = state.tabs.find(
-        (candidate) => candidate.id === state.activeTabId,
-    );
-    return current && isFileTab(current) && current.viewer === "text"
-        ? current
-        : null;
 }

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -254,33 +254,36 @@ export function FileTextTabView() {
         });
     }, []);
 
-    const syncCurrentSelection = useCallback((view: EditorView) => {
-        const selection = view.state.selection.main;
-        if (selection.empty) {
-            useEditorStore.getState().clearCurrentSelection();
-            return;
-        }
+    const syncCurrentSelection = useCallback(
+        (view: EditorView) => {
+            const selection = view.state.selection.main;
+            if (selection.empty) {
+                useEditorStore.getState().clearCurrentSelection();
+                return;
+            }
 
-        const currentTab = tabRef.current;
-        if (!currentTab) {
-            useEditorStore.getState().clearCurrentSelection();
-            return;
-        }
+            const currentTab = tabRef.current;
+            if (!currentTab) {
+                useEditorStore.getState().clearCurrentSelection();
+                return;
+            }
 
-        const startLine = view.state.doc.lineAt(selection.from).number;
-        const endLine = view.state.doc.lineAt(
-            Math.max(selection.from, selection.to - 1),
-        ).number;
-        useEditorStore.getState().setCurrentSelection({
-            noteId: null,
-            path: currentTab.path,
-            text: view.state.sliceDoc(selection.from, selection.to),
-            from: selection.from,
-            to: selection.to,
-            startLine,
-            endLine,
-        });
-    }, []);
+            const startLine = view.state.doc.lineAt(selection.from).number;
+            const endLine = view.state.doc.lineAt(
+                Math.max(selection.from, selection.to - 1),
+            ).number;
+            useEditorStore.getState().setCurrentSelection({
+                noteId: null,
+                path: currentTab.path,
+                text: view.state.sliceDoc(selection.from, selection.to),
+                from: selection.from,
+                to: selection.to,
+                startLine,
+                endLine,
+            });
+        },
+        [tabRef],
+    );
 
     useEffect(() => {
         const container = containerRef.current;

--- a/apps/desktop/src/features/editor/editorSelectionHelpers.ts
+++ b/apps/desktop/src/features/editor/editorSelectionHelpers.ts
@@ -46,4 +46,5 @@ export const EDITOR_INTERACTIVE_PREVIEW_SELECTOR = [
     ".cm-lp-footnote-ref",
     ".cm-lp-table-link",
     ".cm-lp-table-url",
+    "[data-embed-target][data-embed-kind]",
 ].join(", ");

--- a/apps/desktop/src/features/editor/embedNavigation.test.ts
+++ b/apps/desktop/src/features/editor/embedNavigation.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEditorStore } from "../../app/store/editorStore";
+import { openVaultEmbedTarget } from "./embedNavigation";
+import { setEditorTabs, setVaultEntries } from "../../test/test-utils";
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+    openPath: vi.fn(),
+}));
+
+describe("embedNavigation", () => {
+    beforeEach(() => {
+        setEditorTabs([]);
+        setVaultEntries(
+            [
+                {
+                    id: "papers/deepseek-r1",
+                    kind: "pdf",
+                    path: "/vault/RESEARCH/2026/Papers/2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+                    relative_path:
+                        "RESEARCH/2026/Papers/2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+                    title: "DeepSeek R1",
+                    file_name:
+                        "2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+                    extension: "pdf",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 0,
+                    mime_type: "application/pdf",
+                },
+            ],
+            "/vault",
+        );
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("opens vault pdf embeds in the in-app pdf tab", async () => {
+        await openVaultEmbedTarget(
+            "/RESEARCH/2026/Papers/2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+            "pdf",
+        );
+
+        const activeTab = useEditorStore
+            .getState()
+            .tabs.find(
+                (tab) => tab.id === useEditorStore.getState().activeTabId,
+            );
+
+        expect(activeTab).toMatchObject({
+            kind: "pdf",
+            entryId: "papers/deepseek-r1",
+            title: "DeepSeek R1",
+            path: "/vault/RESEARCH/2026/Papers/2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+        });
+    });
+});

--- a/apps/desktop/src/features/editor/embedNavigation.ts
+++ b/apps/desktop/src/features/editor/embedNavigation.ts
@@ -1,0 +1,94 @@
+import { openPath } from "@tauri-apps/plugin-opener";
+
+import { useEditorStore } from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+
+export type VaultEmbedKind = "pdf" | "image";
+
+function normalizeEmbedTargetRelativePath(target: string) {
+    return target.startsWith("/") ? target.slice(1) : target;
+}
+
+export function findVaultEmbedEntry(target: string) {
+    const relativePath = normalizeEmbedTargetRelativePath(target);
+    return (
+        useVaultStore
+            .getState()
+            .entries.find((entry) => entry.relative_path === relativePath) ??
+        null
+    );
+}
+
+export function getVaultEmbedAbsolutePath(target: string) {
+    const vaultPath = useVaultStore.getState().vaultPath;
+    if (!vaultPath) return null;
+
+    const relativePath = normalizeEmbedTargetRelativePath(target);
+    const separator =
+        vaultPath.endsWith("/") || vaultPath.endsWith("\\") ? "" : "/";
+    return `${vaultPath}${separator}${relativePath}`;
+}
+
+export async function openVaultEmbedTarget(
+    target: string,
+    kind: VaultEmbedKind,
+    options?: { newTab?: boolean },
+) {
+    const entry = findVaultEmbedEntry(target);
+    const absolutePath = getVaultEmbedAbsolutePath(target);
+    const editor = useEditorStore.getState();
+
+    if (entry) {
+        const title = entry.title || entry.file_name;
+
+        if (kind === "pdf") {
+            if (options?.newTab) {
+                editor.insertExternalTab({
+                    id: crypto.randomUUID(),
+                    kind: "pdf",
+                    entryId: entry.id,
+                    title,
+                    path: entry.path,
+                    page: 1,
+                    zoom: 1,
+                    viewMode: "continuous",
+                });
+            } else {
+                editor.openPdf(entry.id, title, entry.path);
+            }
+            return true;
+        }
+
+        if (options?.newTab) {
+            editor.insertExternalTab({
+                id: crypto.randomUUID(),
+                kind: "file",
+                relativePath: entry.relative_path,
+                title,
+                path: entry.path,
+                content: "",
+                mimeType: entry.mime_type,
+                viewer: "image",
+                sizeBytes: entry.size,
+                contentTruncated: false,
+            });
+        } else {
+            editor.openFile(
+                entry.relative_path,
+                title,
+                entry.path,
+                "",
+                entry.mime_type,
+                "image",
+            );
+        }
+        return true;
+    }
+
+    if (!absolutePath) {
+        return false;
+    }
+
+    await openPath(absolutePath);
+    return true;
+}

--- a/apps/desktop/src/features/editor/extensions/livePreview.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreview.ts
@@ -3,6 +3,7 @@ import { openUrl } from "@tauri-apps/plugin-opener";
 
 import { resolveLinkHref, linkReferenceField } from "./livePreviewHelpers";
 import { dispatchOpenYouTubeModal } from "../youtube";
+import { openVaultEmbedTarget } from "../embedNavigation";
 import {
     createCodeBlockLivePreviewExtension,
     createImageLivePreviewExtension,
@@ -31,6 +32,7 @@ const POINTER_INTERACTIVE_PREVIEW_SELECTOR = [
     ".cm-note-embed",
     ".cm-lp-footnote-ref",
     ".cm-lp-table-link",
+    "[data-embed-target][data-embed-kind]",
 ].join(", ");
 
 const KEYBOARD_INTERACTIVE_PREVIEW_SELECTOR = [
@@ -255,6 +257,18 @@ function activateInteractivePreview(
     view: EditorView,
     interactions: TableInteractionHandlers,
 ) {
+    const embedWidget = target.closest(
+        "[data-embed-target][data-embed-kind]",
+    ) as HTMLElement | null;
+    const embedKind = embedWidget?.dataset.embedKind;
+    if (
+        embedWidget?.dataset.embedTarget &&
+        (embedKind === "pdf" || embedKind === "image")
+    ) {
+        void openVaultEmbedTarget(embedWidget.dataset.embedTarget, embedKind);
+        return true;
+    }
+
     const embed = target.closest(".cm-note-embed") as HTMLElement | null;
     if (embed?.dataset.wikilinkTarget) {
         interactions.navigateWikilink(embed.dataset.wikilinkTarget);

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -69,4 +69,36 @@ describe("code block live preview", () => {
         view.destroy();
         parent.remove();
     });
+
+    it("renders pdf embeds when the file name contains brackets", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc =
+            "![[/RESEARCH/2026/Papers/2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf]]\nNext line";
+        const state = EditorState.create({
+            doc,
+            selection: EditorSelection.cursor(doc.length),
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                livePreviewExtension("/vault", {
+                    resolveWikilink: () => false,
+                    navigateWikilink: () => {},
+                    getNoteLinkTarget: () => null,
+                    openLinkContextMenu: () => {},
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent });
+
+        const embed = view.dom.querySelector(".cm-pdf-embed-chip");
+        expect(embed).not.toBeNull();
+        expect(view.dom.querySelector(".cm-pdf-embed-name")?.textContent).toBe(
+            "2025 - DeepSeek-R1 Reasoning via RL [DeepSeek].pdf",
+        );
+
+        view.destroy();
+        parent.remove();
+    });
 });

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -1765,18 +1765,23 @@ function isRenderableImageUrl(url: string): boolean {
 function parseWikilinkEmbedTarget(
     raw: string,
 ): { target: string; heading?: string; width?: number } | null {
-    const match = raw.match(/^!\[\[([^\]]+)\]\]$/);
-    if (!match) return null;
-    const parts = match[1].split("|");
-    const inner = parts[0]?.trim() ?? "";
+    if (!raw.startsWith("![[") || !raw.endsWith("]]")) return null;
+
+    let inner = raw.slice(3, -2).trim();
     if (!inner) return null;
 
     let width: number | undefined;
-    const dimStr = parts[1]?.trim();
-    if (dimStr) {
+    const widthSeparator = inner.lastIndexOf("|");
+    if (widthSeparator >= 0) {
+        const dimStr = inner.slice(widthSeparator + 1).trim();
         const dimMatch = dimStr.match(/^(\d+)(?:x\d+)?$/);
-        if (dimMatch) width = Number(dimMatch[1]);
+        if (dimMatch) {
+            width = Number(dimMatch[1]);
+            inner = inner.slice(0, widthSeparator).trim();
+        }
     }
+
+    if (!inner) return null;
 
     const hashIdx = inner.indexOf("#");
     if (hashIdx >= 0) {

--- a/apps/desktop/src/features/editor/useEditableFileResource.ts
+++ b/apps/desktop/src/features/editor/useEditableFileResource.ts
@@ -1,0 +1,495 @@
+import { useCallback, useEffect, useRef } from "react";
+import {
+    fileViewerNeedsTextContent,
+    isFileTab,
+    useEditorStore,
+    type FileTab,
+    type Tab,
+} from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import { vaultInvoke } from "../../app/utils/vaultInvoke";
+import {
+    buildLiveFilePathCacheKey,
+    clearFilePathStateCaches,
+    pruneFilePathStateCaches,
+    type FilePathStateCacheCollection,
+} from "./filePathStateCache";
+import { logError } from "../../app/utils/runtimeLog";
+
+type SavedVaultFileDetail = {
+    relative_path: string;
+    file_name: string;
+    content: string;
+    size_bytes?: number | null;
+    content_truncated?: boolean;
+};
+
+type FileReloadMetadata = {
+    origin?: "user" | "agent" | "external" | "system" | "unknown";
+    opId?: string | null;
+    revision?: number;
+    contentHash?: string | null;
+};
+
+type EditableFileTab = NonNullable<ReturnType<typeof getActiveEditableFileTab>>;
+
+interface UseEditableFileResourceOptions {
+    getCurrentContent: () => string | null;
+    applyIncomingContent: (nextContent: string) => void;
+    acceptTab?: (tab: FileTab) => boolean;
+    autosaveDelayMs?: number;
+}
+
+// Shared file-editing orchestration so multiple viewers can reuse the same
+// autosave, reload and external-conflict behavior without diverging.
+export function useEditableFileResource({
+    getCurrentContent,
+    applyIncomingContent,
+    acceptTab = defaultAcceptEditableFileTab,
+    autosaveDelayMs = 300,
+}: UseEditableFileResourceOptions) {
+    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const previousTabRef = useRef<EditableFileTab | null>(null);
+    const tabRef = useRef<EditableFileTab | null>(null);
+    const lastSavedContentByPathRef = useRef(new Map<string, string>());
+    const lastAckRevisionByPathRef = useRef(new Map<string, number>());
+    const pendingLocalOpIdByPathRef = useRef(new Map<string, string>());
+    const saveRequestIdByPathRef = useRef(new Map<string, number>());
+    const lastLiveFilePathCacheKeyRef = useRef<string | null>(null);
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+    const lastVaultPathRef = useRef<string | null>(vaultPath);
+
+    const tab = useEditorStore((state) =>
+        getActiveEditableFileTab(state, acceptTab),
+    );
+    const hasExternalConflict = useEditorStore((state) => {
+        const relativePath = tab?.relativePath;
+        return relativePath
+            ? state.fileExternalConflicts.has(relativePath)
+            : false;
+    });
+
+    useEffect(() => {
+        tabRef.current = tab;
+    }, [tab]);
+
+    const getFilePathStateCaches = useCallback(
+        (): FilePathStateCacheCollection => ({
+            lastSavedContentByPath: lastSavedContentByPathRef.current,
+            lastAckRevisionByPath: lastAckRevisionByPathRef.current,
+            pendingLocalOpIdByPath: pendingLocalOpIdByPathRef.current,
+            saveRequestIdByPath: saveRequestIdByPathRef.current,
+        }),
+        [],
+    );
+
+    const pruneFilePathStateForOpenTabs = useCallback(
+        (tabs: readonly Tab[]) => {
+            pruneFilePathStateCaches(tabs, getFilePathStateCaches());
+        },
+        [getFilePathStateCaches],
+    );
+
+    useEffect(() => {
+        if (lastVaultPathRef.current === vaultPath) return;
+        lastVaultPathRef.current = vaultPath;
+        lastLiveFilePathCacheKeyRef.current = null;
+        clearFilePathStateCaches(getFilePathStateCaches());
+    }, [getFilePathStateCaches, vaultPath]);
+
+    useEffect(() => {
+        const syncLiveFilePathState = (tabs: readonly Tab[]) => {
+            const nextKey = buildLiveFilePathCacheKey(tabs);
+            if (lastLiveFilePathCacheKeyRef.current === nextKey) return;
+            lastLiveFilePathCacheKeyRef.current = nextKey;
+            pruneFilePathStateForOpenTabs(tabs);
+        };
+
+        syncLiveFilePathState(useEditorStore.getState().tabs);
+        const unsubscribe = useEditorStore.subscribe((state) => {
+            syncLiveFilePathState(state.tabs);
+        });
+        return unsubscribe;
+    }, [pruneFilePathStateForOpenTabs]);
+
+    const saveFile = useCallback(
+        async (targetTab: EditableFileTab, content: string) => {
+            const lastSaved = lastSavedContentByPathRef.current.get(
+                targetTab.relativePath,
+            );
+            if (lastSaved === content) {
+                return;
+            }
+
+            const requestId =
+                (saveRequestIdByPathRef.current.get(targetTab.relativePath) ??
+                    0) + 1;
+            saveRequestIdByPathRef.current.set(
+                targetTab.relativePath,
+                requestId,
+            );
+            const localOpId =
+                typeof crypto !== "undefined" &&
+                typeof crypto.randomUUID === "function"
+                    ? crypto.randomUUID()
+                    : `local-file-save-${Date.now()}-${Math.random()}`;
+
+            // Track the save op so incoming reload events can distinguish a local
+            // save acknowledgement from a genuine external overwrite.
+            pendingLocalOpIdByPathRef.current.set(
+                targetTab.relativePath,
+                localOpId,
+            );
+
+            try {
+                const detail = await vaultInvoke<SavedVaultFileDetail>(
+                    "save_vault_file",
+                    {
+                        relativePath: targetTab.relativePath,
+                        content,
+                        opId: localOpId,
+                    },
+                );
+                if (
+                    saveRequestIdByPathRef.current.get(
+                        targetTab.relativePath,
+                    ) !== requestId
+                ) {
+                    return;
+                }
+
+                lastSavedContentByPathRef.current.set(
+                    targetTab.relativePath,
+                    detail.content,
+                );
+
+                const store = useEditorStore.getState();
+                store.setTabDirty(targetTab.id, false);
+                store.updateFileHistoryTitle(
+                    targetTab.id,
+                    targetTab.relativePath,
+                    detail.file_name,
+                );
+                store.reloadFileContent(targetTab.relativePath, {
+                    title: detail.file_name,
+                    content: detail.content,
+                    sizeBytes: detail.size_bytes ?? null,
+                    contentTruncated: Boolean(detail.content_truncated),
+                    origin: "user",
+                    opId: localOpId,
+                });
+                store.clearFileExternalConflict(targetTab.relativePath);
+            } catch (error) {
+                pendingLocalOpIdByPathRef.current.delete(
+                    targetTab.relativePath,
+                );
+                logError("file-editor", "Failed to save vault file", error);
+            }
+        },
+        [],
+    );
+
+    const scheduleSave = useCallback(
+        (targetTab: EditableFileTab, content: string) => {
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+            }
+
+            saveTimerRef.current = setTimeout(() => {
+                saveTimerRef.current = null;
+                void saveFile(targetTab, content);
+            }, autosaveDelayMs);
+        },
+        [autosaveDelayMs, saveFile],
+    );
+
+    const handleLocalContentChange = useCallback(
+        (content: string) => {
+            const currentTab = tabRef.current;
+            if (!currentTab) {
+                return;
+            }
+
+            const lastSaved =
+                lastSavedContentByPathRef.current.get(
+                    currentTab.relativePath,
+                ) ?? currentTab.content;
+            const store = useEditorStore.getState();
+            store.updateTabContent(currentTab.id, content);
+            store.setTabDirty(currentTab.id, content !== lastSaved);
+            scheduleSave(currentTab, content);
+        },
+        [scheduleSave],
+    );
+
+    const flushPendingSave = useCallback(
+        async (targetTab: EditableFileTab | null, content: string | null) => {
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+                saveTimerRef.current = null;
+            }
+            if (!targetTab || content === null) {
+                return;
+            }
+
+            const lastSaved =
+                lastSavedContentByPathRef.current.get(targetTab.relativePath) ??
+                targetTab.content;
+            if (content === lastSaved) {
+                return;
+            }
+
+            await saveFile(targetTab, content);
+        },
+        [saveFile],
+    );
+
+    useEffect(() => {
+        const previousTab = previousTabRef.current;
+        const currentTab = tabRef.current;
+        const currentContent = getCurrentContent();
+
+        if (previousTab) {
+            void flushPendingSave(previousTab, currentContent);
+        }
+
+        previousTabRef.current = currentTab;
+
+        if (!currentTab) {
+            return;
+        }
+
+        applyIncomingContent(currentTab.content);
+        lastSavedContentByPathRef.current.set(
+            currentTab.relativePath,
+            currentTab.content,
+        );
+        const store = useEditorStore.getState();
+        store.setTabDirty(currentTab.id, false);
+    }, [
+        applyIncomingContent,
+        flushPendingSave,
+        getCurrentContent,
+        tab?.id,
+        tab?.relativePath,
+    ]);
+
+    useEffect(() => {
+        const currentTab = tabRef.current;
+        if (!currentTab) {
+            return;
+        }
+
+        if (!lastSavedContentByPathRef.current.has(currentTab.relativePath)) {
+            lastSavedContentByPathRef.current.set(
+                currentTab.relativePath,
+                currentTab.content,
+            );
+            useEditorStore.getState().setTabDirty(currentTab.id, false);
+        }
+    }, [tab?.content, tab?.relativePath]);
+
+    useEffect(() => {
+        const unsubscribe = useEditorStore.subscribe((state, prev) => {
+            const activeTabId = state.activeTabId;
+            if (!activeTabId) return;
+
+            const currentTab = state.tabs.find(
+                (candidate) => candidate.id === activeTabId,
+            );
+            const previousTab = prev.tabs.find(
+                (candidate) => candidate.id === activeTabId,
+            );
+            if (!currentTab || !previousTab) return;
+            if (!isFileTab(currentTab) || !isFileTab(previousTab)) return;
+            if (!acceptTab(currentTab) || !acceptTab(previousTab)) {
+                return;
+            }
+            if (currentTab.relativePath !== previousTab.relativePath) {
+                return;
+            }
+
+            const relativePath = currentTab.relativePath;
+            const reloadVersion =
+                state._fileReloadVersions?.[relativePath] ?? 0;
+            const previousReloadVersion =
+                prev._fileReloadVersions?.[relativePath] ?? 0;
+            const isForced =
+                state._pendingForceFileReloads?.has(relativePath) ?? false;
+
+            if (reloadVersion === previousReloadVersion && !isForced) {
+                return;
+            }
+
+            const currentContent = getCurrentContent();
+            if (currentContent === null) {
+                return;
+            }
+
+            const lastSaved =
+                lastSavedContentByPathRef.current.get(relativePath) ?? null;
+            const hasLocalUnsavedChanges =
+                lastSaved !== null && currentContent !== lastSaved;
+            const incomingContent = currentTab.content;
+            const reloadMeta = (state._fileReloadMetadata?.[relativePath] ??
+                null) as FileReloadMetadata | null;
+            const incomingOrigin = reloadMeta?.origin ?? "unknown";
+            const incomingOpId = reloadMeta?.opId ?? null;
+            const incomingRevision = reloadMeta?.revision ?? 0;
+            const lastAckRevision =
+                lastAckRevisionByPathRef.current.get(relativePath) ?? 0;
+            const pendingLocalOpId =
+                pendingLocalOpIdByPathRef.current.get(relativePath) ?? null;
+            const isPendingLocalSaveAck =
+                !isForced &&
+                incomingOrigin === "user" &&
+                incomingOpId !== null &&
+                incomingOpId === pendingLocalOpId;
+            const isStaleRevision =
+                !isForced &&
+                incomingRevision > 0 &&
+                incomingRevision <= lastAckRevision &&
+                !isPendingLocalSaveAck;
+            const acknowledgeIncomingRevision = () => {
+                if (incomingRevision <= 0) return;
+                lastAckRevisionByPathRef.current.set(
+                    relativePath,
+                    Math.max(lastAckRevision, incomingRevision),
+                );
+            };
+            const clearPendingLocalAck = () => {
+                if (isPendingLocalSaveAck) {
+                    pendingLocalOpIdByPathRef.current.delete(relativePath);
+                }
+            };
+
+            if (isStaleRevision) {
+                clearPendingLocalAck();
+                return;
+            }
+
+            if (!isForced && incomingContent === currentContent) {
+                acknowledgeIncomingRevision();
+                clearPendingLocalAck();
+                if (lastSaved !== incomingContent) {
+                    lastSavedContentByPathRef.current.set(
+                        relativePath,
+                        incomingContent,
+                    );
+                }
+                const store = useEditorStore.getState();
+                store.setTabDirty(currentTab.id, false);
+                store.clearFileExternalConflict(relativePath);
+                return;
+            }
+
+            if (hasLocalUnsavedChanges && !isForced) {
+                if (isPendingLocalSaveAck) {
+                    acknowledgeIncomingRevision();
+                    clearPendingLocalAck();
+                    lastSavedContentByPathRef.current.set(
+                        relativePath,
+                        incomingContent,
+                    );
+                    const store = useEditorStore.getState();
+                    store.setTabDirty(currentTab.id, false);
+                    store.clearFileExternalConflict(relativePath);
+                    return;
+                }
+                useEditorStore
+                    .getState()
+                    .markFileExternalConflict(relativePath);
+                return;
+            }
+
+            if (isForced) {
+                useEditorStore.getState().clearForceFileReload(relativePath);
+            }
+            acknowledgeIncomingRevision();
+            clearPendingLocalAck();
+            const store = useEditorStore.getState();
+            store.setTabDirty(currentTab.id, false);
+            store.clearFileExternalConflict(relativePath);
+            lastSavedContentByPathRef.current.set(
+                relativePath,
+                incomingContent,
+            );
+            applyIncomingContent(incomingContent);
+        });
+
+        return unsubscribe;
+    }, [acceptTab, applyIncomingContent, getCurrentContent]);
+
+    useEffect(() => {
+        return () => {
+            if (saveTimerRef.current) {
+                clearTimeout(saveTimerRef.current);
+                saveTimerRef.current = null;
+            }
+        };
+    }, []);
+
+    const reloadFileFromDisk = useCallback(async () => {
+        const currentTab = tabRef.current;
+        if (!currentTab) return;
+
+        try {
+            const detail = await vaultInvoke<SavedVaultFileDetail>(
+                "read_vault_file",
+                {
+                    relativePath: currentTab.relativePath,
+                },
+            );
+            useEditorStore
+                .getState()
+                .forceReloadFileContent(currentTab.relativePath, {
+                    title: detail.file_name,
+                    content: detail.content,
+                    sizeBytes: detail.size_bytes ?? null,
+                    contentTruncated: Boolean(detail.content_truncated),
+                });
+            useEditorStore
+                .getState()
+                .clearFileExternalConflict(currentTab.relativePath);
+        } catch (error) {
+            logError("file-editor", "Failed to reload vault file", error);
+        }
+    }, []);
+
+    const keepLocalFileVersion = useCallback(() => {
+        const currentTab = tabRef.current;
+        if (!currentTab) return;
+        useEditorStore
+            .getState()
+            .clearFileExternalConflict(currentTab.relativePath);
+    }, []);
+
+    const flushCurrentSave = useCallback(() => {
+        void flushPendingSave(tabRef.current, getCurrentContent());
+    }, [flushPendingSave, getCurrentContent]);
+
+    return {
+        tab,
+        tabRef,
+        hasExternalConflict,
+        handleLocalContentChange,
+        reloadFileFromDisk,
+        keepLocalFileVersion,
+        flushCurrentSave,
+    };
+}
+
+function defaultAcceptEditableFileTab(tab: FileTab) {
+    return fileViewerNeedsTextContent(tab.viewer);
+}
+
+function getActiveEditableFileTab(
+    state: ReturnType<typeof useEditorStore.getState>,
+    acceptTab: (tab: FileTab) => boolean,
+) {
+    const current = state.tabs.find(
+        (candidate) => candidate.id === state.activeTabId,
+    );
+
+    return current && isFileTab(current) && acceptTab(current) ? current : null;
+}

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1,5 +1,6 @@
 @import "tailwindcss";
 @import "katex/dist/katex.min.css";
+@import "react-datasheet-grid/dist/style.css";
 
 @font-face {
     font-family: "JetBrains Mono";
@@ -879,4 +880,207 @@ body.dragging-tab * {
         opacity: 0.85;
         box-shadow: 0 0 0 6px rgba(185, 28, 28, 0);
     }
+}
+
+.csv-file-grid {
+    --dsg-border-color: var(--border);
+    --dsg-selection-border-color: color-mix(
+        in srgb,
+        var(--accent) 76%,
+        var(--text-primary)
+    );
+    --dsg-selection-background-color: color-mix(
+        in srgb,
+        var(--accent) 12%,
+        transparent
+    );
+    --dsg-header-text-color: var(--text-secondary);
+    --dsg-header-active-text-color: var(--text-primary);
+    --dsg-cell-background-color: var(--bg-primary);
+    --dsg-cell-disabled-background-color: color-mix(
+        in srgb,
+        var(--bg-secondary) 68%,
+        var(--bg-primary)
+    );
+    --dsg-scroll-shadow-color: rgb(0 0 0 / 0.14);
+
+    background: var(--bg-primary);
+}
+
+.csv-file-grid .dsg-container {
+    color: var(--text-primary);
+    background: var(--bg-primary);
+    border-top: 1px solid var(--border);
+    border-left: 1px solid var(--border);
+}
+
+.csv-file-grid .dsg-row-header {
+    box-shadow: 0 1px var(--border) inset;
+}
+
+.csv-file-grid .dsg-cell-header-container {
+    width: 100%;
+    height: 100%;
+    padding: 0 8px;
+    display: flex;
+    align-items: center;
+}
+
+.csv-file-grid .dsg-input {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 12px;
+    outline: none;
+}
+
+.csv-file-grid .dsg-input::selection,
+.csv-file-column-input::selection,
+.csv-file-raw::selection {
+    background: color-mix(in srgb, var(--accent) 24%, transparent);
+}
+
+/* Override react-datasheet-grid context menu to match app ContextMenu style */
+.dsg-context-menu {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    padding: 4px;
+    color: var(--text-primary);
+}
+
+.dsg-context-menu-item {
+    padding: 4px 12px;
+    font-size: 12px;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.dsg-context-menu-item:hover {
+    background: var(--bg-tertiary);
+}
+
+.csv-file-preview-table {
+    width: 100%;
+    min-width: max-content;
+    border-collapse: separate;
+    border-spacing: 0;
+    color: var(--text-primary);
+    background: var(--bg-primary);
+}
+
+.csv-file-preview-table th,
+.csv-file-preview-table td {
+    min-width: 160px;
+    padding: 10px 12px;
+    border-right: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+    font-size: 12px;
+    text-align: left;
+    vertical-align: top;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.csv-file-preview-table th {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background: color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary));
+    color: var(--text-secondary);
+    font-weight: 600;
+}
+
+.csv-file-preview-table th:first-child,
+.csv-file-preview-table td:first-child {
+    border-left: 1px solid var(--border);
+}
+
+.csv-file-preview-table thead tr:first-child th {
+    border-top: 1px solid var(--border);
+}
+
+.csv-file-column-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    width: 100%;
+}
+
+.csv-file-column-input {
+    width: 100%;
+    min-width: 0;
+    height: 26px;
+    padding: 0 8px;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    background: transparent;
+    color: var(--text-primary);
+    font-size: 11px;
+    outline: none;
+}
+
+.csv-file-column-input:focus {
+    border-color: color-mix(in srgb, var(--accent) 28%, var(--border));
+    background: color-mix(in srgb, var(--bg-primary) 88%, white 2%);
+}
+
+.csv-file-column-delete,
+.csv-file-row-delete {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid transparent;
+    border-radius: 6px;
+    background: transparent;
+    color: color-mix(in srgb, #ef4444 50%, var(--text-secondary));
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.5;
+    transition:
+        color 120ms ease,
+        border-color 120ms ease,
+        background-color 120ms ease,
+        opacity 120ms ease;
+}
+
+.csv-file-column-delete {
+    flex: 0 0 auto;
+    padding: 5px;
+}
+
+.csv-file-row-delete {
+    padding: 5px;
+}
+
+.csv-file-column-delete:hover,
+.csv-file-row-delete:hover {
+    background: color-mix(in srgb, #ef4444 10%, transparent);
+    color: #ef4444;
+    opacity: 1;
+}
+
+.csv-file-column-delete:focus-visible,
+.csv-file-row-delete:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
+    outline-offset: 1px;
+}
+
+.csv-file-raw {
+    width: 100%;
+    height: 100%;
+    resize: none;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 14px;
+    background: color-mix(in srgb, var(--bg-secondary) 38%, var(--bg-primary));
+    color: var(--text-primary);
+    font:
+        12px/1.55 "JetBrains Mono",
+        "IBM Plex Mono",
+        monospace;
+    outline: none;
 }

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -220,6 +220,129 @@ vi.mock("@xterm/addon-web-links", () => ({
     },
 }));
 
+vi.mock("react-datasheet-grid", async () => {
+    const React = await import("react");
+
+    return {
+        createTextColumn: (column: unknown) => column,
+        keyColumn: (key: string, column: Record<string, unknown>) => ({
+            ...column,
+            dataKey: key,
+        }),
+        DataSheetGrid: ({
+            value = [],
+            onChange,
+            columns = [],
+            stickyRightColumn,
+            className,
+        }: {
+            value?: Array<Record<string, string>>;
+            onChange?: (rows: Array<Record<string, string>>) => void;
+            columns?: Array<Record<string, unknown>>;
+            stickyRightColumn?: Record<string, unknown>;
+            className?: string;
+        }) =>
+            React.createElement(
+                "div",
+                { className },
+                React.createElement(
+                    "div",
+                    { className: "dsg-container" },
+                    React.createElement(
+                        "div",
+                        { className: "dsg-row dsg-row-header" },
+                        columns.map((column, index) =>
+                            React.createElement(
+                                "div",
+                                {
+                                    key: `header-${String(column.dataKey ?? index)}`,
+                                    className: "dsg-cell-header-container",
+                                },
+                                column.title as React.ReactNode,
+                            ),
+                        ),
+                        stickyRightColumn
+                            ? React.createElement(
+                                  "div",
+                                  {
+                                      key: "sticky-header",
+                                      className: "dsg-cell-header-container",
+                                  },
+                                  stickyRightColumn.title as React.ReactNode,
+                              )
+                            : null,
+                    ),
+                    value.map((row, rowIndex) =>
+                        React.createElement(
+                            "div",
+                            {
+                                key:
+                                    row.__csv_row_id ??
+                                    `row-${rowIndex.toString()}`,
+                                className: "dsg-row",
+                            },
+                            columns.map((column, columnIndex) => {
+                                const dataKey = String(
+                                    column.dataKey ?? columnIndex,
+                                );
+                                return React.createElement("input", {
+                                    key: `cell-${rowIndex.toString()}-${dataKey}`,
+                                    className: "dsg-input",
+                                    value: row[dataKey] ?? "",
+                                    onChange: (
+                                        event: React.ChangeEvent<HTMLInputElement>,
+                                    ) => {
+                                        onChange?.(
+                                            value.map((candidate, index) =>
+                                                index === rowIndex
+                                                    ? {
+                                                          ...candidate,
+                                                          [dataKey]:
+                                                              event.target
+                                                                  .value,
+                                                      }
+                                                    : candidate,
+                                            ),
+                                        );
+                                    },
+                                });
+                            }),
+                            stickyRightColumn?.component
+                                ? React.createElement(
+                                      stickyRightColumn.component as React.ComponentType<{
+                                          rowData: Record<string, string>;
+                                          rowIndex: number;
+                                          deleteRow: () => void;
+                                      }>,
+                                      {
+                                          key: `sticky-cell-${rowIndex.toString()}`,
+                                          rowData: row,
+                                          rowIndex,
+                                          deleteRow: () => {
+                                              onChange?.(
+                                                  value.filter(
+                                                      (_, index) =>
+                                                          index !== rowIndex,
+                                                  ),
+                                              );
+                                          },
+                                      },
+                                  )
+                                : null,
+                        ),
+                    ),
+                ),
+            ),
+    };
+});
+
+vi.mock("react-resize-detector", () => ({
+    useResizeDetector: () => ({
+        width: 960,
+        height: 420,
+    }),
+}));
+
 const mockCurrentWindow = {
     listen: vi.fn(),
     once: vi.fn(),

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
+import { fileURLToPath, URL } from "node:url";
 
 function manualChunks(id: string) {
     if (!id.includes("node_modules")) {
@@ -36,6 +37,23 @@ function manualChunks(id: string) {
 export default defineConfig({
     plugins: [react(), tailwindcss()],
     clearScreen: false,
+    resolve: {
+        dedupe: ["react", "react-dom"],
+        alias: [
+            {
+                find: "react",
+                replacement: fileURLToPath(
+                    new URL("./node_modules/react", import.meta.url),
+                ),
+            },
+            {
+                find: "react-dom",
+                replacement: fileURLToPath(
+                    new URL("./node_modules/react-dom", import.meta.url),
+                ),
+            },
+        ],
+    },
     build: {
         // The desktop app intentionally ships several large lazy chunks
         // (CodeMirror languages, graph tooling, Mermaid definitions).


### PR DESCRIPTION
## Summary
- add a dedicated `CsvFileTabView` with editable table and read-only raw fallback
- reuse a shared editable file resource hook so CSV and text files share autosave, reload and external-conflict behavior
- persist CSV viewer/session metadata, detect CSV files on open, and add large-file / partial-preview safeguards
- harden the grid integration with stable row/column identity and structural remounts so edits, row changes, and column changes reflect immediately

## Validation
- `npm --prefix apps/desktop test -- CsvFileTabView FileTabView editorSession vaultEntries`
- `npm --prefix apps/desktop run build`

## Notes
- CSV table editing is disabled for files larger than 2 MB
- CSV files with more than 500 data rows render a read-only preview table to avoid saving partial representations