### PR TITLE
[codex] Land multi-pane workspace and review flow hardening

### DIFF
--- a/.PERSONAL/plans/Pendientes cierre multipane.md
+++ b/.PERSONAL/plans/Pendientes cierre multipane.md
@@ -1,0 +1,48 @@
+# Pendientes cierre multipane
+
+Fecha: 2026-04-10
+Branch: `feature/multi-pane-workspace`
+Estado: Pendiente después del commit de implementación
+
+## Contexto
+
+La implementación multipane quedó desarrollada localmente y este plan resume lo que sigue antes de considerar la rama lista para merge.
+
+El objetivo de este documento no es volver a planificar la feature, sino listar el trabajo de cierre que todavía conviene ejecutar después de dejar el estado actual comiteado.
+
+## Pendientes reales
+
+### 1. QA manual multipane
+
+- abrir `1`, `2` y `3` panes y verificar resize continuo
+- validar foco visual por pane y sincronía del panel derecho
+- abrir la misma nota en panes distintos y editar sin ambigüedad
+- validar `Add to New Pane`, mover tabs entre panes y `Close Pane`
+- probar pane vacío y reapertura desde file tree/search/wikilinks
+
+### 2. QA manual de review y cambios del agente
+
+- probar `note + review + note` en panes distintos
+- validar aceptación y rechazo de cambios con foco alternando entre panes
+- revisar panel de cambios del agente mientras cambia el pane enfocado
+- verificar que no se aplique una review sobre el pane incorrecto
+
+### 3. Validación ampliada automatizada
+
+- correr una pasada más amplia de tests de integración relacionados con editor, links, file tree, search y chat
+- decidir si vale la pena correr la suite completa de `apps/desktop` antes del merge
+
+### 4. Limpieza final
+
+- revisar si conviene eliminar o resolver los warnings existentes de `act(...)` en `AIReviewView.test.tsx`
+- hacer una pasada visual final de copy y affordances del estado vacío
+- preparar el diff para revisión o PR
+
+## Criterio de salida
+
+La rama puede considerarse lista para merge cuando:
+
+- el flujo multipane se sienta estable en QA manual
+- review inline y cambios del agente no presenten ambigüedad operativa
+- no queden regresiones detectadas en los flujos críticos de editor
+- el diff esté listo para revisión externa

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
         "lint": "eslint .",
         "test": "vitest run",
         "test:watch": "vitest",
+        "test:split-grid-baseline": "vitest run src/app/store/workspaceLayoutTree.test.ts src/app/store/workspaceLayoutNavigation.test.ts src/app/store/editorStore.test.ts src/app/store/editorSession.test.ts src/app/store/layoutStore.test.ts src/features/editor/MultiPaneWorkspace.test.tsx src/features/editor/EditorPaneBar.test.tsx src/features/editor/UnifiedBar.test.tsx src/features/vault/FileTree.test.tsx src/features/ai/hooks/useAutoOpenReviewTab.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/AIReviewView.test.tsx",
         "preview": "vite preview",
         "tauri": "node scripts/run-tauri.mjs"
     },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,7 +9,7 @@
         "lint": "eslint .",
         "test": "vitest run",
         "test:watch": "vitest",
-        "test:split-grid-baseline": "vitest run src/app/store/workspaceLayoutTree.test.ts src/app/store/workspaceLayoutNavigation.test.ts src/app/store/editorStore.test.ts src/app/store/editorSession.test.ts src/app/store/layoutStore.test.ts src/features/editor/MultiPaneWorkspace.test.tsx src/features/editor/EditorPaneBar.test.tsx src/features/editor/UnifiedBar.test.tsx src/features/vault/FileTree.test.tsx src/features/ai/hooks/useAutoOpenReviewTab.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/AIReviewView.test.tsx",
+        "test:split-grid-baseline": "vitest run src/app/store/workspaceLayoutTree.test.ts src/app/store/workspaceLayoutNavigation.test.ts src/app/store/editorStore.test.ts src/app/store/editorSession.test.ts src/app/store/layoutStore.test.ts src/features/editor/MultiPaneWorkspace.test.tsx src/features/editor/EditorPaneBar.test.tsx src/features/editor/workspaceTabDropPreview.test.ts src/features/editor/UnifiedBar.test.tsx src/features/vault/FileTree.test.tsx src/features/ai/hooks/useAutoOpenReviewTab.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/AIReviewView.test.tsx",
         "preview": "vite preview",
         "tauri": "node scripts/run-tauri.mjs"
     },

--- a/apps/desktop/src/App.noteWindow.test.tsx
+++ b/apps/desktop/src/App.noteWindow.test.tsx
@@ -177,4 +177,29 @@ describe("App note window", () => {
         expect(useEditorStore.getState().tabs).toHaveLength(0);
         expect(useEditorStore.getState().activeTabId).toBeNull();
     });
+
+    it("registers workspace split and focus commands", async () => {
+        renderComponent(<App />);
+        await flushPromises();
+
+        await act(async () => {
+            useCommandStore.getState().execute("workspace:split-right");
+            await Promise.resolve();
+        });
+        await flushPromises();
+
+        expect(useEditorStore.getState().panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-2",
+        ]);
+        expect(useEditorStore.getState().focusedPaneId).toBe("pane-2");
+
+        await act(async () => {
+            useCommandStore.getState().execute("workspace:focus-left");
+            await Promise.resolve();
+        });
+        await flushPromises();
+
+        expect(useEditorStore.getState().focusedPaneId).toBe("primary");
+    });
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import { listen } from "@tauri-apps/api/event";
 import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
 import { resolveDeferredUnlisten } from "./app/utils/deferredUnlisten";
-import { perfCount } from "./app/utils/perfInstrumentation";
 import { vaultInvoke } from "./app/utils/vaultInvoke";
 import { AppLayout } from "./components/layout/AppLayout";
 import { ActivityBar, type SidebarView } from "./components/layout/ActivityBar";
@@ -17,16 +16,11 @@ import { LinksPanel } from "./features/notes/LinksPanel";
 import { OutlinePanel } from "./features/notes/OutlinePanel";
 import { AIChatPanel } from "./features/ai/AIChatPanel";
 import { UnifiedBar } from "./features/editor/UnifiedBar";
-import {
-    Editor,
-    REQUEST_CLOSE_ACTIVE_TAB_EVENT,
-} from "./features/editor/Editor";
-import { FileTabView } from "./features/editor/FileTabView";
-import { AIReviewView } from "./features/ai/components/AIReviewView";
+import { REQUEST_CLOSE_ACTIVE_TAB_EVENT } from "./features/editor/Editor";
 import { useAutoOpenReviewTab } from "./features/ai/hooks/useAutoOpenReviewTab";
-import { NewTabView } from "./features/editor/NewTabView";
-import { SearchView } from "./features/search/SearchView";
-import { PdfTabView } from "./features/pdf/PdfTabView";
+import { EditorPaneContent } from "./features/editor/EditorPaneContent";
+import { MultiPaneWorkspace } from "./features/editor/MultiPaneWorkspace";
+import { WorkspaceChromeBar } from "./features/editor/WorkspaceChromeBar";
 import { MapsPanel } from "./features/maps/MapsPanel";
 import { BookmarksPanel } from "./features/bookmarks/BookmarksPanel";
 import { useBookmarkStore } from "./app/store/bookmarkStore";
@@ -62,13 +56,14 @@ import {
     fileViewerNeedsTextContent,
     useEditorStore,
     isFileTab,
-    isGraphTab,
-    isMapTab,
     isNoteTab,
-    isPdfTab,
-    isReviewTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
 } from "./app/store/editorStore";
 import {
+    buildPersistedSession,
+    isSessionReady,
+    writePersistedSession,
     markSessionReady,
     restorePersistedSession,
 } from "./app/store/editorSession";
@@ -126,6 +121,7 @@ const WEB_CLIPPER_ROUTE_POLL_MS = 100;
 const WEB_CLIPPER_ROUTE_TIMEOUT_MS = 10_000;
 const MENU_ACTION_EVENT = "menu-action";
 const DOCK_OPEN_VAULT_EVENT = "dock-open-vault";
+const EXCALIDRAW_RUNTIME_SUPPORTED = canUseExcalidrawRuntime();
 
 function waitForWindowRoute(ms: number) {
     return new Promise<void>((resolve) => {
@@ -317,12 +313,12 @@ function VaultOpeningOverlay() {
 }
 
 function OutlineRightPanel() {
-    const activeNoteId = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
+    const activeNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return tab && isNoteTab(tab) ? tab.noteId : null;
     });
-    const activeContent = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
+    const activeContent = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return tab && isNoteTab(tab) ? tab.content : null;
     });
     const queueSelectionReveal = useEditorStore((s) => s.queueSelectionReveal);
@@ -947,166 +943,11 @@ function useDynamicScrollbars() {
     }, []);
 }
 
-type EditorPanelView =
-    | "pdf"
-    | "file"
-    | "new"
-    | "search"
-    | "ai-review"
-    | "editor"
-    | "map"
-    | "graph";
-
-const LazyExcalidrawTabView = React.lazy(() =>
-    import("./features/maps/ExcalidrawTabView").then((m) => ({
-        default: m.ExcalidrawTabView,
-    })),
-);
-
-const LazyGraphTabView = React.lazy(() =>
-    import("./features/graph/GraphTabView").then((m) => ({
-        default: m.GraphTabView,
-    })),
-);
-
-const GRAPH_KEEP_ALIVE_MS = 15 * 60 * 1000;
-const EXCALIDRAW_RUNTIME_SUPPORTED = canUseExcalidrawRuntime();
-
-function UnsupportedMapView() {
-    return (
-        <div
-            className="h-full flex items-center justify-center p-6"
-            style={{ color: "var(--text-secondary)" }}
-        >
-            <div
-                className="max-w-xl rounded-xl p-5"
-                style={{
-                    border: "1px solid var(--border)",
-                    background: "var(--bg-secondary)",
-                }}
-            >
-                <div
-                    className="text-sm font-semibold"
-                    style={{ color: "var(--text-primary)" }}
-                >
-                    Map view is unavailable in this hardened build
-                </div>
-                <div className="mt-2 text-sm leading-6">
-                    The current release disables dynamic code execution required
-                    by Excalidraw. Existing map tabs are preserved in session
-                    data, but they are not restored automatically and cannot be
-                    rendered until a CSP-compatible runtime is wired in.
-                </div>
-            </div>
-        </div>
-    );
-}
-
-function renderEditorPanelView(
-    view: EditorPanelView,
-    emptyStateMessage?: string,
-) {
-    switch (view) {
-        case "pdf":
-            return <PdfTabView />;
-        case "file":
-            return <FileTabView />;
-        case "ai-review":
-            return <AIReviewView />;
-        case "map":
-            if (!EXCALIDRAW_RUNTIME_SUPPORTED) {
-                return <UnsupportedMapView />;
-            }
-            return (
-                <React.Suspense fallback={null}>
-                    <LazyExcalidrawTabView />
-                </React.Suspense>
-            );
-        case "new":
-            return <NewTabView />;
-        case "search":
-            return <SearchView />;
-        case "graph":
-            return null;
-        default:
-            return <Editor emptyStateMessage={emptyStateMessage} />;
-    }
-}
-
-function EditorPanel({ emptyStateMessage }: { emptyStateMessage?: string }) {
-    const view = useEditorStore((s): EditorPanelView => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
-        if (!tab) return "editor";
-        if (isPdfTab(tab)) return "pdf";
-        if (isFileTab(tab)) return "file";
-        if (isReviewTab(tab)) return "ai-review";
-        if (isMapTab(tab)) return "map";
-        if (isGraphTab(tab)) return "graph";
-        if (!isNoteTab(tab)) return "editor";
-        if (tab.noteId === "") return "new";
-        if (tab.noteId === "__search__") return "search";
-        return "editor";
-    });
-    const hasGraphTab = useEditorStore((s) =>
-        s.tabs.some((tab) => isGraphTab(tab)),
-    );
-    const isGraphActive = view === "graph";
-    const [keepAlive, setKeepAlive] = useState(false);
-    const [prevIsGraphActive, setPrevIsGraphActive] = useState(isGraphActive);
-    const [prevHasGraphTab, setPrevHasGraphTab] = useState(hasGraphTab);
-
-    // Adjust keep-alive based on prop changes (setState during render pattern)
-    if (
-        prevIsGraphActive !== isGraphActive ||
-        prevHasGraphTab !== hasGraphTab
-    ) {
-        setPrevIsGraphActive(isGraphActive);
-        setPrevHasGraphTab(hasGraphTab);
-        if (!hasGraphTab) {
-            if (keepAlive) setKeepAlive(false);
-        } else if (prevIsGraphActive && !isGraphActive) {
-            if (!keepAlive) setKeepAlive(true);
-        } else if (isGraphActive && keepAlive) {
-            setKeepAlive(false);
-        }
-    }
-
-    // Timer to expire keep-alive (setState only in async callback)
-    useEffect(() => {
-        if (!keepAlive) return;
-        const timeoutId = window.setTimeout(() => {
-            perfCount("graph.lifecycle.keepAliveExpired");
-            setKeepAlive(false);
-        }, GRAPH_KEEP_ALIVE_MS);
-        return () => window.clearTimeout(timeoutId);
-    }, [keepAlive]);
-
-    const keepGraphMounted = hasGraphTab && (isGraphActive || keepAlive);
-
-    return (
-        <div className="relative flex-1 min-h-0 min-w-0 w-full overflow-hidden">
-            {keepGraphMounted && (
-                <div
-                    style={{
-                        position: "absolute",
-                        inset: 0,
-                        visibility: isGraphActive ? "visible" : "hidden",
-                        pointerEvents: isGraphActive ? "auto" : "none",
-                    }}
-                >
-                    <React.Suspense fallback={null}>
-                        <LazyGraphTabView isVisible={isGraphActive} />
-                    </React.Suspense>
-                </div>
-            )}
-            {!isGraphActive && renderEditorPanelView(view, emptyStateMessage)}
-        </div>
-    );
-}
-
 export default function App() {
     const sidebarView = useLayoutStore((s) => s.sidebarView);
+    const editorPaneSizes = useLayoutStore((s) => s.editorPaneSizes);
     const setSidebarView = useLayoutStore((s) => s.setSidebarView);
+    const setEditorPaneSizes = useLayoutStore((s) => s.setEditorPaneSizes);
     const bottomPanelView = useLayoutStore((s) => s.bottomPanelView);
     const restoreVault = useVaultStore((s) => s.restoreVault);
     const vaultPath = useVaultStore((s) => s.vaultPath);
@@ -1124,6 +965,7 @@ export default function App() {
     const developerTerminalEnabled = useSettingsStore(
         (s) => s.developerTerminalEnabled,
     );
+    const paneCount = useEditorStore((s) => s.panes.length);
     const windowMode = getWindowMode();
     const vaultParam = readSearchParam("vault");
     const [windowSessionReady, setWindowSessionReady] = useState(
@@ -1303,13 +1145,18 @@ export default function App() {
         const restored = await restorePersistedSession(vaultPath, {
             includeMaps: EXCALIDRAW_RUNTIME_SUPPORTED,
         });
-        if (!restored) return;
+        if (!restored) {
+            setEditorPaneSizes(1, []);
+            return;
+        }
+        const paneCount = restored.panes?.length ?? 1;
+        setEditorPaneSizes(paneCount, restored.paneSizes ?? []);
         if (restored.panes?.length) {
             hydrateWorkspace(restored.panes, restored.focusedPaneId);
             return;
         }
         hydrateTabs(restored.tabs, restored.activeTabId);
-    }, [hydrateTabs, hydrateWorkspace]);
+    }, [hydrateTabs, hydrateWorkspace, setEditorPaneSizes]);
 
     useEffect(() => {
         const blockNativeContextMenu = (event: MouseEvent) => {
@@ -1358,6 +1205,27 @@ export default function App() {
             window.clearInterval(interval);
         };
     }, [activeTabId, tabs, vaultPath, windowMode, windowSessionReady]);
+
+    useEffect(() => {
+        if (!isSessionReady()) return;
+        if (!vaultPath) return;
+
+        const timer = window.setTimeout(() => {
+            const editor = useEditorStore.getState();
+            writePersistedSession(
+                vaultPath,
+                buildPersistedSession({
+                    panes: editor.panes,
+                    focusedPaneId: editor.focusedPaneId,
+                    paneSizes: useLayoutStore.getState().editorPaneSizes,
+                    tabs: editor.tabs,
+                    activeTabId: editor.activeTabId,
+                }),
+            );
+        }, 250);
+
+        return () => window.clearTimeout(timer);
+    }, [editorPaneSizes, vaultPath]);
 
     useEffect(() => {
         if (windowMode === "settings") return;
@@ -1541,9 +1409,9 @@ export default function App() {
                 if (change.kind === "upsert" && change.note) {
                     invalidateLivePreviewNoteCache(change.note.id);
                     const noteId = change.note.id;
-                    const openTab = useEditorStore
-                        .getState()
-                        .tabs.find((t) => isNoteTab(t) && t.noteId === noteId);
+                    const openTab = selectEditorWorkspaceTabs(
+                        useEditorStore.getState(),
+                    ).find((t) => isNoteTab(t) && t.noteId === noteId);
                     if (openTab) {
                         const previousTimer =
                             pendingNoteReloads.get(noteId) ?? null;
@@ -1591,14 +1459,14 @@ export default function App() {
                     change.relative_path
                 ) {
                     const relativePath = change.relative_path;
-                    const openTab = useEditorStore
-                        .getState()
-                        .tabs.find(
-                            (t) =>
-                                isFileTab(t) &&
-                                fileViewerNeedsTextContent(t.viewer) &&
-                                t.relativePath === relativePath,
-                        );
+                    const openTab = selectEditorWorkspaceTabs(
+                        useEditorStore.getState(),
+                    ).find(
+                        (t) =>
+                            isFileTab(t) &&
+                            fileViewerNeedsTextContent(t.viewer) &&
+                            t.relativePath === relativePath,
+                    );
                     if (openTab) {
                         const previousTimer =
                             pendingFileReloads.get(relativePath) ?? null;
@@ -1796,7 +1664,7 @@ export default function App() {
             <div className="h-full min-h-0 min-w-0 flex flex-col overflow-hidden">
                 <UnifiedBar windowMode="note" />
                 <div className="flex-1 min-h-0 min-w-0 overflow-hidden flex flex-col">
-                    <EditorPanel emptyStateMessage="Esta ventana no tiene ninguna nota abierta" />
+                    <EditorPaneContent emptyStateMessage="Esta ventana no tiene ninguna nota abierta" />
                 </div>
                 <YouTubeModalHost />
                 <CommandPalette />
@@ -1807,7 +1675,11 @@ export default function App() {
 
     return (
         <div className="h-full flex flex-col overflow-hidden">
-            <UnifiedBar windowMode="main" />
+            {paneCount > 1 ? (
+                <WorkspaceChromeBar />
+            ) : (
+                <UnifiedBar windowMode="main" />
+            )}
 
             <div className="relative flex-1 flex overflow-hidden">
                 <ActivityBar
@@ -1821,7 +1693,13 @@ export default function App() {
                 <div className="flex-1 overflow-hidden">
                     <AppLayout
                         left={<SidebarPanel view={sidebarView} />}
-                        center={<EditorPanel />}
+                        center={
+                            paneCount > 1 ? (
+                                <MultiPaneWorkspace />
+                            ) : (
+                                <EditorPaneContent />
+                            )
+                        }
                         right={<RightPanel />}
                         bottom={
                             developerModeEnabled &&

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -58,8 +58,14 @@ import {
     isFileTab,
     isNoteTab,
     selectEditorWorkspaceTabs,
+    selectFocusedPaneId,
     selectFocusedEditorTab,
+    selectLeafPaneIds,
+    selectPaneNeighbor,
+    selectPaneCount,
+    selectPaneState,
 } from "./app/store/editorStore";
+import { MAX_EDITOR_PANES } from "./app/store/workspaceLayoutTree";
 import {
     buildPersistedSession,
     isSessionReady,
@@ -392,8 +398,21 @@ function useRegisterCommands(
         const hasVault = () => useVaultStore.getState().vaultPath !== null;
         const hasActiveTab = () =>
             useEditorStore.getState().activeTabId !== null;
+        const canSplitPane = () =>
+            selectPaneCount(useEditorStore.getState()) < MAX_EDITOR_PANES;
+        const canClosePane = () =>
+            selectPaneCount(useEditorStore.getState()) > 1;
         const hasRecentlyClosedTab = () =>
             useEditorStore.getState().recentlyClosedTabs.length > 0;
+        const hasPaneNeighbor = (
+            direction: "left" | "right" | "up" | "down",
+        ) => {
+            const state = useEditorStore.getState();
+            const focusedPaneId = selectFocusedPaneId(state);
+            return focusedPaneId
+                ? selectPaneNeighbor(state, focusedPaneId, direction) !== null
+                : false;
+        };
         const developerModeEnabled = () =>
             developerCommandsEnabled &&
             useSettingsStore.getState().developerModeEnabled &&
@@ -588,6 +607,91 @@ function useRegisterCommands(
             shortcut: platform === "macos" ? "⌘-" : "Ctrl-",
             category: "Editor",
             execute: () => adjustEditorFontSize(-1),
+        });
+
+        register({
+            id: "workspace:split-right",
+            label: "Split Right",
+            category: "Workspace",
+            when: canSplitPane,
+            execute: () => {
+                useEditorStore.getState().splitEditorPane("row");
+            },
+        });
+
+        register({
+            id: "workspace:split-down",
+            label: "Split Down",
+            category: "Workspace",
+            when: canSplitPane,
+            execute: () => {
+                useEditorStore.getState().splitEditorPane("column");
+            },
+        });
+
+        register({
+            id: "workspace:focus-left",
+            label: "Focus Pane Left",
+            category: "Workspace",
+            when: () => hasPaneNeighbor("left"),
+            execute: () => {
+                useEditorStore.getState().focusPaneNeighbor("left");
+            },
+        });
+
+        register({
+            id: "workspace:focus-right",
+            label: "Focus Pane Right",
+            category: "Workspace",
+            when: () => hasPaneNeighbor("right"),
+            execute: () => {
+                useEditorStore.getState().focusPaneNeighbor("right");
+            },
+        });
+
+        register({
+            id: "workspace:focus-up",
+            label: "Focus Pane Up",
+            category: "Workspace",
+            when: () => hasPaneNeighbor("up"),
+            execute: () => {
+                useEditorStore.getState().focusPaneNeighbor("up");
+            },
+        });
+
+        register({
+            id: "workspace:focus-down",
+            label: "Focus Pane Down",
+            category: "Workspace",
+            when: () => hasPaneNeighbor("down"),
+            execute: () => {
+                useEditorStore.getState().focusPaneNeighbor("down");
+            },
+        });
+
+        register({
+            id: "workspace:balance-layout",
+            label: "Balance Layout",
+            category: "Workspace",
+            when: canClosePane,
+            execute: () => {
+                useEditorStore.getState().balancePaneLayout();
+            },
+        });
+
+        register({
+            id: "workspace:close-pane",
+            label: "Close Pane",
+            category: "Workspace",
+            when: canClosePane,
+            execute: () => {
+                const state = useEditorStore.getState();
+                const focusedPaneId = selectFocusedPaneId(state);
+                if (!focusedPaneId) {
+                    return;
+                }
+                state.closePane(focusedPaneId);
+            },
         });
 
         // Layout
@@ -973,7 +1077,7 @@ export default function App() {
     const developerTerminalEnabled = useSettingsStore(
         (s) => s.developerTerminalEnabled,
     );
-    const paneCount = useEditorStore((s) => s.panes.length);
+    const paneCount = useEditorStore(selectPaneCount);
     const windowMode = getWindowMode();
     const vaultParam = readSearchParam("vault");
     const [windowSessionReady, setWindowSessionReady] = useState(
@@ -1160,7 +1264,11 @@ export default function App() {
         const paneCount = restored.panes?.length ?? 1;
         setEditorPaneSizes(paneCount, restored.paneSizes ?? []);
         if (restored.panes?.length) {
-            hydrateWorkspace(restored.panes, restored.focusedPaneId);
+            hydrateWorkspace(
+                restored.panes,
+                restored.focusedPaneId,
+                restored.layoutTree,
+            );
             return;
         }
         hydrateTabs(restored.tabs, restored.activeTabId);
@@ -1220,11 +1328,16 @@ export default function App() {
 
         const timer = window.setTimeout(() => {
             const editor = useEditorStore.getState();
+            const paneIds = selectLeafPaneIds(editor);
+            const focusedPaneId = selectFocusedPaneId(editor);
             writePersistedSession(
                 vaultPath,
                 buildPersistedSession({
-                    panes: editor.panes,
-                    focusedPaneId: editor.focusedPaneId,
+                    panes: paneIds.map((paneId) =>
+                        selectPaneState(editor, paneId),
+                    ),
+                    focusedPaneId,
+                    layoutTree: editor.layoutTree,
                     paneSizes: useLayoutStore.getState().editorPaneSizes,
                     tabs: editor.tabs,
                     activeTabId: editor.activeTabId,
@@ -1566,7 +1679,9 @@ export default function App() {
                     if (disposed) return;
                     const editor = useEditorStore.getState();
                     const targetPaneId =
-                        editor.focusedPaneId ?? editor.panes[0]?.id ?? null;
+                        selectFocusedPaneId(editor) ??
+                        selectLeafPaneIds(editor)[0] ??
+                        null;
 
                     if (targetPaneId) {
                         editor.insertExternalTabInPane(

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1825,7 +1825,7 @@ export default function App() {
                     }}
                     onOpenSettings={openSettings}
                 />
-                <div className="flex-1 overflow-hidden">
+                <div className="min-w-0 flex-1 overflow-hidden">
                     <AppLayout
                         left={<SidebarPanel view={sidebarView} />}
                         center={

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -955,7 +955,6 @@ export default function App() {
     const refreshEntries = useVaultStore((s) => s.refreshEntries);
     const hydrateWorkspace = useEditorStore((s) => s.hydrateWorkspace);
     const hydrateTabs = useEditorStore((s) => s.hydrateTabs);
-    const insertExternalTab = useEditorStore((s) => s.insertExternalTab);
     const tabs = useEditorStore((s) => s.tabs);
     const activeTabId = useEditorStore((s) => s.activeTabId);
     const restoreChatWorkspace = useChatTabsStore((s) => s.restoreWorkspace);
@@ -1556,7 +1555,19 @@ export default function App() {
                 ATTACH_EXTERNAL_TAB_EVENT,
                 (event) => {
                     if (disposed) return;
-                    insertExternalTab(event.payload.tab);
+                    const editor = useEditorStore.getState();
+                    const targetPaneId =
+                        editor.focusedPaneId ?? editor.panes[0]?.id ?? null;
+
+                    if (targetPaneId) {
+                        editor.insertExternalTabInPane(
+                            event.payload.tab,
+                            targetPaneId,
+                        );
+                        return;
+                    }
+
+                    editor.insertExternalTab(event.payload.tab);
                 },
             ),
             {
@@ -1571,7 +1582,7 @@ export default function App() {
             disposed = true;
             unlisten?.();
         };
-    }, [insertExternalTab]);
+    }, []);
 
     useEffect(() => {
         if (windowMode !== "main") return;

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -185,13 +185,22 @@ function adjustEditorFontSize(delta: number) {
 
 function RightPanel() {
     const rightPanelView = useLayoutStore((s) => s.rightPanelView);
-    if (rightPanelView === "chat") {
-        return <AIChatPanel />;
-    }
-    if (rightPanelView === "outline") {
-        return <OutlineRightPanel />;
-    }
-    return <LinksPanel />;
+    return (
+        <>
+            {/* Always mount AIChatPanel so its Tauri event listeners stay
+                bound even when a ChatTab lives in the editor workspace and
+                the sidebar is switched to outline/links. */}
+            <div
+                style={{
+                    display: rightPanelView === "chat" ? "contents" : "none",
+                }}
+            >
+                <AIChatPanel />
+            </div>
+            {rightPanelView === "outline" && <OutlineRightPanel />}
+            {rightPanelView === "links" && <LinksPanel />}
+        </>
+    );
 }
 
 function VaultOpeningOverlay() {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1112,6 +1112,7 @@ export default function App() {
     const vaultPath = useVaultStore((s) => s.vaultPath);
     const applyVaultNoteChange = useVaultStore((s) => s.applyVaultNoteChange);
     const refreshEntries = useVaultStore((s) => s.refreshEntries);
+    const hydrateWorkspace = useEditorStore((s) => s.hydrateWorkspace);
     const hydrateTabs = useEditorStore((s) => s.hydrateTabs);
     const insertExternalTab = useEditorStore((s) => s.insertExternalTab);
     const tabs = useEditorStore((s) => s.tabs);
@@ -1303,8 +1304,12 @@ export default function App() {
             includeMaps: EXCALIDRAW_RUNTIME_SUPPORTED,
         });
         if (!restored) return;
+        if (restored.panes?.length) {
+            hydrateWorkspace(restored.panes, restored.focusedPaneId);
+            return;
+        }
         hydrateTabs(restored.tabs, restored.activeTabId);
-    }, [hydrateTabs]);
+    }, [hydrateTabs, hydrateWorkspace]);
 
     useEffect(() => {
         const blockNativeContextMenu = (event: MouseEvent) => {

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -179,10 +179,15 @@ describe("App web clipper routing", () => {
         string,
         (event: { payload: unknown }) => void
     >();
+    const windowEventHandlers = new Map<
+        string,
+        (event: { payload: unknown }) => void
+    >();
 
     beforeEach(() => {
         window.history.replaceState({}, "", "/?vault=%2Fvaults%2Fa");
         eventHandlers.clear();
+        windowEventHandlers.clear();
         vi.clearAllMocks();
 
         vi.mocked(listen).mockImplementation(async (eventName, handler) => {
@@ -192,7 +197,15 @@ describe("App web clipper routing", () => {
             );
             return vi.fn();
         });
-        vi.mocked(getCurrentWindow().listen).mockResolvedValue(vi.fn());
+        vi.mocked(getCurrentWindow().listen).mockImplementation(
+            async (eventName, handler) => {
+                windowEventHandlers.set(
+                    eventName as string,
+                    handler as (event: { payload: unknown }) => void,
+                );
+                return vi.fn();
+            },
+        );
 
         vi.mocked(readWindowSessionSnapshot).mockReturnValue([]);
         vi.mocked(getAllWebviewWindows).mockResolvedValue([
@@ -243,6 +256,72 @@ describe("App web clipper routing", () => {
         expect(invoke).toHaveBeenCalledWith("unregister_window_vault_route", {
             label: "main",
         });
+    });
+
+    it("re-attaches an external tab into the focused pane when split view is active", async () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "tab-a",
+                            kind: "note",
+                            noteId: "notes/a",
+                            title: "Alpha",
+                            content: "Alpha",
+                        },
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "tab-b",
+                            kind: "note",
+                            noteId: "notes/b",
+                            title: "Beta",
+                            content: "Beta",
+                        },
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "secondary",
+        );
+
+        renderComponent(<App />);
+        await flushPromises();
+
+        const handler = windowEventHandlers.get(
+            "neverwrite:attach-external-tab",
+        );
+        expect(handler).toBeDefined();
+
+        await act(async () => {
+            handler?.({
+                payload: {
+                    tab: {
+                        id: "tab-c",
+                        kind: "note",
+                        noteId: "notes/c",
+                        title: "Gamma",
+                        content: "Gamma",
+                    },
+                },
+            });
+            await Promise.resolve();
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
+        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-b",
+            "tab-c",
+        ]);
+        expect(state.panes[1]?.activeTabId).toBe("tab-c");
     });
 
     it("restores a persisted multipane workspace and reapplies pane sizes", async () => {

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -1,4 +1,4 @@
-import { act } from "@testing-library/react";
+import { act, screen } from "@testing-library/react";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -8,6 +8,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "./App";
 import { openVaultWindow } from "./app/detachedWindows";
 import { useEditorStore } from "./app/store/editorStore";
+import { getEditorSessionKey } from "./app/store/editorSession";
+import { useLayoutStore } from "./app/store/layoutStore";
 import { useVaultStore } from "./app/store/vaultStore";
 import { readWindowSessionSnapshot } from "./app/windowSession";
 import { useCommandStore } from "./features/command-palette/store/commandStore";
@@ -77,6 +79,18 @@ vi.mock("./features/editor/UnifiedBar", () => ({
     UnifiedBar: ({ windowMode }: { windowMode: string }) => (
         <div data-testid="unified-bar" data-window-mode={windowMode} />
     ),
+}));
+
+vi.mock("./features/editor/WorkspaceChromeBar", () => ({
+    WorkspaceChromeBar: () => <div data-testid="workspace-chrome-bar" />,
+}));
+
+vi.mock("./features/editor/MultiPaneWorkspace", () => ({
+    MultiPaneWorkspace: () => <div data-testid="multi-pane-workspace" />,
+}));
+
+vi.mock("./features/editor/EditorPaneContent", () => ({
+    EditorPaneContent: () => <div data-testid="editor-pane-content" />,
 }));
 
 vi.mock("./features/editor/Editor", () => ({
@@ -192,6 +206,9 @@ describe("App web clipper routing", () => {
             isLoading: false,
             error: null,
         });
+        useLayoutStore.setState({
+            editorPaneSizes: [1],
+        });
 
         useEditorStore.setState({
             tabs: [],
@@ -226,6 +243,59 @@ describe("App web clipper routing", () => {
         expect(invoke).toHaveBeenCalledWith("unregister_window_vault_route", {
             label: "main",
         });
+    });
+
+    it("restores a persisted multipane workspace and reapplies pane sizes", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/a"),
+            JSON.stringify({
+                panes: [
+                    {
+                        id: "primary",
+                        tabs: [
+                            {
+                                id: "tab-a",
+                                kind: "note",
+                                noteId: "notes/a",
+                                title: "A",
+                                content: "Alpha",
+                                history: [],
+                                historyIndex: 0,
+                            },
+                        ],
+                        activeTabId: "tab-a",
+                    },
+                    {
+                        id: "secondary",
+                        tabs: [
+                            {
+                                id: "tab-b",
+                                kind: "note",
+                                noteId: "notes/b",
+                                title: "B",
+                                content: "Beta",
+                                history: [],
+                                historyIndex: 0,
+                            },
+                        ],
+                        activeTabId: "tab-b",
+                    },
+                ],
+                focusedPaneId: "secondary",
+                paneSizes: [0.4, 0.6],
+                noteIds: [],
+                activeNoteId: null,
+            }),
+        );
+
+        renderComponent(<App />);
+        await flushPromises();
+
+        expect(useEditorStore.getState().panes).toHaveLength(2);
+        expect(useEditorStore.getState().focusedPaneId).toBe("secondary");
+        expect(screen.getByTestId("workspace-chrome-bar")).toBeInTheDocument();
+        expect(screen.getByTestId("multi-pane-workspace")).toBeInTheDocument();
+        expect(useLayoutStore.getState().editorPaneSizes).toEqual([0.4, 0.6]);
     });
 
     it("dispatches native menu actions into the command store", async () => {

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -9,6 +9,7 @@ import { normalizeHistoryTab } from "./editorTabRegistry";
 import { safeStorageClear } from "../utils/safeStorage";
 import { useLayoutStore } from "./layoutStore";
 import { useVaultStore } from "./vaultStore";
+import { createInitialLayout, splitPane } from "./workspaceLayoutTree";
 
 vi.mock("@tauri-apps/api/core", () => ({
     invoke: vi.fn(),
@@ -261,6 +262,12 @@ describe("editorSession", () => {
         useLayoutStore.setState({
             editorPaneSizes: [0.35, 0.65],
         });
+        const layoutTree = splitPane(
+            createInitialLayout("pane-1"),
+            "pane-1",
+            "row",
+            "pane-2",
+        );
         const session = buildPersistedSession({
             panes: [
                 {
@@ -321,6 +328,7 @@ describe("editorSession", () => {
                 },
             ],
             focusedPaneId: "pane-2",
+            layoutTree,
             tabs: [
                 {
                     id: "file-1",
@@ -359,6 +367,7 @@ describe("editorSession", () => {
             }),
         ]);
         expect(session.focusedPaneId).toBe("pane-2");
+        expect(session.layoutTree).toEqual(layoutTree);
         expect(session.paneSizes).toEqual([0.35, 0.65]);
 
         localStorage.setItem(
@@ -369,6 +378,7 @@ describe("editorSession", () => {
         const restored = await restorePersistedSession("/vaults/project-alpha");
 
         expect(restored?.focusedPaneId).toBe("pane-2");
+        expect(restored?.layoutTree).toEqual(layoutTree);
         expect(restored?.paneSizes).toEqual([0.35, 0.65]);
         expect(restored?.panes).toHaveLength(2);
         expect(restored?.panes?.[0]).toMatchObject({
@@ -385,6 +395,81 @@ describe("editorSession", () => {
             relativePath: "src/main.ts",
         });
         expect(restored?.activeTabId).toBe("file-1");
+    });
+
+    it("restores nested layout trees for mixed split workspaces", async () => {
+        const nestedLayoutTree = splitPane(
+            splitPane(
+                createInitialLayout("primary"),
+                "primary",
+                "row",
+                "secondary",
+            ),
+            "secondary",
+            "column",
+            "tertiary",
+        );
+
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                panes: [
+                    {
+                        id: "primary",
+                        tabs: [
+                            {
+                                id: "note-0",
+                                kind: "note",
+                                noteId: "notes/root",
+                                title: "Root",
+                                content: "Root body",
+                            },
+                        ],
+                        activeTabId: "note-0",
+                    },
+                    {
+                        id: "secondary",
+                        tabs: [
+                            {
+                                id: "note-1",
+                                kind: "note",
+                                noteId: "notes/a",
+                                title: "Note A",
+                                content: "Body A",
+                            },
+                        ],
+                        activeTabId: "note-1",
+                    },
+                    {
+                        id: "tertiary",
+                        tabs: [
+                            {
+                                id: "note-2",
+                                kind: "note",
+                                noteId: "notes/c",
+                                title: "Note C",
+                                content: "Body C",
+                            },
+                        ],
+                        activeTabId: "note-2",
+                    },
+                ],
+                focusedPaneId: "secondary",
+                layoutTree: nestedLayoutTree,
+                noteIds: [],
+                activeNoteId: null,
+            }),
+        );
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored?.focusedPaneId).toBe("secondary");
+        expect(restored?.layoutTree).toEqual(nestedLayoutTree);
+        expect(restored?.panes?.map((pane) => pane.id)).toEqual([
+            "primary",
+            "secondary",
+            "tertiary",
+        ]);
     });
 
     it("drops empty panes from pane-aware workspace sessions when other panes have tabs", async () => {
@@ -446,6 +531,74 @@ describe("editorSession", () => {
             ]),
         );
         expect(restored?.activeTabId).toBe("note-1");
+    });
+
+    it("migrates legacy pane-aware sessions without layoutTree into a row tree", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                panes: [
+                    {
+                        id: "primary",
+                        tabs: [
+                            {
+                                id: "note-1",
+                                kind: "note",
+                                noteId: "notes/a",
+                                title: "Note A",
+                                content: "Body A",
+                            },
+                        ],
+                        activeTabId: "note-1",
+                    },
+                    {
+                        id: "secondary",
+                        tabs: [
+                            {
+                                id: "note-2",
+                                kind: "note",
+                                noteId: "notes/b",
+                                title: "Note B",
+                                content: "Body B",
+                            },
+                        ],
+                        activeTabId: "note-2",
+                    },
+                    {
+                        id: "tertiary",
+                        tabs: [
+                            {
+                                id: "note-3",
+                                kind: "note",
+                                noteId: "notes/c",
+                                title: "Note C",
+                                content: "Body C",
+                            },
+                        ],
+                        activeTabId: "note-3",
+                    },
+                ],
+                focusedPaneId: "secondary",
+                paneSizes: [0.2, 0.3, 0.5],
+                noteIds: [],
+                activeNoteId: null,
+            }),
+        );
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored?.layoutTree).toEqual({
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            children: [
+                { type: "pane", id: "primary", paneId: "primary" },
+                { type: "pane", id: "secondary", paneId: "secondary" },
+                { type: "pane", id: "tertiary", paneId: "tertiary" },
+            ],
+            sizes: [0.2, 0.3, 0.5],
+        });
+        expect(restored?.paneSizes).toEqual([0.2, 0.3, 0.5]);
     });
 
     it("restores legacy persisted sessions through the session module", async () => {

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -255,6 +255,131 @@ describe("editorSession", () => {
         expect(session.activeFilePath).toBe("data/report.csv");
     });
 
+    it("serializes and restores pane-aware workspace sessions", async () => {
+        const session = buildPersistedSession({
+            panes: [
+                {
+                    id: "pane-1",
+                    tabs: [
+                        {
+                            id: "note-1",
+                            kind: "note",
+                            noteId: "notes/a",
+                            title: "Note A",
+                            content: "Body A",
+                            history: [
+                                {
+                                    kind: "note",
+                                    noteId: "notes/a",
+                                    title: "Note A",
+                                    content: "Body A",
+                                },
+                            ],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "note-1",
+                    activationHistory: ["note-1"],
+                    tabNavigationHistory: ["note-1"],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [
+                        {
+                            id: "file-1",
+                            kind: "file",
+                            relativePath: "src/main.ts",
+                            title: "main.ts",
+                            path: "/vault/src/main.ts",
+                            content: "console.log('ok')",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                            history: [
+                                {
+                                    kind: "file",
+                                    relativePath: "src/main.ts",
+                                    title: "main.ts",
+                                    path: "/vault/src/main.ts",
+                                    content: "console.log('ok')",
+                                    mimeType: "text/typescript",
+                                    viewer: "text",
+                                },
+                            ],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "file-1",
+                    activationHistory: ["file-1"],
+                    tabNavigationHistory: ["file-1"],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "pane-2",
+            tabs: [
+                {
+                    id: "file-1",
+                    kind: "file",
+                    relativePath: "src/main.ts",
+                    title: "main.ts",
+                    path: "/vault/src/main.ts",
+                    content: "console.log('ok')",
+                    mimeType: "text/typescript",
+                    viewer: "text",
+                    history: [
+                        {
+                            kind: "file",
+                            relativePath: "src/main.ts",
+                            title: "main.ts",
+                            path: "/vault/src/main.ts",
+                            content: "console.log('ok')",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "file-1",
+        });
+
+        expect(session.panes).toEqual([
+            expect.objectContaining({
+                id: "pane-1",
+                activeTabId: "note-1",
+            }),
+            expect.objectContaining({
+                id: "pane-2",
+                activeTabId: "file-1",
+            }),
+        ]);
+        expect(session.focusedPaneId).toBe("pane-2");
+
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify(session),
+        );
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored?.focusedPaneId).toBe("pane-2");
+        expect(restored?.panes).toHaveLength(2);
+        expect(restored?.panes?.[0]).toMatchObject({
+            id: "pane-1",
+            activeTabId: "note-1",
+        });
+        expect(restored?.panes?.[1]).toMatchObject({
+            id: "pane-2",
+            activeTabId: "file-1",
+        });
+        expect(restored?.tabs[0]).toMatchObject({
+            id: "file-1",
+            kind: "file",
+            relativePath: "src/main.ts",
+        });
+        expect(restored?.activeTabId).toBe("file-1");
+    });
+
     it("restores legacy persisted sessions through the session module", async () => {
         localStorage.setItem(
             getEditorSessionKey("/vaults/project-alpha"),

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -387,7 +387,7 @@ describe("editorSession", () => {
         expect(restored?.activeTabId).toBe("file-1");
     });
 
-    it("restores empty panes from pane-aware workspace sessions", async () => {
+    it("drops empty panes from pane-aware workspace sessions when other panes have tabs", async () => {
         localStorage.setItem(
             getEditorSessionKey("/vaults/project-alpha"),
             JSON.stringify({
@@ -429,21 +429,23 @@ describe("editorSession", () => {
 
         const restored = await restorePersistedSession("/vaults/project-alpha");
 
-        expect(restored?.focusedPaneId).toBe("primary");
-        expect(restored?.paneSizes).toEqual([0.5, 0.5]);
+        expect(restored?.focusedPaneId).toBe("secondary");
+        expect(restored?.paneSizes).toEqual([1]);
         expect(restored?.panes).toEqual([
-            expect.objectContaining({
-                id: "primary",
-                tabs: [],
-                activeTabId: null,
-            }),
             expect.objectContaining({
                 id: "secondary",
                 activeTabId: "note-1",
             }),
         ]);
-        expect(restored?.tabs).toEqual([]);
-        expect(restored?.activeTabId).toBeNull();
+        expect(restored?.tabs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    id: "note-1",
+                    kind: "note",
+                }),
+            ]),
+        );
+        expect(restored?.activeTabId).toBe("note-1");
     });
 
     it("restores legacy persisted sessions through the session module", async () => {

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -7,6 +7,7 @@ import {
 } from "./editorSession";
 import { normalizeHistoryTab } from "./editorTabRegistry";
 import { safeStorageClear } from "../utils/safeStorage";
+import { useLayoutStore } from "./layoutStore";
 import { useVaultStore } from "./vaultStore";
 
 vi.mock("@tauri-apps/api/core", () => ({
@@ -18,6 +19,7 @@ describe("editorSession", () => {
         safeStorageClear();
         localStorage.clear();
         useVaultStore.setState({ vaultPath: "/vaults/project-alpha" });
+        useLayoutStore.setState({ editorPaneSizes: [1] });
     });
 
     afterEach(() => {
@@ -256,6 +258,9 @@ describe("editorSession", () => {
     });
 
     it("serializes and restores pane-aware workspace sessions", async () => {
+        useLayoutStore.setState({
+            editorPaneSizes: [0.35, 0.65],
+        });
         const session = buildPersistedSession({
             panes: [
                 {
@@ -354,6 +359,7 @@ describe("editorSession", () => {
             }),
         ]);
         expect(session.focusedPaneId).toBe("pane-2");
+        expect(session.paneSizes).toEqual([0.35, 0.65]);
 
         localStorage.setItem(
             getEditorSessionKey("/vaults/project-alpha"),
@@ -363,6 +369,7 @@ describe("editorSession", () => {
         const restored = await restorePersistedSession("/vaults/project-alpha");
 
         expect(restored?.focusedPaneId).toBe("pane-2");
+        expect(restored?.paneSizes).toEqual([0.35, 0.65]);
         expect(restored?.panes).toHaveLength(2);
         expect(restored?.panes?.[0]).toMatchObject({
             id: "pane-1",
@@ -378,6 +385,65 @@ describe("editorSession", () => {
             relativePath: "src/main.ts",
         });
         expect(restored?.activeTabId).toBe("file-1");
+    });
+
+    it("restores empty panes from pane-aware workspace sessions", async () => {
+        localStorage.setItem(
+            getEditorSessionKey("/vaults/project-alpha"),
+            JSON.stringify({
+                panes: [
+                    {
+                        id: "primary",
+                        tabs: [],
+                        activeTabId: null,
+                    },
+                    {
+                        id: "secondary",
+                        tabs: [
+                            {
+                                id: "note-1",
+                                kind: "note",
+                                noteId: "notes/a",
+                                title: "Note A",
+                                content: "Body A",
+                                history: [
+                                    {
+                                        kind: "note",
+                                        noteId: "notes/a",
+                                        title: "Note A",
+                                        content: "Body A",
+                                    },
+                                ],
+                                historyIndex: 0,
+                            },
+                        ],
+                        activeTabId: "note-1",
+                    },
+                ],
+                focusedPaneId: "primary",
+                paneSizes: [0.5, 0.5],
+                noteIds: [],
+                activeNoteId: null,
+            }),
+        );
+
+        const restored = await restorePersistedSession("/vaults/project-alpha");
+
+        expect(restored?.focusedPaneId).toBe("primary");
+        expect(restored?.paneSizes).toEqual([0.5, 0.5]);
+        expect(restored?.panes).toEqual([
+            expect.objectContaining({
+                id: "primary",
+                tabs: [],
+                activeTabId: null,
+            }),
+            expect.objectContaining({
+                id: "secondary",
+                activeTabId: "note-1",
+            }),
+        ]);
+        expect(restored?.tabs).toEqual([]);
+        expect(restored?.activeTabId).toBeNull();
     });
 
     it("restores legacy persisted sessions through the session module", async () => {

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -203,7 +203,7 @@ function buildPersistedPanes(
             : undefined;
     }
 
-    return state.panes
+    const persistedPanes = state.panes
         .map((pane) => ({
             id: pane.id,
             tabs: normalizePersistedTabs(pane.tabs),
@@ -221,6 +221,20 @@ function buildPersistedPanes(
             tabNavigationIndex: pane.tabNavigationIndex,
         }))
         .filter((pane) => pane.id.trim().length > 0);
+
+    if (persistedPanes.some((pane) => pane.tabs.length > 0)) {
+        return persistedPanes.filter((pane) => pane.tabs.length > 0);
+    }
+
+    return persistedPanes.length > 0 ? [persistedPanes[0]] : undefined;
+}
+
+function compactRestoredPanes(panes: PersistedSessionPane[]) {
+    if (panes.some((pane) => pane.tabs.length > 0)) {
+        return panes.filter((pane) => pane.tabs.length > 0);
+    }
+
+    return panes.length > 0 ? [panes[0]] : [];
 }
 
 function normalizePaneSizesForPersistence(count: number, paneSizes?: number[]) {
@@ -685,13 +699,15 @@ export async function restorePersistedSession(
     }
 
     if (session?.panes?.length) {
-        const restoredPanes = restorePersistedPaneTabs(session.panes);
-        const focusedPaneId =
+        const restoredPanes = compactRestoredPanes(
+            restorePersistedPaneTabs(session.panes),
+        );
+        const requestedFocusedPaneId =
             typeof session.focusedPaneId === "string"
                 ? session.focusedPaneId
                 : (restoredPanes[0]?.id ?? null);
         const focusedPane =
-            restoredPanes.find((pane) => pane.id === focusedPaneId) ??
+            restoredPanes.find((pane) => pane.id === requestedFocusedPaneId) ??
             restoredPanes[0] ??
             null;
 
@@ -701,7 +717,7 @@ export async function restorePersistedSession(
 
         return {
             panes: restoredPanes,
-            focusedPaneId,
+            focusedPaneId: focusedPane.id,
             paneSizes: normalizePaneSizesForPersistence(
                 restoredPanes.length,
                 session.paneSizes,

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -7,6 +7,7 @@ import {
     isNoteTab,
     normalizeFileViewer,
     isPdfTab,
+    isChatTab,
     isReviewTab,
     type FileViewerMode,
     type PdfViewMode,
@@ -285,7 +286,7 @@ export function getEditorSessionSignature(state: EditorSessionState) {
 
     let signature = state.activeTabId ?? "";
     for (const tab of state.tabs) {
-        if (isReviewTab(tab)) {
+        if (isReviewTab(tab) || isChatTab(tab)) {
             continue;
         }
         if (isGraphTab(tab)) {
@@ -383,7 +384,7 @@ export function buildPersistedSession(
 }
 
 function normalizeRestoredTabInput(tab: TabInput): TabInput | null {
-    if (isReviewTab(tab)) {
+    if (isReviewTab(tab) || isChatTab(tab)) {
         return null;
     }
     if (isHistoryTab(tab)) {

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -17,6 +17,7 @@ import { getHistoryTabHandler, normalizeHistoryTab } from "./editorTabRegistry";
 import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
 import { vaultInvoke } from "../utils/vaultInvoke";
 import { toVaultRelativePath } from "../utils/vaultPaths";
+import { useLayoutStore } from "./layoutStore";
 
 const SESSION_KEY = "neverwrite.session.tabs";
 const SESSION_KEY_PREFIX = "neverwrite.session.tabs:";
@@ -33,6 +34,7 @@ export interface PersistedSessionPane {
 export interface PersistedSession {
     panes?: PersistedSessionPane[];
     focusedPaneId?: string | null;
+    paneSizes?: number[];
     tabs?: TabInput[];
     activeTabId?: string | null;
     noteIds: Array<{
@@ -102,6 +104,7 @@ export interface EditorSessionState {
         tabNavigationIndex: number;
     }>;
     focusedPaneId?: string | null;
+    paneSizes?: number[];
     tabs: Tab[];
     activeTabId: string | null;
 }
@@ -109,6 +112,7 @@ export interface EditorSessionState {
 export interface RestoredEditorSession {
     panes?: PersistedSessionPane[];
     focusedPaneId?: string | null;
+    paneSizes?: number[];
     tabs: TabInput[];
     activeTabId: string | null;
 }
@@ -216,13 +220,34 @@ function buildPersistedPanes(
             ),
             tabNavigationIndex: pane.tabNavigationIndex,
         }))
-        .filter((pane) => pane.tabs.length > 0 || pane.activeTabId !== null);
+        .filter((pane) => pane.id.trim().length > 0);
+}
+
+function normalizePaneSizesForPersistence(count: number, paneSizes?: number[]) {
+    const normalizedCount = Math.max(1, Math.min(3, Math.floor(count) || 1));
+    const incoming = (paneSizes ?? []).filter(
+        (value) => Number.isFinite(value) && value > 0,
+    );
+
+    if (incoming.length === normalizedCount) {
+        const total = incoming.reduce((sum, value) => sum + value, 0);
+        if (total > 0) {
+            return incoming.map((value) => value / total);
+        }
+    }
+
+    return Array.from({ length: normalizedCount }, () => 1 / normalizedCount);
 }
 
 export function getEditorSessionSignature(state: EditorSessionState) {
     const panes = buildPersistedPanes(state);
     if (panes?.length) {
         let signature = state.focusedPaneId ?? "";
+        const paneSizes = normalizePaneSizesForPersistence(
+            panes.length,
+            state.paneSizes ?? useLayoutStore.getState().editorPaneSizes,
+        );
+        signature += `|sizes:${paneSizes.map((value) => value.toFixed(6)).join(",")}`;
         for (const pane of panes) {
             signature += `|pane:${pane.id}:${pane.activeTabId ?? ""}`;
             for (const tab of pane.tabs) {
@@ -270,9 +295,13 @@ export function buildPersistedSession(
     state: EditorSessionState,
 ): PersistedSession {
     const panes = buildPersistedPanes(state);
+    const allTabs =
+        state.panes?.length && panes?.length
+            ? panes.flatMap((pane) => pane.tabs)
+            : state.tabs;
     const activeTab =
         state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
-    const normalizedTabs = state.tabs.flatMap((tab) => {
+    const normalizedTabs = allTabs.flatMap((tab) => {
         if (!isHistoryTab(tab)) {
             return [];
         }
@@ -310,15 +339,23 @@ export function buildPersistedSession(
         );
     }
 
+    const paneSizes = panes?.length
+        ? normalizePaneSizesForPersistence(
+              panes.length,
+              state.paneSizes ?? useLayoutStore.getState().editorPaneSizes,
+          )
+        : undefined;
+
     return {
         panes,
         focusedPaneId: state.focusedPaneId ?? panes?.[0]?.id ?? null,
+        paneSizes,
         activeTabId: activeTab?.id ?? null,
         noteIds,
         pdfTabs,
         fileTabs,
         mapTabs,
-        hasGraphTab: state.tabs.some((tab) => isGraphTab(tab)),
+        hasGraphTab: allTabs.some((tab) => isGraphTab(tab)),
         activeNoteId:
             activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
         activePdfEntryId:
@@ -647,6 +684,33 @@ export async function restorePersistedSession(
         return null;
     }
 
+    if (session?.panes?.length) {
+        const restoredPanes = restorePersistedPaneTabs(session.panes);
+        const focusedPaneId =
+            typeof session.focusedPaneId === "string"
+                ? session.focusedPaneId
+                : (restoredPanes[0]?.id ?? null);
+        const focusedPane =
+            restoredPanes.find((pane) => pane.id === focusedPaneId) ??
+            restoredPanes[0] ??
+            null;
+
+        if (!focusedPane) {
+            return null;
+        }
+
+        return {
+            panes: restoredPanes,
+            focusedPaneId,
+            paneSizes: normalizePaneSizesForPersistence(
+                restoredPanes.length,
+                session.paneSizes,
+            ),
+            tabs: focusedPane.tabs,
+            activeTabId: focusedPane.activeTabId,
+        };
+    }
+
     const restoredTabs: TabInput[] = [];
     if (session?.tabs?.length) {
         restoredTabs.push(...session.tabs);
@@ -674,30 +738,8 @@ export async function restorePersistedSession(
         return null;
     }
 
-    if (session?.panes?.length) {
-        const restoredPanes = restorePersistedPaneTabs(session.panes);
-        const focusedPaneId =
-            typeof session.focusedPaneId === "string"
-                ? session.focusedPaneId
-                : (restoredPanes[0]?.id ?? null);
-        const focusedPane =
-            restoredPanes.find((pane) => pane.id === focusedPaneId) ??
-            restoredPanes[0] ??
-            null;
-
-        if (!focusedPane) {
-            return null;
-        }
-
-        return {
-            panes: restoredPanes,
-            focusedPaneId,
-            tabs: focusedPane.tabs,
-            activeTabId: focusedPane.activeTabId,
-        };
-    }
-
     return {
+        paneSizes: normalizePaneSizesForPersistence(1, session?.paneSizes),
         tabs: restoredTabs,
         activeTabId: session
             ? resolveRestoredActiveTabId(session, restoredTabs, vaultPath)

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -19,6 +19,12 @@ import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
 import { vaultInvoke } from "../utils/vaultInvoke";
 import { toVaultRelativePath } from "../utils/vaultPaths";
 import { useLayoutStore } from "./layoutStore";
+import {
+    createInitialLayout,
+    getLayoutPaneIds,
+    normalizeLayoutTree,
+    type WorkspaceLayoutNode,
+} from "./workspaceLayoutTree";
 
 const SESSION_KEY = "neverwrite.session.tabs";
 const SESSION_KEY_PREFIX = "neverwrite.session.tabs:";
@@ -35,6 +41,7 @@ export interface PersistedSessionPane {
 export interface PersistedSession {
     panes?: PersistedSessionPane[];
     focusedPaneId?: string | null;
+    layoutTree?: WorkspaceLayoutNode;
     paneSizes?: number[];
     tabs?: TabInput[];
     activeTabId?: string | null;
@@ -105,6 +112,7 @@ export interface EditorSessionState {
         tabNavigationIndex: number;
     }>;
     focusedPaneId?: string | null;
+    layoutTree?: WorkspaceLayoutNode;
     paneSizes?: number[];
     tabs: Tab[];
     activeTabId: string | null;
@@ -113,6 +121,7 @@ export interface EditorSessionState {
 export interface RestoredEditorSession {
     panes?: PersistedSessionPane[];
     focusedPaneId?: string | null;
+    layoutTree?: WorkspaceLayoutNode;
     paneSizes?: number[];
     tabs: TabInput[];
     activeTabId: string | null;
@@ -239,7 +248,7 @@ function compactRestoredPanes(panes: PersistedSessionPane[]) {
 }
 
 function normalizePaneSizesForPersistence(count: number, paneSizes?: number[]) {
-    const normalizedCount = Math.max(1, Math.min(3, Math.floor(count) || 1));
+    const normalizedCount = Math.max(1, Math.floor(count) || 1);
     const incoming = (paneSizes ?? []).filter(
         (value) => Number.isFinite(value) && value > 0,
     );
@@ -254,15 +263,73 @@ function normalizePaneSizesForPersistence(count: number, paneSizes?: number[]) {
     return Array.from({ length: normalizedCount }, () => 1 / normalizedCount);
 }
 
+function buildLegacyRowLayoutTree(
+    paneIds: readonly string[],
+    paneSizes?: readonly number[],
+): WorkspaceLayoutNode {
+    if (paneIds.length <= 1) {
+        return createInitialLayout(paneIds[0] ?? "primary");
+    }
+
+    return normalizeLayoutTree({
+        type: "split",
+        id: "split-1",
+        direction: "row",
+        children: paneIds.map((paneId) => ({
+            type: "pane" as const,
+            id: paneId,
+            paneId,
+        })),
+        sizes: normalizePaneSizesForPersistence(paneIds.length, [
+            ...(paneSizes ?? []),
+        ]),
+    });
+}
+
+function normalizeLayoutTreeForPersistence(
+    layoutTree: WorkspaceLayoutNode | undefined,
+    paneIds: readonly string[],
+    paneSizes?: readonly number[],
+) {
+    if (layoutTree) {
+        try {
+            const normalizedTree = normalizeLayoutTree(layoutTree);
+            if (
+                JSON.stringify(getLayoutPaneIds(normalizedTree)) ===
+                JSON.stringify(paneIds)
+            ) {
+                return normalizedTree;
+            }
+        } catch {
+            // Fall back to the legacy row migration when persisted tree data is invalid.
+        }
+    }
+
+    return buildLegacyRowLayoutTree(paneIds, paneSizes);
+}
+
+function getLayoutTreeSignature(tree: WorkspaceLayoutNode): string {
+    if (tree.type === "pane") {
+        return `pane:${tree.paneId}`;
+    }
+
+    return `split:${tree.id}:${tree.direction}:${tree.sizes
+        .map((size) => size.toFixed(6))
+        .join(
+            ",",
+        )}[${tree.children.map((child) => getLayoutTreeSignature(child)).join("|")}]`;
+}
+
 export function getEditorSessionSignature(state: EditorSessionState) {
     const panes = buildPersistedPanes(state);
     if (panes?.length) {
         let signature = state.focusedPaneId ?? "";
-        const paneSizes = normalizePaneSizesForPersistence(
-            panes.length,
+        const layoutTree = normalizeLayoutTreeForPersistence(
+            state.layoutTree,
+            panes.map((pane) => pane.id),
             state.paneSizes ?? useLayoutStore.getState().editorPaneSizes,
         );
-        signature += `|sizes:${paneSizes.map((value) => value.toFixed(6)).join(",")}`;
+        signature += `|layout:${getLayoutTreeSignature(layoutTree)}`;
         for (const pane of panes) {
             signature += `|pane:${pane.id}:${pane.activeTabId ?? ""}`;
             for (const tab of pane.tabs) {
@@ -310,6 +377,7 @@ export function buildPersistedSession(
     state: EditorSessionState,
 ): PersistedSession {
     const panes = buildPersistedPanes(state);
+    const persistedPaneIds = panes?.map((pane) => pane.id) ?? [];
     const allTabs =
         state.panes?.length && panes?.length
             ? panes.flatMap((pane) => pane.tabs)
@@ -354,16 +422,26 @@ export function buildPersistedSession(
         );
     }
 
-    const paneSizes = panes?.length
-        ? normalizePaneSizesForPersistence(
-              panes.length,
-              state.paneSizes ?? useLayoutStore.getState().editorPaneSizes,
-          )
-        : undefined;
+    const paneSizes =
+        panes?.length && persistedPaneIds.length > 1
+            ? normalizePaneSizesForPersistence(
+                  persistedPaneIds.length,
+                  state.paneSizes ?? useLayoutStore.getState().editorPaneSizes,
+              )
+            : undefined;
+    const layoutTree =
+        panes?.length && persistedPaneIds.length > 0
+            ? normalizeLayoutTreeForPersistence(
+                  state.layoutTree,
+                  persistedPaneIds,
+                  paneSizes,
+              )
+            : undefined;
 
     return {
         panes,
         focusedPaneId: state.focusedPaneId ?? panes?.[0]?.id ?? null,
+        layoutTree,
         paneSizes,
         activeTabId: activeTab?.id ?? null,
         noteIds,
@@ -703,6 +781,11 @@ export async function restorePersistedSession(
         const restoredPanes = compactRestoredPanes(
             restorePersistedPaneTabs(session.panes),
         );
+        const restoredLayoutTree = normalizeLayoutTreeForPersistence(
+            session.layoutTree,
+            restoredPanes.map((pane) => pane.id),
+            session.paneSizes,
+        );
         const requestedFocusedPaneId =
             typeof session.focusedPaneId === "string"
                 ? session.focusedPaneId
@@ -719,6 +802,7 @@ export async function restorePersistedSession(
         return {
             panes: restoredPanes,
             focusedPaneId: focusedPane.id,
+            layoutTree: restoredLayoutTree,
             paneSizes: normalizePaneSizesForPersistence(
                 restoredPanes.length,
                 session.paneSizes,

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -21,7 +21,18 @@ import { toVaultRelativePath } from "../utils/vaultPaths";
 const SESSION_KEY = "neverwrite.session.tabs";
 const SESSION_KEY_PREFIX = "neverwrite.session.tabs:";
 
+export interface PersistedSessionPane {
+    id: string;
+    tabs: TabInput[];
+    activeTabId: string | null;
+    activationHistory?: string[];
+    tabNavigationHistory?: string[];
+    tabNavigationIndex?: number;
+}
+
 export interface PersistedSession {
+    panes?: PersistedSessionPane[];
+    focusedPaneId?: string | null;
     tabs?: TabInput[];
     activeTabId?: string | null;
     noteIds: Array<{
@@ -82,11 +93,22 @@ export interface PersistedSession {
 }
 
 export interface EditorSessionState {
+    panes?: Array<{
+        id: string;
+        tabs: Tab[];
+        activeTabId: string | null;
+        activationHistory: string[];
+        tabNavigationHistory: string[];
+        tabNavigationIndex: number;
+    }>;
+    focusedPaneId?: string | null;
     tabs: Tab[];
     activeTabId: string | null;
 }
 
 export interface RestoredEditorSession {
+    panes?: PersistedSessionPane[];
+    focusedPaneId?: string | null;
     tabs: TabInput[];
     activeTabId: string | null;
 }
@@ -132,7 +154,8 @@ export function hasPersistedSessionData(
 ) {
     return Boolean(
         session &&
-        (session.noteIds.length ||
+        (session.panes?.length ||
+            session.noteIds.length ||
             session.tabs?.length ||
             session.pdfTabs?.length ||
             session.fileTabs?.length ||
@@ -141,7 +164,86 @@ export function hasPersistedSessionData(
     );
 }
 
+function normalizePersistedTabs(tabs: Tab[]) {
+    return tabs.flatMap((tab): TabInput[] => {
+        if (!isHistoryTab(tab)) {
+            return isGraphTab(tab) || isMapTab(tab) ? [tab] : [];
+        }
+
+        const normalized = normalizeHistoryTab(tab);
+        return normalized ? [normalized] : [];
+    });
+}
+
+function buildPersistedPanes(
+    state: EditorSessionState,
+): PersistedSessionPane[] | undefined {
+    if (!state.panes?.length) {
+        const tabs = normalizePersistedTabs(state.tabs);
+        const activeTabId =
+            state.activeTabId &&
+            tabs.some((tab) => tab.id === state.activeTabId)
+                ? state.activeTabId
+                : null;
+        return tabs.length > 0 || activeTabId
+            ? [
+                  {
+                      id: "primary",
+                      tabs,
+                      activeTabId,
+                      activationHistory: activeTabId ? [activeTabId] : [],
+                      tabNavigationHistory: activeTabId ? [activeTabId] : [],
+                      tabNavigationIndex: activeTabId ? 0 : -1,
+                  },
+              ]
+            : undefined;
+    }
+
+    return state.panes
+        .map((pane) => ({
+            id: pane.id,
+            tabs: normalizePersistedTabs(pane.tabs),
+            activeTabId:
+                pane.activeTabId &&
+                pane.tabs.some((tab) => tab.id === pane.activeTabId)
+                    ? pane.activeTabId
+                    : null,
+            activationHistory: pane.activationHistory.filter((tabId) =>
+                pane.tabs.some((tab) => tab.id === tabId),
+            ),
+            tabNavigationHistory: pane.tabNavigationHistory.filter((tabId) =>
+                pane.tabs.some((tab) => tab.id === tabId),
+            ),
+            tabNavigationIndex: pane.tabNavigationIndex,
+        }))
+        .filter((pane) => pane.tabs.length > 0 || pane.activeTabId !== null);
+}
+
 export function getEditorSessionSignature(state: EditorSessionState) {
+    const panes = buildPersistedPanes(state);
+    if (panes?.length) {
+        let signature = state.focusedPaneId ?? "";
+        for (const pane of panes) {
+            signature += `|pane:${pane.id}:${pane.activeTabId ?? ""}`;
+            for (const tab of pane.tabs) {
+                if (isGraphTab(tab)) {
+                    signature += "|graph";
+                    continue;
+                }
+                if (isHistoryTab(tab)) {
+                    const normalized = normalizeHistoryTab(tab);
+                    if (!normalized) {
+                        continue;
+                    }
+                    signature += getHistoryTabHandler(
+                        normalized.kind,
+                    ).fingerprint(normalized as never);
+                }
+            }
+        }
+        return signature;
+    }
+
     let signature = state.activeTabId ?? "";
     for (const tab of state.tabs) {
         if (isReviewTab(tab)) {
@@ -167,6 +269,7 @@ export function getEditorSessionSignature(state: EditorSessionState) {
 export function buildPersistedSession(
     state: EditorSessionState,
 ): PersistedSession {
+    const panes = buildPersistedPanes(state);
     const activeTab =
         state.tabs.find((tab) => tab.id === state.activeTabId) ?? null;
     const normalizedTabs = state.tabs.flatMap((tab) => {
@@ -208,6 +311,8 @@ export function buildPersistedSession(
     }
 
     return {
+        panes,
+        focusedPaneId: state.focusedPaneId ?? panes?.[0]?.id ?? null,
         activeTabId: activeTab?.id ?? null,
         noteIds,
         pdfTabs,
@@ -224,6 +329,19 @@ export function buildPersistedSession(
             activeTab && isMapTab(activeTab) ? activeTab.relativePath : null,
         activeGraphTab: activeTab ? isGraphTab(activeTab) : false,
     };
+}
+
+function normalizeRestoredTabInput(tab: TabInput): TabInput | null {
+    if (isReviewTab(tab)) {
+        return null;
+    }
+    if (isHistoryTab(tab)) {
+        return normalizeHistoryTab(tab);
+    }
+    if (isGraphTab(tab) || isMapTab(tab)) {
+        return tab;
+    }
+    return null;
 }
 
 async function restoreLegacyNoteTabs(session: PersistedSession) {
@@ -261,6 +379,50 @@ async function restoreLegacyNoteTabs(session: PersistedSession) {
         }
     }
     return restoredTabs;
+}
+
+function restorePersistedPaneTabs(
+    panes: PersistedSessionPane[],
+): PersistedSessionPane[] {
+    const seenGraph = new Set<string>();
+
+    return panes.map((pane, index) => {
+        const tabs = pane.tabs.flatMap((tab): TabInput[] => {
+            const normalized = normalizeRestoredTabInput(tab);
+            if (!normalized) {
+                return [];
+            }
+            if (isGraphTab(normalized)) {
+                if (seenGraph.size > 0) {
+                    return [];
+                }
+                seenGraph.add(normalized.id);
+            }
+            return [normalized];
+        });
+        const activeTabId =
+            pane.activeTabId && tabs.some((tab) => tab.id === pane.activeTabId)
+                ? pane.activeTabId
+                : (tabs[0]?.id ?? null);
+
+        return {
+            id: pane.id || `pane-${index + 1}`,
+            tabs,
+            activeTabId,
+            activationHistory: (pane.activationHistory ?? []).filter((tabId) =>
+                tabs.some((tab) => tab.id === tabId),
+            ),
+            tabNavigationHistory: (pane.tabNavigationHistory ?? []).filter(
+                (tabId) => tabs.some((tab) => tab.id === tabId),
+            ),
+            tabNavigationIndex:
+                typeof pane.tabNavigationIndex === "number"
+                    ? pane.tabNavigationIndex
+                    : activeTabId
+                      ? 0
+                      : -1,
+        };
+    });
 }
 
 function restoreLegacyPdfTabs(session: PersistedSession) {
@@ -510,6 +672,29 @@ export async function restorePersistedSession(
 
     if (!restoredTabs.length) {
         return null;
+    }
+
+    if (session?.panes?.length) {
+        const restoredPanes = restorePersistedPaneTabs(session.panes);
+        const focusedPaneId =
+            typeof session.focusedPaneId === "string"
+                ? session.focusedPaneId
+                : (restoredPanes[0]?.id ?? null);
+        const focusedPane =
+            restoredPanes.find((pane) => pane.id === focusedPaneId) ??
+            restoredPanes[0] ??
+            null;
+
+        if (!focusedPane) {
+            return null;
+        }
+
+        return {
+            panes: restoredPanes,
+            focusedPaneId,
+            tabs: focusedPane.tabs,
+            activeTabId: focusedPane.activeTabId,
+        };
     }
 
     return {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -3029,6 +3029,78 @@ describe("editorStore tab management", () => {
         expect(nestedSplit.sizes[1]).toBeCloseTo(0.5, 3);
     });
 
+    it("unifies all panes into the requested pane and resets the split layout", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+                {
+                    id: "pane-3",
+                    tabs: [
+                        makeTab({
+                            id: "tab-c",
+                            noteId: "notes/c",
+                            title: "C",
+                            content: "Gamma",
+                        }),
+                    ],
+                    activeTabId: "tab-c",
+                },
+            ],
+            "secondary",
+            splitPane(
+                splitPane(
+                    createInitialLayout("primary"),
+                    "primary",
+                    "row",
+                    "secondary",
+                ),
+                "secondary",
+                "column",
+                "pane-3",
+            ),
+        );
+
+        useEditorStore.getState().unifyAllPanesInto("secondary");
+
+        const state = useEditorStore.getState();
+        expect(state.panes.map((pane) => pane.id)).toEqual(["secondary"]);
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-b",
+            "tab-a",
+            "tab-c",
+        ]);
+        expect(state.panes[0]?.activeTabId).toBe("tab-b");
+        expect(state.layoutTree.type).toBe("pane");
+        if (state.layoutTree.type !== "pane") {
+            throw new Error("Expected a single-pane layout");
+        }
+        expect(state.layoutTree.paneId).toBe("secondary");
+    });
+
     it("moves tabs between panes, focuses the target pane, and closes empty sources", () => {
         useEditorStore.getState().hydrateWorkspace(
             [

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+    isChatTab,
     type FileViewerMode,
     isFileTab,
     isGraphTab,
@@ -2981,6 +2982,55 @@ describe("editorStore tab management", () => {
             "tab-a",
         ]);
         expect(state.activeTabId).toBe("tab-a");
+    });
+
+    it("updates chat tab titles even when the tab lives in a non-focused pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().openChat("session-a", {
+            title: "Initial chat",
+            paneId: "secondary",
+            background: true,
+        });
+
+        const before = useEditorStore
+            .getState()
+            .panes.find((pane) => pane.id === "secondary");
+        const chatTabId =
+            before?.tabs.find((tab) => isChatTab(tab))?.id ?? null;
+
+        expect(chatTabId).not.toBeNull();
+
+        useEditorStore.getState().updateTabTitle(chatTabId ?? "", "Renamed");
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("primary");
+        expect(
+            state.panes
+                .find((pane) => pane.id === "secondary")
+                ?.tabs.find((tab) => tab.id === chatTabId)?.title,
+        ).toBe("Renamed");
     });
 
     it("moves a tab into a split relative to the target pane", () => {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2875,6 +2875,94 @@ describe("editorStore tab management", () => {
         expect(state.panes[1]?.tabs[0]?.id).toBe("tab-b");
     });
 
+    it("preserves a nested down split when moving a tab from the left pane of a side-by-side workspace", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-c",
+                            noteId: "notes/c",
+                            title: "C",
+                            content: "Gamma",
+                        }),
+                    ],
+                    activeTabId: "tab-c",
+                },
+            ],
+            "primary",
+        );
+
+        const paneId = useEditorStore
+            .getState()
+            .moveTabToNewSplit("tab-b", "column");
+
+        const state = useEditorStore.getState();
+        expect(paneId).toBe("pane-3");
+        expect(state.focusedPaneId).toBe("pane-3");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-3",
+            "secondary",
+        ]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "primary")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-a"]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "pane-3")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-b"]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "secondary")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-c"]);
+        expect(state.layoutTree.type).toBe("split");
+        if (state.layoutTree.type !== "split") {
+            throw new Error("Expected root split layout");
+        }
+        expect(state.layoutTree.direction).toBe("row");
+        const nestedSplit = state.layoutTree.children[0];
+        expect(nestedSplit?.type).toBe("split");
+        if (!nestedSplit || nestedSplit.type !== "split") {
+            throw new Error("Expected nested split on the left branch");
+        }
+        expect(nestedSplit.direction).toBe("column");
+        expect(
+            nestedSplit.children.map((child) =>
+                child.type === "pane" ? child.paneId : child.id,
+            ),
+        ).toEqual(["primary", "pane-3"]);
+        const rightBranch = state.layoutTree.children[1];
+        expect(rightBranch?.type).toBe("pane");
+        if (!rightBranch || rightBranch.type !== "pane") {
+            throw new Error("Expected right branch to remain a pane");
+        }
+        expect(rightBranch.paneId).toBe("secondary");
+    });
+
     it("focuses adjacent panes through directional navigation", () => {
         useEditorStore.getState().hydrateWorkspace(
             [

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -16,6 +16,7 @@ import {
 import { useSettingsStore } from "./settingsStore";
 import { safeStorageClear } from "../utils/safeStorage";
 import { useVaultStore } from "./vaultStore";
+import { MAX_EDITOR_PANES } from "./workspaceLayoutTree";
 
 function makeTab(overrides: {
     id: string;
@@ -2304,14 +2305,50 @@ describe("editorStore tab management", () => {
         });
 
         const state = useEditorStore.getState();
-        expect(paneId).toBe("secondary");
-        expect(state.focusedPaneId).toBe("secondary");
+        expect(paneId).toBe("pane-2");
+        expect(state.focusedPaneId).toBe("pane-2");
         expect(state.panes).toHaveLength(2);
         expect(state.panes[1]?.tabs[0]).toMatchObject({
             id: "tab-b",
             noteId: "notes/b",
         });
         expect(state.activeTabId).toBe("tab-b");
+    });
+
+    it("creates panes with dynamic ids until reaching the centralized cap", () => {
+        useEditorStore.getState().hydrateTabs(
+            [
+                makeTab({
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                }),
+            ],
+            "tab-a",
+        );
+
+        const createdPaneIds = Array.from(
+            { length: MAX_EDITOR_PANES - 1 },
+            () => useEditorStore.getState().createEmptyPane(),
+        );
+
+        expect(createdPaneIds).toEqual([
+            "pane-2",
+            "pane-3",
+            "pane-4",
+            "pane-5",
+            "pane-6",
+        ]);
+        expect(useEditorStore.getState().createEmptyPane()).toBeNull();
+        expect(useEditorStore.getState().panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-2",
+            "pane-3",
+            "pane-4",
+            "pane-5",
+            "pane-6",
+        ]);
     });
 
     it("moves tabs between panes and focuses the target pane", () => {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -1585,7 +1585,7 @@ describe("editorStore tab management", () => {
         expect(state.panes[1]?.activeTabId).toBe("tab-b");
     });
 
-    it("closes a tab in a non-focused pane without collapsing that pane", () => {
+    it("closes a tab in a non-focused pane and removes the empty pane", () => {
         useEditorStore.getState().hydrateWorkspace(
             [
                 {
@@ -1621,9 +1621,9 @@ describe("editorStore tab management", () => {
         const state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("primary");
         expect(state.activeTabId).toBe("tab-a");
-        expect(state.panes).toHaveLength(2);
-        expect(state.panes[1]?.tabs).toEqual([]);
-        expect(state.panes[1]?.activeTabId).toBeNull();
+        expect(state.panes).toHaveLength(1);
+        expect(state.panes[0]?.id).toBe("primary");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
     });
 
     it("reuses and closes review tabs across panes", () => {
@@ -1693,10 +1693,11 @@ describe("editorStore tab management", () => {
 
         state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("primary");
-        expect(state.panes[1]?.tabs.some((tab) => isReviewTab(tab))).toBe(
+        expect(state.panes).toHaveLength(1);
+        expect(state.panes[0]?.id).toBe("primary");
+        expect(state.panes[0]?.tabs.some((tab) => isReviewTab(tab))).toBe(
             false,
         );
-        expect(state.panes[1]?.activeTabId).toBeNull();
     });
 
     it("tracks dirty tabs and clears them when the tab closes", () => {
@@ -2354,6 +2355,48 @@ describe("editorStore tab management", () => {
             "tab-a",
         ]);
         expect(state.activeTabId).toBe("tab-a");
+    });
+
+    it("reorders tabs within a pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                        makeTab({
+                            id: "tab-c",
+                            noteId: "notes/c",
+                            title: "C",
+                            content: "Gamma",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().reorderPaneTabs("primary", 0, 2);
+
+        const state = useEditorStore.getState();
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-b",
+            "tab-c",
+            "tab-a",
+        ]);
+        expect(state.activeTabId).toBe("tab-b");
     });
 
     it("closes a pane explicitly and merges its tabs into a neighboring pane", () => {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2869,11 +2869,9 @@ describe("editorStore tab management", () => {
         expect(state.focusedPaneId).toBe("pane-3");
         expect(state.panes.map((pane) => pane.id)).toEqual([
             "primary",
-            "secondary",
             "pane-3",
         ]);
-        expect(state.panes[1]?.tabs).toHaveLength(0);
-        expect(state.panes[2]?.tabs[0]?.id).toBe("tab-b");
+        expect(state.panes[1]?.tabs[0]?.id).toBe("tab-b");
     });
 
     it("focuses adjacent panes through directional navigation", () => {
@@ -2942,7 +2940,7 @@ describe("editorStore tab management", () => {
         expect(nestedSplit.sizes[1]).toBeCloseTo(0.5, 3);
     });
 
-    it("moves tabs between panes and focuses the target pane", () => {
+    it("moves tabs between panes, focuses the target pane, and closes empty sources", () => {
         useEditorStore.getState().hydrateWorkspace(
             [
                 {
@@ -2977,8 +2975,8 @@ describe("editorStore tab management", () => {
 
         const state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("secondary");
-        expect(state.panes[0]?.tabs).toHaveLength(0);
-        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual([
+        expect(state.panes.map((pane) => pane.id)).toEqual(["secondary"]);
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual([
             "tab-b",
             "tab-a",
         ]);
@@ -3024,13 +3022,9 @@ describe("editorStore tab management", () => {
         expect(createdPaneId).toBe("pane-3");
         expect(state.focusedPaneId).toBe("pane-3");
         expect(state.panes.map((pane) => pane.id)).toEqual([
-            "primary",
             "pane-3",
             "secondary",
         ]);
-        expect(
-            state.panes.find((pane) => pane.id === "primary")?.tabs,
-        ).toHaveLength(0);
         expect(
             state.panes.find((pane) => pane.id === "pane-3")?.tabs[0]?.id,
         ).toBe("tab-a");
@@ -3040,7 +3034,6 @@ describe("editorStore tab management", () => {
         }
         expect(state.layoutTree.direction).toBe("row");
         expect(state.layoutTree.children.map((child) => child.id)).toEqual([
-            "primary",
             "pane-3",
             "secondary",
         ]);

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -9,6 +9,11 @@ import {
     isReviewTab,
     markSessionReady,
     readPersistedSession,
+    selectFocusedPaneId,
+    selectLeafPaneIds,
+    selectPaneCount,
+    selectPaneNeighbor,
+    selectPaneState,
     useEditorStore,
     type MapTab,
     type MapTabInput,
@@ -16,7 +21,11 @@ import {
 import { useSettingsStore } from "./settingsStore";
 import { safeStorageClear } from "../utils/safeStorage";
 import { useVaultStore } from "./vaultStore";
-import { MAX_EDITOR_PANES } from "./workspaceLayoutTree";
+import {
+    MAX_EDITOR_PANES,
+    createInitialLayout,
+    splitPane,
+} from "./workspaceLayoutTree";
 
 function makeTab(overrides: {
     id: string;
@@ -155,6 +164,252 @@ afterEach(() => {
     vi.restoreAllMocks();
     safeStorageClear();
     localStorage.clear();
+});
+
+describe("editorStore pane selector contract", () => {
+    it("derives pane ids, pane count, focused pane and neighbors from the flat workspace", () => {
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-3",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: "pane-2",
+        });
+
+        const state = useEditorStore.getState();
+        expect(selectLeafPaneIds(state)).toEqual([
+            "primary",
+            "pane-2",
+            "pane-3",
+        ]);
+        expect(selectPaneCount(state)).toBe(3);
+        expect(selectFocusedPaneId(state)).toBe("pane-2");
+        expect(selectPaneNeighbor(state, "pane-2", "left")).toBe("primary");
+        expect(selectPaneNeighbor(state, "pane-2", "right")).toBe("pane-3");
+        expect(selectPaneNeighbor(state, "pane-2", "up")).toBeNull();
+        expect(selectPaneNeighbor(state, "pane-2", "down")).toBeNull();
+    });
+
+    it("keeps legacy single-pane fallbacks behind the selector contract", () => {
+        const legacyTab = makeTab({
+            id: "legacy-tab",
+            noteId: "notes/legacy",
+            title: "Legacy",
+            content: "legacy content",
+        });
+
+        const state = {
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: null,
+            tabs: [legacyTab],
+            activeTabId: legacyTab.id,
+            activationHistory: [legacyTab.id],
+            tabNavigationHistory: [legacyTab.id],
+            tabNavigationIndex: 0,
+        };
+
+        expect(selectLeafPaneIds(state)).toEqual(["primary"]);
+        expect(selectFocusedPaneId(state)).toBe("primary");
+        expect(selectPaneCount(state)).toBe(1);
+        expect(selectPaneState(state).tabs.map((tab) => tab.id)).toEqual([
+            "legacy-tab",
+        ]);
+    });
+
+    it("derives pane order from the layout tree when the workspace cache is aligned", () => {
+        const layoutTree = splitPane(
+            splitPane(
+                createInitialLayout("primary"),
+                "primary",
+                "row",
+                "pane-2",
+            ),
+            "pane-2",
+            "column",
+            "pane-3",
+        );
+
+        const state = {
+            layoutTree,
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-3",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: "pane-3",
+            tabs: [],
+            activeTabId: null,
+            activationHistory: [],
+            tabNavigationHistory: [],
+            tabNavigationIndex: -1,
+        };
+
+        expect(selectLeafPaneIds(state)).toEqual([
+            "primary",
+            "pane-2",
+            "pane-3",
+        ]);
+        expect(selectFocusedPaneId(state)).toBe("pane-3");
+        expect(selectPaneState(state, "pane-2").id).toBe("pane-2");
+    });
+
+    it("derives geometric up and down neighbors from the layout tree", () => {
+        const layoutTree = splitPane(
+            splitPane(
+                createInitialLayout("primary"),
+                "primary",
+                "row",
+                "pane-2",
+            ),
+            "pane-2",
+            "column",
+            "pane-3",
+        );
+
+        const state = {
+            layoutTree,
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "pane-3",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: "pane-3",
+            tabs: [],
+            activeTabId: null,
+            activationHistory: [],
+            tabNavigationHistory: [],
+            tabNavigationIndex: -1,
+        };
+
+        expect(selectPaneNeighbor(state, "pane-3", "up")).toBe("pane-2");
+        expect(selectPaneNeighbor(state, "pane-2", "down")).toBe("pane-3");
+    });
+
+    it("resizes only the targeted split branch in tree-backed workspaces", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "pane-3",
+                    tabs: [],
+                    activeTabId: null,
+                },
+            ],
+            "primary",
+        );
+
+        const layoutTree = splitPane(
+            splitPane(
+                createInitialLayout("primary"),
+                "primary",
+                "row",
+                "pane-2",
+            ),
+            "pane-2",
+            "column",
+            "pane-3",
+        );
+
+        useEditorStore.setState({ layoutTree });
+        useEditorStore.getState().resizePaneSplit("split-2", [0.7, 0.3]);
+
+        const nextLayoutTree = useEditorStore.getState().layoutTree;
+        expect(nextLayoutTree.type).toBe("split");
+        if (nextLayoutTree.type !== "split") {
+            throw new Error("Expected root split layout");
+        }
+        expect(nextLayoutTree.sizes).toEqual([0.5, 0.5]);
+
+        const nestedSplit = nextLayoutTree.children[1];
+        expect(nestedSplit?.type).toBe("split");
+        if (!nestedSplit || nestedSplit.type !== "split") {
+            throw new Error("Expected nested column split");
+        }
+        expect(nestedSplit.sizes[0]).toBeCloseTo(0.7, 3);
+        expect(nestedSplit.sizes[1]).toBeCloseTo(0.3, 3);
+    });
 });
 
 describe("editorStore session persistence", () => {
@@ -1981,6 +2236,69 @@ describe("editorStore tab management", () => {
         });
     });
 
+    it("reloads the same note across multiple panes without changing pane focus", () => {
+        const layoutTree = splitPane(
+            createInitialLayout("primary"),
+            "primary",
+            "row",
+            "secondary",
+        );
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "note-a-primary",
+                            noteId: "notes/a",
+                            title: "Old title",
+                            content: "Old body",
+                        }),
+                    ],
+                    activeTabId: "note-a-primary",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "note-a-secondary",
+                            noteId: "notes/a",
+                            title: "Old title",
+                            content: "Old body",
+                        }),
+                    ],
+                    activeTabId: "note-a-secondary",
+                },
+            ],
+            "secondary",
+            layoutTree,
+        );
+
+        useEditorStore.getState().reloadNoteContent("notes/a", {
+            title: "New title",
+            content: "New body",
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(
+            state.panes.map((pane) =>
+                pane.tabs.find(
+                    (tab) => isNoteTab(tab) && tab.noteId === "notes/a",
+                ),
+            ),
+        ).toEqual([
+            expect.objectContaining({
+                title: "New title",
+                content: "New body",
+            }),
+            expect.objectContaining({
+                title: "New title",
+                content: "New body",
+            }),
+        ]);
+    });
+
     it("tracks logical reloads even when content stays the same", () => {
         useEditorStore.setState({
             tabs: [
@@ -2099,6 +2417,133 @@ describe("editorStore tab management", () => {
             revision: 7,
             opId: "external-7",
         });
+    });
+
+    it("force reloads matching file tabs across panes", () => {
+        const layoutTree = splitPane(
+            createInitialLayout("primary"),
+            "primary",
+            "row",
+            "secondary",
+        );
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeFileTab({
+                            id: "file-a-primary",
+                            relativePath: "src/a.ts",
+                            title: "a.ts",
+                            path: "/vault/src/a.ts",
+                            content: "before",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        }),
+                    ],
+                    activeTabId: "file-a-primary",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeFileTab({
+                            id: "file-a-secondary",
+                            relativePath: "src/a.ts",
+                            title: "a.ts",
+                            path: "/vault/src/a.ts",
+                            content: "before",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        }),
+                    ],
+                    activeTabId: "file-a-secondary",
+                },
+            ],
+            "primary",
+            layoutTree,
+        );
+
+        useEditorStore.getState().forceReloadFileContent("src/a.ts", {
+            title: "a.ts",
+            content: "after",
+            origin: "agent",
+            revision: 9,
+            opId: "agent-9",
+        });
+
+        const state = useEditorStore.getState();
+        expect(state._pendingForceFileReloads.has("src/a.ts")).toBe(true);
+        expect(
+            state.panes.flatMap((pane) =>
+                pane.tabs.filter(
+                    (tab) => isFileTab(tab) && tab.relativePath === "src/a.ts",
+                ),
+            ),
+        ).toEqual([
+            expect.objectContaining({ content: "after" }),
+            expect.objectContaining({ content: "after" }),
+        ]);
+    });
+
+    it("removes deleted note tabs from every pane and collapses emptied panes", () => {
+        const layoutTree = splitPane(
+            createInitialLayout("primary"),
+            "primary",
+            "row",
+            "secondary",
+        );
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "note-a-primary",
+                            noteId: "notes/a",
+                            title: "Alpha",
+                            content: "body a",
+                        }),
+                    ],
+                    activeTabId: "note-a-primary",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "note-a-secondary",
+                            noteId: "notes/a",
+                            title: "Alpha",
+                            content: "body a",
+                        }),
+                        makeTab({
+                            id: "note-b-secondary",
+                            noteId: "notes/b",
+                            title: "Beta",
+                            content: "body b",
+                        }),
+                    ],
+                    activeTabId: "note-b-secondary",
+                },
+            ],
+            "primary",
+            layoutTree,
+        );
+
+        useEditorStore.getState().handleNoteDeleted("notes/a");
+
+        const state = useEditorStore.getState();
+        expect(selectLeafPaneIds(state)).toEqual(["secondary"]);
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(
+            state.panes[0]?.tabs.some(
+                (tab) => isNoteTab(tab) && tab.noteId === "notes/a",
+            ),
+        ).toBe(false);
+        expect(
+            state.panes[0]?.tabs.find(
+                (tab) => isNoteTab(tab) && tab.noteId === "notes/b",
+            ),
+        ).toBeDefined();
     });
 
     it("force reloads a note target through the shared target API", () => {
@@ -2351,6 +2796,152 @@ describe("editorStore tab management", () => {
         ]);
     });
 
+    it("splits the focused pane to the right and focuses the new pane", () => {
+        useEditorStore.getState().hydrateTabs(
+            [
+                makeTab({
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                }),
+            ],
+            "tab-a",
+        );
+
+        const paneId = useEditorStore.getState().splitEditorPane("row");
+
+        const state = useEditorStore.getState();
+        expect(paneId).toBe("pane-2");
+        expect(state.focusedPaneId).toBe("pane-2");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-2",
+        ]);
+        expect(state.layoutTree.type).toBe("split");
+        if (state.layoutTree.type !== "split") {
+            throw new Error("Expected split layout");
+        }
+        expect(state.layoutTree.direction).toBe("row");
+        expect(state.layoutTree.children.map((child) => child.id)).toEqual([
+            "primary",
+            "pane-2",
+        ]);
+    });
+
+    it("moves a tab into a new down split without destroying the source pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        const paneId = useEditorStore
+            .getState()
+            .moveTabToNewSplit("tab-b", "column");
+
+        const state = useEditorStore.getState();
+        expect(paneId).toBe("pane-3");
+        expect(state.focusedPaneId).toBe("pane-3");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "secondary",
+            "pane-3",
+        ]);
+        expect(state.panes[1]?.tabs).toHaveLength(0);
+        expect(state.panes[2]?.tabs[0]?.id).toBe("tab-b");
+    });
+
+    it("focuses adjacent panes through directional navigation", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "secondary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().splitEditorPane("column", "secondary");
+        useEditorStore.getState().focusPane("pane-3");
+        useEditorStore.getState().focusPaneNeighbor("up");
+        expect(useEditorStore.getState().focusedPaneId).toBe("secondary");
+
+        useEditorStore.getState().focusPaneNeighbor("left");
+        expect(useEditorStore.getState().focusedPaneId).toBe("primary");
+    });
+
+    it("balances the workspace layout without changing pane order", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "secondary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().splitEditorPane("column", "secondary");
+        useEditorStore.getState().resizePaneSplit("split-2", [0.7, 0.3]);
+        useEditorStore.getState().balancePaneLayout();
+
+        const state = useEditorStore.getState();
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "secondary",
+            "pane-3",
+        ]);
+        expect(state.layoutTree.type).toBe("split");
+        if (state.layoutTree.type !== "split") {
+            throw new Error("Expected root split layout");
+        }
+        const nestedSplit = state.layoutTree.children[1];
+        expect(nestedSplit?.type).toBe("split");
+        if (!nestedSplit || nestedSplit.type !== "split") {
+            throw new Error("Expected nested split");
+        }
+        expect(nestedSplit.sizes[0]).toBeCloseTo(0.5, 3);
+        expect(nestedSplit.sizes[1]).toBeCloseTo(0.5, 3);
+    });
+
     it("moves tabs between panes and focuses the target pane", () => {
         useEditorStore.getState().hydrateWorkspace(
             [
@@ -2392,6 +2983,67 @@ describe("editorStore tab management", () => {
             "tab-a",
         ]);
         expect(state.activeTabId).toBe("tab-a");
+    });
+
+    it("moves a tab into a split relative to the target pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        const createdPaneId = useEditorStore
+            .getState()
+            .moveTabToPaneDropTarget("tab-a", "secondary", "left");
+
+        const state = useEditorStore.getState();
+        expect(createdPaneId).toBe("pane-3");
+        expect(state.focusedPaneId).toBe("pane-3");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-3",
+            "secondary",
+        ]);
+        expect(
+            state.panes.find((pane) => pane.id === "primary")?.tabs,
+        ).toHaveLength(0);
+        expect(
+            state.panes.find((pane) => pane.id === "pane-3")?.tabs[0]?.id,
+        ).toBe("tab-a");
+        expect(state.layoutTree.type).toBe("split");
+        if (state.layoutTree.type !== "split") {
+            throw new Error("Expected root split layout");
+        }
+        expect(state.layoutTree.direction).toBe("row");
+        expect(state.layoutTree.children.map((child) => child.id)).toEqual([
+            "primary",
+            "pane-3",
+            "secondary",
+        ]);
     });
 
     it("reorders tabs within a pane", () => {

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -116,6 +116,17 @@ beforeEach(() => {
     safeStorageClear();
     localStorage.clear();
     useEditorStore.setState({
+        panes: [
+            {
+                id: "primary",
+                tabs: [],
+                activeTabId: null,
+                activationHistory: [],
+                tabNavigationHistory: [],
+                tabNavigationIndex: -1,
+            },
+        ],
+        focusedPaneId: "primary",
         tabs: [],
         activeTabId: null,
         recentlyClosedTabs: [],
@@ -1534,6 +1545,160 @@ describe("editorStore tab management", () => {
         expect(state.activeTabId).toBe("tab-a");
     });
 
+    it("switches to a tab in another pane and focuses that pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().switchTab("tab-b");
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.activeTabId).toBe("tab-b");
+        expect(state.panes[0]?.activeTabId).toBe("tab-a");
+        expect(state.panes[1]?.activeTabId).toBe("tab-b");
+    });
+
+    it("closes a tab in a non-focused pane without collapsing that pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().closeTab("tab-b");
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("primary");
+        expect(state.activeTabId).toBe("tab-a");
+        expect(state.panes).toHaveLength(2);
+        expect(state.panes[1]?.tabs).toEqual([]);
+        expect(state.panes[1]?.activeTabId).toBeNull();
+    });
+
+    it("reuses and closes review tabs across panes", () => {
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                    activationHistory: ["tab-a"],
+                    tabNavigationHistory: ["tab-a"],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "review-1",
+                            kind: "ai-review",
+                            sessionId: "session-1",
+                            title: "Initial review",
+                        },
+                    ],
+                    activeTabId: "review-1",
+                    activationHistory: ["review-1"],
+                    tabNavigationHistory: ["review-1"],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "primary",
+            tabs: [
+                makeTab({
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                }),
+            ],
+            activeTabId: "tab-a",
+            activationHistory: ["tab-a"],
+            tabNavigationHistory: ["tab-a"],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore.getState().openReview("session-1", {
+            title: "Updated review",
+        });
+
+        let state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.activeTabId).toBe("review-1");
+        expect(
+            state.panes[1]?.tabs.find((tab) => isReviewTab(tab)),
+        ).toMatchObject({
+            title: "Updated review",
+        });
+
+        useEditorStore.getState().focusPane("primary");
+        useEditorStore.getState().closeReview("session-1");
+
+        state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("primary");
+        expect(state.panes[1]?.tabs.some((tab) => isReviewTab(tab))).toBe(
+            false,
+        );
+        expect(state.panes[1]?.activeTabId).toBeNull();
+    });
+
     it("tracks dirty tabs and clears them when the tab closes", () => {
         useEditorStore.setState({
             tabs: [
@@ -2114,5 +2279,122 @@ describe("editorStore tab management", () => {
             relativePath: "src/main.ts",
         });
         expect(state.activeTabId).toBe("file-b");
+    });
+
+    it("creates a new pane with an external tab and focuses it", () => {
+        useEditorStore.getState().hydrateTabs(
+            [
+                makeTab({
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                }),
+            ],
+            "tab-a",
+        );
+
+        const paneId = useEditorStore.getState().insertExternalTabInNewPane({
+            id: "tab-b",
+            kind: "note",
+            noteId: "notes/b",
+            title: "B",
+            content: "Beta",
+        });
+
+        const state = useEditorStore.getState();
+        expect(paneId).toBe("secondary");
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes).toHaveLength(2);
+        expect(state.panes[1]?.tabs[0]).toMatchObject({
+            id: "tab-b",
+            noteId: "notes/b",
+        });
+        expect(state.activeTabId).toBe("tab-b");
+    });
+
+    it("moves tabs between panes and focuses the target pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        useEditorStore.getState().moveTabToPane("tab-a", "secondary");
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes[0]?.tabs).toHaveLength(0);
+        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-b",
+            "tab-a",
+        ]);
+        expect(state.activeTabId).toBe("tab-a");
+    });
+
+    it("closes a pane explicitly and merges its tabs into a neighboring pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        makeTab({
+                            id: "tab-b",
+                            noteId: "notes/b",
+                            title: "B",
+                            content: "Beta",
+                        }),
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "secondary",
+        );
+
+        useEditorStore.getState().closePane("secondary");
+
+        const state = useEditorStore.getState();
+        expect(state.panes).toHaveLength(1);
+        expect(state.focusedPaneId).toBe("primary");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-a",
+            "tab-b",
+        ]);
     });
 });

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -1473,6 +1473,140 @@ describe("editorStore tab history mode", () => {
         });
     });
 
+    it("handleMapDeleted closes matching map tabs across panes and collapses empty panes", () => {
+        const noteTab = makeTab({
+            id: "note-a",
+            noteId: "notes/a",
+            title: "A",
+            content: "Alpha",
+        });
+        const mapTab = makeMapTab({
+            id: "map-a",
+            relativePath: "Excalidraw/Board.excalidraw",
+            title: "Board",
+        });
+        const layoutTree = splitPane(
+            createInitialLayout("primary"),
+            "primary",
+            "row",
+            "secondary",
+        );
+
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [noteTab],
+                    activeTabId: noteTab.id,
+                    activationHistory: [noteTab.id],
+                    tabNavigationHistory: [noteTab.id],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "secondary",
+                    tabs: [mapTab],
+                    activeTabId: mapTab.id,
+                    activationHistory: [mapTab.id],
+                    tabNavigationHistory: [mapTab.id],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "primary",
+            layoutTree,
+            tabs: [noteTab],
+            activeTabId: noteTab.id,
+            activationHistory: [noteTab.id],
+            tabNavigationHistory: [noteTab.id],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore
+            .getState()
+            .handleMapDeleted("Excalidraw/Board.excalidraw");
+
+        const state = useEditorStore.getState();
+        expect(selectLeafPaneIds(state)).toEqual(["primary"]);
+        expect(state.panes).toHaveLength(1);
+        expect(
+            state.panes
+                .flatMap((pane) => pane.tabs)
+                .some((tab) => isMapTab(tab)),
+        ).toBe(false);
+        expect(state.tabs[0]).toMatchObject({
+            id: noteTab.id,
+            kind: "note",
+        });
+    });
+
+    it("handleMapRenamed updates matching map tabs across panes without changing focus", () => {
+        const noteTab = makeTab({
+            id: "note-a",
+            noteId: "notes/a",
+            title: "A",
+            content: "Alpha",
+        });
+        const mapTab = makeMapTab({
+            id: "map-a",
+            relativePath: "Excalidraw/Board.excalidraw",
+            title: "Board",
+        });
+        const layoutTree = splitPane(
+            createInitialLayout("primary"),
+            "primary",
+            "row",
+            "secondary",
+        );
+
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [noteTab],
+                    activeTabId: noteTab.id,
+                    activationHistory: [noteTab.id],
+                    tabNavigationHistory: [noteTab.id],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "secondary",
+                    tabs: [mapTab],
+                    activeTabId: mapTab.id,
+                    activationHistory: [mapTab.id],
+                    tabNavigationHistory: [mapTab.id],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "primary",
+            layoutTree,
+            tabs: [noteTab],
+            activeTabId: noteTab.id,
+            activationHistory: [noteTab.id],
+            tabNavigationHistory: [noteTab.id],
+            tabNavigationIndex: 0,
+        });
+
+        useEditorStore
+            .getState()
+            .handleMapRenamed(
+                "Excalidraw/Board.excalidraw",
+                "Excalidraw/Architecture.excalidraw",
+                "Architecture",
+            );
+
+        const state = useEditorStore.getState();
+        const secondaryPane = selectPaneState(state, "secondary");
+        expect(state.focusedPaneId).toBe("primary");
+        expect(secondaryPane?.tabs[0]).toMatchObject({
+            kind: "map",
+            relativePath: "Excalidraw/Architecture.excalidraw",
+            title: "Architecture",
+        });
+        expect(state.tabs[0]).toMatchObject({
+            id: noteTab.id,
+            kind: "note",
+        });
+    });
+
     it("handleNoteDeleted removes reload and conflict state even when the note is not open", () => {
         useEditorStore.setState({
             tabs: [

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2061,4 +2061,58 @@ describe("editorStore tab management", () => {
             viewMode: "single",
         });
     });
+
+    it("hydrates pane workspaces while mirroring the focused pane into legacy fields", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "pane-1",
+                    tabs: [
+                        makeTab({
+                            id: "tab-a",
+                            noteId: "notes/a",
+                            title: "A",
+                            content: "Alpha",
+                        }),
+                    ],
+                    activeTabId: "tab-a",
+                    activationHistory: ["tab-a"],
+                    tabNavigationHistory: ["tab-a"],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "pane-2",
+                    tabs: [
+                        makeFileTab({
+                            id: "file-b",
+                            relativePath: "src/main.ts",
+                            title: "main.ts",
+                            path: "/vault/src/main.ts",
+                            content: "console.log('ok')",
+                            mimeType: "text/typescript",
+                            viewer: "text",
+                        }),
+                    ],
+                    activeTabId: "file-b",
+                    activationHistory: ["file-b"],
+                    tabNavigationHistory: ["file-b"],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            "pane-2",
+        );
+
+        const state = useEditorStore.getState();
+
+        expect(state.focusedPaneId).toBe("pane-2");
+        expect(state.panes).toHaveLength(2);
+        expect(state.panes[0]?.activeTabId).toBe("tab-a");
+        expect(state.panes[1]?.activeTabId).toBe("file-b");
+        expect(state.tabs[0]).toMatchObject({
+            id: "file-b",
+            kind: "file",
+            relativePath: "src/main.ts",
+        });
+        expect(state.activeTabId).toBe("file-b");
+    });
 });

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -50,9 +50,21 @@ import {
 import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
 import {
+    balanceSplit,
     DEFAULT_EDITOR_PANE_ID as INITIAL_EDITOR_PANE_ID,
+    closePaneAndCollapse,
+    createInitialLayout,
     getNextGeneratedPaneId,
+    getLayoutPaneIds,
+    movePane,
+    normalizeLayoutTree,
+    resizeSplit,
+    splitPane,
+    type WorkspaceLayoutNode,
+    type WorkspaceMovePosition,
+    type WorkspaceSplitDirection,
 } from "./workspaceLayoutTree";
+import { findAdjacentPane } from "./workspaceLayoutNavigation";
 
 export {
     fileViewerNeedsTextContent,
@@ -120,6 +132,8 @@ export interface EditorPaneInput {
     tabNavigationIndex?: number;
 }
 
+export type WorkspacePaneNeighborDirection = "left" | "right" | "up" | "down";
+
 function normalizeLegacyWorkspaceState(
     workspace: Partial<LegacyWorkspaceState>,
 ): LegacyWorkspaceState {
@@ -182,6 +196,13 @@ function stringArraysEqual(left: readonly string[], right: readonly string[]) {
     );
 }
 
+function tabsShallowEqual(left: readonly Tab[], right: readonly Tab[]) {
+    return (
+        left.length === right.length &&
+        left.every((value, index) => value === right[index])
+    );
+}
+
 function getResolvedFocusedPaneId(
     panes: readonly EditorPaneState[],
     focusedPaneId: string | null | undefined,
@@ -196,9 +217,56 @@ function getNextEditorPaneId(panes: readonly EditorPaneState[]) {
     return getNextGeneratedPaneId(panes.map((pane) => pane.id));
 }
 
+function buildLinearLayoutTree(paneIds: readonly string[]) {
+    if (paneIds.length === 0) {
+        return createInitialLayout(INITIAL_EDITOR_PANE_ID);
+    }
+
+    let tree = createInitialLayout(paneIds[0] ?? INITIAL_EDITOR_PANE_ID);
+    for (let index = 1; index < paneIds.length; index += 1) {
+        const paneId = paneIds[index];
+        const anchorPaneId = paneIds[index - 1];
+        if (!paneId || !anchorPaneId) {
+            continue;
+        }
+        tree = splitPane(tree, anchorPaneId, "row", paneId);
+    }
+
+    return tree;
+}
+
+function buildPaneCacheMap(panes: readonly EditorPaneState[]) {
+    return new Map(
+        panes.map((pane) => [pane.id, createEditorPaneState(pane.id, pane)]),
+    );
+}
+
+function resolveLayoutTreeFromState<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState, paneIds?: readonly string[]) {
+    const resolvedPaneIds =
+        paneIds ??
+        (state.panes.length > 0
+            ? state.panes.map((pane) => pane.id)
+            : [INITIAL_EDITOR_PANE_ID]);
+
+    if (state.layoutTree) {
+        const normalizedTree = normalizeLayoutTree(state.layoutTree);
+        const treePaneIds = getLayoutPaneIds(normalizedTree);
+        if (stringArraysEqual(treePaneIds, resolvedPaneIds)) {
+            return normalizedTree;
+        }
+    }
+
+    return buildLinearLayoutTree(resolvedPaneIds);
+}
+
 function getEffectivePaneWorkspace<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState) {
     const panes = state.panes.length > 0 ? state.panes : [];
     const hasLegacyWorkspace =
@@ -214,10 +282,21 @@ function getEffectivePaneWorkspace<
             panes.length > 0
                 ? panes
                 : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)];
+        const layoutTree = resolveLayoutTreeFromState(
+            state,
+            effectivePanes.map((pane) => pane.id),
+        );
+        const paneCache = new Map(
+            effectivePanes.map((pane) => [pane.id, pane] as const),
+        );
+        const orderedPanes = getLayoutPaneIds(layoutTree).map(
+            (paneId) => paneCache.get(paneId) ?? createEditorPaneState(paneId),
+        );
         return {
-            panes: effectivePanes,
+            layoutTree,
+            panes: orderedPanes,
             focusedPaneId: getResolvedFocusedPaneId(
-                effectivePanes,
+                orderedPanes,
                 state.focusedPaneId,
             ),
         };
@@ -234,7 +313,12 @@ function getEffectivePaneWorkspace<
         singlePane.tabNavigationIndex === -1;
 
     if (!isPlaceholderInitialPane) {
+        const layoutTree = resolveLayoutTreeFromState(
+            state,
+            panes.map((pane) => pane.id),
+        );
         return {
+            layoutTree,
             panes,
             focusedPaneId: getResolvedFocusedPaneId(panes, state.focusedPaneId),
         };
@@ -247,8 +331,10 @@ function getEffectivePaneWorkspace<
         tabNavigationHistory: state.tabNavigationHistory ?? [],
         tabNavigationIndex: state.tabNavigationIndex ?? -1,
     });
+    const layoutTree = resolveLayoutTreeFromState(state, [legacyPane.id]);
 
     return {
+        layoutTree,
         panes: [legacyPane],
         focusedPaneId: getResolvedFocusedPaneId(
             [legacyPane],
@@ -259,7 +345,40 @@ function getEffectivePaneWorkspace<
 
 export function selectEditorPaneState<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState, paneId?: string | null) {
+    return selectPaneState(state, paneId);
+}
+
+export function selectLeafPaneIds<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState) {
+    return getLayoutPaneIds(getEffectivePaneWorkspace(state).layoutTree);
+}
+
+export function selectFocusedPaneId<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState) {
+    return getEffectivePaneWorkspace(state).focusedPaneId;
+}
+
+export function selectPaneCount<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState) {
+    return selectLeafPaneIds(state).length;
+}
+
+export function selectPaneState<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState, paneId?: string | null) {
     const { panes, focusedPaneId } = getEffectivePaneWorkspace(state);
     const resolvedPaneId = paneId
@@ -273,31 +392,70 @@ export function selectEditorPaneState<
     );
 }
 
+export function selectPaneNeighbor<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState, paneId: string, direction: WorkspacePaneNeighborDirection) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const geometricNeighbor = findAdjacentPane(
+        workspace.layoutTree,
+        paneId,
+        direction,
+    );
+    if (geometricNeighbor) {
+        return geometricNeighbor;
+    }
+
+    const paneIds = getLayoutPaneIds(workspace.layoutTree);
+    const paneIndex = paneIds.indexOf(paneId);
+    if (paneIndex === -1) {
+        return null;
+    }
+
+    if (direction === "left" || direction === "up") {
+        if (direction === "up") {
+            return null;
+        }
+        return paneIds[paneIndex - 1] ?? null;
+    }
+
+    if (direction === "down") {
+        return null;
+    }
+
+    return paneIds[paneIndex + 1] ?? null;
+}
+
 export function selectEditorPaneTabs<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState, paneId?: string | null) {
-    return selectEditorPaneState(state, paneId).tabs;
+    return selectPaneState(state, paneId).tabs;
 }
 
 export function selectEditorPaneActiveTab<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState, paneId?: string | null) {
-    const pane = selectEditorPaneState(state, paneId);
+    const pane = selectPaneState(state, paneId);
     return pane.tabs.find((tab) => tab.id === pane.activeTabId) ?? null;
 }
 
 export function selectFocusedEditorTab<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState) {
     return selectEditorPaneActiveTab(state);
 }
 
 export function selectEditorWorkspaceTabs<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
-        Partial<LegacyWorkspaceState>,
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
 >(state: TState) {
     return getEffectivePaneWorkspace(state).panes.flatMap((pane) => pane.tabs);
 }
@@ -305,16 +463,31 @@ export function selectEditorWorkspaceTabs<
 function buildFocusedPaneProjection(args: {
     panes: EditorPaneState[];
     focusedPaneId?: string | null;
+    layoutTree?: WorkspaceLayoutNode;
 }) {
-    const panes =
+    const paneStates =
         args.panes.length > 0
             ? args.panes.map((pane) => createEditorPaneState(pane.id, pane))
             : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)];
+    const paneIds = paneStates.map((pane) => pane.id);
+    const layoutTree =
+        args.layoutTree &&
+        stringArraysEqual(
+            getLayoutPaneIds(normalizeLayoutTree(args.layoutTree)),
+            paneIds,
+        )
+            ? normalizeLayoutTree(args.layoutTree)
+            : buildLinearLayoutTree(paneIds);
+    const paneCache = buildPaneCacheMap(paneStates);
+    const panes = getLayoutPaneIds(layoutTree).map(
+        (paneId) => paneCache.get(paneId) ?? createEditorPaneState(paneId),
+    );
     const focusedPaneId = getResolvedFocusedPaneId(panes, args.focusedPaneId);
     const focusedPane =
         panes.find((pane) => pane.id === focusedPaneId) ?? panes[0];
 
     return {
+        layoutTree,
         panes,
         focusedPaneId,
         tabs: focusedPane.tabs,
@@ -633,6 +806,51 @@ function getPaneRecipientIdForRemoval(
     return panes[paneIndex - 1]?.id ?? panes[paneIndex + 1]?.id ?? null;
 }
 
+function getPaneRecipientIdForWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState> &
+        Partial<Pick<EditorStore, "layoutTree">>,
+>(state: TState, paneId: string) {
+    return (
+        selectPaneNeighbor(state, paneId, "left") ??
+        selectPaneNeighbor(state, paneId, "right") ??
+        selectPaneNeighbor(state, paneId, "up") ??
+        selectPaneNeighbor(state, paneId, "down") ??
+        getPaneRecipientIdForRemoval(
+            getEffectivePaneWorkspace(state).panes,
+            paneId,
+        )
+    );
+}
+
+function getSplitAnchorPaneId(
+    workspace: Pick<EditorStore, "panes" | "focusedPaneId">,
+    paneId?: string | null,
+) {
+    return getResolvedFocusedPaneId(
+        workspace.panes,
+        paneId ?? workspace.focusedPaneId,
+    );
+}
+
+function buildSplitPaneProjection(
+    workspace: Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+    anchorPaneId: string,
+    direction: WorkspaceSplitDirection,
+    nextPane: EditorPaneState,
+) {
+    return buildFocusedPaneProjection({
+        panes: [...workspace.panes, nextPane],
+        focusedPaneId: nextPane.id,
+        layoutTree: splitPane(
+            workspace.layoutTree,
+            anchorPaneId,
+            direction,
+            nextPane.id,
+        ),
+    });
+}
+
 function findPaneContainingTab(
     panes: readonly EditorPaneState[],
     tabId: string,
@@ -643,7 +861,7 @@ function findPaneContainingTab(
 }
 
 function activatePaneTab(
-    state: Pick<EditorStore, "panes" | "focusedPaneId">,
+    state: Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
     paneId: string,
     tabId: string,
     options?: { recordNavigation?: boolean },
@@ -663,6 +881,7 @@ function activatePaneTab(
                 : pane,
         ),
         focusedPaneId: paneId,
+        layoutTree: state.layoutTree,
     });
 }
 
@@ -771,6 +990,229 @@ function getTabOpenBehavior() {
     return useSettingsStore.getState().tabOpenBehavior;
 }
 
+function updatePaneWithTabs(pane: EditorPaneState, tabs: readonly Tab[]) {
+    if (tabsShallowEqual(pane.tabs, tabs)) {
+        return pane;
+    }
+
+    return createEditorPaneState(pane.id, {
+        ...pane,
+        tabs: [...tabs],
+    });
+}
+
+function applyResourceReloadAcrossWorkspace<
+    TState extends Pick<
+        EditorStore,
+        | "panes"
+        | "focusedPaneId"
+        | "layoutTree"
+        | "_pendingForceReloads"
+        | "_pendingForceFileReloads"
+        | "_noteReloadVersions"
+        | "_noteReloadMetadata"
+        | "_fileReloadVersions"
+        | "_fileReloadMetadata"
+    >,
+>(
+    state: TState,
+    kind: "note" | "file",
+    resourceId: string,
+    detail: ReloadedDetail,
+    options?: {
+        force?: boolean;
+        fallbackOrigin?: "unknown" | "system" | "external" | "agent";
+    },
+) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const handler = getResourceHandler(kind);
+    const nextPanes = workspace.panes.map((pane) => {
+        const next = buildResourceReloadUpdate(
+            handler,
+            {
+                tabs: pane.tabs,
+                pendingForceReloads: new Set<string>(),
+                reloadVersions: {},
+                reloadMetadata: {},
+            },
+            resourceId,
+            detail,
+            options,
+        );
+
+        return updatePaneWithTabs(pane, next.tabs);
+    });
+    const projection = buildFocusedPaneProjection({
+        panes: nextPanes,
+        focusedPaneId: workspace.focusedPaneId,
+        layoutTree: workspace.layoutTree,
+    });
+    const didChange =
+        nextPanes.length !== workspace.panes.length ||
+        nextPanes.some((pane, index) => pane !== workspace.panes[index]);
+
+    if (kind === "note") {
+        const nextMetadata = buildResourceReloadUpdate(
+            handler,
+            {
+                tabs: state.tabs,
+                pendingForceReloads: state._pendingForceReloads,
+                reloadVersions: state._noteReloadVersions,
+                reloadMetadata: state._noteReloadMetadata,
+            },
+            resourceId,
+            detail,
+            options,
+        );
+
+        return {
+            projection,
+            didChange,
+            pendingForceReloads: nextMetadata.pendingForceReloads,
+            reloadVersions: nextMetadata.reloadVersions,
+            reloadMetadata: nextMetadata.reloadMetadata,
+        };
+    }
+
+    const nextMetadata = buildResourceReloadUpdate(
+        handler,
+        {
+            tabs: state.tabs,
+            pendingForceReloads: state._pendingForceFileReloads,
+            reloadVersions: state._fileReloadVersions,
+            reloadMetadata: state._fileReloadMetadata,
+        },
+        resourceId,
+        detail,
+        options,
+    );
+
+    return {
+        projection,
+        didChange,
+        pendingForceReloads: nextMetadata.pendingForceReloads,
+        reloadVersions: nextMetadata.reloadVersions,
+        reloadMetadata: nextMetadata.reloadMetadata,
+    };
+}
+
+function applyResourceDeleteAcrossWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+>(state: TState, kind: "note" | "file", resourceId: string) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const handler = getResourceHandler(kind);
+    let nextPanes = workspace.panes.map((pane) => {
+        const next = buildResourceDeleteUpdate(
+            handler,
+            {
+                tabs: pane.tabs,
+                activeTabId: pane.activeTabId,
+                activationHistory: pane.activationHistory,
+                tabNavigationHistory: pane.tabNavigationHistory,
+                tabNavigationIndex: pane.tabNavigationIndex,
+                pendingForceReloads: new Set<string>(),
+                reloadVersions: {},
+                reloadMetadata: {},
+                externalConflicts: new Set<string>(),
+            },
+            resourceId,
+        );
+
+        return next
+            ? createEditorPaneState(pane.id, {
+                  tabs: next.tabs,
+                  activeTabId: next.activeTabId,
+                  activationHistory: next.activationHistory,
+                  tabNavigationHistory: next.tabNavigationHistory,
+                  tabNavigationIndex: next.tabNavigationIndex,
+              })
+            : pane;
+    });
+
+    let nextLayoutTree = workspace.layoutTree;
+    let nextFocusedPaneId = workspace.focusedPaneId;
+
+    for (const pane of [...nextPanes]) {
+        if (pane.tabs.length > 0 || nextPanes.length <= 1) {
+            continue;
+        }
+
+        const workspaceBeforeRemoval = {
+            panes: nextPanes,
+            focusedPaneId: nextFocusedPaneId,
+            layoutTree: nextLayoutTree,
+        };
+        if (nextFocusedPaneId === pane.id) {
+            nextFocusedPaneId =
+                getPaneRecipientIdForWorkspace(
+                    workspaceBeforeRemoval,
+                    pane.id,
+                ) ?? nextFocusedPaneId;
+        }
+
+        nextPanes = nextPanes.filter((candidate) => candidate.id !== pane.id);
+        nextLayoutTree = closePaneAndCollapse(nextLayoutTree, pane.id);
+    }
+
+    const didChange =
+        nextLayoutTree !== workspace.layoutTree ||
+        nextFocusedPaneId !== workspace.focusedPaneId ||
+        nextPanes.length !== workspace.panes.length ||
+        nextPanes.some((pane, index) => pane !== workspace.panes[index]);
+
+    return {
+        projection: buildFocusedPaneProjection({
+            panes: nextPanes,
+            focusedPaneId: nextFocusedPaneId,
+            layoutTree: nextLayoutTree,
+        }),
+        didChange,
+    };
+}
+
+function renameNoteAcrossWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+>(state: TState, oldNoteId: string, newNoteId: string, newTitle: string) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const nextPanes = workspace.panes.map((pane) => {
+        let didChange = false;
+        const tabs = pane.tabs.map((tab) => {
+            if (!isNoteTab(tab)) {
+                return tab;
+            }
+
+            const history = tab.history.map((entry) => {
+                if (entry.kind !== "note" || entry.noteId !== oldNoteId) {
+                    return entry;
+                }
+                didChange = true;
+                return {
+                    ...entry,
+                    noteId: newNoteId,
+                    title: newTitle,
+                };
+            });
+
+            return didChange
+                ? buildTabFromHistory(tab.id, history, tab.historyIndex)
+                : tab;
+        });
+
+        return didChange ? updatePaneWithTabs(pane, tabs) : pane;
+    });
+
+    return {
+        projection: buildFocusedPaneProjection({
+            panes: nextPanes,
+            focusedPaneId: workspace.focusedPaneId,
+            layoutTree: workspace.layoutTree,
+        }),
+        didChange:
+            nextPanes.length !== workspace.panes.length ||
+            nextPanes.some((pane, index) => pane !== workspace.panes[index]),
+    };
+}
+
 export interface PendingReveal {
     noteId: string;
     targets: string[];
@@ -805,6 +1247,7 @@ export interface ReloadedDetail {
 }
 
 interface EditorStore {
+    layoutTree: WorkspaceLayoutNode;
     panes: EditorPaneState[];
     focusedPaneId: string | null;
     tabs: Tab[];
@@ -858,13 +1301,38 @@ interface EditorStore {
     reopenLastClosedTab: () => void;
     switchTab: (tabId: string) => void;
     focusPane: (paneId: string) => void;
+    focusPaneNeighbor: (
+        direction: WorkspacePaneNeighborDirection,
+        paneId?: string,
+    ) => void;
+    resizePaneSplit: (splitId: string, sizes: readonly number[]) => void;
+    splitEditorPane: (
+        direction: WorkspaceSplitDirection,
+        paneId?: string,
+    ) => string | null;
+    balancePaneLayout: (splitId?: string) => void;
     createEmptyPane: () => string | null;
     insertExternalTabInPane: (
         tab: TabInput,
         paneId: string,
         index?: number,
     ) => void;
+    insertExternalTabInNewSplit: (
+        tab: TabInput,
+        direction: WorkspaceSplitDirection,
+        paneId?: string,
+    ) => string | null;
     insertExternalTabInNewPane: (tab: TabInput) => string | null;
+    moveTabToNewSplit: (
+        tabId: string,
+        direction: WorkspaceSplitDirection,
+    ) => string | null;
+    moveTabToPaneDropTarget: (
+        tabId: string,
+        targetPaneId: string,
+        position: WorkspaceMovePosition | "center",
+        index?: number,
+    ) => string | null;
     moveTabToPane: (tabId: string, paneId: string, index?: number) => void;
     reorderPaneTabs: (
         paneId: string,
@@ -887,6 +1355,7 @@ interface EditorStore {
     hydrateWorkspace: (
         panes: EditorPaneInput[],
         focusedPaneId?: string | null,
+        layoutTree?: WorkspaceLayoutNode,
     ) => void;
     hydrateTabs: (tabs: TabInput[], activeTabId: string | null) => void;
     insertExternalTab: (tab: TabInput, index?: number) => void;
@@ -923,6 +1392,7 @@ interface EditorStore {
 }
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
+    layoutTree: createInitialLayout(INITIAL_EDITOR_PANE_ID),
     panes: [createEditorPaneState(INITIAL_EDITOR_PANE_ID)],
     focusedPaneId: INITIAL_EDITOR_PANE_ID,
     tabs: [],
@@ -1055,10 +1525,12 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
                         focusedPaneId: workspace.focusedPaneId,
+                        layoutTree: workspace.layoutTree,
                     });
                 }
                 const projection = activatePaneTab(
                     {
+                        layoutTree: workspace.layoutTree,
                         panes: workspace.panes.map((pane) =>
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
@@ -1074,6 +1546,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
                         focusedPaneId: existingPane.id,
+                        layoutTree: workspace.layoutTree,
                     })
                 );
             }
@@ -1102,6 +1575,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                         pane.id === focusedPane.id ? nextPane : pane,
                     ),
                     focusedPaneId: workspace.focusedPaneId,
+                    layoutTree: workspace.layoutTree,
                 });
             }
 
@@ -1110,6 +1584,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                     pane.id === focusedPane.id ? nextPane : pane,
                 ),
                 focusedPaneId: focusedPane.id,
+                layoutTree: workspace.layoutTree,
             });
         });
     },
@@ -1158,10 +1633,12 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
                         focusedPaneId: workspace.focusedPaneId,
+                        layoutTree: workspace.layoutTree,
                     });
                 }
                 const projection = activatePaneTab(
                     {
+                        layoutTree: workspace.layoutTree,
                         panes: workspace.panes.map((pane) =>
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
@@ -1177,6 +1654,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                             pane.id === existingPane.id ? nextPane : pane,
                         ),
                         focusedPaneId: existingPane.id,
+                        layoutTree: workspace.layoutTree,
                     })
                 );
             }
@@ -1210,6 +1688,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                         pane.id === focusedPane.id ? nextPane : pane,
                     ),
                     focusedPaneId: workspace.focusedPaneId,
+                    layoutTree: workspace.layoutTree,
                 });
             }
 
@@ -1218,6 +1697,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                     pane.id === focusedPane.id ? nextPane : pane,
                 ),
                 focusedPaneId: focusedPane.id,
+                layoutTree: workspace.layoutTree,
             });
         });
     },
@@ -1320,6 +1800,9 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             );
             const shouldRemoveEmptyPane =
                 nextTargetPane.tabs.length === 0 && workspace.panes.length > 1;
+            const nextLayoutTree = shouldRemoveEmptyPane
+                ? closePaneAndCollapse(workspace.layoutTree, targetPane.id)
+                : workspace.layoutTree;
             const nextPanes = shouldRemoveEmptyPane
                 ? workspace.panes.filter((pane) => pane.id !== targetPane.id)
                 : workspace.panes.map((pane) =>
@@ -1327,8 +1810,8 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                   );
             const focusedPaneId = shouldRemoveEmptyPane
                 ? workspace.focusedPaneId === targetPane.id
-                    ? (getPaneRecipientIdForRemoval(
-                          workspace.panes,
+                    ? (getPaneRecipientIdForWorkspace(
+                          workspace,
                           targetPane.id,
                       ) ?? workspace.focusedPaneId)
                     : workspace.focusedPaneId
@@ -1336,6 +1819,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             const projection = buildFocusedPaneProjection({
                 panes: nextPanes,
                 focusedPaneId,
+                layoutTree: nextLayoutTree,
             });
 
             return {
@@ -1402,23 +1886,68 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             return buildFocusedPaneProjection({
                 panes: workspace.panes,
                 focusedPaneId: nextFocusedPaneId,
+                layoutTree: workspace.layoutTree,
             });
         }),
 
-    createEmptyPane: () => {
-        const nextPaneId = getNextEditorPaneId(get().panes);
+    focusPaneNeighbor: (direction, paneId) =>
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+            const sourcePaneId = getSplitAnchorPaneId(workspace, paneId);
+            const targetPaneId = selectPaneNeighbor(
+                workspace,
+                sourcePaneId,
+                direction,
+            );
+
+            if (!targetPaneId || targetPaneId === workspace.focusedPaneId) {
+                return state;
+            }
+
+            return buildFocusedPaneProjection({
+                panes: workspace.panes,
+                focusedPaneId: targetPaneId,
+                layoutTree: workspace.layoutTree,
+            });
+        }),
+
+    resizePaneSplit: (splitId, sizes) =>
+        set((state) => ({
+            layoutTree: resizeSplit(state.layoutTree, splitId, sizes),
+        })),
+
+    splitEditorPane: (direction, paneId) => {
+        const workspace = getEffectivePaneWorkspace(get());
+        const nextPaneId = getNextEditorPaneId(workspace.panes);
         if (!nextPaneId) {
             return null;
         }
 
+        const anchorPaneId = getSplitAnchorPaneId(workspace, paneId);
         set((state) =>
-            buildFocusedPaneProjection({
-                panes: [...state.panes, createEditorPaneState(nextPaneId)],
-                focusedPaneId: nextPaneId,
-            }),
+            buildSplitPaneProjection(
+                getEffectivePaneWorkspace(state),
+                anchorPaneId,
+                direction,
+                createEditorPaneState(nextPaneId),
+            ),
         );
 
         return nextPaneId;
+    },
+
+    balancePaneLayout: (splitId) =>
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+            return buildFocusedPaneProjection({
+                panes: workspace.panes,
+                focusedPaneId: workspace.focusedPaneId,
+                layoutTree: balanceSplit(workspace.layoutTree, splitId),
+            });
+        }),
+
+    createEmptyPane: () => {
+        return get().splitEditorPane("row");
     },
 
     insertExternalTabInPane: (tab, paneId, index) => {
@@ -1428,13 +1957,16 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 return state;
             }
 
-            const existingPane = state.panes.find((pane) => pane.id === paneId);
+            const workspace = getEffectivePaneWorkspace(state);
+            const existingPane = workspace.panes.find(
+                (pane) => pane.id === paneId,
+            );
             if (!existingPane) {
                 return state;
             }
 
             return buildFocusedPaneProjection({
-                panes: state.panes.map((pane) =>
+                panes: workspace.panes.map((pane) =>
                     pane.id === paneId
                         ? createEditorPaneState(
                               pane.id,
@@ -1443,46 +1975,190 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                         : pane,
                 ),
                 focusedPaneId: paneId,
+                layoutTree: workspace.layoutTree,
             });
         });
     },
 
-    insertExternalTabInNewPane: (tab) => {
+    insertExternalTabInNewSplit: (tab, direction, paneId) => {
         const incoming = normalizeExternalTab(tab);
         if (!incoming) {
             return null;
         }
 
-        const nextPaneId = getNextEditorPaneId(get().panes);
+        const workspace = getEffectivePaneWorkspace(get());
+        const nextPaneId = getNextEditorPaneId(workspace.panes);
         if (!nextPaneId) {
             return null;
         }
 
+        const anchorPaneId = getSplitAnchorPaneId(workspace, paneId);
+
         set((state) =>
-            buildFocusedPaneProjection({
-                panes: [
-                    ...state.panes,
+            buildSplitPaneProjection(
+                getEffectivePaneWorkspace(state),
+                anchorPaneId,
+                direction,
+                createEditorPaneState(
+                    nextPaneId,
+                    insertNormalizedTab(
+                        createEditorPaneState(nextPaneId),
+                        incoming,
+                    ),
+                ),
+            ),
+        );
+
+        return nextPaneId;
+    },
+
+    insertExternalTabInNewPane: (tab) => {
+        return get().insertExternalTabInNewSplit(tab, "row");
+    },
+
+    moveTabToNewSplit: (tabId, direction) => {
+        const workspace = getEffectivePaneWorkspace(get());
+        const sourcePane = findPaneContainingTab(workspace.panes, tabId);
+        const nextPaneId = getNextEditorPaneId(workspace.panes);
+        if (!sourcePane || !nextPaneId) {
+            return null;
+        }
+
+        set((state) => {
+            const currentWorkspace = getEffectivePaneWorkspace(state);
+            const currentSourcePane = findPaneContainingTab(
+                currentWorkspace.panes,
+                tabId,
+            );
+            const movingTab =
+                currentSourcePane?.tabs.find((tab) => tab.id === tabId) ?? null;
+
+            if (!currentSourcePane || !movingTab) {
+                return state;
+            }
+
+            const nextSourcePane = createEditorPaneState(
+                currentSourcePane.id,
+                removeTabFromWorkspaceState(currentSourcePane, tabId),
+            );
+
+            return buildSplitPaneProjection(
+                {
+                    ...currentWorkspace,
+                    panes: currentWorkspace.panes.map((pane) =>
+                        pane.id === currentSourcePane.id
+                            ? nextSourcePane
+                            : pane,
+                    ),
+                },
+                currentSourcePane.id,
+                direction,
+                createEditorPaneState(
+                    nextPaneId,
+                    insertNormalizedTab(
+                        createEditorPaneState(nextPaneId),
+                        movingTab,
+                    ),
+                ),
+            );
+        });
+
+        return nextPaneId;
+    },
+
+    moveTabToPaneDropTarget: (tabId, targetPaneId, position, index) => {
+        if (position === "center") {
+            get().moveTabToPane(tabId, targetPaneId, index);
+            return null;
+        }
+
+        const workspace = getEffectivePaneWorkspace(get());
+        const sourcePane = findPaneContainingTab(workspace.panes, tabId);
+        const targetPane = workspace.panes.find(
+            (pane) => pane.id === targetPaneId,
+        );
+        const nextPaneId = getNextEditorPaneId(workspace.panes);
+        if (!sourcePane || !targetPane || !nextPaneId) {
+            return null;
+        }
+
+        set((state) => {
+            const currentWorkspace = getEffectivePaneWorkspace(state);
+            const currentSourcePane = findPaneContainingTab(
+                currentWorkspace.panes,
+                tabId,
+            );
+            const currentTargetPane = currentWorkspace.panes.find(
+                (pane) => pane.id === targetPaneId,
+            );
+            const movingTab =
+                currentSourcePane?.tabs.find((tab) => tab.id === tabId) ?? null;
+
+            if (!currentSourcePane || !currentTargetPane || !movingTab) {
+                return state;
+            }
+
+            const nextSourcePane = createEditorPaneState(
+                currentSourcePane.id,
+                removeTabFromWorkspaceState(currentSourcePane, tabId),
+            );
+            const splitDirection =
+                position === "left" || position === "right" ? "row" : "column";
+            const splitLayoutTree = splitPane(
+                currentWorkspace.layoutTree,
+                currentTargetPane.id,
+                splitDirection,
+                nextPaneId,
+            );
+            const nextLayoutTree =
+                position === "right" || position === "down"
+                    ? splitLayoutTree
+                    : movePane(
+                          splitLayoutTree,
+                          nextPaneId,
+                          currentTargetPane.id,
+                          position,
+                      );
+            const nextPaneMap = new Map([
+                ...currentWorkspace.panes.map((pane) => [
+                    pane.id,
+                    pane.id === currentSourcePane.id ? nextSourcePane : pane,
+                ]),
+                [
+                    nextPaneId,
                     createEditorPaneState(
                         nextPaneId,
                         insertNormalizedTab(
                             createEditorPaneState(nextPaneId),
-                            incoming,
+                            movingTab,
                         ),
                     ),
                 ],
+            ] satisfies ReadonlyArray<[string, EditorPaneState]>);
+
+            return buildFocusedPaneProjection({
+                panes: getLayoutPaneIds(nextLayoutTree).map(
+                    (paneId) =>
+                        nextPaneMap.get(paneId) ??
+                        createEditorPaneState(paneId),
+                ),
                 focusedPaneId: nextPaneId,
-            }),
-        );
+                layoutTree: nextLayoutTree,
+            });
+        });
 
         return nextPaneId;
     },
 
     moveTabToPane: (tabId, paneId, index) => {
         set((state) => {
-            const sourcePane = state.panes.find((pane) =>
+            const workspace = getEffectivePaneWorkspace(state);
+            const sourcePane = workspace.panes.find((pane) =>
                 pane.tabs.some((tab) => tab.id === tabId),
             );
-            const targetPane = state.panes.find((pane) => pane.id === paneId);
+            const targetPane = workspace.panes.find(
+                (pane) => pane.id === paneId,
+            );
             if (!sourcePane || !targetPane || sourcePane.id === targetPane.id) {
                 return state;
             }
@@ -1503,19 +2179,21 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             );
 
             return buildFocusedPaneProjection({
-                panes: state.panes.map((pane) => {
+                panes: workspace.panes.map((pane) => {
                     if (pane.id === sourcePane.id) return nextSourcePane;
                     if (pane.id === targetPane.id) return nextTargetPane;
                     return pane;
                 }),
                 focusedPaneId: targetPane.id,
+                layoutTree: workspace.layoutTree,
             });
         });
     },
 
     reorderPaneTabs: (paneId, fromIndex, toIndex) => {
         set((state) => {
-            const pane = state.panes.find(
+            const workspace = getEffectivePaneWorkspace(state);
+            const pane = workspace.panes.find(
                 (candidate) => candidate.id === paneId,
             );
             if (!pane) {
@@ -1537,7 +2215,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             tabs.splice(toIndex, 0, tab);
 
             return buildFocusedPaneProjection({
-                panes: state.panes.map((candidate) =>
+                panes: workspace.panes.map((candidate) =>
                     candidate.id === paneId
                         ? createEditorPaneState(candidate.id, {
                               ...candidate,
@@ -1545,35 +2223,37 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                           })
                         : candidate,
                 ),
-                focusedPaneId: state.focusedPaneId,
+                focusedPaneId: workspace.focusedPaneId,
+                layoutTree: workspace.layoutTree,
             });
         });
     },
 
     closePane: (paneId) => {
         set((state) => {
-            if (state.panes.length <= 1) {
+            const workspace = getEffectivePaneWorkspace(state);
+            if (workspace.panes.length <= 1) {
                 return state;
             }
 
-            const paneIndex = state.panes.findIndex(
+            const paneIndex = workspace.panes.findIndex(
                 (pane) => pane.id === paneId,
             );
             if (paneIndex === -1) {
                 return state;
             }
 
-            const closingPane = state.panes[paneIndex];
-            const recipientPaneId =
-                state.panes[paneIndex - 1]?.id ??
-                state.panes[paneIndex + 1]?.id ??
-                null;
+            const closingPane = workspace.panes[paneIndex];
+            const recipientPaneId = getPaneRecipientIdForWorkspace(
+                workspace,
+                paneId,
+            );
 
             if (!recipientPaneId) {
                 return state;
             }
 
-            const nextPanes = state.panes
+            const nextPanes = workspace.panes
                 .filter((pane) => pane.id !== paneId)
                 .map((pane) =>
                     pane.id === recipientPaneId
@@ -1584,12 +2264,13 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
             return buildFocusedPaneProjection({
                 panes: nextPanes,
                 focusedPaneId:
-                    state.focusedPaneId === paneId
+                    workspace.focusedPaneId === paneId
                         ? recipientPaneId
                         : getResolvedFocusedPaneId(
                               nextPanes,
-                              state.focusedPaneId,
+                              workspace.focusedPaneId,
                           ),
+                layoutTree: closePaneAndCollapse(workspace.layoutTree, paneId),
             });
         });
     },
@@ -1729,7 +2410,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         });
     },
 
-    hydrateWorkspace: (panes, focusedPaneId) => {
+    hydrateWorkspace: (panes, focusedPaneId, layoutTree) => {
         const seenGraph = new Set<string>();
         const hydratedPanes = panes.flatMap((pane, index) => {
             const hydratedTabs: Tab[] = pane.tabs.flatMap((tab): Tab[] => {
@@ -1764,6 +2445,19 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                         ? hydratedPanes
                         : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)],
                 focusedPaneId,
+                layoutTree: normalizeLayoutTree(
+                    layoutTree ??
+                        buildLinearLayoutTree(
+                            (hydratedPanes.length > 0
+                                ? hydratedPanes
+                                : [
+                                      createEditorPaneState(
+                                          INITIAL_EDITOR_PANE_ID,
+                                      ),
+                                  ]
+                            ).map((pane) => pane.id),
+                        ),
+                ),
             }),
             recentlyClosedTabs: [],
             dirtyTabIds: new Set<string>(),
@@ -1790,6 +2484,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 ? activeTabId
                 : (hydratedTabs[0]?.id ?? null);
         set({
+            layoutTree: createInitialLayout(INITIAL_EDITOR_PANE_ID),
             panes: [
                 createEditorPaneState(INITIAL_EDITOR_PANE_ID, {
                     tabs: hydratedTabs,
@@ -1837,95 +2532,97 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     reloadNoteContent: (noteId, detail) => {
         set((state) => {
-            const next = buildResourceReloadUpdate(
-                getResourceHandler("note"),
-                {
-                    tabs: state.tabs,
-                    pendingForceReloads: state._pendingForceReloads,
-                    reloadVersions: state._noteReloadVersions,
-                    reloadMetadata: state._noteReloadMetadata,
-                },
+            const next = applyResourceReloadAcrossWorkspace(
+                state,
+                "note",
                 noteId,
                 detail,
                 { fallbackOrigin: "unknown" },
             );
 
-            return {
-                tabs: next.tabs,
-                _noteReloadVersions: next.reloadVersions,
-                _noteReloadMetadata: next.reloadMetadata,
-            };
+            return next.didChange
+                ? {
+                      ...next.projection,
+                      _noteReloadVersions: next.reloadVersions,
+                      _noteReloadMetadata: next.reloadMetadata,
+                  }
+                : {
+                      _noteReloadVersions: next.reloadVersions,
+                      _noteReloadMetadata: next.reloadMetadata,
+                  };
         });
     },
 
     reloadFileContent: (relativePath, detail) => {
         set((state) => {
-            const next = buildResourceReloadUpdate(
-                getResourceHandler("file"),
-                {
-                    tabs: state.tabs,
-                    pendingForceReloads: state._pendingForceFileReloads,
-                    reloadVersions: state._fileReloadVersions,
-                    reloadMetadata: state._fileReloadMetadata,
-                },
+            const next = applyResourceReloadAcrossWorkspace(
+                state,
+                "file",
                 relativePath,
                 detail,
                 { fallbackOrigin: "unknown" },
             );
 
-            return {
-                tabs: next.tabs,
-                _fileReloadVersions: next.reloadVersions,
-                _fileReloadMetadata: next.reloadMetadata,
-            };
+            return next.didChange
+                ? {
+                      ...next.projection,
+                      _fileReloadVersions: next.reloadVersions,
+                      _fileReloadMetadata: next.reloadMetadata,
+                  }
+                : {
+                      _fileReloadVersions: next.reloadVersions,
+                      _fileReloadMetadata: next.reloadMetadata,
+                  };
         });
     },
 
     forceReloadNoteContent: (noteId, detail) => {
         set((state) => {
-            const next = buildResourceReloadUpdate(
-                getResourceHandler("note"),
-                {
-                    tabs: state.tabs,
-                    pendingForceReloads: state._pendingForceReloads,
-                    reloadVersions: state._noteReloadVersions,
-                    reloadMetadata: state._noteReloadMetadata,
-                },
+            const next = applyResourceReloadAcrossWorkspace(
+                state,
+                "note",
                 noteId,
                 detail,
                 { force: true, fallbackOrigin: "system" },
             );
 
-            return {
-                tabs: next.tabs,
-                _pendingForceReloads: next.pendingForceReloads,
-                _noteReloadVersions: next.reloadVersions,
-                _noteReloadMetadata: next.reloadMetadata,
-            };
+            return next.didChange
+                ? {
+                      ...next.projection,
+                      _pendingForceReloads: next.pendingForceReloads,
+                      _noteReloadVersions: next.reloadVersions,
+                      _noteReloadMetadata: next.reloadMetadata,
+                  }
+                : {
+                      _pendingForceReloads: next.pendingForceReloads,
+                      _noteReloadVersions: next.reloadVersions,
+                      _noteReloadMetadata: next.reloadMetadata,
+                  };
         });
     },
 
     forceReloadFileContent: (relativePath, detail) => {
         set((state) => {
-            const next = buildResourceReloadUpdate(
-                getResourceHandler("file"),
-                {
-                    tabs: state.tabs,
-                    pendingForceReloads: state._pendingForceFileReloads,
-                    reloadVersions: state._fileReloadVersions,
-                    reloadMetadata: state._fileReloadMetadata,
-                },
+            const next = applyResourceReloadAcrossWorkspace(
+                state,
+                "file",
                 relativePath,
                 detail,
                 { force: true, fallbackOrigin: "system" },
             );
 
-            return {
-                tabs: next.tabs,
-                _pendingForceFileReloads: next.pendingForceReloads,
-                _fileReloadVersions: next.reloadVersions,
-                _fileReloadMetadata: next.reloadMetadata,
-            };
+            return next.didChange
+                ? {
+                      ...next.projection,
+                      _pendingForceFileReloads: next.pendingForceReloads,
+                      _fileReloadVersions: next.reloadVersions,
+                      _fileReloadMetadata: next.reloadMetadata,
+                  }
+                : {
+                      _pendingForceFileReloads: next.pendingForceReloads,
+                      _fileReloadVersions: next.reloadVersions,
+                      _fileReloadMetadata: next.reloadMetadata,
+                  };
         });
     },
 
@@ -2005,103 +2702,100 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     handleNoteDeleted: (noteId) => {
         set((state) => {
-            const next = buildResourceDeleteUpdate(
-                getResourceHandler("note"),
-                {
-                    tabs: state.tabs,
-                    activeTabId: state.activeTabId,
-                    activationHistory: state.activationHistory,
-                    tabNavigationHistory: state.tabNavigationHistory,
-                    tabNavigationIndex: state.tabNavigationIndex,
-                    pendingForceReloads: state._pendingForceReloads,
-                    reloadVersions: state._noteReloadVersions,
-                    reloadMetadata: state._noteReloadMetadata,
-                    externalConflicts: state.noteExternalConflicts,
-                },
+            const next = applyResourceDeleteAcrossWorkspace(
+                state,
+                "note",
                 noteId,
             );
+            const pendingForceReloads = new Set(state._pendingForceReloads);
+            const noteExternalConflicts = new Set(state.noteExternalConflicts);
+            const hadPendingForceReload = pendingForceReloads.delete(noteId);
+            const hadExternalConflict = noteExternalConflicts.delete(noteId);
+            const hadReloadVersion = noteId in state._noteReloadVersions;
+            const hadReloadMetadata = noteId in state._noteReloadMetadata;
 
-            if (!next) {
+            if (
+                !next.didChange &&
+                !hadPendingForceReload &&
+                !hadExternalConflict &&
+                !hadReloadVersion &&
+                !hadReloadMetadata
+            ) {
                 return state;
             }
 
             return {
-                tabs: next.tabs,
-                activeTabId: next.activeTabId,
-                activationHistory: next.activationHistory,
-                tabNavigationHistory: next.tabNavigationHistory,
-                tabNavigationIndex: next.tabNavigationIndex,
-                _pendingForceReloads: next.pendingForceReloads,
-                _noteReloadVersions: next.reloadVersions,
-                _noteReloadMetadata: next.reloadMetadata,
-                noteExternalConflicts: next.externalConflicts,
+                ...next.projection,
+                _pendingForceReloads: pendingForceReloads,
+                _noteReloadVersions: Object.fromEntries(
+                    Object.entries(state._noteReloadVersions).filter(
+                        ([key]) => key !== noteId,
+                    ),
+                ),
+                _noteReloadMetadata: Object.fromEntries(
+                    Object.entries(state._noteReloadMetadata).filter(
+                        ([key]) => key !== noteId,
+                    ),
+                ),
+                noteExternalConflicts,
             };
         });
     },
 
     handleFileDeleted: (relativePath) => {
         set((state) => {
-            const next = buildResourceDeleteUpdate(
-                getResourceHandler("file"),
-                {
-                    tabs: state.tabs,
-                    activeTabId: state.activeTabId,
-                    activationHistory: state.activationHistory,
-                    tabNavigationHistory: state.tabNavigationHistory,
-                    tabNavigationIndex: state.tabNavigationIndex,
-                    pendingForceReloads: state._pendingForceFileReloads,
-                    reloadVersions: state._fileReloadVersions,
-                    reloadMetadata: state._fileReloadMetadata,
-                    externalConflicts: state.fileExternalConflicts,
-                },
+            const next = applyResourceDeleteAcrossWorkspace(
+                state,
+                "file",
                 relativePath,
             );
+            const pendingForceReloads = new Set(state._pendingForceFileReloads);
+            const fileExternalConflicts = new Set(state.fileExternalConflicts);
+            const hadPendingForceReload =
+                pendingForceReloads.delete(relativePath);
+            const hadExternalConflict =
+                fileExternalConflicts.delete(relativePath);
+            const hadReloadVersion = relativePath in state._fileReloadVersions;
+            const hadReloadMetadata = relativePath in state._fileReloadMetadata;
 
-            if (!next) {
+            if (
+                !next.didChange &&
+                !hadPendingForceReload &&
+                !hadExternalConflict &&
+                !hadReloadVersion &&
+                !hadReloadMetadata
+            ) {
                 return state;
             }
 
             return {
-                tabs: next.tabs,
-                activeTabId: next.activeTabId,
-                activationHistory: next.activationHistory,
-                tabNavigationHistory: next.tabNavigationHistory,
-                tabNavigationIndex: next.tabNavigationIndex,
-                _pendingForceFileReloads: next.pendingForceReloads,
-                _fileReloadVersions: next.reloadVersions,
-                _fileReloadMetadata: next.reloadMetadata,
-                fileExternalConflicts: next.externalConflicts,
+                ...next.projection,
+                _pendingForceFileReloads: pendingForceReloads,
+                _fileReloadVersions: Object.fromEntries(
+                    Object.entries(state._fileReloadVersions).filter(
+                        ([key]) => key !== relativePath,
+                    ),
+                ),
+                _fileReloadMetadata: Object.fromEntries(
+                    Object.entries(state._fileReloadMetadata).filter(
+                        ([key]) => key !== relativePath,
+                    ),
+                ),
+                fileExternalConflicts,
             };
         });
     },
 
     handleNoteRenamed: (oldNoteId, newNoteId, newTitle) => {
-        set((state) => ({
-            tabs: state.tabs.map((t) => {
-                if (!isNoteTab(t)) {
-                    return t;
-                }
-
-                let didChange = false;
-                const history = t.history.map((entry) => {
-                    if (entry.kind !== "note" || entry.noteId !== oldNoteId) {
-                        return entry;
-                    }
-                    didChange = true;
-                    return {
-                        ...entry,
-                        noteId: newNoteId,
-                        title: newTitle,
-                    };
-                });
-
-                if (!didChange) {
-                    return t;
-                }
-
-                return buildTabFromHistory(t.id, history, t.historyIndex);
-            }),
-        }));
+        set((state) => {
+            const next = renameNoteAcrossWorkspace(
+                state,
+                oldNoteId,
+                newNoteId,
+                newTitle,
+            );
+            return next.didChange ? next.projection : state;
+        });
     },
 }));
 
@@ -2138,6 +2832,7 @@ useEditorStore.subscribe((state) => {
                       }),
                   ],
         focusedPaneId: state.focusedPaneId,
+        layoutTree: state.layoutTree,
     });
 
     const focusedPane = projection.panes.find(

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -89,6 +89,123 @@ export type {
 export { markSessionReady, readPersistedSession } from "./editorSession";
 
 const MAX_RECENTLY_CLOSED_TABS = 20;
+export const PRIMARY_EDITOR_PANE_ID = "primary";
+
+interface LegacyWorkspaceState {
+    tabs: Tab[];
+    activeTabId: string | null;
+    activationHistory: string[];
+    tabNavigationHistory: string[];
+    tabNavigationIndex: number;
+}
+
+export interface EditorPaneState extends LegacyWorkspaceState {
+    id: string;
+}
+
+export interface EditorPaneInput {
+    id?: string;
+    tabs: TabInput[];
+    activeTabId: string | null;
+    activationHistory?: string[];
+    tabNavigationHistory?: string[];
+    tabNavigationIndex?: number;
+}
+
+function normalizeLegacyWorkspaceState(
+    workspace: Partial<LegacyWorkspaceState>,
+): LegacyWorkspaceState {
+    const tabs = workspace.tabs ?? [];
+    const tabIds = new Set(tabs.map((tab) => tab.id));
+    const activeTabId =
+        workspace.activeTabId && tabIds.has(workspace.activeTabId)
+            ? workspace.activeTabId
+            : (tabs[0]?.id ?? null);
+
+    const activationHistory = (workspace.activationHistory ?? []).filter((id) =>
+        tabIds.has(id),
+    );
+    if (activeTabId && !activationHistory.includes(activeTabId)) {
+        activationHistory.push(activeTabId);
+    }
+
+    const tabNavigationHistory = (workspace.tabNavigationHistory ?? []).filter(
+        (id) => tabIds.has(id),
+    );
+
+    if (activeTabId && !tabNavigationHistory.includes(activeTabId)) {
+        tabNavigationHistory.push(activeTabId);
+    }
+
+    const tabNavigationIndex = activeTabId
+        ? Math.max(
+              0,
+              Math.min(
+                  workspace.tabNavigationIndex ??
+                      tabNavigationHistory.lastIndexOf(activeTabId),
+                  tabNavigationHistory.length - 1,
+              ),
+          )
+        : -1;
+
+    return {
+        tabs,
+        activeTabId,
+        activationHistory,
+        tabNavigationHistory,
+        tabNavigationIndex,
+    };
+}
+
+function createEditorPaneState(
+    id: string,
+    workspace: Partial<LegacyWorkspaceState> = {},
+): EditorPaneState {
+    return {
+        id,
+        ...normalizeLegacyWorkspaceState(workspace),
+    };
+}
+
+function stringArraysEqual(left: readonly string[], right: readonly string[]) {
+    return (
+        left.length === right.length &&
+        left.every((value, index) => value === right[index])
+    );
+}
+
+function getResolvedFocusedPaneId(
+    panes: readonly EditorPaneState[],
+    focusedPaneId: string | null | undefined,
+) {
+    if (focusedPaneId && panes.some((pane) => pane.id === focusedPaneId)) {
+        return focusedPaneId;
+    }
+    return panes[0]?.id ?? PRIMARY_EDITOR_PANE_ID;
+}
+
+function buildFocusedPaneProjection(args: {
+    panes: EditorPaneState[];
+    focusedPaneId?: string | null;
+}) {
+    const panes =
+        args.panes.length > 0
+            ? args.panes.map((pane) => createEditorPaneState(pane.id, pane))
+            : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)];
+    const focusedPaneId = getResolvedFocusedPaneId(panes, args.focusedPaneId);
+    const focusedPane =
+        panes.find((pane) => pane.id === focusedPaneId) ?? panes[0];
+
+    return {
+        panes,
+        focusedPaneId,
+        tabs: focusedPane.tabs,
+        activeTabId: focusedPane.activeTabId,
+        activationHistory: focusedPane.activationHistory,
+        tabNavigationHistory: focusedPane.tabNavigationHistory,
+        tabNavigationIndex: focusedPane.tabNavigationIndex,
+    };
+}
 
 function pushTabToActivation(history: string[], tabId: string) {
     return [...history.filter((id) => id !== tabId), tabId];
@@ -430,6 +547,8 @@ export interface ReloadedDetail {
 }
 
 interface EditorStore {
+    panes: EditorPaneState[];
+    focusedPaneId: string | null;
     tabs: Tab[];
     activeTabId: string | null;
     recentlyClosedTabs: RecentlyClosedTab[];
@@ -487,6 +606,10 @@ interface EditorStore {
     updatePdfZoom: (tabId: string, zoom: number) => void;
     updatePdfViewMode: (tabId: string, viewMode: PdfViewMode) => void;
     reorderTabs: (fromIndex: number, toIndex: number) => void;
+    hydrateWorkspace: (
+        panes: EditorPaneInput[],
+        focusedPaneId?: string | null,
+    ) => void;
     hydrateTabs: (tabs: TabInput[], activeTabId: string | null) => void;
     insertExternalTab: (tab: TabInput, index?: number) => void;
     queueReveal: (reveal: PendingReveal) => void;
@@ -522,6 +645,8 @@ interface EditorStore {
 }
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
+    panes: [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)],
+    focusedPaneId: PRIMARY_EDITOR_PANE_ID,
     tabs: [],
     activeTabId: null,
     recentlyClosedTabs: [],
@@ -969,6 +1094,47 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         });
     },
 
+    hydrateWorkspace: (panes, focusedPaneId) => {
+        const seenGraph = new Set<string>();
+        const hydratedPanes = panes.flatMap((pane, index) => {
+            const hydratedTabs: Tab[] = pane.tabs.flatMap((tab): Tab[] => {
+                const normalized = normalizeHydratedTab(tab);
+                if (!normalized) {
+                    return [];
+                }
+                if (isGraphTab(normalized)) {
+                    if (seenGraph.size > 0) {
+                        return [];
+                    }
+                    seenGraph.add(normalized.id);
+                }
+                return [normalized];
+            });
+
+            return [
+                createEditorPaneState(pane.id?.trim() || `pane-${index + 1}`, {
+                    tabs: hydratedTabs,
+                    activeTabId: pane.activeTabId,
+                    activationHistory: pane.activationHistory,
+                    tabNavigationHistory: pane.tabNavigationHistory,
+                    tabNavigationIndex: pane.tabNavigationIndex,
+                }),
+            ];
+        });
+
+        set({
+            ...buildFocusedPaneProjection({
+                panes:
+                    hydratedPanes.length > 0
+                        ? hydratedPanes
+                        : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)],
+                focusedPaneId,
+            }),
+            recentlyClosedTabs: [],
+            dirtyTabIds: new Set<string>(),
+        });
+    },
+
     hydrateTabs: (tabs, activeTabId) => {
         const seenGraph = new Set<string>();
         const hydratedTabs: Tab[] = tabs.flatMap((tab): Tab[] => {
@@ -989,6 +1155,18 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 ? activeTabId
                 : (hydratedTabs[0]?.id ?? null);
         set({
+            panes: [
+                createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+                    tabs: hydratedTabs,
+                    activeTabId: nextActiveTabId,
+                    activationHistory: nextActiveTabId ? [nextActiveTabId] : [],
+                    tabNavigationHistory: nextActiveTabId
+                        ? [nextActiveTabId]
+                        : [],
+                    tabNavigationIndex: nextActiveTabId ? 0 : -1,
+                }),
+            ],
+            focusedPaneId: PRIMARY_EDITOR_PANE_ID,
             tabs: hydratedTabs,
             activeTabId: nextActiveTabId,
             recentlyClosedTabs: [],
@@ -1291,6 +1469,100 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
         }));
     },
 }));
+
+let _syncingPaneMirror = false;
+
+useEditorStore.subscribe((state) => {
+    if (_syncingPaneMirror) {
+        return;
+    }
+
+    const projection = buildFocusedPaneProjection({
+        panes:
+            state.panes.length > 0
+                ? state.panes.map((pane) =>
+                      pane.id ===
+                      getResolvedFocusedPaneId(state.panes, state.focusedPaneId)
+                          ? createEditorPaneState(pane.id, {
+                                tabs: state.tabs,
+                                activeTabId: state.activeTabId,
+                                activationHistory: state.activationHistory,
+                                tabNavigationHistory:
+                                    state.tabNavigationHistory,
+                                tabNavigationIndex: state.tabNavigationIndex,
+                            })
+                          : pane,
+                  )
+                : [
+                      createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+                          tabs: state.tabs,
+                          activeTabId: state.activeTabId,
+                          activationHistory: state.activationHistory,
+                          tabNavigationHistory: state.tabNavigationHistory,
+                          tabNavigationIndex: state.tabNavigationIndex,
+                      }),
+                  ],
+        focusedPaneId: state.focusedPaneId,
+    });
+
+    const focusedPane = projection.panes.find(
+        (pane) => pane.id === projection.focusedPaneId,
+    );
+    const currentFocusedPane = state.panes.find(
+        (pane) => pane.id === projection.focusedPaneId,
+    );
+
+    const panesChanged =
+        state.panes.length !== projection.panes.length ||
+        projection.panes.some((pane, index) => {
+            const current = state.panes[index];
+            return (
+                !current ||
+                current.id !== pane.id ||
+                current.activeTabId !== pane.activeTabId ||
+                current.tabNavigationIndex !== pane.tabNavigationIndex ||
+                current.tabs !== pane.tabs ||
+                !stringArraysEqual(
+                    current.activationHistory,
+                    pane.activationHistory,
+                ) ||
+                !stringArraysEqual(
+                    current.tabNavigationHistory,
+                    pane.tabNavigationHistory,
+                )
+            );
+        });
+    const legacyChanged =
+        state.focusedPaneId !== projection.focusedPaneId ||
+        state.tabs !== focusedPane?.tabs ||
+        state.activeTabId !== focusedPane?.activeTabId ||
+        !stringArraysEqual(
+            state.activationHistory,
+            focusedPane?.activationHistory ?? [],
+        ) ||
+        !stringArraysEqual(
+            state.tabNavigationHistory,
+            focusedPane?.tabNavigationHistory ?? [],
+        ) ||
+        state.tabNavigationIndex !== focusedPane?.tabNavigationIndex ||
+        !currentFocusedPane;
+
+    if (!panesChanged && !legacyChanged) {
+        return;
+    }
+
+    _syncingPaneMirror = true;
+    useEditorStore.setState({
+        panes: projection.panes,
+        focusedPaneId: projection.focusedPaneId,
+        tabs: projection.tabs,
+        activeTabId: projection.activeTabId,
+        activationHistory: projection.activationHistory,
+        tabNavigationHistory: projection.tabNavigationHistory,
+        tabNavigationIndex: projection.tabNavigationIndex,
+    });
+    _syncingPaneMirror = false;
+});
 
 // Debounced session persistence — only write when tab list or active tab changes
 let _sessionTimer: ReturnType<typeof setTimeout> | null = null;

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -851,6 +851,63 @@ function buildSplitPaneProjection(
     });
 }
 
+function removeEmptyPanesFromWorkspace(
+    workspace: Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+    options?: {
+        preferredFocusedPaneId?: string | null;
+    },
+) {
+    let nextPanes = workspace.panes;
+    let nextLayoutTree = workspace.layoutTree;
+    let nextFocusedPaneId = workspace.focusedPaneId;
+
+    for (const pane of [...nextPanes]) {
+        if (pane.tabs.length > 0) {
+            continue;
+        }
+
+        if (nextPanes.length === 1) {
+            nextPanes = [];
+            nextLayoutTree = createInitialLayout(INITIAL_EDITOR_PANE_ID);
+            nextFocusedPaneId = INITIAL_EDITOR_PANE_ID;
+            break;
+        }
+
+        const workspaceBeforeRemoval = {
+            panes: nextPanes,
+            focusedPaneId: nextFocusedPaneId,
+            layoutTree: nextLayoutTree,
+        };
+
+        if (nextFocusedPaneId === pane.id) {
+            nextFocusedPaneId =
+                getPaneRecipientIdForWorkspace(
+                    workspaceBeforeRemoval,
+                    pane.id,
+                ) ??
+                nextPanes.find((candidate) => candidate.id !== pane.id)?.id ??
+                INITIAL_EDITOR_PANE_ID;
+        }
+
+        nextPanes = nextPanes.filter((candidate) => candidate.id !== pane.id);
+        nextLayoutTree = closePaneAndCollapse(nextLayoutTree, pane.id);
+    }
+
+    const preferredFocusedPaneId = options?.preferredFocusedPaneId;
+    if (
+        preferredFocusedPaneId &&
+        nextPanes.some((pane) => pane.id === preferredFocusedPaneId)
+    ) {
+        nextFocusedPaneId = preferredFocusedPaneId;
+    }
+
+    return {
+        panes: nextPanes,
+        focusedPaneId: nextFocusedPaneId,
+        layoutTree: nextLayoutTree,
+    };
+}
+
 function findPaneContainingTab(
     panes: readonly EditorPaneState[],
     tabId: string,
@@ -1129,43 +1186,22 @@ function applyResourceDeleteAcrossWorkspace<
             : pane;
     });
 
-    let nextLayoutTree = workspace.layoutTree;
-    let nextFocusedPaneId = workspace.focusedPaneId;
-
-    for (const pane of [...nextPanes]) {
-        if (pane.tabs.length > 0 || nextPanes.length <= 1) {
-            continue;
-        }
-
-        const workspaceBeforeRemoval = {
-            panes: nextPanes,
-            focusedPaneId: nextFocusedPaneId,
-            layoutTree: nextLayoutTree,
-        };
-        if (nextFocusedPaneId === pane.id) {
-            nextFocusedPaneId =
-                getPaneRecipientIdForWorkspace(
-                    workspaceBeforeRemoval,
-                    pane.id,
-                ) ?? nextFocusedPaneId;
-        }
-
-        nextPanes = nextPanes.filter((candidate) => candidate.id !== pane.id);
-        nextLayoutTree = closePaneAndCollapse(nextLayoutTree, pane.id);
-    }
+    const compactedWorkspace = removeEmptyPanesFromWorkspace({
+        panes: nextPanes,
+        focusedPaneId: workspace.focusedPaneId,
+        layoutTree: workspace.layoutTree,
+    });
 
     const didChange =
-        nextLayoutTree !== workspace.layoutTree ||
-        nextFocusedPaneId !== workspace.focusedPaneId ||
-        nextPanes.length !== workspace.panes.length ||
-        nextPanes.some((pane, index) => pane !== workspace.panes[index]);
+        compactedWorkspace.layoutTree !== workspace.layoutTree ||
+        compactedWorkspace.focusedPaneId !== workspace.focusedPaneId ||
+        compactedWorkspace.panes.length !== workspace.panes.length ||
+        compactedWorkspace.panes.some(
+            (pane, index) => pane !== workspace.panes[index],
+        );
 
     return {
-        projection: buildFocusedPaneProjection({
-            panes: nextPanes,
-            focusedPaneId: nextFocusedPaneId,
-            layoutTree: nextLayoutTree,
-        }),
+        projection: buildFocusedPaneProjection(compactedWorkspace),
         didChange,
     };
 }
@@ -1798,29 +1834,15 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 targetPane.id,
                 removeTabFromWorkspaceState(targetPane, tabId),
             );
-            const shouldRemoveEmptyPane =
-                nextTargetPane.tabs.length === 0 && workspace.panes.length > 1;
-            const nextLayoutTree = shouldRemoveEmptyPane
-                ? closePaneAndCollapse(workspace.layoutTree, targetPane.id)
-                : workspace.layoutTree;
-            const nextPanes = shouldRemoveEmptyPane
-                ? workspace.panes.filter((pane) => pane.id !== targetPane.id)
-                : workspace.panes.map((pane) =>
-                      pane.id === targetPane.id ? nextTargetPane : pane,
-                  );
-            const focusedPaneId = shouldRemoveEmptyPane
-                ? workspace.focusedPaneId === targetPane.id
-                    ? (getPaneRecipientIdForWorkspace(
-                          workspace,
-                          targetPane.id,
-                      ) ?? workspace.focusedPaneId)
-                    : workspace.focusedPaneId
-                : workspace.focusedPaneId;
-            const projection = buildFocusedPaneProjection({
-                panes: nextPanes,
-                focusedPaneId,
-                layoutTree: nextLayoutTree,
-            });
+            const projection = buildFocusedPaneProjection(
+                removeEmptyPanesFromWorkspace({
+                    panes: workspace.panes.map((pane) =>
+                        pane.id === targetPane.id ? nextTargetPane : pane,
+                    ),
+                    focusedPaneId: workspace.focusedPaneId,
+                    layoutTree: workspace.layoutTree,
+                }),
+            );
 
             return {
                 ...projection,
@@ -2041,26 +2063,37 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 currentSourcePane.id,
                 removeTabFromWorkspaceState(currentSourcePane, tabId),
             );
-
-            return buildSplitPaneProjection(
+            const nextWorkspace = removeEmptyPanesFromWorkspace(
                 {
-                    ...currentWorkspace,
-                    panes: currentWorkspace.panes.map((pane) =>
-                        pane.id === currentSourcePane.id
-                            ? nextSourcePane
-                            : pane,
+                    panes: currentWorkspace.panes
+                        .map((pane) =>
+                            pane.id === currentSourcePane.id
+                                ? nextSourcePane
+                                : pane,
+                        )
+                        .concat(
+                            createEditorPaneState(
+                                nextPaneId,
+                                insertNormalizedTab(
+                                    createEditorPaneState(nextPaneId),
+                                    movingTab,
+                                ),
+                            ),
+                        ),
+                    focusedPaneId: nextPaneId,
+                    layoutTree: splitPane(
+                        currentWorkspace.layoutTree,
+                        currentSourcePane.id,
+                        direction,
+                        nextPaneId,
                     ),
                 },
-                currentSourcePane.id,
-                direction,
-                createEditorPaneState(
-                    nextPaneId,
-                    insertNormalizedTab(
-                        createEditorPaneState(nextPaneId),
-                        movingTab,
-                    ),
-                ),
+                {
+                    preferredFocusedPaneId: nextPaneId,
+                },
             );
+
+            return buildFocusedPaneProjection(nextWorkspace);
         });
 
         return nextPaneId;
@@ -2136,15 +2169,22 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 ],
             ] satisfies ReadonlyArray<[string, EditorPaneState]>);
 
-            return buildFocusedPaneProjection({
-                panes: getLayoutPaneIds(nextLayoutTree).map(
-                    (paneId) =>
-                        nextPaneMap.get(paneId) ??
-                        createEditorPaneState(paneId),
+            return buildFocusedPaneProjection(
+                removeEmptyPanesFromWorkspace(
+                    {
+                        panes: getLayoutPaneIds(nextLayoutTree).map(
+                            (paneId) =>
+                                nextPaneMap.get(paneId) ??
+                                createEditorPaneState(paneId),
+                        ),
+                        focusedPaneId: nextPaneId,
+                        layoutTree: nextLayoutTree,
+                    },
+                    {
+                        preferredFocusedPaneId: nextPaneId,
+                    },
                 ),
-                focusedPaneId: nextPaneId,
-                layoutTree: nextLayoutTree,
-            });
+            );
         });
 
         return nextPaneId;
@@ -2178,15 +2218,24 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 insertNormalizedTab(targetPane, movingTab, index),
             );
 
-            return buildFocusedPaneProjection({
-                panes: workspace.panes.map((pane) => {
-                    if (pane.id === sourcePane.id) return nextSourcePane;
-                    if (pane.id === targetPane.id) return nextTargetPane;
-                    return pane;
-                }),
-                focusedPaneId: targetPane.id,
-                layoutTree: workspace.layoutTree,
-            });
+            return buildFocusedPaneProjection(
+                removeEmptyPanesFromWorkspace(
+                    {
+                        panes: workspace.panes.map((pane) => {
+                            if (pane.id === sourcePane.id)
+                                return nextSourcePane;
+                            if (pane.id === targetPane.id)
+                                return nextTargetPane;
+                            return pane;
+                        }),
+                        focusedPaneId: targetPane.id,
+                        layoutTree: workspace.layoutTree,
+                    },
+                    {
+                        preferredFocusedPaneId: targetPane.id,
+                    },
+                ),
+            );
         });
     },
 

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -1433,6 +1433,7 @@ interface EditorStore {
         paneId?: string,
     ) => string | null;
     balancePaneLayout: (splitId?: string) => void;
+    unifyAllPanesInto: (paneId?: string) => void;
     createEmptyPane: () => string | null;
     insertExternalTabInPane: (
         tab: TabInput,
@@ -2051,6 +2052,36 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 panes: workspace.panes,
                 focusedPaneId: workspace.focusedPaneId,
                 layoutTree: balanceSplit(workspace.layoutTree, splitId),
+            });
+        }),
+
+    unifyAllPanesInto: (paneId) =>
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+            if (workspace.panes.length <= 1) {
+                return state;
+            }
+
+            const targetPaneId = getSplitAnchorPaneId(workspace, paneId);
+            const targetPane = workspace.panes.find(
+                (candidate) => candidate.id === targetPaneId,
+            );
+            if (!targetPane) {
+                return state;
+            }
+
+            const mergedPane = workspace.panes
+                .filter((candidate) => candidate.id !== targetPaneId)
+                .reduce(
+                    (currentPane, candidate) =>
+                        mergePaneStates(currentPane, candidate),
+                    targetPane,
+                );
+
+            return buildFocusedPaneProjection({
+                panes: [mergedPane],
+                focusedPaneId: targetPaneId,
+                layoutTree: createInitialLayout(targetPaneId),
             });
         }),
 

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -90,6 +90,13 @@ export { markSessionReady, readPersistedSession } from "./editorSession";
 
 const MAX_RECENTLY_CLOSED_TABS = 20;
 export const PRIMARY_EDITOR_PANE_ID = "primary";
+export const SECONDARY_EDITOR_PANE_ID = "secondary";
+export const TERTIARY_EDITOR_PANE_ID = "tertiary";
+const EDITOR_PANE_ORDER = [
+    PRIMARY_EDITOR_PANE_ID,
+    SECONDARY_EDITOR_PANE_ID,
+    TERTIARY_EDITOR_PANE_ID,
+] as const;
 
 interface LegacyWorkspaceState {
     tabs: Tab[];
@@ -182,6 +189,122 @@ function getResolvedFocusedPaneId(
         return focusedPaneId;
     }
     return panes[0]?.id ?? PRIMARY_EDITOR_PANE_ID;
+}
+
+function getNextEditorPaneId(panes: readonly EditorPaneState[]) {
+    return (
+        EDITOR_PANE_ORDER.find(
+            (paneId) => !panes.some((pane) => pane.id === paneId),
+        ) ?? null
+    );
+}
+
+function getEffectivePaneWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState) {
+    const normalizedPanes = state.panes.length
+        ? state.panes.map((pane) => createEditorPaneState(pane.id, pane))
+        : [];
+    const hasLegacyWorkspace =
+        Array.isArray(state.tabs) &&
+        (state.tabs.length > 0 ||
+            state.activeTabId !== null ||
+            (state.activationHistory?.length ?? 0) > 0 ||
+            (state.tabNavigationHistory?.length ?? 0) > 0 ||
+            (state.tabNavigationIndex ?? -1) >= 0);
+
+    if (normalizedPanes.length > 1 || !hasLegacyWorkspace) {
+        const panes =
+            normalizedPanes.length > 0
+                ? normalizedPanes
+                : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)];
+        return {
+            panes,
+            focusedPaneId: getResolvedFocusedPaneId(panes, state.focusedPaneId),
+        };
+    }
+
+    const singlePane =
+        normalizedPanes[0] ?? createEditorPaneState(PRIMARY_EDITOR_PANE_ID);
+    const isPlaceholderPrimaryPane =
+        singlePane.id === PRIMARY_EDITOR_PANE_ID &&
+        singlePane.tabs.length === 0 &&
+        singlePane.activeTabId === null &&
+        singlePane.activationHistory.length === 0 &&
+        singlePane.tabNavigationHistory.length === 0 &&
+        singlePane.tabNavigationIndex === -1;
+
+    if (!isPlaceholderPrimaryPane) {
+        return {
+            panes: normalizedPanes,
+            focusedPaneId: getResolvedFocusedPaneId(
+                normalizedPanes,
+                state.focusedPaneId,
+            ),
+        };
+    }
+
+    const legacyPane = createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+        tabs: state.tabs ?? [],
+        activeTabId: state.activeTabId ?? null,
+        activationHistory: state.activationHistory ?? [],
+        tabNavigationHistory: state.tabNavigationHistory ?? [],
+        tabNavigationIndex: state.tabNavigationIndex ?? -1,
+    });
+
+    return {
+        panes: [legacyPane],
+        focusedPaneId: getResolvedFocusedPaneId(
+            [legacyPane],
+            state.focusedPaneId,
+        ),
+    };
+}
+
+export function selectEditorPaneState<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState, paneId?: string | null) {
+    const { panes, focusedPaneId } = getEffectivePaneWorkspace(state);
+    const resolvedPaneId = paneId
+        ? getResolvedFocusedPaneId(panes, paneId)
+        : getResolvedFocusedPaneId(panes, focusedPaneId);
+
+    return (
+        panes.find((pane) => pane.id === resolvedPaneId) ??
+        panes[0] ??
+        createEditorPaneState(PRIMARY_EDITOR_PANE_ID)
+    );
+}
+
+export function selectEditorPaneTabs<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState, paneId?: string | null) {
+    return selectEditorPaneState(state, paneId).tabs;
+}
+
+export function selectEditorPaneActiveTab<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState, paneId?: string | null) {
+    const pane = selectEditorPaneState(state, paneId);
+    return pane.tabs.find((tab) => tab.id === pane.activeTabId) ?? null;
+}
+
+export function selectFocusedEditorTab<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState) {
+    return selectEditorPaneActiveTab(state);
+}
+
+export function selectEditorWorkspaceTabs<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
+        Partial<LegacyWorkspaceState>,
+>(state: TState) {
+    return getEffectivePaneWorkspace(state).panes.flatMap((pane) => pane.tabs);
 }
 
 function buildFocusedPaneProjection(args: {
@@ -408,6 +531,134 @@ function insertNormalizedTab(
     };
 }
 
+function removeTabFromWorkspaceState(
+    state: Pick<
+        EditorStore,
+        | "tabs"
+        | "activeTabId"
+        | "activationHistory"
+        | "tabNavigationHistory"
+        | "tabNavigationIndex"
+    >,
+    tabId: string,
+) {
+    const idx = state.tabs.findIndex((tab) => tab.id === tabId);
+    if (idx === -1) {
+        return state;
+    }
+
+    const tabs = state.tabs.filter((tab) => tab.id !== tabId);
+    let activeTabId = state.activeTabId;
+    const activationHistory = state.activationHistory.filter(
+        (id) => id !== tabId,
+    );
+    const tabNavigationHistory = state.tabNavigationHistory.filter(
+        (id) => id !== tabId,
+    );
+    let tabNavigationIndex = Math.min(
+        state.tabNavigationIndex,
+        tabNavigationHistory.length - 1,
+    );
+
+    if (activeTabId === tabId) {
+        activeTabId =
+            [...activationHistory]
+                .reverse()
+                .find((id) => tabs.some((tab) => tab.id === id)) ??
+            tabs[Math.min(idx, tabs.length - 1)]?.id ??
+            null;
+    }
+
+    if (activeTabId) {
+        const navigationIndex = tabNavigationHistory.lastIndexOf(activeTabId);
+        if (navigationIndex === -1) {
+            const navigation = pushTabToNavigation(
+                tabNavigationHistory,
+                tabNavigationIndex,
+                activeTabId,
+            );
+            return {
+                tabs,
+                activeTabId,
+                activationHistory,
+                tabNavigationHistory: navigation.history,
+                tabNavigationIndex: navigation.index,
+            };
+        }
+        tabNavigationIndex = navigationIndex;
+    } else {
+        tabNavigationIndex = -1;
+    }
+
+    return {
+        tabs,
+        activeTabId,
+        activationHistory,
+        tabNavigationHistory,
+        tabNavigationIndex,
+    };
+}
+
+function mergePaneStates(
+    targetPane: EditorPaneState,
+    sourcePane: EditorPaneState,
+) {
+    const tabs = [...targetPane.tabs, ...sourcePane.tabs];
+    const activeTabId = targetPane.activeTabId ?? sourcePane.activeTabId;
+    const activationHistory = [
+        ...targetPane.activationHistory,
+        ...sourcePane.activationHistory,
+    ].filter((tabId, index, items) => items.indexOf(tabId) === index);
+    const tabNavigationHistory = [
+        ...targetPane.tabNavigationHistory,
+        ...sourcePane.tabNavigationHistory,
+    ].filter((tabId, index, items) => items.indexOf(tabId) === index);
+    const tabNavigationIndex = activeTabId
+        ? Math.max(0, tabNavigationHistory.lastIndexOf(activeTabId))
+        : -1;
+
+    return createEditorPaneState(targetPane.id, {
+        tabs,
+        activeTabId,
+        activationHistory,
+        tabNavigationHistory,
+        tabNavigationIndex,
+    });
+}
+
+function findPaneContainingTab(
+    panes: readonly EditorPaneState[],
+    tabId: string,
+): EditorPaneState | null {
+    return (
+        panes.find((pane) => pane.tabs.some((tab) => tab.id === tabId)) ?? null
+    );
+}
+
+function activatePaneTab(
+    state: Pick<EditorStore, "panes" | "focusedPaneId">,
+    paneId: string,
+    tabId: string,
+    options?: { recordNavigation?: boolean },
+) {
+    const targetPane = state.panes.find((pane) => pane.id === paneId);
+    if (!targetPane) {
+        return null;
+    }
+
+    return buildFocusedPaneProjection({
+        panes: state.panes.map((pane) =>
+            pane.id === paneId
+                ? createEditorPaneState(pane.id, {
+                      ...pane,
+                      ...activateTab(pane, tabId, options),
+                  })
+                : pane,
+        ),
+        focusedPaneId: paneId,
+    });
+}
+
 function patchCurrentHistoryEntry(
     tab: HistoryTab,
     patch: (entry: TabHistoryEntry) => TabHistoryEntry,
@@ -594,6 +845,16 @@ interface EditorStore {
     closeTab: (tabId: string, options?: { reason?: TabCloseReason }) => void;
     reopenLastClosedTab: () => void;
     switchTab: (tabId: string) => void;
+    focusPane: (paneId: string) => void;
+    createEmptyPane: () => string | null;
+    insertExternalTabInPane: (
+        tab: TabInput,
+        paneId: string,
+        index?: number,
+    ) => void;
+    insertExternalTabInNewPane: (tab: TabInput) => string | null;
+    moveTabToPane: (tabId: string, paneId: string, index?: number) => void;
+    closePane: (paneId: string) => void;
     setTabDirty: (tabId: string, dirty: boolean) => void;
     updateTabContent: (tabId: string, content: string) => void;
     updateTabTitle: (tabId: string, title: string) => void;
@@ -744,26 +1005,60 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     openReview: (sessionId, options) => {
         set((state) => {
-            const existing = state.tabs.find(
-                (tab) => isReviewTab(tab) && tab.sessionId === sessionId,
+            const workspace = getEffectivePaneWorkspace(state);
+            const existingPane = workspace.panes.find((pane) =>
+                pane.tabs.some(
+                    (tab) => isReviewTab(tab) && tab.sessionId === sessionId,
+                ),
             );
-            if (existing) {
+            const existing =
+                existingPane?.tabs.find(
+                    (tab): tab is ReviewTab =>
+                        isReviewTab(tab) && tab.sessionId === sessionId,
+                ) ?? null;
+            if (existingPane && existing) {
                 const nextTitle = options?.title ?? existing.title;
-                const nextTabs =
+                const nextPane =
                     nextTitle === existing.title
-                        ? state.tabs
-                        : state.tabs.map((tab) =>
-                              tab.id === existing.id
-                                  ? { ...tab, title: nextTitle }
-                                  : tab,
-                          );
+                        ? existingPane
+                        : createEditorPaneState(existingPane.id, {
+                              ...existingPane,
+                              tabs: existingPane.tabs.map((tab) =>
+                                  tab.id === existing.id
+                                      ? { ...tab, title: nextTitle }
+                                      : tab,
+                              ),
+                          });
                 if (options?.background) {
-                    return nextTabs === state.tabs ? state : { tabs: nextTabs };
+                    if (nextPane === existingPane) {
+                        return state;
+                    }
+                    return buildFocusedPaneProjection({
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: workspace.focusedPaneId,
+                    });
                 }
-                return {
-                    tabs: nextTabs,
-                    ...activateTab(state, existing.id),
-                };
+                const projection = activatePaneTab(
+                    {
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: existingPane.id,
+                    },
+                    existingPane.id,
+                    existing.id,
+                );
+                return (
+                    projection ??
+                    buildFocusedPaneProjection({
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: existingPane.id,
+                    })
+                );
             }
 
             const newTab: ReviewTab = {
@@ -773,19 +1068,37 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 title: options?.title ?? "Review",
             };
 
+            const focusedPane = selectEditorPaneState(workspace);
+            const nextPane = options?.background
+                ? createEditorPaneState(focusedPane.id, {
+                      ...focusedPane,
+                      tabs: [...focusedPane.tabs, newTab],
+                  })
+                : createEditorPaneState(
+                      focusedPane.id,
+                      insertNormalizedTab(focusedPane, newTab),
+                  );
+
             if (options?.background) {
-                return { tabs: [...state.tabs, newTab] };
+                return buildFocusedPaneProjection({
+                    panes: workspace.panes.map((pane) =>
+                        pane.id === focusedPane.id ? nextPane : pane,
+                    ),
+                    focusedPaneId: workspace.focusedPaneId,
+                });
             }
 
-            return {
-                tabs: [...state.tabs, newTab],
-                ...activateTab(state, newTab.id),
-            };
+            return buildFocusedPaneProjection({
+                panes: workspace.panes.map((pane) =>
+                    pane.id === focusedPane.id ? nextPane : pane,
+                ),
+                focusedPaneId: focusedPane.id,
+            });
         });
     },
 
     closeReview: (sessionId) => {
-        const tab = get().tabs.find(
+        const tab = selectEditorWorkspaceTabs(get()).find(
             (t) => isReviewTab(t) && t.sessionId === sessionId,
         );
         if (tab) get().closeTab(tab.id);
@@ -860,12 +1173,14 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
 
     closeTab: (tabId, options) => {
         set((state) => {
-            const idx = state.tabs.findIndex((t) => t.id === tabId);
+            const workspace = getEffectivePaneWorkspace(state);
+            const targetPane =
+                findPaneContainingTab(workspace.panes, tabId) ??
+                selectEditorPaneState(workspace);
+            const idx = targetPane.tabs.findIndex((t) => t.id === tabId);
             if (idx === -1) return state;
 
-            const closedTab = state.tabs[idx];
-            const tabs = state.tabs.filter((t) => t.id !== tabId);
-            let activeTabId = state.activeTabId;
+            const closedTab = targetPane.tabs[idx];
             const reason = options?.reason ?? "user";
             const recentlyClosedTabs = shouldRememberClosedTab(reason)
                 ? pushRecentlyClosedTab(
@@ -874,59 +1189,23 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                       idx,
                   )
                 : state.recentlyClosedTabs;
-            const activationHistory = state.activationHistory.filter(
-                (id) => id !== tabId,
+            const nextTargetPane = createEditorPaneState(
+                targetPane.id,
+                removeTabFromWorkspaceState(targetPane, tabId),
             );
-            const tabNavigationHistory = state.tabNavigationHistory.filter(
-                (id) => id !== tabId,
-            );
-            let tabNavigationIndex = Math.min(
-                state.tabNavigationIndex,
-                tabNavigationHistory.length - 1,
-            );
-            if (activeTabId === tabId) {
-                activeTabId =
-                    [...activationHistory]
-                        .reverse()
-                        .find((id) => tabs.some((tab) => tab.id === id)) ??
-                    tabs[Math.min(idx, tabs.length - 1)]?.id ??
-                    null;
-            }
-            if (activeTabId) {
-                const lastActiveIndex =
-                    tabNavigationHistory.lastIndexOf(activeTabId);
-                if (lastActiveIndex === -1) {
-                    const navigation = pushTabToNavigation(
-                        tabNavigationHistory,
-                        tabNavigationIndex,
-                        activeTabId,
-                    );
-                    return {
-                        tabs,
-                        activeTabId,
-                        recentlyClosedTabs,
-                        activationHistory,
-                        dirtyTabIds: new Set(
-                            [...state.dirtyTabIds].filter((id) => id !== tabId),
-                        ),
-                        tabNavigationHistory: navigation.history,
-                        tabNavigationIndex: navigation.index,
-                    };
-                }
-                tabNavigationIndex = lastActiveIndex;
-            } else {
-                tabNavigationIndex = -1;
-            }
+            const projection = buildFocusedPaneProjection({
+                panes: workspace.panes.map((pane) =>
+                    pane.id === targetPane.id ? nextTargetPane : pane,
+                ),
+                focusedPaneId: workspace.focusedPaneId,
+            });
+
             return {
-                tabs,
-                activeTabId,
+                ...projection,
                 recentlyClosedTabs,
-                activationHistory,
                 dirtyTabIds: new Set(
                     [...state.dirtyTabIds].filter((id) => id !== tabId),
                 ),
-                tabNavigationHistory,
-                tabNavigationIndex,
             };
         });
     },
@@ -955,9 +1234,190 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     },
 
     switchTab: (tabId) =>
+        set((state) => {
+            if (state.activeTabId === tabId) {
+                return state;
+            }
+
+            const workspace = getEffectivePaneWorkspace(state);
+            const targetPane = findPaneContainingTab(workspace.panes, tabId);
+            if (!targetPane) {
+                return activateTab(state, tabId);
+            }
+
+            const projection = activatePaneTab(workspace, targetPane.id, tabId);
+            return projection ?? state;
+        }),
+
+    focusPane: (paneId) =>
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+            const nextFocusedPaneId = getResolvedFocusedPaneId(
+                workspace.panes,
+                paneId,
+            );
+
+            if (workspace.focusedPaneId === nextFocusedPaneId) {
+                return state;
+            }
+
+            return buildFocusedPaneProjection({
+                panes: workspace.panes,
+                focusedPaneId: nextFocusedPaneId,
+            });
+        }),
+
+    createEmptyPane: () => {
+        const nextPaneId = getNextEditorPaneId(get().panes);
+        if (!nextPaneId) {
+            return null;
+        }
+
         set((state) =>
-            state.activeTabId === tabId ? state : activateTab(state, tabId),
-        ),
+            buildFocusedPaneProjection({
+                panes: [...state.panes, createEditorPaneState(nextPaneId)],
+                focusedPaneId: nextPaneId,
+            }),
+        );
+
+        return nextPaneId;
+    },
+
+    insertExternalTabInPane: (tab, paneId, index) => {
+        set((state) => {
+            const incoming = normalizeExternalTab(tab);
+            if (!incoming) {
+                return state;
+            }
+
+            const existingPane = state.panes.find((pane) => pane.id === paneId);
+            if (!existingPane) {
+                return state;
+            }
+
+            return buildFocusedPaneProjection({
+                panes: state.panes.map((pane) =>
+                    pane.id === paneId
+                        ? createEditorPaneState(
+                              pane.id,
+                              insertNormalizedTab(pane, incoming, index),
+                          )
+                        : pane,
+                ),
+                focusedPaneId: paneId,
+            });
+        });
+    },
+
+    insertExternalTabInNewPane: (tab) => {
+        const incoming = normalizeExternalTab(tab);
+        if (!incoming) {
+            return null;
+        }
+
+        const nextPaneId = getNextEditorPaneId(get().panes);
+        if (!nextPaneId) {
+            return null;
+        }
+
+        set((state) =>
+            buildFocusedPaneProjection({
+                panes: [
+                    ...state.panes,
+                    createEditorPaneState(
+                        nextPaneId,
+                        insertNormalizedTab(
+                            createEditorPaneState(nextPaneId),
+                            incoming,
+                        ),
+                    ),
+                ],
+                focusedPaneId: nextPaneId,
+            }),
+        );
+
+        return nextPaneId;
+    },
+
+    moveTabToPane: (tabId, paneId, index) => {
+        set((state) => {
+            const sourcePane = state.panes.find((pane) =>
+                pane.tabs.some((tab) => tab.id === tabId),
+            );
+            const targetPane = state.panes.find((pane) => pane.id === paneId);
+            if (!sourcePane || !targetPane || sourcePane.id === targetPane.id) {
+                return state;
+            }
+
+            const movingTab =
+                sourcePane.tabs.find((tab) => tab.id === tabId) ?? null;
+            if (!movingTab) {
+                return state;
+            }
+
+            const nextSourcePane = createEditorPaneState(
+                sourcePane.id,
+                removeTabFromWorkspaceState(sourcePane, tabId),
+            );
+            const nextTargetPane = createEditorPaneState(
+                targetPane.id,
+                insertNormalizedTab(targetPane, movingTab, index),
+            );
+
+            return buildFocusedPaneProjection({
+                panes: state.panes.map((pane) => {
+                    if (pane.id === sourcePane.id) return nextSourcePane;
+                    if (pane.id === targetPane.id) return nextTargetPane;
+                    return pane;
+                }),
+                focusedPaneId: targetPane.id,
+            });
+        });
+    },
+
+    closePane: (paneId) => {
+        set((state) => {
+            if (state.panes.length <= 1) {
+                return state;
+            }
+
+            const paneIndex = state.panes.findIndex(
+                (pane) => pane.id === paneId,
+            );
+            if (paneIndex === -1) {
+                return state;
+            }
+
+            const closingPane = state.panes[paneIndex];
+            const recipientPaneId =
+                state.panes[paneIndex - 1]?.id ??
+                state.panes[paneIndex + 1]?.id ??
+                null;
+
+            if (!recipientPaneId) {
+                return state;
+            }
+
+            const nextPanes = state.panes
+                .filter((pane) => pane.id !== paneId)
+                .map((pane) =>
+                    pane.id === recipientPaneId
+                        ? mergePaneStates(pane, closingPane)
+                        : pane,
+                );
+
+            return buildFocusedPaneProjection({
+                panes: nextPanes,
+                focusedPaneId:
+                    state.focusedPaneId === paneId
+                        ? recipientPaneId
+                        : getResolvedFocusedPaneId(
+                              nextPanes,
+                              state.focusedPaneId,
+                          ),
+            });
+        });
+    },
 
     setTabDirty: (tabId, dirty) => {
         set((state) => {

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -49,6 +49,10 @@ import {
 } from "./editorSession";
 import { useSettingsStore } from "./settingsStore";
 import { useVaultStore } from "./vaultStore";
+import {
+    DEFAULT_EDITOR_PANE_ID as INITIAL_EDITOR_PANE_ID,
+    getNextGeneratedPaneId,
+} from "./workspaceLayoutTree";
 
 export {
     fileViewerNeedsTextContent,
@@ -94,14 +98,6 @@ export type {
 export { markSessionReady, readPersistedSession } from "./editorSession";
 
 const MAX_RECENTLY_CLOSED_TABS = 20;
-export const PRIMARY_EDITOR_PANE_ID = "primary";
-export const SECONDARY_EDITOR_PANE_ID = "secondary";
-export const TERTIARY_EDITOR_PANE_ID = "tertiary";
-const EDITOR_PANE_ORDER = [
-    PRIMARY_EDITOR_PANE_ID,
-    SECONDARY_EDITOR_PANE_ID,
-    TERTIARY_EDITOR_PANE_ID,
-] as const;
 
 interface LegacyWorkspaceState {
     tabs: Tab[];
@@ -193,15 +189,11 @@ function getResolvedFocusedPaneId(
     if (focusedPaneId && panes.some((pane) => pane.id === focusedPaneId)) {
         return focusedPaneId;
     }
-    return panes[0]?.id ?? PRIMARY_EDITOR_PANE_ID;
+    return panes[0]?.id ?? INITIAL_EDITOR_PANE_ID;
 }
 
 function getNextEditorPaneId(panes: readonly EditorPaneState[]) {
-    return (
-        EDITOR_PANE_ORDER.find(
-            (paneId) => !panes.some((pane) => pane.id === paneId),
-        ) ?? null
-    );
+    return getNextGeneratedPaneId(panes.map((pane) => pane.id));
 }
 
 function getEffectivePaneWorkspace<
@@ -221,7 +213,7 @@ function getEffectivePaneWorkspace<
         const effectivePanes =
             panes.length > 0
                 ? panes
-                : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)];
+                : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)];
         return {
             panes: effectivePanes,
             focusedPaneId: getResolvedFocusedPaneId(
@@ -232,23 +224,23 @@ function getEffectivePaneWorkspace<
     }
 
     const singlePane =
-        panes[0] ?? createEditorPaneState(PRIMARY_EDITOR_PANE_ID);
-    const isPlaceholderPrimaryPane =
-        singlePane.id === PRIMARY_EDITOR_PANE_ID &&
+        panes[0] ?? createEditorPaneState(INITIAL_EDITOR_PANE_ID);
+    const isPlaceholderInitialPane =
+        singlePane.id === INITIAL_EDITOR_PANE_ID &&
         singlePane.tabs.length === 0 &&
         singlePane.activeTabId === null &&
         singlePane.activationHistory.length === 0 &&
         singlePane.tabNavigationHistory.length === 0 &&
         singlePane.tabNavigationIndex === -1;
 
-    if (!isPlaceholderPrimaryPane) {
+    if (!isPlaceholderInitialPane) {
         return {
             panes,
             focusedPaneId: getResolvedFocusedPaneId(panes, state.focusedPaneId),
         };
     }
 
-    const legacyPane = createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+    const legacyPane = createEditorPaneState(INITIAL_EDITOR_PANE_ID, {
         tabs: state.tabs ?? [],
         activeTabId: state.activeTabId ?? null,
         activationHistory: state.activationHistory ?? [],
@@ -277,7 +269,7 @@ export function selectEditorPaneState<
     return (
         panes.find((pane) => pane.id === resolvedPaneId) ??
         panes[0] ??
-        createEditorPaneState(PRIMARY_EDITOR_PANE_ID)
+        createEditorPaneState(INITIAL_EDITOR_PANE_ID)
     );
 }
 
@@ -317,7 +309,7 @@ function buildFocusedPaneProjection(args: {
     const panes =
         args.panes.length > 0
             ? args.panes.map((pane) => createEditorPaneState(pane.id, pane))
-            : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)];
+            : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)];
     const focusedPaneId = getResolvedFocusedPaneId(panes, args.focusedPaneId);
     const focusedPane =
         panes.find((pane) => pane.id === focusedPaneId) ?? panes[0];
@@ -931,8 +923,8 @@ interface EditorStore {
 }
 
 export const useEditorStore = create<EditorStore>((set, get) => ({
-    panes: [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)],
-    focusedPaneId: PRIMARY_EDITOR_PANE_ID,
+    panes: [createEditorPaneState(INITIAL_EDITOR_PANE_ID)],
+    focusedPaneId: INITIAL_EDITOR_PANE_ID,
     tabs: [],
     activeTabId: null,
     recentlyClosedTabs: [],
@@ -1770,7 +1762,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 panes:
                     hydratedPanes.length > 0
                         ? hydratedPanes
-                        : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)],
+                        : [createEditorPaneState(INITIAL_EDITOR_PANE_ID)],
                 focusedPaneId,
             }),
             recentlyClosedTabs: [],
@@ -1799,7 +1791,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 : (hydratedTabs[0]?.id ?? null);
         set({
             panes: [
-                createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+                createEditorPaneState(INITIAL_EDITOR_PANE_ID, {
                     tabs: hydratedTabs,
                     activeTabId: nextActiveTabId,
                     activationHistory: nextActiveTabId ? [nextActiveTabId] : [],
@@ -1809,7 +1801,7 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                     tabNavigationIndex: nextActiveTabId ? 0 : -1,
                 }),
             ],
-            focusedPaneId: PRIMARY_EDITOR_PANE_ID,
+            focusedPaneId: INITIAL_EDITOR_PANE_ID,
             tabs: hydratedTabs,
             activeTabId: nextActiveTabId,
             recentlyClosedTabs: [],
@@ -2137,7 +2129,7 @@ useEditorStore.subscribe((state) => {
                           : pane,
                   )
                 : [
-                      createEditorPaneState(PRIMARY_EDITOR_PANE_ID, {
+                      createEditorPaneState(INITIAL_EDITOR_PANE_ID, {
                           tabs: state.tabs,
                           activeTabId: state.activeTabId,
                           activationHistory: state.activationHistory,

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -1335,6 +1335,76 @@ function renameNoteAcrossWorkspace<
     };
 }
 
+function deleteMapAcrossWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+>(state: TState, relativePath: string) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const nextPanes = workspace.panes.map((pane) => {
+        const tabs = pane.tabs.filter(
+            (tab) => !isMapTab(tab) || tab.relativePath !== relativePath,
+        );
+        return tabs.length !== pane.tabs.length
+            ? updatePaneWithTabs(pane, tabs)
+            : pane;
+    });
+
+    const compactedWorkspace = removeEmptyPanesFromWorkspace({
+        panes: nextPanes,
+        focusedPaneId: workspace.focusedPaneId,
+        layoutTree: workspace.layoutTree,
+    });
+
+    return {
+        projection: buildFocusedPaneProjection(compactedWorkspace),
+        didChange:
+            compactedWorkspace.layoutTree !== workspace.layoutTree ||
+            compactedWorkspace.focusedPaneId !== workspace.focusedPaneId ||
+            compactedWorkspace.panes.length !== workspace.panes.length ||
+            compactedWorkspace.panes.some(
+                (pane, index) => pane !== workspace.panes[index],
+            ),
+    };
+}
+
+function renameMapAcrossWorkspace<
+    TState extends Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
+>(
+    state: TState,
+    oldRelativePath: string,
+    newRelativePath: string,
+    newTitle: string,
+) {
+    const workspace = getEffectivePaneWorkspace(state);
+    const nextPanes = workspace.panes.map((pane) => {
+        let didChange = false;
+        const tabs = pane.tabs.map((tab) => {
+            if (!isMapTab(tab) || tab.relativePath !== oldRelativePath) {
+                return tab;
+            }
+
+            didChange = true;
+            return {
+                ...tab,
+                relativePath: newRelativePath,
+                title: newTitle,
+            };
+        });
+
+        return didChange ? updatePaneWithTabs(pane, tabs) : pane;
+    });
+
+    return {
+        projection: buildFocusedPaneProjection({
+            panes: nextPanes,
+            focusedPaneId: workspace.focusedPaneId,
+            layoutTree: workspace.layoutTree,
+        }),
+        didChange:
+            nextPanes.length !== workspace.panes.length ||
+            nextPanes.some((pane, index) => pane !== workspace.panes[index]),
+    };
+}
+
 export interface PendingReveal {
     noteId: string;
     targets: string[];
@@ -1507,6 +1577,12 @@ interface EditorStore {
     clearFileExternalConflict: (relativePath: string) => void;
     handleNoteDeleted: (noteId: string) => void;
     handleFileDeleted: (relativePath: string) => void;
+    handleMapDeleted: (relativePath: string) => void;
+    handleMapRenamed: (
+        oldRelativePath: string,
+        newRelativePath: string,
+        newTitle: string,
+    ) => void;
     handleNoteRenamed: (
         oldNoteId: string,
         newNoteId: string,
@@ -2966,6 +3042,25 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 ),
                 fileExternalConflicts,
             };
+        });
+    },
+
+    handleMapDeleted: (relativePath) => {
+        set((state) => {
+            const next = deleteMapAcrossWorkspace(state, relativePath);
+            return next.didChange ? next.projection : state;
+        });
+    },
+
+    handleMapRenamed: (oldRelativePath, newRelativePath, newTitle) => {
+        set((state) => {
+            const next = renameMapAcrossWorkspace(
+                state,
+                oldRelativePath,
+                newRelativePath,
+                newTitle,
+            );
+            return next.didChange ? next.projection : state;
         });
     },
 

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -196,6 +196,23 @@ function stringArraysEqual(left: readonly string[], right: readonly string[]) {
     );
 }
 
+function paneIdCollectionsEqual(
+    left: readonly string[],
+    right: readonly string[],
+) {
+    if (left.length !== right.length) {
+        return false;
+    }
+
+    const leftIds = new Set(left);
+    const rightIds = new Set(right);
+    if (leftIds.size !== left.length || rightIds.size !== right.length) {
+        return false;
+    }
+
+    return left.every((paneId) => rightIds.has(paneId));
+}
+
 function tabsShallowEqual(left: readonly Tab[], right: readonly Tab[]) {
     return (
         left.length === right.length &&
@@ -255,7 +272,7 @@ function resolveLayoutTreeFromState<
     if (state.layoutTree) {
         const normalizedTree = normalizeLayoutTree(state.layoutTree);
         const treePaneIds = getLayoutPaneIds(normalizedTree);
-        if (stringArraysEqual(treePaneIds, resolvedPaneIds)) {
+        if (paneIdCollectionsEqual(treePaneIds, resolvedPaneIds)) {
             return normalizedTree;
         }
     }
@@ -472,7 +489,7 @@ function buildFocusedPaneProjection(args: {
     const paneIds = paneStates.map((pane) => pane.id);
     const layoutTree =
         args.layoutTree &&
-        stringArraysEqual(
+        paneIdCollectionsEqual(
             getLayoutPaneIds(normalizeLayoutTree(args.layoutTree)),
             paneIds,
         )

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -2,9 +2,11 @@ import { create } from "zustand";
 import type { EditorTarget } from "../../features/editor/editorTargetResolver";
 import {
     buildTabFromHistory,
+    createChatTab,
     createGraphTab,
     createMapTab,
     ensureFileTabDefaults,
+    isChatTab,
     isFileTab,
     isGraphTab,
     isHistoryTab,
@@ -13,6 +15,7 @@ import {
     isNoteTab,
     isPdfTab,
     isReviewTab,
+    type ChatTab,
     type FileViewerMode,
     type HistoryTab,
     type NavigableHistoryTab,
@@ -49,6 +52,7 @@ import { useVaultStore } from "./vaultStore";
 
 export {
     fileViewerNeedsTextContent,
+    isChatTab,
     isFileTab,
     isGraphTab,
     isHistoryTab,
@@ -61,6 +65,7 @@ export {
     isTransientTab,
 } from "./editorTabs";
 export type {
+    ChatTab,
     FileHistoryEntry,
     FileTab,
     FileTabInput,
@@ -474,7 +479,7 @@ function normalizeExternalTab(tab: TabInput): Tab | null {
     if (isHistoryTab(tab)) {
         return normalizeHistoryTab(tab);
     }
-    if (isReviewTab(tab) || isGraphTab(tab)) {
+    if (isReviewTab(tab) || isChatTab(tab) || isGraphTab(tab)) {
         return tab;
     }
     return null;
@@ -849,6 +854,11 @@ interface EditorStore {
         options?: { background?: boolean; title?: string },
     ) => void;
     closeReview: (sessionId: string) => void;
+    openChat: (
+        sessionId: string,
+        options?: { background?: boolean; title?: string; paneId?: string },
+    ) => void;
+    closeChat: (sessionId: string) => void;
     goBack: () => void;
     goForward: () => void;
     navigateToHistoryIndex: (index: number) => void;
@@ -1115,6 +1125,114 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     closeReview: (sessionId) => {
         const tab = selectEditorWorkspaceTabs(get()).find(
             (t) => isReviewTab(t) && t.sessionId === sessionId,
+        );
+        if (tab) get().closeTab(tab.id);
+    },
+
+    openChat: (sessionId, options) => {
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+
+            // Reuse existing ChatTab for this session if already open
+            const existingPane = workspace.panes.find((pane) =>
+                pane.tabs.some(
+                    (tab) => isChatTab(tab) && tab.sessionId === sessionId,
+                ),
+            );
+            const existing =
+                existingPane?.tabs.find(
+                    (tab): tab is ChatTab =>
+                        isChatTab(tab) && tab.sessionId === sessionId,
+                ) ?? null;
+            if (existingPane && existing) {
+                const nextTitle = options?.title ?? existing.title;
+                const nextPane =
+                    nextTitle === existing.title
+                        ? existingPane
+                        : createEditorPaneState(existingPane.id, {
+                              ...existingPane,
+                              tabs: existingPane.tabs.map((tab) =>
+                                  tab.id === existing.id
+                                      ? { ...tab, title: nextTitle }
+                                      : tab,
+                              ),
+                          });
+                if (options?.background) {
+                    if (nextPane === existingPane) {
+                        return state;
+                    }
+                    return buildFocusedPaneProjection({
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: workspace.focusedPaneId,
+                    });
+                }
+                const projection = activatePaneTab(
+                    {
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: existingPane.id,
+                    },
+                    existingPane.id,
+                    existing.id,
+                );
+                return (
+                    projection ??
+                    buildFocusedPaneProjection({
+                        panes: workspace.panes.map((pane) =>
+                            pane.id === existingPane.id ? nextPane : pane,
+                        ),
+                        focusedPaneId: existingPane.id,
+                    })
+                );
+            }
+
+            const newTab: ChatTab = createChatTab(
+                sessionId,
+                options?.title ?? "Chat",
+            );
+
+            // Insert into specified pane or focused pane
+            const targetPaneId =
+                options?.paneId ?? workspace.focusedPaneId ?? null;
+            const targetPane = targetPaneId
+                ? (workspace.panes.find((p) => p.id === targetPaneId) ?? null)
+                : null;
+            const focusedPane = targetPane ?? selectEditorPaneState(workspace);
+
+            const nextPane = options?.background
+                ? createEditorPaneState(focusedPane.id, {
+                      ...focusedPane,
+                      tabs: [...focusedPane.tabs, newTab],
+                  })
+                : createEditorPaneState(
+                      focusedPane.id,
+                      insertNormalizedTab(focusedPane, newTab),
+                  );
+
+            if (options?.background) {
+                return buildFocusedPaneProjection({
+                    panes: workspace.panes.map((pane) =>
+                        pane.id === focusedPane.id ? nextPane : pane,
+                    ),
+                    focusedPaneId: workspace.focusedPaneId,
+                });
+            }
+
+            return buildFocusedPaneProjection({
+                panes: workspace.panes.map((pane) =>
+                    pane.id === focusedPane.id ? nextPane : pane,
+                ),
+                focusedPaneId: focusedPane.id,
+            });
+        });
+    },
+
+    closeChat: (sessionId) => {
+        const tab = selectEditorWorkspaceTabs(get()).find(
+            (t) => isChatTab(t) && t.sessionId === sessionId,
         );
         if (tab) get().closeTab(tab.id);
     },

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -1058,12 +1058,66 @@ function updatePaneWithTabs(pane: EditorPaneState, tabs: readonly Tab[]) {
     });
 }
 
+function updateTabTitleInTabs(
+    tabs: readonly Tab[],
+    tabId: string,
+    title: string,
+) {
+    let didChange = false;
+    const nextTabs = tabs.map((tab) => {
+        if (tab.id !== tabId) {
+            return tab;
+        }
+
+        const nextTab = !isHistoryTab(tab)
+            ? tab.title === title
+                ? tab
+                : { ...tab, title }
+            : updateTabHistoryTitle(tab, title);
+
+        didChange ||= nextTab !== tab;
+        return nextTab;
+    });
+
+    return didChange ? nextTabs : tabs;
+}
+
+function applyResourceReloadToWorkspacePanes<K extends "note" | "file">(
+    workspace: ReturnType<typeof getEffectivePaneWorkspace>,
+    kind: K,
+    resourceId: string,
+    detail: ReloadedDetail,
+    options?: {
+        force?: boolean;
+        fallbackOrigin?: "unknown" | "system" | "external" | "agent";
+    },
+) {
+    const handler = getResourceHandler(kind);
+    return workspace.panes.map((pane) => {
+        const next = buildResourceReloadUpdate(
+            handler,
+            {
+                tabs: pane.tabs,
+                pendingForceReloads: new Set<string>(),
+                reloadVersions: {},
+                reloadMetadata: {},
+            },
+            resourceId,
+            detail,
+            options,
+        );
+
+        return updatePaneWithTabs(pane, next.tabs);
+    });
+}
+
 function applyResourceReloadAcrossWorkspace<
     TState extends Pick<
         EditorStore,
         | "panes"
         | "focusedPaneId"
         | "layoutTree"
+        | "tabs"
         | "_pendingForceReloads"
         | "_pendingForceFileReloads"
         | "_noteReloadVersions"
@@ -1082,23 +1136,22 @@ function applyResourceReloadAcrossWorkspace<
     },
 ) {
     const workspace = getEffectivePaneWorkspace(state);
-    const handler = getResourceHandler(kind);
-    const nextPanes = workspace.panes.map((pane) => {
-        const next = buildResourceReloadUpdate(
-            handler,
-            {
-                tabs: pane.tabs,
-                pendingForceReloads: new Set<string>(),
-                reloadVersions: {},
-                reloadMetadata: {},
-            },
-            resourceId,
-            detail,
-            options,
-        );
-
-        return updatePaneWithTabs(pane, next.tabs);
-    });
+    const nextPanes =
+        kind === "note"
+            ? applyResourceReloadToWorkspacePanes(
+                  workspace,
+                  "note",
+                  resourceId,
+                  detail,
+                  options,
+              )
+            : applyResourceReloadToWorkspacePanes(
+                  workspace,
+                  "file",
+                  resourceId,
+                  detail,
+                  options,
+              );
     const projection = buildFocusedPaneProjection({
         panes: nextPanes,
         focusedPaneId: workspace.focusedPaneId,
@@ -1110,7 +1163,7 @@ function applyResourceReloadAcrossWorkspace<
 
     if (kind === "note") {
         const nextMetadata = buildResourceReloadUpdate(
-            handler,
+            getResourceHandler("note"),
             {
                 tabs: state.tabs,
                 pendingForceReloads: state._pendingForceReloads,
@@ -1132,7 +1185,7 @@ function applyResourceReloadAcrossWorkspace<
     }
 
     const nextMetadata = buildResourceReloadUpdate(
-        handler,
+        getResourceHandler("file"),
         {
             tabs: state.tabs,
             pendingForceReloads: state._pendingForceFileReloads,
@@ -1157,23 +1210,39 @@ function applyResourceDeleteAcrossWorkspace<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId" | "layoutTree">,
 >(state: TState, kind: "note" | "file", resourceId: string) {
     const workspace = getEffectivePaneWorkspace(state);
-    const handler = getResourceHandler(kind);
-    let nextPanes = workspace.panes.map((pane) => {
-        const next = buildResourceDeleteUpdate(
-            handler,
-            {
-                tabs: pane.tabs,
-                activeTabId: pane.activeTabId,
-                activationHistory: pane.activationHistory,
-                tabNavigationHistory: pane.tabNavigationHistory,
-                tabNavigationIndex: pane.tabNavigationIndex,
-                pendingForceReloads: new Set<string>(),
-                reloadVersions: {},
-                reloadMetadata: {},
-                externalConflicts: new Set<string>(),
-            },
-            resourceId,
-        );
+    const nextPanes = workspace.panes.map((pane) => {
+        const next =
+            kind === "note"
+                ? buildResourceDeleteUpdate(
+                      getResourceHandler("note"),
+                      {
+                          tabs: pane.tabs,
+                          activeTabId: pane.activeTabId,
+                          activationHistory: pane.activationHistory,
+                          tabNavigationHistory: pane.tabNavigationHistory,
+                          tabNavigationIndex: pane.tabNavigationIndex,
+                          pendingForceReloads: new Set<string>(),
+                          reloadVersions: {},
+                          reloadMetadata: {},
+                          externalConflicts: new Set<string>(),
+                      },
+                      resourceId,
+                  )
+                : buildResourceDeleteUpdate(
+                      getResourceHandler("file"),
+                      {
+                          tabs: pane.tabs,
+                          activeTabId: pane.activeTabId,
+                          activationHistory: pane.activationHistory,
+                          tabNavigationHistory: pane.tabNavigationHistory,
+                          tabNavigationIndex: pane.tabNavigationIndex,
+                          pendingForceReloads: new Set<string>(),
+                          reloadVersions: {},
+                          reloadMetadata: {},
+                          externalConflicts: new Set<string>(),
+                      },
+                      resourceId,
+                  );
 
         return next
             ? createEditorPaneState(pane.id, {
@@ -2152,22 +2221,24 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                           currentTargetPane.id,
                           position,
                       );
-            const nextPaneMap = new Map([
-                ...currentWorkspace.panes.map((pane) => [
+            const nextPaneEntries: Array<[string, EditorPaneState]> =
+                currentWorkspace.panes.map((pane) => [
                     pane.id,
                     pane.id === currentSourcePane.id ? nextSourcePane : pane,
-                ]),
-                [
+                ]);
+            nextPaneEntries.push([
+                nextPaneId,
+                createEditorPaneState(
                     nextPaneId,
-                    createEditorPaneState(
-                        nextPaneId,
-                        insertNormalizedTab(
-                            createEditorPaneState(nextPaneId),
-                            movingTab,
-                        ),
+                    insertNormalizedTab(
+                        createEditorPaneState(nextPaneId),
+                        movingTab,
                     ),
-                ],
-            ] satisfies ReadonlyArray<[string, EditorPaneState]>);
+                ),
+            ]);
+            const nextPaneMap = new Map<string, EditorPaneState>(
+                nextPaneEntries,
+            );
 
             return buildFocusedPaneProjection(
                 removeEmptyPanesFromWorkspace(
@@ -2360,15 +2431,30 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
     },
 
     updateTabTitle: (tabId, title) => {
-        set((state) => ({
-            tabs: state.tabs.map((t) => {
-                if (t.id !== tabId) return t;
-                if (!isHistoryTab(t)) {
-                    return t.title === title ? t : { ...t, title };
-                }
-                return updateTabHistoryTitle(t, title);
-            }),
-        }));
+        set((state) => {
+            const workspace = getEffectivePaneWorkspace(state);
+            let didChange = false;
+            const nextPanes = workspace.panes.map((pane) => {
+                const nextTabs = updateTabTitleInTabs(pane.tabs, tabId, title);
+                didChange ||= nextTabs !== pane.tabs;
+                return nextTabs === pane.tabs
+                    ? pane
+                    : createEditorPaneState(pane.id, {
+                          ...pane,
+                          tabs: [...nextTabs],
+                      });
+            });
+
+            if (!didChange) {
+                return state;
+            }
+
+            return buildFocusedPaneProjection({
+                panes: nextPanes,
+                focusedPaneId: workspace.focusedPaneId,
+                layoutTree: workspace.layoutTree,
+            });
+        });
     },
 
     updateFileHistoryTitle: (tabId, relativePath, title) => {

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -203,9 +203,7 @@ function getEffectivePaneWorkspace<
     TState extends Pick<EditorStore, "panes" | "focusedPaneId"> &
         Partial<LegacyWorkspaceState>,
 >(state: TState) {
-    const normalizedPanes = state.panes.length
-        ? state.panes.map((pane) => createEditorPaneState(pane.id, pane))
-        : [];
+    const panes = state.panes.length > 0 ? state.panes : [];
     const hasLegacyWorkspace =
         Array.isArray(state.tabs) &&
         (state.tabs.length > 0 ||
@@ -214,19 +212,22 @@ function getEffectivePaneWorkspace<
             (state.tabNavigationHistory?.length ?? 0) > 0 ||
             (state.tabNavigationIndex ?? -1) >= 0);
 
-    if (normalizedPanes.length > 1 || !hasLegacyWorkspace) {
-        const panes =
-            normalizedPanes.length > 0
-                ? normalizedPanes
+    if (panes.length > 1 || !hasLegacyWorkspace) {
+        const effectivePanes =
+            panes.length > 0
+                ? panes
                 : [createEditorPaneState(PRIMARY_EDITOR_PANE_ID)];
         return {
-            panes,
-            focusedPaneId: getResolvedFocusedPaneId(panes, state.focusedPaneId),
+            panes: effectivePanes,
+            focusedPaneId: getResolvedFocusedPaneId(
+                effectivePanes,
+                state.focusedPaneId,
+            ),
         };
     }
 
     const singlePane =
-        normalizedPanes[0] ?? createEditorPaneState(PRIMARY_EDITOR_PANE_ID);
+        panes[0] ?? createEditorPaneState(PRIMARY_EDITOR_PANE_ID);
     const isPlaceholderPrimaryPane =
         singlePane.id === PRIMARY_EDITOR_PANE_ID &&
         singlePane.tabs.length === 0 &&
@@ -237,11 +238,8 @@ function getEffectivePaneWorkspace<
 
     if (!isPlaceholderPrimaryPane) {
         return {
-            panes: normalizedPanes,
-            focusedPaneId: getResolvedFocusedPaneId(
-                normalizedPanes,
-                state.focusedPaneId,
-            ),
+            panes,
+            focusedPaneId: getResolvedFocusedPaneId(panes, state.focusedPaneId),
         };
     }
 
@@ -626,6 +624,18 @@ function mergePaneStates(
     });
 }
 
+function getPaneRecipientIdForRemoval(
+    panes: readonly EditorPaneState[],
+    paneId: string,
+) {
+    const paneIndex = panes.findIndex((pane) => pane.id === paneId);
+    if (paneIndex === -1) {
+        return null;
+    }
+
+    return panes[paneIndex - 1]?.id ?? panes[paneIndex + 1]?.id ?? null;
+}
+
 function findPaneContainingTab(
     panes: readonly EditorPaneState[],
     tabId: string,
@@ -854,6 +864,11 @@ interface EditorStore {
     ) => void;
     insertExternalTabInNewPane: (tab: TabInput) => string | null;
     moveTabToPane: (tabId: string, paneId: string, index?: number) => void;
+    reorderPaneTabs: (
+        paneId: string,
+        fromIndex: number,
+        toIndex: number,
+    ) => void;
     closePane: (paneId: string) => void;
     setTabDirty: (tabId: string, dirty: boolean) => void;
     updateTabContent: (tabId: string, content: string) => void;
@@ -1193,11 +1208,24 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                 targetPane.id,
                 removeTabFromWorkspaceState(targetPane, tabId),
             );
+            const shouldRemoveEmptyPane =
+                nextTargetPane.tabs.length === 0 && workspace.panes.length > 1;
+            const nextPanes = shouldRemoveEmptyPane
+                ? workspace.panes.filter((pane) => pane.id !== targetPane.id)
+                : workspace.panes.map((pane) =>
+                      pane.id === targetPane.id ? nextTargetPane : pane,
+                  );
+            const focusedPaneId = shouldRemoveEmptyPane
+                ? workspace.focusedPaneId === targetPane.id
+                    ? (getPaneRecipientIdForRemoval(
+                          workspace.panes,
+                          targetPane.id,
+                      ) ?? workspace.focusedPaneId)
+                    : workspace.focusedPaneId
+                : workspace.focusedPaneId;
             const projection = buildFocusedPaneProjection({
-                panes: workspace.panes.map((pane) =>
-                    pane.id === targetPane.id ? nextTargetPane : pane,
-                ),
-                focusedPaneId: workspace.focusedPaneId,
+                panes: nextPanes,
+                focusedPaneId,
             });
 
             return {
@@ -1371,6 +1399,43 @@ export const useEditorStore = create<EditorStore>((set, get) => ({
                     return pane;
                 }),
                 focusedPaneId: targetPane.id,
+            });
+        });
+    },
+
+    reorderPaneTabs: (paneId, fromIndex, toIndex) => {
+        set((state) => {
+            const pane = state.panes.find(
+                (candidate) => candidate.id === paneId,
+            );
+            if (!pane) {
+                return state;
+            }
+
+            if (
+                fromIndex === toIndex ||
+                fromIndex < 0 ||
+                toIndex < 0 ||
+                fromIndex >= pane.tabs.length ||
+                toIndex >= pane.tabs.length
+            ) {
+                return state;
+            }
+
+            const tabs = [...pane.tabs];
+            const [tab] = tabs.splice(fromIndex, 1);
+            tabs.splice(toIndex, 0, tab);
+
+            return buildFocusedPaneProjection({
+                panes: state.panes.map((candidate) =>
+                    candidate.id === paneId
+                        ? createEditorPaneState(candidate.id, {
+                              ...candidate,
+                              tabs,
+                          })
+                        : candidate,
+                ),
+                focusedPaneId: state.focusedPaneId,
             });
         });
     },

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -152,6 +152,13 @@ export interface ReviewTab {
     title: string;
 }
 
+export interface ChatTab {
+    id: string;
+    kind: "ai-chat";
+    sessionId: string;
+    title: string;
+}
+
 export interface MapTab {
     id: string;
     kind: "map";
@@ -167,7 +174,14 @@ export interface GraphTab {
     title: string;
 }
 
-export type Tab = NoteTab | PdfTab | FileTab | ReviewTab | MapTab | GraphTab;
+export type Tab =
+    | NoteTab
+    | PdfTab
+    | FileTab
+    | ReviewTab
+    | ChatTab
+    | MapTab
+    | GraphTab;
 
 export type NoteTabInput = Omit<
     NoteTab,
@@ -220,6 +234,7 @@ export type TabInput =
     | PdfTabInput
     | FileTabInput
     | ReviewTab
+    | ChatTab
     | MapTabInput
     | GraphTab;
 
@@ -234,7 +249,7 @@ export type NavigableHistoryTabInput =
     | NoteTabInput
     | PdfTabInput
     | FileTabInput;
-export type TransientTab = ReviewTab | GraphTab;
+export type TransientTab = ReviewTab | ChatTab | GraphTab;
 export type ResourceBackedTab = NoteTab | FileTab;
 export type TabCloseReason =
     | "user"
@@ -310,6 +325,14 @@ export function isReviewTab(
     return inferTabKind(tab) === "ai-review";
 }
 
+export function isChatTab(tab: Tab | null | undefined): tab is ChatTab;
+export function isChatTab(tab: TabInput | null | undefined): tab is ChatTab;
+export function isChatTab(
+    tab: Tab | TabInput | null | undefined,
+): tab is ChatTab {
+    return inferTabKind(tab) === "ai-chat";
+}
+
 export function isMapTab(tab: Tab | null | undefined): tab is MapTab;
 export function isMapTab(tab: TabInput | null | undefined): tab is MapTabInput;
 export function isMapTab(
@@ -362,7 +385,7 @@ export function isTransientTab(
     tab: Tab | TabInput | null | undefined,
 ): tab is TransientTab {
     const kind = inferTabKind(tab);
-    return kind === "ai-review" || kind === "graph";
+    return kind === "ai-review" || kind === "ai-chat" || kind === "graph";
 }
 
 export function isResourceBackedTab(
@@ -712,6 +735,15 @@ export function createGraphTab(): GraphTab {
         id: crypto.randomUUID(),
         kind: "graph",
         title: "Graph View",
+    };
+}
+
+export function createChatTab(sessionId: string, title: string): ChatTab {
+    return {
+        id: crypto.randomUUID(),
+        kind: "ai-chat",
+        sessionId,
+        title,
     };
 }
 

--- a/apps/desktop/src/app/store/layoutStore.test.ts
+++ b/apps/desktop/src/app/store/layoutStore.test.ts
@@ -27,7 +27,9 @@ describe("layoutStore bottom panel", () => {
             bottomPanelHeight: 320,
             bottomPanelView: "terminal",
         });
-        expect(localStorage.getItem("neverwrite.bottompanel.height")).toBe("320");
+        expect(localStorage.getItem("neverwrite.bottompanel.height")).toBe(
+            "320",
+        );
         expect(localStorage.getItem("neverwrite.bottompanel.collapsed")).toBe(
             "false",
         );
@@ -53,6 +55,17 @@ describe("layoutStore bottom panel", () => {
         });
         expect(localStorage.getItem("neverwrite.bottompanel.view")).toBe(
             "terminal",
+        );
+    });
+
+    it("normalizes and persists editor pane proportions", () => {
+        useLayoutStore.getState().setEditorPaneSizes(3, [2, 1, 1]);
+
+        expect(useLayoutStore.getState().editorPaneSizes).toEqual([
+            0.5, 0.25, 0.25,
+        ]);
+        expect(localStorage.getItem("neverwrite.editor-pane.sizes")).toBe(
+            JSON.stringify([0.5, 0.25, 0.25]),
         );
     });
 });

--- a/apps/desktop/src/app/store/layoutStore.test.ts
+++ b/apps/desktop/src/app/store/layoutStore.test.ts
@@ -68,4 +68,20 @@ describe("layoutStore bottom panel", () => {
             JSON.stringify([0.5, 0.25, 0.25]),
         );
     });
+
+    it("supports more than three persisted editor pane proportions", () => {
+        useLayoutStore.getState().setEditorPaneSizes(6, [3, 1, 1, 1, 1, 1]);
+
+        expect(useLayoutStore.getState().editorPaneSizes).toEqual([
+            3 / 8,
+            1 / 8,
+            1 / 8,
+            1 / 8,
+            1 / 8,
+            1 / 8,
+        ]);
+        expect(localStorage.getItem("neverwrite.editor-pane.sizes")).toBe(
+            JSON.stringify([3 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8, 1 / 8]),
+        );
+    });
 });

--- a/apps/desktop/src/app/store/layoutStore.ts
+++ b/apps/desktop/src/app/store/layoutStore.ts
@@ -41,7 +41,7 @@ type BottomPanelView = (typeof BOTTOM_PANEL_VIEWS)[number];
 const DEFAULT_EDITOR_PANE_SIZES = [1];
 
 function normalizeEditorPaneSizesForCount(count: number, sizes?: number[]) {
-    const normalizedCount = Math.max(1, Math.min(3, Math.floor(count) || 1));
+    const normalizedCount = Math.max(1, Math.floor(count) || 1);
     const incoming = (sizes ?? []).filter(
         (value) => Number.isFinite(value) && value > 0,
     );

--- a/apps/desktop/src/app/store/layoutStore.ts
+++ b/apps/desktop/src/app/store/layoutStore.ts
@@ -23,6 +23,7 @@ export const MAX_BOTTOM_PANEL_HEIGHT_RATIO = 0.45;
 const BOTTOM_PANEL_HEIGHT_KEY = "neverwrite.bottompanel.height";
 const BOTTOM_PANEL_COLLAPSED_KEY = "neverwrite.bottompanel.collapsed";
 const BOTTOM_PANEL_VIEW_KEY = "neverwrite.bottompanel.view";
+const EDITOR_PANE_SIZES_KEY = "neverwrite.editor-pane.sizes";
 
 const SIDEBAR_VIEWS: SidebarView[] = [
     "files",
@@ -36,6 +37,24 @@ const BOTTOM_PANEL_VIEWS = ["terminal"] as const;
 
 type RightPanelView = (typeof RIGHT_PANEL_VIEWS)[number];
 type BottomPanelView = (typeof BOTTOM_PANEL_VIEWS)[number];
+
+const DEFAULT_EDITOR_PANE_SIZES = [1];
+
+function normalizeEditorPaneSizesForCount(count: number, sizes?: number[]) {
+    const normalizedCount = Math.max(1, Math.min(3, Math.floor(count) || 1));
+    const incoming = (sizes ?? []).filter(
+        (value) => Number.isFinite(value) && value > 0,
+    );
+
+    if (incoming.length === normalizedCount) {
+        const total = incoming.reduce((sum, value) => sum + value, 0);
+        if (total > 0) {
+            return incoming.map((value) => value / total);
+        }
+    }
+
+    return Array.from({ length: normalizedCount }, () => 1 / normalizedCount);
+}
 
 interface LayoutStore {
     sidebarCollapsed: boolean;
@@ -61,10 +80,13 @@ interface LayoutStore {
     bottomPanelCollapsed: boolean;
     bottomPanelHeight: number;
     bottomPanelView: BottomPanelView;
+    editorPaneSizes: number[];
     toggleBottomPanel: () => void;
     showBottomPanelAtHeight: (height: number) => void;
     collapseBottomPanelToHeight: (height: number) => void;
     activateBottomView: (view: BottomPanelView) => void;
+    ensureEditorPaneSizeCount: (count: number) => void;
+    setEditorPaneSizes: (count: number, sizes: number[]) => void;
 }
 
 type LayoutSnapshot = Pick<
@@ -78,6 +100,7 @@ type LayoutSnapshot = Pick<
     | "bottomPanelCollapsed"
     | "bottomPanelHeight"
     | "bottomPanelView"
+    | "editorPaneSizes"
 >;
 
 function clampSidebarWidth(width: number) {
@@ -162,6 +185,18 @@ function readHydratedLayoutSnapshot(): LayoutSnapshot {
         )
             ? (bottomPanelViewRaw as BottomPanelView)
             : "terminal",
+        editorPaneSizes: (() => {
+            try {
+                const raw = safeStorageGetItem(EDITOR_PANE_SIZES_KEY);
+                if (!raw) return DEFAULT_EDITOR_PANE_SIZES;
+                const parsed = JSON.parse(raw);
+                return Array.isArray(parsed)
+                    ? normalizeEditorPaneSizesForCount(parsed.length, parsed)
+                    : DEFAULT_EDITOR_PANE_SIZES;
+            } catch {
+                return DEFAULT_EDITOR_PANE_SIZES;
+            }
+        })(),
     };
 }
 
@@ -171,6 +206,10 @@ function persistBoolean(key: string, value: boolean) {
 
 function persistNumber(key: string, value: number) {
     safeStorageSetItem(key, String(value));
+}
+
+function persistEditorPaneSizes(value: number[]) {
+    safeStorageSetItem(EDITOR_PANE_SIZES_KEY, JSON.stringify(value));
 }
 
 function createDefaultState(): LayoutSnapshot {
@@ -184,6 +223,7 @@ function createDefaultState(): LayoutSnapshot {
         bottomPanelCollapsed: true,
         bottomPanelHeight: DEFAULT_BOTTOM_PANEL_HEIGHT,
         bottomPanelView: "terminal",
+        editorPaneSizes: DEFAULT_EDITOR_PANE_SIZES,
     };
 }
 
@@ -319,6 +359,28 @@ export const useLayoutStore = create<LayoutStore>((set) => ({
             bottomPanelView: view,
             bottomPanelCollapsed: false,
         });
+    },
+    ensureEditorPaneSizeCount: (count) =>
+        set((state) => {
+            const nextSizes = normalizeEditorPaneSizesForCount(
+                count,
+                state.editorPaneSizes,
+            );
+            const unchanged =
+                nextSizes.length === state.editorPaneSizes.length &&
+                nextSizes.every(
+                    (value, index) => value === state.editorPaneSizes[index],
+                );
+            if (unchanged) {
+                return state;
+            }
+            persistEditorPaneSizes(nextSizes);
+            return { editorPaneSizes: nextSizes };
+        }),
+    setEditorPaneSizes: (count, sizes) => {
+        const nextSizes = normalizeEditorPaneSizesForCount(count, sizes);
+        persistEditorPaneSizes(nextSizes);
+        set({ editorPaneSizes: nextSizes });
     },
 }));
 

--- a/apps/desktop/src/app/store/workspaceLayoutNavigation.test.ts
+++ b/apps/desktop/src/app/store/workspaceLayoutNavigation.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+import { findAdjacentPane } from "./workspaceLayoutNavigation";
+import type { WorkspaceLayoutNode } from "./workspaceLayoutTree";
+
+describe("workspaceLayoutNavigation", () => {
+    it("finds left, right, up and down neighbors from a grid-like split tree", () => {
+        const tree = {
+            type: "split",
+            id: "split-root",
+            direction: "column",
+            sizes: [0.5, 0.5],
+            children: [
+                {
+                    type: "split",
+                    id: "split-top",
+                    direction: "row",
+                    sizes: [0.5, 0.5],
+                    children: [
+                        { type: "pane", id: "pane-a", paneId: "pane-a" },
+                        { type: "pane", id: "pane-b", paneId: "pane-b" },
+                    ],
+                },
+                {
+                    type: "split",
+                    id: "split-bottom",
+                    direction: "row",
+                    sizes: [0.5, 0.5],
+                    children: [
+                        { type: "pane", id: "pane-c", paneId: "pane-c" },
+                        { type: "pane", id: "pane-d", paneId: "pane-d" },
+                    ],
+                },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        expect(findAdjacentPane(tree, "pane-a", "right")).toBe("pane-b");
+        expect(findAdjacentPane(tree, "pane-a", "down")).toBe("pane-c");
+        expect(findAdjacentPane(tree, "pane-d", "left")).toBe("pane-c");
+        expect(findAdjacentPane(tree, "pane-d", "up")).toBe("pane-b");
+        expect(findAdjacentPane(tree, "pane-a", "left")).toBeNull();
+        expect(findAdjacentPane(tree, "pane-a", "up")).toBeNull();
+    });
+
+    it("prefers the nearest overlapping pane in the requested direction", () => {
+        const tree = {
+            type: "split",
+            id: "split-root",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+                { type: "pane", id: "pane-a", paneId: "pane-a" },
+                {
+                    type: "split",
+                    id: "split-right",
+                    direction: "column",
+                    sizes: [0.6, 0.4],
+                    children: [
+                        { type: "pane", id: "pane-b", paneId: "pane-b" },
+                        { type: "pane", id: "pane-c", paneId: "pane-c" },
+                    ],
+                },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        expect(findAdjacentPane(tree, "pane-c", "up")).toBe("pane-b");
+        expect(findAdjacentPane(tree, "pane-b", "down")).toBe("pane-c");
+    });
+});

--- a/apps/desktop/src/app/store/workspaceLayoutNavigation.ts
+++ b/apps/desktop/src/app/store/workspaceLayoutNavigation.ts
@@ -1,0 +1,150 @@
+import type {
+    WorkspaceLayoutNode,
+    WorkspaceMovePosition,
+} from "./workspaceLayoutTree";
+
+type WorkspaceNeighborDirection = WorkspaceMovePosition;
+
+interface PaneRect {
+    paneId: string;
+    left: number;
+    top: number;
+    right: number;
+    bottom: number;
+}
+
+const RECT_EPSILON = 1e-6;
+
+function collectPaneRects(
+    tree: WorkspaceLayoutNode,
+    left = 0,
+    top = 0,
+    width = 1,
+    height = 1,
+    rects: PaneRect[] = [],
+) {
+    if (tree.type === "pane") {
+        rects.push({
+            paneId: tree.paneId,
+            left,
+            top,
+            right: left + width,
+            bottom: top + height,
+        });
+        return rects;
+    }
+
+    let cursor = 0;
+    tree.children.forEach((child, index) => {
+        const size = tree.sizes[index] ?? 0;
+        if (tree.direction === "row") {
+            collectPaneRects(
+                child,
+                left + width * cursor,
+                top,
+                width * size,
+                height,
+                rects,
+            );
+        } else {
+            collectPaneRects(
+                child,
+                left,
+                top + height * cursor,
+                width,
+                height * size,
+                rects,
+            );
+        }
+        cursor += size;
+    });
+    return rects;
+}
+
+function getOverlap(sourceStart: number, sourceEnd: number, targetStart: number, targetEnd: number) {
+    return Math.max(
+        0,
+        Math.min(sourceEnd, targetEnd) - Math.max(sourceStart, targetStart),
+    );
+}
+
+export function findAdjacentPane(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+    direction: WorkspaceNeighborDirection,
+) {
+    const rects = collectPaneRects(tree);
+    const source = rects.find((rect) => rect.paneId === paneId);
+    if (!source) {
+        return null;
+    }
+
+    const candidates = rects
+        .filter((candidate) => candidate.paneId !== paneId)
+        .map((candidate) => {
+            switch (direction) {
+                case "left": {
+                    const distance = source.left - candidate.right;
+                    const overlap = getOverlap(
+                        source.top,
+                        source.bottom,
+                        candidate.top,
+                        candidate.bottom,
+                    );
+                    return { candidate, distance, overlap };
+                }
+                case "right": {
+                    const distance = candidate.left - source.right;
+                    const overlap = getOverlap(
+                        source.top,
+                        source.bottom,
+                        candidate.top,
+                        candidate.bottom,
+                    );
+                    return { candidate, distance, overlap };
+                }
+                case "up": {
+                    const distance = source.top - candidate.bottom;
+                    const overlap = getOverlap(
+                        source.left,
+                        source.right,
+                        candidate.left,
+                        candidate.right,
+                    );
+                    return { candidate, distance, overlap };
+                }
+                case "down": {
+                    const distance = candidate.top - source.bottom;
+                    const overlap = getOverlap(
+                        source.left,
+                        source.right,
+                        candidate.left,
+                        candidate.right,
+                    );
+                    return { candidate, distance, overlap };
+                }
+            }
+        })
+        .filter(
+            (entry) =>
+                entry.distance >= -RECT_EPSILON && entry.overlap > RECT_EPSILON,
+        )
+        .sort((left, right) => {
+            if (Math.abs(left.distance - right.distance) > RECT_EPSILON) {
+                return left.distance - right.distance;
+            }
+            if (Math.abs(left.overlap - right.overlap) > RECT_EPSILON) {
+                return right.overlap - left.overlap;
+            }
+
+            const leftCenter =
+                (left.candidate.left + left.candidate.right) / 2 +
+                (left.candidate.top + left.candidate.bottom) / 2;
+            const rightCenter =
+                (right.candidate.left + right.candidate.right) / 2 +
+                (right.candidate.top + right.candidate.bottom) / 2;
+            return leftCenter - rightCenter;
+        });
+
+    return candidates[0]?.candidate.paneId ?? null;
+}

--- a/apps/desktop/src/app/store/workspaceLayoutTree.test.ts
+++ b/apps/desktop/src/app/store/workspaceLayoutTree.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, it } from "vitest";
+import {
+    assertLayoutInvariants,
+    balanceSplit,
+    closePaneAndCollapse,
+    createInitialLayout,
+    DEFAULT_EDITOR_PANE_ID,
+    findPanePath,
+    getLayoutPaneIds,
+    getNextGeneratedPaneId,
+    MAX_EDITOR_PANES,
+    movePane,
+    normalizeLayoutTree,
+    resizeSplit,
+    splitPane,
+    type WorkspaceLayoutNode,
+} from "./workspaceLayoutTree";
+
+function makeThreePaneRow(): WorkspaceLayoutNode {
+    return {
+        type: "split",
+        id: "split-1",
+        direction: "row",
+        sizes: [0.5, 0.25, 0.25],
+        children: [
+            { type: "pane", id: "pane-a", paneId: "pane-a" },
+            { type: "pane", id: "pane-b", paneId: "pane-b" },
+            { type: "pane", id: "pane-c", paneId: "pane-c" },
+        ],
+    };
+}
+
+describe("workspaceLayoutTree", () => {
+    it("creates the initial layout as a single pane", () => {
+        const tree = createInitialLayout();
+
+        expect(tree).toEqual({
+            type: "pane",
+            id: DEFAULT_EDITOR_PANE_ID,
+            paneId: DEFAULT_EDITOR_PANE_ID,
+        });
+    });
+
+    it("generates pane ids dynamically while preserving legacy slots", () => {
+        expect(getNextGeneratedPaneId(["primary"])).toBe("pane-2");
+        expect(getNextGeneratedPaneId(["primary", "secondary"])).toBe("pane-3");
+        expect(
+            getNextGeneratedPaneId([
+                "primary",
+                "secondary",
+                "tertiary",
+                "pane-4",
+                "pane-5",
+            ]),
+        ).toBe("pane-6");
+        expect(
+            getNextGeneratedPaneId([
+                "primary",
+                "secondary",
+                "tertiary",
+                "pane-4",
+                "pane-5",
+                "pane-6",
+            ]),
+        ).toBeNull();
+        expect(MAX_EDITOR_PANES).toBe(6);
+    });
+
+    it("finds a pane path as child indexes from the root", () => {
+        const tree = {
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+                { type: "pane", id: "pane-a", paneId: "pane-a" },
+                {
+                    type: "split",
+                    id: "split-2",
+                    direction: "column",
+                    sizes: [0.5, 0.5],
+                    children: [
+                        { type: "pane", id: "pane-b", paneId: "pane-b" },
+                        { type: "pane", id: "pane-c", paneId: "pane-c" },
+                    ],
+                },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        expect(findPanePath(tree, "pane-a")).toEqual([0]);
+        expect(findPanePath(tree, "pane-c")).toEqual([1, 1]);
+        expect(findPanePath(tree, "missing")).toBeNull();
+    });
+
+    it("splits into the same direction without creating an extra nested split", () => {
+        const tree = {
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+                { type: "pane", id: "pane-a", paneId: "pane-a" },
+                { type: "pane", id: "pane-b", paneId: "pane-b" },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        const next = splitPane(tree, "pane-a", "row", "pane-c");
+
+        expect(next.type).toBe("split");
+        if (next.type !== "split") {
+            return;
+        }
+
+        expect(next.direction).toBe("row");
+        expect(getLayoutPaneIds(next)).toEqual(["pane-a", "pane-c", "pane-b"]);
+        expect(next.sizes).toEqual([0.25, 0.25, 0.5]);
+    });
+
+    it("splits into a perpendicular direction by nesting only the target pane", () => {
+        const tree = {
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+                { type: "pane", id: "pane-a", paneId: "pane-a" },
+                { type: "pane", id: "pane-b", paneId: "pane-b" },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        const next = splitPane(tree, "pane-a", "column", "pane-c");
+
+        expect(next.type).toBe("split");
+        if (next.type !== "split") {
+            return;
+        }
+
+        expect(next.direction).toBe("row");
+        expect(next.children[0]).toMatchObject({
+            type: "split",
+            direction: "column",
+        });
+        expect(getLayoutPaneIds(next)).toEqual(["pane-a", "pane-c", "pane-b"]);
+    });
+
+    it("collapses a parent split when closing a pane leaves a single child", () => {
+        const tree = {
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            sizes: [0.5, 0.5],
+            children: [
+                { type: "pane", id: "pane-a", paneId: "pane-a" },
+                {
+                    type: "split",
+                    id: "split-2",
+                    direction: "column",
+                    sizes: [0.5, 0.5],
+                    children: [
+                        { type: "pane", id: "pane-b", paneId: "pane-b" },
+                        { type: "pane", id: "pane-c", paneId: "pane-c" },
+                    ],
+                },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        const next = closePaneAndCollapse(tree, "pane-b");
+
+        expect(next.type).toBe("split");
+        if (next.type !== "split") {
+            return;
+        }
+        expect(getLayoutPaneIds(next)).toEqual(["pane-a", "pane-c"]);
+        expect(next.children[1]).toMatchObject({
+            type: "pane",
+            paneId: "pane-c",
+        });
+    });
+
+    it("moves panes around the tree and normalizes the result", () => {
+        const tree = makeThreePaneRow();
+
+        const next = movePane(tree, "pane-c", "pane-a", "down");
+
+        expect(next.type).toBe("split");
+        if (next.type !== "split") {
+            return;
+        }
+
+        expect(getLayoutPaneIds(next)).toEqual(["pane-a", "pane-c", "pane-b"]);
+        expect(next.children[0]).toMatchObject({
+            type: "split",
+            direction: "column",
+        });
+    });
+
+    it("resizes and balances splits with normalized proportions", () => {
+        const tree = makeThreePaneRow();
+
+        const resized = resizeSplit(tree, "split-1", [2, 1, 1]);
+        expect(resized).toMatchObject({
+            type: "split",
+            sizes: [0.5, 0.25, 0.25],
+        });
+
+        const balanced = balanceSplit(resized, "split-1");
+        expect(balanced).toMatchObject({
+            type: "split",
+            sizes: [1 / 3, 1 / 3, 1 / 3],
+        });
+    });
+
+    it("normalizes nested same-direction splits", () => {
+        const tree = {
+            type: "split",
+            id: "split-1",
+            direction: "row",
+            sizes: [0.4, 0.6],
+            children: [
+                {
+                    type: "split",
+                    id: "split-2",
+                    direction: "row",
+                    sizes: [0.25, 0.75],
+                    children: [
+                        { type: "pane", id: "pane-a", paneId: "pane-a" },
+                        { type: "pane", id: "pane-b", paneId: "pane-b" },
+                    ],
+                },
+                { type: "pane", id: "pane-c", paneId: "pane-c" },
+            ],
+        } satisfies WorkspaceLayoutNode;
+
+        const next = normalizeLayoutTree(tree);
+
+        expect(next).toMatchObject({
+            type: "split",
+            direction: "row",
+        });
+        if (next.type !== "split") {
+            return;
+        }
+
+        expect(getLayoutPaneIds(next)).toEqual(["pane-a", "pane-b", "pane-c"]);
+        expect(next.sizes[0]).toBeCloseTo(0.1);
+        expect(next.sizes[1]).toBeCloseTo(0.3);
+        expect(next.sizes[2]).toBeCloseTo(0.6);
+    });
+
+    it("detects invalid trees eagerly in dev mode", () => {
+        expect(() =>
+            assertLayoutInvariants({
+                type: "split",
+                id: "split-1",
+                direction: "row",
+                sizes: [1],
+                children: [{ type: "pane", id: "pane-a", paneId: "pane-a" }],
+            }),
+        ).toThrow(/at least two children/);
+
+        expect(() =>
+            assertLayoutInvariants({
+                type: "split",
+                id: "split-1",
+                direction: "row",
+                sizes: [0.5, 0.25],
+                children: [
+                    { type: "pane", id: "pane-a", paneId: "pane-a" },
+                    { type: "pane", id: "pane-b", paneId: "pane-b" },
+                ],
+            }),
+        ).toThrow(/sizes must sum to 1/);
+
+        expect(() =>
+            assertLayoutInvariants({
+                type: "split",
+                id: "split-1",
+                direction: "row",
+                sizes: [0.5, 0.5],
+                children: [
+                    { type: "pane", id: "pane-a", paneId: "pane-a" },
+                    { type: "pane", id: "pane-b", paneId: "pane-a" },
+                ],
+            }),
+        ).toThrow(/duplicate pane id/);
+    });
+});

--- a/apps/desktop/src/app/store/workspaceLayoutTree.ts
+++ b/apps/desktop/src/app/store/workspaceLayoutTree.ts
@@ -1,0 +1,593 @@
+export const MAX_EDITOR_PANES = 6;
+export const DEFAULT_EDITOR_PANE_ID = "primary";
+
+const LAYOUT_SIZE_EPSILON = 1e-6;
+
+export type WorkspaceSplitDirection = "row" | "column";
+export type WorkspaceMovePosition = "left" | "right" | "up" | "down";
+export type WorkspacePanePath = number[];
+
+export interface WorkspacePaneNode {
+    type: "pane";
+    id: string;
+    paneId: string;
+}
+
+export interface WorkspaceSplitNode {
+    type: "split";
+    id: string;
+    direction: WorkspaceSplitDirection;
+    children: WorkspaceLayoutNode[];
+    sizes: number[];
+}
+
+export type WorkspaceLayoutNode = WorkspacePaneNode | WorkspaceSplitNode;
+
+function isProdBuild() {
+    return import.meta.env?.PROD ?? false;
+}
+
+function createPaneNode(paneId: string): WorkspacePaneNode {
+    return {
+        type: "pane",
+        id: paneId,
+        paneId,
+    };
+}
+
+function normalizeSizes(count: number, sizes?: readonly number[]) {
+    const incoming = (sizes ?? []).filter(
+        (value) => Number.isFinite(value) && value > 0,
+    );
+
+    if (incoming.length !== count || count <= 0) {
+        return Array.from({ length: Math.max(0, count) }, () => 1 / count);
+    }
+
+    const total = incoming.reduce((sum, value) => sum + value, 0);
+    if (total <= 0) {
+        return Array.from({ length: count }, () => 1 / count);
+    }
+
+    return incoming.map((value) => value / total);
+}
+
+function getLegacyPaneSlot(paneId: string) {
+    switch (paneId) {
+        case "primary":
+            return 1;
+        case "secondary":
+            return 2;
+        case "tertiary":
+            return 3;
+        default:
+            return null;
+    }
+}
+
+function parseGeneratedPaneId(paneId: string) {
+    const match = /^pane-(\d+)$/.exec(paneId.trim());
+    if (!match) {
+        return null;
+    }
+    const numeric = Number.parseInt(match[1] ?? "", 10);
+    return Number.isFinite(numeric) && numeric > 0 ? numeric : null;
+}
+
+function collectNodeIds(tree: WorkspaceLayoutNode, ids = new Set<string>()) {
+    ids.add(tree.id);
+    if (tree.type === "split") {
+        tree.children.forEach((child) => collectNodeIds(child, ids));
+    }
+    return ids;
+}
+
+function collectPaneIds(
+    tree: WorkspaceLayoutNode,
+    paneIds: string[] = [],
+): string[] {
+    if (tree.type === "pane") {
+        paneIds.push(tree.paneId);
+        return paneIds;
+    }
+
+    tree.children.forEach((child) => collectPaneIds(child, paneIds));
+    return paneIds;
+}
+
+function generateNextSplitId(tree: WorkspaceLayoutNode) {
+    const taken = collectNodeIds(tree);
+    let next = 1;
+    while (taken.has(`split-${next}`)) {
+        next += 1;
+    }
+    return `split-${next}`;
+}
+
+function mapLayoutNodeAtPath(
+    tree: WorkspaceLayoutNode,
+    path: WorkspacePanePath,
+    updater: (node: WorkspaceLayoutNode) => WorkspaceLayoutNode,
+): WorkspaceLayoutNode {
+    if (path.length === 0) {
+        return updater(tree);
+    }
+
+    if (tree.type !== "split") {
+        return tree;
+    }
+
+    const [childIndex, ...rest] = path;
+    return {
+        ...tree,
+        children: tree.children.map((child, index) =>
+            index === childIndex
+                ? mapLayoutNodeAtPath(child, rest, updater)
+                : child,
+        ),
+    };
+}
+
+function removePaneNode(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+): { nextTree: WorkspaceLayoutNode | null; removed: boolean } {
+    if (tree.type === "pane") {
+        return tree.paneId === paneId
+            ? { nextTree: null, removed: true }
+            : { nextTree: tree, removed: false };
+    }
+
+    let removed = false;
+    const nextChildren: WorkspaceLayoutNode[] = [];
+    const nextSizes: number[] = [];
+
+    tree.children.forEach((child, index) => {
+        const result = removePaneNode(child, paneId);
+        removed ||= result.removed;
+        if (result.nextTree) {
+            nextChildren.push(result.nextTree);
+            nextSizes.push(tree.sizes[index] ?? 0);
+        }
+    });
+
+    if (!removed) {
+        return { nextTree: tree, removed: false };
+    }
+
+    if (nextChildren.length === 0) {
+        return { nextTree: null, removed: true };
+    }
+
+    if (nextChildren.length === 1) {
+        return { nextTree: nextChildren[0] ?? null, removed: true };
+    }
+
+    return {
+        nextTree: {
+            ...tree,
+            children: nextChildren,
+            sizes: normalizeSizes(nextChildren.length, nextSizes),
+        },
+        removed: true,
+    };
+}
+
+function insertPaneRelative(
+    tree: WorkspaceLayoutNode,
+    targetPaneId: string,
+    position: WorkspaceMovePosition,
+    paneToInsert: WorkspacePaneNode,
+): WorkspaceLayoutNode {
+    const path = findPanePath(tree, targetPaneId);
+    if (!path) {
+        return tree;
+    }
+
+    const direction =
+        position === "left" || position === "right" ? "row" : "column";
+    const insertBefore = position === "left" || position === "up";
+
+    if (path.length === 0) {
+        return {
+            type: "split",
+            id: generateNextSplitId(tree),
+            direction,
+            children: insertBefore
+                ? [paneToInsert, tree]
+                : [tree, paneToInsert],
+            sizes: [0.5, 0.5],
+        };
+    }
+
+    const parentPath = path.slice(0, -1);
+    const targetChildIndex = path[path.length - 1] ?? 0;
+    const parentNode = getNodeAtPath(tree, parentPath);
+    if (!parentNode || parentNode.type !== "split") {
+        return tree;
+    }
+
+    if (parentNode.direction === direction) {
+        const anchorSize = parentNode.sizes[targetChildIndex] ?? 0;
+        const insertionIndex = insertBefore
+            ? targetChildIndex
+            : targetChildIndex + 1;
+        return mapLayoutNodeAtPath(tree, parentPath, (node) => {
+            if (node.type !== "split") {
+                return node;
+            }
+
+            const nextChildren = [...node.children];
+            nextChildren.splice(insertionIndex, 0, paneToInsert);
+
+            const nextSizes = [...node.sizes];
+            const targetSize =
+                anchorSize > 0 ? anchorSize : 1 / nextChildren.length;
+            nextSizes[targetChildIndex] = targetSize / 2;
+            nextSizes.splice(insertionIndex, 0, targetSize / 2);
+
+            return {
+                ...node,
+                children: nextChildren,
+                sizes: normalizeSizes(nextChildren.length, nextSizes),
+            };
+        });
+    }
+
+    return mapLayoutNodeAtPath(tree, parentPath, (node) => {
+        if (node.type !== "split") {
+            return node;
+        }
+
+        const targetNode = node.children[targetChildIndex];
+        if (!targetNode) {
+            return node;
+        }
+
+        const replacement: WorkspaceSplitNode = {
+            type: "split",
+            id: generateNextSplitId(tree),
+            direction,
+            children: insertBefore
+                ? [paneToInsert, targetNode]
+                : [targetNode, paneToInsert],
+            sizes: [0.5, 0.5],
+        };
+
+        const nextChildren = [...node.children];
+        nextChildren[targetChildIndex] = replacement;
+        return {
+            ...node,
+            children: nextChildren,
+        };
+    });
+}
+
+function getNodeAtPath(
+    tree: WorkspaceLayoutNode,
+    path: WorkspacePanePath,
+): WorkspaceLayoutNode | null {
+    let current: WorkspaceLayoutNode | null = tree;
+    for (const childIndex of path) {
+        if (!current || current.type !== "split") {
+            return null;
+        }
+        current = current.children[childIndex] ?? null;
+    }
+    return current;
+}
+
+function normalizeLayoutNode(tree: WorkspaceLayoutNode): WorkspaceLayoutNode {
+    if (tree.type === "pane") {
+        return tree;
+    }
+
+    const normalizedChildren = tree.children.map((child) =>
+        normalizeLayoutNode(child),
+    );
+    const normalizedSizes = normalizeSizes(
+        normalizedChildren.length,
+        tree.sizes,
+    );
+
+    const flattenedChildren: WorkspaceLayoutNode[] = [];
+    const flattenedSizes: number[] = [];
+
+    normalizedChildren.forEach((child, index) => {
+        const childSize = normalizedSizes[index] ?? 0;
+        if (child.type === "split" && child.direction === tree.direction) {
+            child.children.forEach((grandChild, grandIndex) => {
+                flattenedChildren.push(grandChild);
+                flattenedSizes.push(childSize * (child.sizes[grandIndex] ?? 0));
+            });
+            return;
+        }
+
+        flattenedChildren.push(child);
+        flattenedSizes.push(childSize);
+    });
+
+    if (flattenedChildren.length === 1) {
+        return flattenedChildren[0]!;
+    }
+
+    return {
+        ...tree,
+        children: flattenedChildren,
+        sizes: normalizeSizes(flattenedChildren.length, flattenedSizes),
+    };
+}
+
+export function createInitialLayout(
+    paneId = DEFAULT_EDITOR_PANE_ID,
+): WorkspaceLayoutNode {
+    const tree = createPaneNode(paneId);
+    assertLayoutInvariants(tree);
+    return tree;
+}
+
+export function getNextGeneratedPaneId(
+    existingPaneIds: readonly string[],
+    options?: { maxPaneCount?: number },
+) {
+    const maxPaneCount = options?.maxPaneCount ?? MAX_EDITOR_PANES;
+    if (existingPaneIds.length >= maxPaneCount) {
+        return null;
+    }
+
+    const occupiedSlots = new Set<number>();
+    existingPaneIds.forEach((paneId) => {
+        const generatedSlot = parseGeneratedPaneId(paneId);
+        if (generatedSlot !== null) {
+            occupiedSlots.add(generatedSlot);
+            return;
+        }
+
+        const legacySlot = getLegacyPaneSlot(paneId);
+        if (legacySlot !== null) {
+            occupiedSlots.add(legacySlot);
+        }
+    });
+
+    for (let candidate = 1; candidate <= maxPaneCount; candidate += 1) {
+        if (occupiedSlots.has(candidate)) {
+            continue;
+        }
+        return `pane-${candidate}`;
+    }
+
+    return null;
+}
+
+export function findPanePath(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+): WorkspacePanePath | null {
+    if (tree.type === "pane") {
+        return tree.paneId === paneId ? [] : null;
+    }
+
+    for (let index = 0; index < tree.children.length; index += 1) {
+        const child = tree.children[index];
+        if (!child) {
+            continue;
+        }
+        const childPath = findPanePath(child, paneId);
+        if (childPath) {
+            return [index, ...childPath];
+        }
+    }
+
+    return null;
+}
+
+export function normalizeLayoutTree(tree: WorkspaceLayoutNode) {
+    const normalized = normalizeLayoutNode(tree);
+    assertLayoutInvariants(normalized);
+    return normalized;
+}
+
+export function splitPane(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+    direction: WorkspaceSplitDirection,
+    newPaneId: string,
+) {
+    const nextTree = insertPaneRelative(
+        tree,
+        paneId,
+        direction === "row" ? "right" : "down",
+        createPaneNode(newPaneId),
+    );
+    const normalized = normalizeLayoutTree(nextTree);
+    assertLayoutInvariants(normalized);
+    return normalized;
+}
+
+export function closePaneAndCollapse(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+) {
+    const result = removePaneNode(tree, paneId);
+    const nextTree = result.nextTree;
+    if (!result.removed || !nextTree) {
+        assertLayoutInvariants(tree);
+        return tree;
+    }
+
+    const normalized = normalizeLayoutTree(nextTree);
+    assertLayoutInvariants(normalized);
+    return normalized;
+}
+
+export function movePane(
+    tree: WorkspaceLayoutNode,
+    paneId: string,
+    targetPaneId: string,
+    position: WorkspaceMovePosition,
+) {
+    if (paneId === targetPaneId) {
+        assertLayoutInvariants(tree);
+        return tree;
+    }
+    if (!findPanePath(tree, paneId) || !findPanePath(tree, targetPaneId)) {
+        assertLayoutInvariants(tree);
+        return tree;
+    }
+
+    const removal = removePaneNode(tree, paneId);
+    if (!removal.removed || !removal.nextTree) {
+        assertLayoutInvariants(tree);
+        return tree;
+    }
+
+    const inserted = insertPaneRelative(
+        removal.nextTree,
+        targetPaneId,
+        position,
+        createPaneNode(paneId),
+    );
+    const normalized = normalizeLayoutTree(inserted);
+    assertLayoutInvariants(normalized);
+    return normalized;
+}
+
+export function resizeSplit(
+    tree: WorkspaceLayoutNode,
+    splitId: string,
+    sizes: readonly number[],
+) {
+    const splitPath = findNodePath(tree, splitId);
+    if (!splitPath) {
+        assertLayoutInvariants(tree);
+        return tree;
+    }
+
+    const nextTree = mapLayoutNodeAtPath(tree, splitPath, (node) =>
+        node.type === "split"
+            ? {
+                  ...node,
+                  sizes: normalizeSizes(node.children.length, sizes),
+              }
+            : node,
+    );
+    const normalized = normalizeLayoutTree(nextTree);
+    assertLayoutInvariants(normalized);
+    return normalized;
+}
+
+export function balanceSplit(tree: WorkspaceLayoutNode, splitId?: string) {
+    const rebalance = (node: WorkspaceLayoutNode): WorkspaceLayoutNode => {
+        if (node.type === "pane") {
+            return node;
+        }
+
+        const children = node.children.map((child) => rebalance(child));
+        if (splitId && node.id !== splitId) {
+            return {
+                ...node,
+                children,
+            };
+        }
+
+        return {
+            ...node,
+            children,
+            sizes: normalizeSizes(children.length),
+        };
+    };
+
+    const balanced = normalizeLayoutTree(rebalance(tree));
+    assertLayoutInvariants(balanced);
+    return balanced;
+}
+
+function findNodePath(
+    tree: WorkspaceLayoutNode,
+    nodeId: string,
+): WorkspacePanePath | null {
+    if (tree.id === nodeId) {
+        return [];
+    }
+
+    if (tree.type === "pane") {
+        return null;
+    }
+
+    for (let index = 0; index < tree.children.length; index += 1) {
+        const child = tree.children[index];
+        if (!child) {
+            continue;
+        }
+        const childPath = findNodePath(child, nodeId);
+        if (childPath) {
+            return [index, ...childPath];
+        }
+    }
+
+    return null;
+}
+
+export function assertLayoutInvariants(tree: WorkspaceLayoutNode): void {
+    if (isProdBuild()) {
+        return;
+    }
+
+    const seenNodeIds = new Set<string>();
+    const seenPaneIds = new Set<string>();
+
+    const visit = (node: WorkspaceLayoutNode) => {
+        if (seenNodeIds.has(node.id)) {
+            throw new Error(
+                `Layout invariant violated: duplicate node id "${node.id}"`,
+            );
+        }
+        seenNodeIds.add(node.id);
+
+        if (node.type === "pane") {
+            if (node.paneId.trim().length === 0) {
+                throw new Error(
+                    'Layout invariant violated: pane nodes require a non-empty "paneId"',
+                );
+            }
+            if (seenPaneIds.has(node.paneId)) {
+                throw new Error(
+                    `Layout invariant violated: duplicate pane id "${node.paneId}"`,
+                );
+            }
+            seenPaneIds.add(node.paneId);
+            return;
+        }
+
+        if (node.children.length < 2) {
+            throw new Error(
+                `Layout invariant violated: split "${node.id}" must have at least two children`,
+            );
+        }
+        if (node.sizes.length !== node.children.length) {
+            throw new Error(
+                `Layout invariant violated: split "${node.id}" must keep one size per child`,
+            );
+        }
+
+        const total = node.sizes.reduce((sum, value) => sum + value, 0);
+        if (!node.sizes.every((value) => Number.isFinite(value) && value > 0)) {
+            throw new Error(
+                `Layout invariant violated: split "${node.id}" contains invalid sizes`,
+            );
+        }
+        if (Math.abs(total - 1) > LAYOUT_SIZE_EPSILON) {
+            throw new Error(
+                `Layout invariant violated: split "${node.id}" sizes must sum to 1`,
+            );
+        }
+
+        node.children.forEach((child) => visit(child));
+    };
+
+    visit(tree);
+}
+
+export function getLayoutPaneIds(tree: WorkspaceLayoutNode) {
+    return collectPaneIds(tree, []);
+}

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -367,13 +367,22 @@ async function buildVaultEntryTab(
 export async function insertVaultEntryTab(
     entry: VaultEntryDto,
     index?: number,
+    options?: { paneId?: string; newPane?: boolean },
 ) {
     const nextTab = await buildVaultEntryTab(entry);
     if (!nextTab) {
         return false;
     }
 
-    useEditorStore.getState().insertExternalTab(nextTab, index);
+    const store = useEditorStore.getState();
+    if (options?.newPane) {
+        return store.insertExternalTabInNewPane(nextTab) !== null;
+    }
+    if (options?.paneId) {
+        store.insertExternalTabInPane(nextTab, options.paneId, index);
+        return true;
+    }
+    store.insertExternalTab(nextTab, index);
     return true;
 }
 
@@ -385,17 +394,32 @@ export function isExcalidrawVaultEntry(
 
 export async function openVaultFileEntry(
     entry: VaultEntryDto,
-    options?: { newTab?: boolean },
+    options?: { newTab?: boolean; paneId?: string; newPane?: boolean },
 ) {
+    const store = useEditorStore.getState();
+
     if (isExcalidrawVaultEntry(entry)) {
-        useEditorStore
-            .getState()
-            .openMap(entry.relative_path, entry.title || entry.file_name);
+        if (options?.newPane) {
+            store.insertExternalTabInNewPane({
+                id: crypto.randomUUID(),
+                kind: "map",
+                relativePath: entry.relative_path,
+                title: entry.title || entry.file_name,
+            });
+            return;
+        }
+        if (options?.paneId) {
+            store.focusPane(options.paneId);
+        }
+        store.openMap(entry.relative_path, entry.title || entry.file_name);
         return;
     }
 
-    if (options?.newTab) {
-        const inserted = await insertVaultEntryTab(entry);
+    if (options?.newTab || options?.newPane || options?.paneId) {
+        const inserted = await insertVaultEntryTab(entry, undefined, {
+            paneId: options?.paneId,
+            newPane: options?.newPane,
+        });
         if (!inserted) {
             try {
                 await openPath(entry.path);
@@ -407,20 +431,21 @@ export async function openVaultFileEntry(
     }
 
     if (getVaultEntryViewerKind(entry) === "image") {
-        useEditorStore
-            .getState()
-            .openFile(
-                entry.relative_path,
-                entry.file_name,
-                entry.path,
-                "",
-                entry.mime_type,
-                "image",
-                {
-                    sizeBytes: entry.size,
-                    contentTruncated: false,
-                },
-            );
+        if (options?.paneId) {
+            store.focusPane(options.paneId);
+        }
+        store.openFile(
+            entry.relative_path,
+            entry.file_name,
+            entry.path,
+            "",
+            entry.mime_type,
+            "image",
+            {
+                sizeBytes: entry.size,
+                contentTruncated: false,
+            },
+        );
         return;
     }
 

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -7,6 +7,7 @@ import {
     type TabInput,
 } from "../store/editorStore";
 import { inferFileViewer } from "../store/editorTabs";
+import type { WorkspaceSplitDirection } from "../store/workspaceLayoutTree";
 import { useVaultStore, type VaultEntryDto } from "../store/vaultStore";
 import { toVaultRelativePath } from "./vaultPaths";
 import { vaultInvoke } from "./vaultInvoke";
@@ -367,7 +368,11 @@ async function buildVaultEntryTab(
 export async function insertVaultEntryTab(
     entry: VaultEntryDto,
     index?: number,
-    options?: { paneId?: string; newPane?: boolean },
+    options?: {
+        paneId?: string;
+        newPane?: boolean;
+        splitDirection?: WorkspaceSplitDirection;
+    },
 ) {
     const nextTab = await buildVaultEntryTab(entry);
     if (!nextTab) {
@@ -375,8 +380,17 @@ export async function insertVaultEntryTab(
     }
 
     const store = useEditorStore.getState();
+    if (options?.splitDirection) {
+        return (
+            store.insertExternalTabInNewSplit(
+                nextTab,
+                options.splitDirection,
+                options.paneId,
+            ) !== null
+        );
+    }
     if (options?.newPane) {
-        return store.insertExternalTabInNewPane(nextTab) !== null;
+        return store.insertExternalTabInNewSplit(nextTab, "row") !== null;
     }
     if (options?.paneId) {
         store.insertExternalTabInPane(nextTab, options.paneId, index);
@@ -394,18 +408,39 @@ export function isExcalidrawVaultEntry(
 
 export async function openVaultFileEntry(
     entry: VaultEntryDto,
-    options?: { newTab?: boolean; paneId?: string; newPane?: boolean },
+    options?: {
+        newTab?: boolean;
+        paneId?: string;
+        newPane?: boolean;
+        splitDirection?: WorkspaceSplitDirection;
+    },
 ) {
     const store = useEditorStore.getState();
 
     if (isExcalidrawVaultEntry(entry)) {
+        if (options?.splitDirection) {
+            store.insertExternalTabInNewSplit(
+                {
+                    id: crypto.randomUUID(),
+                    kind: "map",
+                    relativePath: entry.relative_path,
+                    title: entry.title || entry.file_name,
+                },
+                options.splitDirection,
+                options.paneId,
+            );
+            return;
+        }
         if (options?.newPane) {
-            store.insertExternalTabInNewPane({
-                id: crypto.randomUUID(),
-                kind: "map",
-                relativePath: entry.relative_path,
-                title: entry.title || entry.file_name,
-            });
+            store.insertExternalTabInNewSplit(
+                {
+                    id: crypto.randomUUID(),
+                    kind: "map",
+                    relativePath: entry.relative_path,
+                    title: entry.title || entry.file_name,
+                },
+                "row",
+            );
             return;
         }
         if (options?.paneId) {
@@ -415,10 +450,16 @@ export async function openVaultFileEntry(
         return;
     }
 
-    if (options?.newTab || options?.newPane || options?.paneId) {
+    if (
+        options?.newTab ||
+        options?.newPane ||
+        options?.paneId ||
+        options?.splitDirection
+    ) {
         const inserted = await insertVaultEntryTab(entry, undefined, {
             paneId: options?.paneId,
             newPane: options?.newPane,
+            splitDirection: options?.splitDirection,
         });
         if (!inserted) {
             try {

--- a/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
@@ -161,4 +161,41 @@ describe("ContextMenu scroll-to-close behaviour", () => {
         });
         expect(callOrder).toEqual(["close", "action"]);
     });
+
+    it("resets open submenu state when the menu identity changes", () => {
+        const { rerender } = render(
+            <ContextMenu
+                menu={{ x: 100, y: 100, payload: undefined }}
+                entries={[
+                    {
+                        label: "New Agent",
+                        children: [{ label: "Claude", action: vi.fn() }],
+                    },
+                ]}
+                onClose={vi.fn()}
+            />,
+        );
+
+        fireEvent.mouseEnter(screen.getByRole("button", { name: "New Agent" }));
+        expect(
+            screen.getByRole("button", { name: "Claude" }),
+        ).toBeInTheDocument();
+
+        rerender(
+            <ContextMenu
+                menu={{ x: 120, y: 100, payload: undefined }}
+                entries={[
+                    {
+                        label: "New Agent",
+                        children: [{ label: "Claude", action: vi.fn() }],
+                    },
+                ]}
+                onClose={vi.fn()}
+            />,
+        );
+
+        expect(
+            screen.queryByRole("button", { name: "Claude" }),
+        ).not.toBeInTheDocument();
+    });
 });

--- a/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ContextMenu, type ContextMenuEntry } from "./ContextMenu";
 
@@ -102,5 +102,63 @@ describe("ContextMenu scroll-to-close behaviour", () => {
         renderMenu(onClose);
         fireEvent.mouseDown(document.body);
         expect(onClose).toHaveBeenCalled();
+    });
+
+    it("closes before running a leaf action", async () => {
+        const callOrder: string[] = [];
+        const onClose = vi.fn(() => {
+            callOrder.push("close");
+        });
+        const action = vi.fn(() => {
+            callOrder.push("action");
+        });
+
+        render(
+            <ContextMenu
+                menu={{ x: 100, y: 100, payload: undefined }}
+                entries={[{ label: "New Agent", action }]}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "New Agent" }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+        expect(callOrder).toEqual(["close", "action"]);
+    });
+
+    it("closes before running a submenu action", async () => {
+        const callOrder: string[] = [];
+        const onClose = vi.fn(() => {
+            callOrder.push("close");
+        });
+        const action = vi.fn(() => {
+            callOrder.push("action");
+        });
+
+        render(
+            <ContextMenu
+                menu={{ x: 100, y: 100, payload: undefined }}
+                entries={[
+                    {
+                        label: "New Agent",
+                        children: [{ label: "Claude", action }],
+                    },
+                ]}
+                onClose={onClose}
+            />,
+        );
+
+        fireEvent.mouseEnter(screen.getByRole("button", { name: "New Agent" }));
+        fireEvent.click(screen.getByRole("button", { name: "Claude" }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        await waitFor(() => {
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+        expect(callOrder).toEqual(["close", "action"]);
     });
 });

--- a/apps/desktop/src/components/context-menu/ContextMenu.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.tsx
@@ -44,6 +44,23 @@ export function ContextMenu<T>({
     const [submenuDirectionByLabel, setSubmenuDirectionByLabel] = useState<
         Record<string, "left" | "right">
     >({});
+    const closeAndRunAction = (action?: () => void) => {
+        onClose();
+        if (!action) return;
+        // Provider changes can reorder menu entries; close first so the menu
+        // is not rerendered while a submenu click is still in flight.
+        queueMicrotask(action);
+    };
+    const entriesResetKey = entries
+        .map((entry) => {
+            if (entry.type === "separator") {
+                return "separator";
+            }
+            return `${entry.label}:${entry.disabled ? "1" : "0"}:${
+                entry.children?.length ?? 0
+            }`;
+        })
+        .join("|");
 
     useLayoutEffect(() => {
         const element = ref.current;
@@ -61,8 +78,10 @@ export function ContextMenu<T>({
 
     useEffect(() => {
         setOpenSubmenuLabel(null);
-        setSubmenuDirectionByLabel({});
-    }, [menu.x, menu.y, entries]);
+        setSubmenuDirectionByLabel((current) =>
+            Object.keys(current).length > 0 ? {} : current,
+        );
+    }, [menu.x, menu.y, entriesResetKey]);
 
     useEffect(() => {
         const handleDown = (event: MouseEvent) => {
@@ -188,8 +207,7 @@ export function ContextMenu<T>({
                                     );
                                     return;
                                 }
-                                entry.action?.();
-                                onClose();
+                                closeAndRunAction(entry.action);
                             }}
                             className="text-left px-3 py-1.5 text-xs rounded"
                             style={{
@@ -277,8 +295,7 @@ export function ContextMenu<T>({
                                             disabled={child.disabled}
                                             onClick={() => {
                                                 if (child.disabled) return;
-                                                child.action?.();
-                                                onClose();
+                                                closeAndRunAction(child.action);
                                             }}
                                             className="text-left px-3 py-1.5 text-xs rounded"
                                             style={{

--- a/apps/desktop/src/components/context-menu/ContextMenu.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.tsx
@@ -21,6 +21,8 @@ export interface ContextMenuState<T = void> {
     payload: T;
 }
 
+const EMPTY_SUBMENU_DIRECTIONS: Readonly<Record<string, "left" | "right">> = {};
+
 export function ContextMenu<T>({
     menu,
     entries,
@@ -38,12 +40,6 @@ export function ContextMenu<T>({
 }) {
     const ref = useRef<HTMLDivElement>(null);
     const [position, setPosition] = useState({ x: menu.x, y: menu.y });
-    const [openSubmenuLabel, setOpenSubmenuLabel] = useState<string | null>(
-        null,
-    );
-    const [submenuDirectionByLabel, setSubmenuDirectionByLabel] = useState<
-        Record<string, "left" | "right">
-    >({});
     const closeAndRunAction = (action?: () => void) => {
         onClose();
         if (!action) return;
@@ -61,6 +57,42 @@ export function ContextMenu<T>({
             }`;
         })
         .join("|");
+    const submenuStateResetKey = `${menu.x}:${menu.y}:${entriesResetKey}`;
+    const [submenuState, setSubmenuState] = useState<{
+        resetKey: string;
+        openSubmenuLabel: string | null;
+        submenuDirectionByLabel: Record<string, "left" | "right">;
+    }>({
+        resetKey: submenuStateResetKey,
+        openSubmenuLabel: null,
+        submenuDirectionByLabel: {},
+    });
+    const currentSubmenuState =
+        submenuState.resetKey === submenuStateResetKey
+            ? submenuState
+            : {
+                  resetKey: submenuStateResetKey,
+                  openSubmenuLabel: null,
+                  submenuDirectionByLabel: EMPTY_SUBMENU_DIRECTIONS,
+              };
+    const updateSubmenuState = (
+        updater: (
+            current: typeof currentSubmenuState,
+        ) => typeof currentSubmenuState,
+    ) => {
+        setSubmenuState((current) => {
+            const base =
+                current.resetKey === submenuStateResetKey
+                    ? current
+                    : {
+                          resetKey: submenuStateResetKey,
+                          openSubmenuLabel: null,
+                          submenuDirectionByLabel: {},
+                      };
+            return updater(base);
+        });
+    };
+    const { openSubmenuLabel, submenuDirectionByLabel } = currentSubmenuState;
 
     useLayoutEffect(() => {
         const element = ref.current;
@@ -75,13 +107,6 @@ export function ContextMenu<T>({
             ),
         );
     }, [menu.x, menu.y, entries.length]);
-
-    useEffect(() => {
-        setOpenSubmenuLabel(null);
-        setSubmenuDirectionByLabel((current) =>
-            Object.keys(current).length > 0 ? {} : current,
-        );
-    }, [menu.x, menu.y, entriesResetKey]);
 
     useEffect(() => {
         const handleDown = (event: MouseEvent) => {
@@ -170,27 +195,42 @@ export function ContextMenu<T>({
                         style={{ position: "relative" }}
                         onMouseEnter={(event) => {
                             if (!hasChildren || entry.disabled) {
-                                setOpenSubmenuLabel(null);
+                                updateSubmenuState((current) =>
+                                    current.openSubmenuLabel === null
+                                        ? current
+                                        : {
+                                              ...current,
+                                              openSubmenuLabel: null,
+                                          },
+                                );
                                 return;
                             }
                             const rect = (
                                 event.currentTarget as HTMLDivElement
                             ).getBoundingClientRect();
                             const submenuWidth = minWidth;
-                            setSubmenuDirectionByLabel((current) => ({
+                            updateSubmenuState((current) => ({
                                 ...current,
-                                [entry.label]:
-                                    rect.right + submenuWidth + 8 >
-                                    window.innerWidth
-                                        ? "left"
-                                        : "right",
+                                openSubmenuLabel: entry.label,
+                                submenuDirectionByLabel: {
+                                    ...current.submenuDirectionByLabel,
+                                    [entry.label]:
+                                        rect.right + submenuWidth + 8 >
+                                        window.innerWidth
+                                            ? "left"
+                                            : "right",
+                                },
                             }));
-                            setOpenSubmenuLabel(entry.label);
                         }}
                         onMouseLeave={() => {
                             if (!hasChildren) return;
-                            setOpenSubmenuLabel((current) =>
-                                current === entry.label ? null : current,
+                            updateSubmenuState((current) =>
+                                current.openSubmenuLabel === entry.label
+                                    ? {
+                                          ...current,
+                                          openSubmenuLabel: null,
+                                      }
+                                    : current,
                             );
                         }}
                     >
@@ -200,11 +240,14 @@ export function ContextMenu<T>({
                             onClick={() => {
                                 if (entry.disabled) return;
                                 if (hasChildren) {
-                                    setOpenSubmenuLabel((current) =>
-                                        current === entry.label
-                                            ? null
-                                            : entry.label,
-                                    );
+                                    updateSubmenuState((current) => ({
+                                        ...current,
+                                        openSubmenuLabel:
+                                            current.openSubmenuLabel ===
+                                            entry.label
+                                                ? null
+                                                : entry.label,
+                                    }));
                                     return;
                                 }
                                 closeAndRunAction(entry.action);

--- a/apps/desktop/src/components/context-menu/ContextMenu.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.tsx
@@ -6,9 +6,10 @@ export type ContextMenuEntry =
     | {
           type?: "item";
           label: string;
-          action: () => void;
+          action?: () => void;
           danger?: boolean;
           disabled?: boolean;
+          children?: ContextMenuEntry[];
       }
     | {
           type: "separator";
@@ -37,6 +38,12 @@ export function ContextMenu<T>({
 }) {
     const ref = useRef<HTMLDivElement>(null);
     const [position, setPosition] = useState({ x: menu.x, y: menu.y });
+    const [openSubmenuLabel, setOpenSubmenuLabel] = useState<string | null>(
+        null,
+    );
+    const [submenuDirectionByLabel, setSubmenuDirectionByLabel] = useState<
+        Record<string, "left" | "right">
+    >({});
 
     useLayoutEffect(() => {
         const element = ref.current;
@@ -51,6 +58,11 @@ export function ContextMenu<T>({
             ),
         );
     }, [menu.x, menu.y, entries.length]);
+
+    useEffect(() => {
+        setOpenSubmenuLabel(null);
+        setSubmenuDirectionByLabel({});
+    }, [menu.x, menu.y, entries]);
 
     useEffect(() => {
         const handleDown = (event: MouseEvent) => {
@@ -128,41 +140,180 @@ export function ContextMenu<T>({
                     );
                 }
 
+                const hasChildren =
+                    Array.isArray(entry.children) && entry.children.length > 0;
+                const submenuDirection =
+                    submenuDirectionByLabel[entry.label] ?? "right";
+
                 return (
-                    <button
+                    <div
                         key={`${entry.label}-${index}`}
-                        type="button"
-                        disabled={entry.disabled}
-                        onClick={() => {
-                            if (entry.disabled) return;
-                            entry.action();
-                            onClose();
-                        }}
-                        className="text-left px-3 py-1.5 text-xs rounded"
-                        style={{
-                            display: "block",
-                            color: entry.danger
-                                ? "#ef4444"
-                                : "var(--text-primary)",
-                            background: "transparent",
-                            opacity: entry.disabled ? 0.45 : 1,
-                            cursor: entry.disabled ? "default" : "pointer",
-                            whiteSpace: "nowrap",
-                        }}
+                        style={{ position: "relative" }}
                         onMouseEnter={(event) => {
-                            if (entry.disabled) return;
-                            event.currentTarget.style.backgroundColor =
-                                entry.danger
-                                    ? "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))"
-                                    : "var(--bg-tertiary)";
+                            if (!hasChildren || entry.disabled) {
+                                setOpenSubmenuLabel(null);
+                                return;
+                            }
+                            const rect = (
+                                event.currentTarget as HTMLDivElement
+                            ).getBoundingClientRect();
+                            const submenuWidth = minWidth;
+                            setSubmenuDirectionByLabel((current) => ({
+                                ...current,
+                                [entry.label]:
+                                    rect.right + submenuWidth + 8 >
+                                    window.innerWidth
+                                        ? "left"
+                                        : "right",
+                            }));
+                            setOpenSubmenuLabel(entry.label);
                         }}
-                        onMouseLeave={(event) => {
-                            event.currentTarget.style.backgroundColor =
-                                "transparent";
+                        onMouseLeave={() => {
+                            if (!hasChildren) return;
+                            setOpenSubmenuLabel((current) =>
+                                current === entry.label ? null : current,
+                            );
                         }}
                     >
-                        {entry.label}
-                    </button>
+                        <button
+                            type="button"
+                            disabled={entry.disabled}
+                            onClick={() => {
+                                if (entry.disabled) return;
+                                if (hasChildren) {
+                                    setOpenSubmenuLabel((current) =>
+                                        current === entry.label
+                                            ? null
+                                            : entry.label,
+                                    );
+                                    return;
+                                }
+                                entry.action?.();
+                                onClose();
+                            }}
+                            className="text-left px-3 py-1.5 text-xs rounded"
+                            style={{
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                gap: 12,
+                                width: "100%",
+                                color: entry.danger
+                                    ? "#ef4444"
+                                    : "var(--text-primary)",
+                                background: "transparent",
+                                opacity: entry.disabled ? 0.45 : 1,
+                                cursor: entry.disabled ? "default" : "pointer",
+                                whiteSpace: "nowrap",
+                            }}
+                            onMouseEnter={(event) => {
+                                if (entry.disabled) return;
+                                event.currentTarget.style.backgroundColor =
+                                    entry.danger
+                                        ? "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))"
+                                        : "var(--bg-tertiary)";
+                            }}
+                            onMouseLeave={(event) => {
+                                event.currentTarget.style.backgroundColor =
+                                    "transparent";
+                            }}
+                        >
+                            <span>{entry.label}</span>
+                            {hasChildren ? (
+                                <span
+                                    aria-hidden="true"
+                                    style={{
+                                        fontSize: 10,
+                                        opacity: 0.7,
+                                        transform:
+                                            submenuDirection === "left"
+                                                ? "rotate(180deg)"
+                                                : "none",
+                                    }}
+                                >
+                                    ›
+                                </span>
+                            ) : null}
+                        </button>
+                        {hasChildren && openSubmenuLabel === entry.label ? (
+                            <div
+                                style={{
+                                    position: "absolute",
+                                    top: -4,
+                                    [submenuDirection === "right"
+                                        ? "left"
+                                        : "right"]: "calc(100% + 4px)",
+                                    zIndex: zIndex + 1,
+                                    display: "inline-flex",
+                                    flexDirection: "column",
+                                    alignItems: "stretch",
+                                    width: "fit-content",
+                                    minWidth,
+                                    padding: 4,
+                                    borderRadius: 8,
+                                    backgroundColor: "var(--bg-secondary)",
+                                    border: "1px solid var(--border)",
+                                    boxShadow: "0 4px 16px rgba(0,0,0,0.25)",
+                                }}
+                            >
+                                {entry.children!.map((child, childIndex) => {
+                                    if (child.type === "separator") {
+                                        return (
+                                            <div
+                                                key={`submenu-separator-${childIndex}`}
+                                                style={{
+                                                    borderTop:
+                                                        "1px solid var(--border)",
+                                                    margin: "4px 0",
+                                                }}
+                                            />
+                                        );
+                                    }
+
+                                    return (
+                                        <button
+                                            key={`${child.label}-${childIndex}`}
+                                            type="button"
+                                            disabled={child.disabled}
+                                            onClick={() => {
+                                                if (child.disabled) return;
+                                                child.action?.();
+                                                onClose();
+                                            }}
+                                            className="text-left px-3 py-1.5 text-xs rounded"
+                                            style={{
+                                                display: "block",
+                                                color: child.danger
+                                                    ? "#ef4444"
+                                                    : "var(--text-primary)",
+                                                background: "transparent",
+                                                opacity: child.disabled
+                                                    ? 0.45
+                                                    : 1,
+                                                cursor: child.disabled
+                                                    ? "default"
+                                                    : "pointer",
+                                                whiteSpace: "nowrap",
+                                            }}
+                                            onMouseEnter={(event) => {
+                                                if (child.disabled) return;
+                                                event.currentTarget.style.backgroundColor =
+                                                    child.danger
+                                                        ? "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))"
+                                                        : "var(--bg-tertiary)";
+                                            }}
+                                            onMouseLeave={(event) => {
+                                                event.currentTarget.style.backgroundColor =
+                                                    "transparent";
+                                            }}
+                                        >
+                                            {child.label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        ) : null}
+                    </div>
                 );
             })}
         </div>,

--- a/apps/desktop/src/features/ai/AIChatPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.test.tsx
@@ -761,7 +761,7 @@ describe("AIChatPanel tabs lifecycle", () => {
         });
     });
 
-    it("shows the active note auto-context without rendering a selection pill", () => {
+    it("does not render implicit note context when the active-note preference is enabled", () => {
         const session = createSession("session-a", "First conversation");
 
         useVaultStore.setState({
@@ -830,7 +830,7 @@ describe("AIChatPanel tabs lifecycle", () => {
 
         renderComponent(<AIChatPanel />);
 
-        expect(screen.getByText("TAREAS")).toBeTruthy();
+        expect(screen.queryByText("TAREAS")).toBeNull();
         expect(screen.queryByText(/\(11:19\)/)).toBeNull();
     });
 

--- a/apps/desktop/src/features/ai/AIChatPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.test.tsx
@@ -530,6 +530,69 @@ describe("AIChatPanel tabs lifecycle", () => {
         ).not.toBeInTheDocument();
     });
 
+    it("does not recreate a sidebar tab when the active session already lives in workspace", async () => {
+        const sessionA = createSession(
+            "session-a",
+            "Workspace conversation",
+            "idle",
+            {
+                runtimeId: "claude-acp",
+            },
+        );
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [runtimeDescriptor, claudeRuntimeDescriptor],
+            sessionsById: {
+                [sessionA.sessionId]: sessionA,
+            },
+            sessionOrder: [sessionA.sessionId],
+            activeSessionId: sessionA.sessionId,
+            selectedRuntimeId: "claude-acp",
+            composerPartsBySessionId: {
+                [sessionA.sessionId]: [],
+            },
+            setupStatusByRuntimeId: {
+                "claude-acp": {
+                    runtimeId: "claude-acp",
+                    binaryReady: true,
+                    binarySource: "bundled",
+                    authReady: true,
+                    authMethods: [],
+                    onboardingRequired: false,
+                },
+            },
+            runtimeConnectionByRuntimeId: {
+                "claude-acp": { status: "ready", message: null },
+            },
+        }));
+        useChatTabsStore.setState({
+            tabs: [
+                {
+                    id: "workspace-tab-a",
+                    sessionId: sessionA.sessionId,
+                    runtimeId: "claude-acp",
+                    location: "workspace",
+                },
+            ],
+            activeTabId: null,
+        });
+
+        renderComponent(<AIChatPanel />);
+
+        await waitFor(() => {
+            expect(useChatTabsStore.getState().tabs).toEqual([
+                {
+                    id: "workspace-tab-a",
+                    sessionId: sessionA.sessionId,
+                    runtimeId: "claude-acp",
+                    location: "workspace",
+                },
+            ]);
+        });
+        expect(useChatTabsStore.getState().activeTabId).toBeNull();
+    });
+
     it("switches to the nearest remaining session when closing the active tab", async () => {
         const sessionA = createSession("session-a", "First conversation");
         const sessionB = createSession("session-b", "Second conversation");

--- a/apps/desktop/src/features/ai/AIChatPanel.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.tsx
@@ -8,11 +8,7 @@ import {
 } from "react";
 import { open as tauriOpen } from "@tauri-apps/plugin-dialog";
 import { useShallow } from "zustand/react/shallow";
-import {
-    useEditorStore,
-    isNoteTab,
-    selectFocusedEditorTab,
-} from "../../app/store/editorStore";
+import { useEditorStore } from "../../app/store/editorStore";
 import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import { useLayoutStore } from "../../app/store/layoutStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -256,10 +252,6 @@ export function AIChatPanel() {
         [chatActions, refreshEntries],
     );
 
-    const autoContextEnabled = useChatStore(
-        (state) => state.autoContextEnabled,
-    );
-    const toggleAutoContext = useChatStore((state) => state.toggleAutoContext);
     const requireCmdEnterToSend = useChatStore(
         (state) => state.requireCmdEnterToSend,
     );
@@ -286,10 +278,6 @@ export function AIChatPanel() {
     const entries = useVaultStore((state) => state.entries);
     const createNote = useVaultStore((state) => state.createNote);
     const openNote = useEditorStore((state) => state.openNote);
-    const activeEditorNoteId = useEditorStore((state) => {
-        const tab = selectFocusedEditorTab(state);
-        return tab && isNoteTab(tab) ? tab.noteId : null;
-    });
     const activeTab = activeTabId
         ? (tabs.find((tab) => tab.id === activeTabId) ?? null)
         : null;
@@ -421,29 +409,6 @@ export function AIChatPanel() {
         title: note.title,
         path: note.path,
     }));
-    const activeNote = activeEditorNoteId
-        ? (notes.find((note) => note.id === activeEditorNoteId) ?? null)
-        : null;
-    const autoContextAttachments = autoContextEnabled
-        ? [
-              activeNote &&
-              !currentSession?.attachments.some(
-                  (attachment) =>
-                      (attachment.type === "current_note" ||
-                          attachment.type === "note") &&
-                      attachment.noteId === activeNote.id,
-              )
-                  ? {
-                        id: `auto:current_note:${activeNote.id}`,
-                        label: activeNote.title,
-                        path: activeNote.path,
-                        removable: false,
-                    }
-                  : null,
-          ].filter((attachment): attachment is NonNullable<typeof attachment> =>
-              Boolean(attachment),
-          )
-        : [];
     const selectedSetupStatus = useChatStore((state) =>
         selectedRuntimeId
             ? (state.setupStatusByRuntimeId[selectedRuntimeId] ?? null)
@@ -953,8 +918,6 @@ export function AIChatPanel() {
                     status={currentSession?.status ?? "idle"}
                     runtimeName={composerRuntimeLabel}
                     runtimeId={currentSession?.runtimeId}
-                    autoContextEnabled={autoContextEnabled}
-                    hasActiveNote={activeNote !== null}
                     requireCmdEnterToSend={requireCmdEnterToSend}
                     composerFontSize={composerFontSize}
                     composerFontFamily={composerFontFamily}
@@ -965,7 +928,6 @@ export function AIChatPanel() {
                     hasPendingSubmitAfterStop={Boolean(
                         composerInterruptedTurnState?.pendingManualSend,
                     )}
-                    onToggleAutoContext={toggleAutoContext}
                     expanded={composerExpanded}
                     onToggleExpanded={() => setComposerExpanded((v) => !v)}
                     disabled={
@@ -1007,7 +969,6 @@ export function AIChatPanel() {
                                         status: attachment.status,
                                         errorMessage: attachment.errorMessage,
                                     })),
-                                ...autoContextAttachments,
                             ]}
                             onRemoveAttachment={(attachmentId) => {
                                 if (!composerSessionId) return;

--- a/apps/desktop/src/features/ai/AIChatPanel.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.tsx
@@ -8,7 +8,11 @@ import {
 } from "react";
 import { open as tauriOpen } from "@tauri-apps/plugin-dialog";
 import { useShallow } from "zustand/react/shallow";
-import { useEditorStore, isNoteTab } from "../../app/store/editorStore";
+import {
+    useEditorStore,
+    isNoteTab,
+    selectFocusedEditorTab,
+} from "../../app/store/editorStore";
 import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import { useLayoutStore } from "../../app/store/layoutStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -278,9 +282,7 @@ export function AIChatPanel() {
     const createNote = useVaultStore((state) => state.createNote);
     const openNote = useEditorStore((state) => state.openNote);
     const activeEditorNoteId = useEditorStore((state) => {
-        const tab = state.tabs.find(
-            (candidate) => candidate.id === state.activeTabId,
-        );
+        const tab = selectFocusedEditorTab(state);
         return tab && isNoteTab(tab) ? tab.noteId : null;
     });
     const activeTab = activeTabId

--- a/apps/desktop/src/features/ai/AIChatPanel.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.tsx
@@ -683,22 +683,30 @@ export function AIChatPanel() {
             return;
         }
 
-        const activeSessionHasTab = tabs.some(
+        const activeSessionSidebarTabId =
+            tabs.find((tab) => tab.sessionId === activeSessionId)?.id ?? null;
+        const activeSessionHasAnyTab = allChatTabs.some(
             (tab) => tab.sessionId === activeSessionId,
         );
-        if (!activeSessionHasTab || !activeTabId) {
+        if (!activeSessionHasAnyTab) {
             const tabId = ensureSessionTab(
                 activeSessionId,
                 activeSession?.historySessionId ?? null,
                 activeSession?.runtimeId ?? null,
             );
             setActiveTab(tabId);
+            return;
+        }
+
+        if (!activeTabId && activeSessionSidebarTabId) {
+            setActiveTab(activeSessionSidebarTabId);
         }
     }, [
         activeSessionId,
         activeSession,
         activeTabId,
         activeTabSessionId,
+        allChatTabs,
         currentSession,
         ensureSessionTab,
         setActiveTab,

--- a/apps/desktop/src/features/ai/AIChatPanel.tsx
+++ b/apps/desktop/src/features/ai/AIChatPanel.tsx
@@ -269,7 +269,12 @@ export function AIChatPanel() {
     );
     const chatFontSize = useChatStore((state) => state.chatFontSize);
     const chatFontFamily = useChatStore((state) => state.chatFontFamily);
-    const tabs = useChatTabsStore((state) => state.tabs);
+    const allChatTabs = useChatTabsStore((state) => state.tabs);
+    // Only show sidebar tabs — workspace tabs are rendered by AIChatSessionView
+    const tabs = useMemo(
+        () => allChatTabs.filter((tab) => tab.location !== "workspace"),
+        [allChatTabs],
+    );
     const activeTabId = useChatTabsStore((state) => state.activeTabId);
     const tabsReady = useChatTabsStore((state) => state.isReady);
     const ensureSessionTab = useChatTabsStore(
@@ -815,6 +820,20 @@ export function AIChatPanel() {
         shouldFocusSelectedRuntime,
         tabsReady,
     ]);
+
+    // When the active sidebar tab moves to workspace, switch to the next sidebar tab
+    useEffect(() => {
+        if (!activeTabId) return;
+        const activeTab = allChatTabs.find((t) => t.id === activeTabId);
+        if (activeTab?.location === "workspace") {
+            const nextSidebarTab = allChatTabs.find(
+                (t) => t.id !== activeTabId && t.location !== "workspace",
+            );
+            if (nextSidebarTab) {
+                setActiveTab(nextSidebarTab.id);
+            }
+        }
+    }, [activeTabId, allChatTabs, setActiveTab]);
 
     if (historyViewOpen) {
         return <ChatHistoryView />;

--- a/apps/desktop/src/features/ai/chatNoteNavigation.ts
+++ b/apps/desktop/src/features/ai/chatNoteNavigation.ts
@@ -2,6 +2,7 @@ import { invoke } from "@tauri-apps/api/core";
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -44,8 +45,7 @@ function findNoteByReference(reference: string) {
 }
 
 async function readNoteContent(noteId: string) {
-    const { tabs } = useEditorStore.getState();
-    const existing = tabs.find(
+    const existing = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
         (tab): tab is NoteTab => isNoteTab(tab) && tab.noteId === noteId,
     );
     if (existing) {

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -1,0 +1,55 @@
+import { useChatTabsStore } from "./store/chatTabsStore";
+import { useChatStore } from "./store/chatStore";
+import { useEditorStore } from "../../app/store/editorStore";
+import { getSessionTitle } from "./sessionPresentation";
+
+/**
+ * Move a chat session from the sidebar into an editor workspace pane.
+ * The session tab is marked as "workspace" so the sidebar hides it,
+ * and a ChatTab is created in the specified (or focused) editor pane.
+ */
+export function moveChatToWorkspace(
+    sessionId: string,
+    options?: { paneId?: string },
+) {
+    const session = useChatStore.getState().sessionsById[sessionId];
+    if (!session) return;
+
+    const title = getSessionTitle(session);
+
+    useChatTabsStore.getState().moveToWorkspace(sessionId);
+    useEditorStore.getState().openChat(sessionId, {
+        title,
+        paneId: options?.paneId,
+    });
+}
+
+/**
+ * Create a new chat session with the given runtime and open it directly
+ * in the editor workspace (bypassing the sidebar).
+ */
+export async function newChatInWorkspace(runtimeId: string) {
+    const chatState = useChatStore.getState();
+    const beforeIds = new Set(Object.keys(chatState.sessionsById));
+
+    await chatState.newSession(runtimeId);
+
+    // Find the newly created session by diffing keys
+    const afterIds = Object.keys(useChatStore.getState().sessionsById);
+    const newSessionId = afterIds.find((id) => !beforeIds.has(id));
+    if (newSessionId) {
+        moveChatToWorkspace(newSessionId);
+    }
+}
+
+/**
+ * Move a chat session from the editor workspace back to the sidebar.
+ * The ChatTab is closed in the editor, the session tab is unmarked,
+ * and the sidebar re-activates it.
+ */
+export function moveChatToSidebar(sessionId: string) {
+    useEditorStore.getState().closeChat(sessionId);
+    const chatTabs = useChatTabsStore.getState();
+    chatTabs.moveToSidebar(sessionId);
+    chatTabs.openSessionTab(sessionId, { activate: true });
+}

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -62,8 +62,6 @@ interface AIChatComposerProps {
     runtimeName: string;
     runtimeId?: string;
     disabled?: boolean;
-    autoContextEnabled?: boolean;
-    hasActiveNote?: boolean;
     requireCmdEnterToSend?: boolean;
     composerFontSize?: number;
     composerFontFamily?: EditorFontFamily;
@@ -77,7 +75,6 @@ interface AIChatComposerProps {
     onMentionAttach: (note: AIChatNoteSummary) => void;
     onFileMentionAttach?: (file: AIChatFileSummary) => void;
     onFolderAttach: (folderPath: string, name: string) => void;
-    onToggleAutoContext?: () => void;
     onToggleExpanded?: () => void;
     onAttachFile?: () => void;
     onPasteImage?: (file: File) => void;
@@ -922,8 +919,6 @@ export function AIChatComposer({
     runtimeName,
     runtimeId,
     disabled = false,
-    autoContextEnabled = true,
-    hasActiveNote = false,
     requireCmdEnterToSend = false,
     composerFontSize = 14,
     composerFontFamily = "system",
@@ -937,7 +932,6 @@ export function AIChatComposer({
     onMentionAttach,
     onFileMentionAttach,
     onFolderAttach,
-    onToggleAutoContext,
     onToggleExpanded,
     onAttachFile,
     onPasteImage,
@@ -2106,72 +2100,6 @@ export function AIChatComposer({
                                 </>
                             )}
                         </div>
-                    )}
-                    {hasActiveNote && (
-                        <button
-                            type="button"
-                            tabIndex={-1}
-                            onClick={onToggleAutoContext}
-                            onMouseDown={(e) => e.preventDefault()}
-                            className="flex shrink-0 items-center justify-center rounded-md"
-                            style={{
-                                width: 28,
-                                height: 28,
-                                color: autoContextEnabled
-                                    ? "var(--accent)"
-                                    : "var(--text-secondary)",
-                                backgroundColor: autoContextEnabled
-                                    ? "color-mix(in srgb, var(--accent) 12%, transparent)"
-                                    : "transparent",
-                                border: "none",
-                                transition: "all 0.15s ease",
-                                outline: "none",
-                                appearance: "none",
-                                WebkitAppearance: "none",
-                            }}
-                            title={
-                                autoContextEnabled
-                                    ? "Active note included as context"
-                                    : "Active note not included as context"
-                            }
-                            aria-label="Toggle active note context"
-                        >
-                            {autoContextEnabled ? (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                >
-                                    <path d="M4 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2Z" />
-                                    <path d="M5 6h6M5 8.5h6M5 11h3" />
-                                </svg>
-                            ) : (
-                                <svg
-                                    width="16"
-                                    height="16"
-                                    viewBox="0 0 16 16"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                >
-                                    <rect
-                                        x="2"
-                                        y="2"
-                                        width="12"
-                                        height="12"
-                                        rx="2"
-                                    />
-                                    <path d="M5 11L11 5" />
-                                </svg>
-                            )}
-                        </button>
                     )}
                     <button
                         type="button"

--- a/apps/desktop/src/features/ai/components/AIChatHeader.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatHeader.tsx
@@ -205,7 +205,11 @@ export function AIChatHeader({
             className={`flex items-center justify-between ${
                 isCompact ? "gap-1 px-1.5 py-1" : "gap-2 px-2 py-1"
             }`}
-            style={{ borderBottom: "1px solid var(--border)" }}
+            style={{
+                height: 39,
+                boxSizing: "border-box",
+                borderBottom: "1px solid var(--border)",
+            }}
         >
             {showTabs ? (
                 <AIChatTabs

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -14,9 +14,7 @@ import { open as tauriOpen } from "@tauri-apps/plugin-dialog";
 import { useShallow } from "zustand/react/shallow";
 import {
     isChatTab,
-    isNoteTab,
     selectEditorPaneActiveTab,
-    selectFocusedEditorTab,
     selectEditorWorkspaceTabs,
     useEditorStore,
 } from "../../../app/store/editorStore";
@@ -40,7 +38,6 @@ import {
     appendFileAttachmentPart,
     appendScreenshotPart,
     createEmptyComposerParts,
-    normalizeComposerParts,
 } from "../composerParts";
 import { getSessionTitle } from "../sessionPresentation";
 import { moveChatToSidebar } from "../chatPaneMovement";
@@ -132,8 +129,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
     }, [session, activeRuntime]);
 
     // Settings
-    const autoContextEnabled = useChatStore((s) => s.autoContextEnabled);
-    const toggleAutoContext = useChatStore((s) => s.toggleAutoContext);
     const requireCmdEnterToSend = useChatStore((s) => s.requireCmdEnterToSend);
     const composerFontSize = useChatStore((s) => s.composerFontSize);
     const composerFontFamily = useChatStore((s) => s.composerFontFamily);
@@ -161,37 +156,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 })),
         [entries],
     );
-
-    // Active note for auto-context
-    const activeEditorNoteId = useEditorStore((state) => {
-        const tab = selectFocusedEditorTab(state);
-        return tab && isNoteTab(tab) ? tab.noteId : null;
-    });
-    const activeNote = activeEditorNoteId
-        ? (notes.find((n) => n.id === activeEditorNoteId) ?? null)
-        : null;
-    const autoContextAttachments = autoContextEnabled
-        ? ([
-              activeNote &&
-              !session?.attachments.some(
-                  (a) =>
-                      (a.type === "current_note" || a.type === "note") &&
-                      a.noteId === activeNote.id,
-              )
-                  ? {
-                        id: `auto:current_note:${activeNote.id}`,
-                        label: activeNote.title,
-                        path: activeNote.path,
-                        removable: false,
-                    }
-                  : null,
-          ].filter(Boolean) as Array<{
-              id: string;
-              label: string;
-              path: string;
-              removable: boolean;
-          }>)
-        : [];
 
     const runtimeLabel =
         activeRuntime?.runtime.name.replace(/ ACP$/, "") ?? "Assistant";
@@ -328,19 +292,15 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         const title = getSessionTitle(session);
         const editorState = useEditorStore.getState();
         const allTabs = selectEditorWorkspaceTabs(editorState);
-        const chatTab = allTabs.find(
+        const chatTabs = allTabs.filter(
             (t) => isChatTab(t) && t.sessionId === sessionId,
         );
-        if (chatTab && chatTab.title !== title) {
-            editorState.updateTabTitle(chatTab.id, title);
+        for (const chatTab of chatTabs) {
+            if (chatTab.title !== title) {
+                editorState.updateTabTitle(chatTab.id, title);
+            }
         }
-    }, [
-        session?.title,
-        session?.customTitle,
-        session?.persistedTitle,
-        session?.messages?.length,
-        sessionId,
-    ]);
+    }, [session, sessionId]);
 
     if (!sessionId) {
         return (
@@ -362,6 +322,8 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
             <div
                 className="flex items-center gap-2 px-3 py-1.5 text-xs shrink-0"
                 style={{
+                    height: 39,
+                    boxSizing: "border-box",
                     borderBottom: "1px solid var(--border)",
                     color: "var(--text-secondary)",
                 }}
@@ -464,8 +426,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     status={session?.status ?? "idle"}
                     runtimeName={runtimeLabel}
                     runtimeId={session?.runtimeId}
-                    autoContextEnabled={autoContextEnabled}
-                    hasActiveNote={activeNote !== null}
                     requireCmdEnterToSend={requireCmdEnterToSend}
                     composerFontSize={composerFontSize}
                     composerFontFamily={composerFontFamily}
@@ -474,7 +434,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     hasPendingSubmitAfterStop={Boolean(
                         interruptedTurnState?.pendingManualSend,
                     )}
-                    onToggleAutoContext={toggleAutoContext}
                     expanded={composerExpanded}
                     onToggleExpanded={() => setComposerExpanded((v) => !v)}
                     disabled={
@@ -514,7 +473,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                                         status: attachment.status,
                                         errorMessage: attachment.errorMessage,
                                     })),
-                                ...autoContextAttachments,
                             ]}
                             onRemoveAttachment={handleRemoveAttachment}
                             onClearAll={handleClearAttachments}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -1,0 +1,570 @@
+/**
+ * AIChatSessionView — renders a single chat session inside an editor workspace pane.
+ *
+ * Unlike AIChatPanel (the sidebar host), this component:
+ * - Does NOT bind Tauri event listeners (AIChatPanel owns those for ALL sessions).
+ * - Does NOT manage tabs or history — the workspace pane handles that.
+ * - Derives its sessionId from the active ChatTab in the pane via editorStore.
+ *
+ * All session data is read reactively from chatStore, which is the single
+ * source of truth regardless of where the UI renders.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { open as tauriOpen } from "@tauri-apps/plugin-dialog";
+import { useShallow } from "zustand/react/shallow";
+import {
+    isChatTab,
+    isNoteTab,
+    selectEditorPaneActiveTab,
+    selectFocusedEditorTab,
+    useEditorStore,
+} from "../../../app/store/editorStore";
+import { useVaultStore } from "../../../app/store/vaultStore";
+import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
+import { vaultInvoke } from "../../../app/utils/vaultInvoke";
+import {
+    type AIComposerPart,
+    type AIRuntimeConnectionState,
+    type QueuedChatMessage,
+} from "../types";
+import { useChatStore } from "../store/chatStore";
+import { AIChatMessageList } from "./AIChatMessageList";
+import { AIChatComposer } from "./AIChatComposer";
+import { AIChatContextBar } from "./AIChatContextBar";
+import { AIChatAgentControls } from "./AIChatAgentControls";
+import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
+import { QueuedMessagesPanel } from "./QueuedMessagesPanel";
+import { AIChatRuntimeBanner } from "./AIChatRuntimeBanner";
+import {
+    appendFileAttachmentPart,
+    appendScreenshotPart,
+    createEmptyComposerParts,
+    normalizeComposerParts,
+} from "../composerParts";
+import { getSessionTitle } from "../sessionPresentation";
+import { moveChatToSidebar } from "../chatPaneMovement";
+
+const EMPTY_COMPOSER_PARTS: AIComposerPart[] = [];
+const EMPTY_QUEUED_MESSAGES: QueuedChatMessage[] = [];
+const IDLE_CONNECTION: AIRuntimeConnectionState = {
+    status: "idle",
+    message: null,
+};
+
+interface AIChatSessionViewProps {
+    paneId?: string;
+}
+
+export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
+    const [composerExpanded, setComposerExpanded] = useState(false);
+
+    // Resolve sessionId from the active ChatTab in this pane
+    const sessionId = useEditorStore((state) => {
+        const tab = selectEditorPaneActiveTab(state, paneId);
+        return tab && isChatTab(tab) ? tab.sessionId : null;
+    });
+
+    // Actions ref — avoids subscribing to every action
+    const chatActions = useRef(useChatStore.getState()).current;
+    const refreshEntries = useVaultStore((state) => state.refreshEntries);
+
+    // Session data
+    const {
+        session,
+        composerParts,
+        queuedMessages,
+        queuedMessageEdit,
+        interruptedTurnState,
+    } = useChatStore(
+        useShallow((state) => {
+            const s = sessionId
+                ? (state.sessionsById[sessionId] ?? null)
+                : null;
+            const sid = s?.sessionId ?? null;
+            return {
+                session: s,
+                composerParts: sid
+                    ? (state.composerPartsBySessionId[sid] ??
+                      EMPTY_COMPOSER_PARTS)
+                    : EMPTY_COMPOSER_PARTS,
+                queuedMessages: sid
+                    ? (state.queuedMessagesBySessionId[sid] ??
+                      EMPTY_QUEUED_MESSAGES)
+                    : EMPTY_QUEUED_MESSAGES,
+                queuedMessageEdit: sid
+                    ? (state.queuedMessageEditBySessionId[sid] ?? null)
+                    : null,
+                interruptedTurnState: sid
+                    ? (state.interruptedTurnStateBySessionId[sid] ?? null)
+                    : null,
+            };
+        }),
+    );
+
+    // Runtime resolution
+    const runtimes = useChatStore((s) => s.runtimes);
+    const activeRuntimeId = session?.runtimeId ?? null;
+    const activeRuntime = runtimes.find(
+        (d) => d.runtime.id === activeRuntimeId,
+    );
+    const activeConnection = useChatStore((state) =>
+        activeRuntimeId
+            ? (state.runtimeConnectionByRuntimeId[activeRuntimeId] ??
+              IDLE_CONNECTION)
+            : IDLE_CONNECTION,
+    );
+
+    const agentCatalog = useMemo(() => {
+        const models =
+            session && session.models.length > 0
+                ? session.models
+                : (activeRuntime?.models ?? []);
+        const modes =
+            session && session.modes.length > 0
+                ? session.modes
+                : (activeRuntime?.modes ?? []);
+        const configOptions =
+            session && session.configOptions.length > 0
+                ? session.configOptions
+                : (activeRuntime?.configOptions ?? []);
+        return { models, modes, configOptions };
+    }, [session, activeRuntime]);
+
+    // Settings
+    const autoContextEnabled = useChatStore((s) => s.autoContextEnabled);
+    const toggleAutoContext = useChatStore((s) => s.toggleAutoContext);
+    const requireCmdEnterToSend = useChatStore((s) => s.requireCmdEnterToSend);
+    const composerFontSize = useChatStore((s) => s.composerFontSize);
+    const composerFontFamily = useChatStore((s) => s.composerFontFamily);
+    const chatFontSize = useChatStore((s) => s.chatFontSize);
+    const chatFontFamily = useChatStore((s) => s.chatFontFamily);
+
+    // Notes/files for mentions
+    const notes = useVaultStore((s) => s.notes);
+    const entries = useVaultStore((s) => s.entries);
+    const noteOptions = useMemo(
+        () => notes.map((n) => ({ id: n.id, title: n.title, path: n.path })),
+        [notes],
+    );
+    const fileOptions = useMemo(
+        () =>
+            entries
+                .filter((e) => e.kind === "file" && isTextLikeVaultEntry(e))
+                .map((e) => ({
+                    id: e.id,
+                    title: e.title,
+                    path: e.path,
+                    relativePath: e.relative_path,
+                    fileName: e.file_name,
+                    mimeType: e.mime_type,
+                })),
+        [entries],
+    );
+
+    // Active note for auto-context
+    const activeEditorNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
+        return tab && isNoteTab(tab) ? tab.noteId : null;
+    });
+    const activeNote = activeEditorNoteId
+        ? (notes.find((n) => n.id === activeEditorNoteId) ?? null)
+        : null;
+    const autoContextAttachments = autoContextEnabled
+        ? ([
+              activeNote &&
+              !session?.attachments.some(
+                  (a) =>
+                      (a.type === "current_note" || a.type === "note") &&
+                      a.noteId === activeNote.id,
+              )
+                  ? {
+                        id: `auto:current_note:${activeNote.id}`,
+                        label: activeNote.title,
+                        path: activeNote.path,
+                        removable: false,
+                    }
+                  : null,
+          ].filter(Boolean) as Array<{
+              id: string;
+              label: string;
+              path: string;
+              removable: boolean;
+          }>)
+        : [];
+
+    const runtimeLabel =
+        activeRuntime?.runtime.name.replace(/ ACP$/, "") ?? "Assistant";
+    const agentControlsDisabled =
+        !session || Boolean(session.isResumingSession);
+
+    // Handlers
+    const handleRemoveAttachment = useCallback(
+        (attachmentId: string) => {
+            if (!sessionId) return;
+            chatActions.removeAttachment(attachmentId, sessionId);
+        },
+        [chatActions, sessionId],
+    );
+
+    const handleClearAttachments = useCallback(() => {
+        if (!sessionId) return;
+        chatActions.clearAttachments(sessionId);
+    }, [chatActions, sessionId]);
+
+    const handleAttachFile = useCallback(async () => {
+        if (!sessionId) return;
+        const selected = await tauriOpen({
+            multiple: false,
+            filters: [
+                {
+                    name: "Files",
+                    extensions: [
+                        "txt",
+                        "json",
+                        "csv",
+                        "pdf",
+                        "xml",
+                        "yaml",
+                        "yml",
+                        "toml",
+                        "log",
+                    ],
+                },
+            ],
+        });
+        if (!selected) return;
+        const filePath =
+            typeof selected === "string"
+                ? selected
+                : (selected as { path: string }).path;
+        const fileName = filePath.split(/[/\\]/).pop() ?? "file";
+        const ext = fileName.split(".").pop()?.toLowerCase() ?? "";
+        const mimeMap: Record<string, string> = {
+            txt: "text/plain",
+            json: "application/json",
+            csv: "text/csv",
+            pdf: "application/pdf",
+            xml: "application/xml",
+            yaml: "text/yaml",
+            yml: "text/yaml",
+            toml: "text/toml",
+            log: "text/plain",
+        };
+        const currentParts =
+            useChatStore.getState().composerPartsBySessionId[sessionId] ??
+            createEmptyComposerParts();
+        chatActions.setComposerParts(
+            appendFileAttachmentPart(currentParts, {
+                filePath,
+                mimeType: mimeMap[ext] ?? "application/octet-stream",
+                label: fileName,
+            }),
+            sessionId,
+        );
+    }, [chatActions, sessionId]);
+
+    const handlePasteImage = useCallback(
+        async (file: File) => {
+            if (!sessionId) return;
+            const MAX_SIZE = 25 * 1024 * 1024;
+            if (file.size > MAX_SIZE) return;
+            try {
+                const buffer = await file.arrayBuffer();
+                const bytes = Array.from(new Uint8Array(buffer));
+                const ext =
+                    file.type === "image/jpeg"
+                        ? "jpg"
+                        : file.type === "image/gif"
+                          ? "gif"
+                          : file.type === "image/webp"
+                            ? "webp"
+                            : "png";
+                const now = new Date();
+                const ts = [
+                    now.getFullYear(),
+                    String(now.getMonth() + 1).padStart(2, "0"),
+                    String(now.getDate()).padStart(2, "0"),
+                    "-",
+                    String(now.getHours()).padStart(2, "0"),
+                    String(now.getMinutes()).padStart(2, "0"),
+                    String(now.getSeconds()).padStart(2, "0"),
+                ].join("");
+                const fileName = `pasted-image-${ts}.${ext}`;
+                const saved = await vaultInvoke<{
+                    path: string;
+                    relative_path: string;
+                    file_name: string;
+                    mime_type: string | null;
+                }>("save_vault_binary_file", {
+                    relativeDir: "assets/chat",
+                    fileName,
+                    bytes,
+                });
+                await refreshEntries();
+                const timeLabel = `Screenshot ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")} hrs`;
+                const currentParts =
+                    useChatStore.getState().composerPartsBySessionId[
+                        sessionId
+                    ] ?? createEmptyComposerParts();
+                chatActions.setComposerParts(
+                    appendScreenshotPart(currentParts, {
+                        filePath: saved.path,
+                        mimeType: saved.mime_type ?? file.type,
+                        label: timeLabel,
+                    }),
+                    sessionId,
+                );
+            } catch (error) {
+                console.error("[chat] Failed to save pasted image:", error);
+            }
+        },
+        [chatActions, refreshEntries, sessionId],
+    );
+
+    // Title sync: keep the editor tab title in sync with session title
+    useEffect(() => {
+        if (!session || !sessionId) return;
+        const title = getSessionTitle(session);
+        const editorState = useEditorStore.getState();
+        const allTabs = editorState.panes.flatMap((p) => p.tabs);
+        const chatTab = allTabs.find(
+            (t) => isChatTab(t) && t.sessionId === sessionId,
+        );
+        if (chatTab && chatTab.title !== title) {
+            editorState.updateTabTitle(chatTab.id, title);
+        }
+    }, [
+        session?.title,
+        session?.customTitle,
+        session?.persistedTitle,
+        session?.messages?.length,
+        sessionId,
+    ]);
+
+    if (!sessionId) {
+        return (
+            <div
+                className="flex h-full items-center justify-center"
+                style={{ color: "var(--text-secondary)" }}
+            >
+                No active chat session
+            </div>
+        );
+    }
+
+    return (
+        <div
+            className="relative flex h-full min-h-0 flex-col"
+            style={{ backgroundColor: "var(--bg-secondary)" }}
+        >
+            {/* Compact header with return-to-sidebar action */}
+            <div
+                className="flex items-center gap-2 px-3 py-1.5 text-xs shrink-0"
+                style={{
+                    borderBottom: "1px solid var(--border)",
+                    color: "var(--text-secondary)",
+                }}
+            >
+                <span
+                    className="flex-1 truncate font-medium"
+                    style={{ color: "var(--text-primary)" }}
+                >
+                    {session ? getSessionTitle(session) : "Chat"}
+                </span>
+                <button
+                    className="shrink-0 rounded px-2 py-0.5 text-[11px] hover:opacity-80"
+                    style={{
+                        background:
+                            "color-mix(in srgb, var(--accent) 10%, transparent)",
+                        color: "var(--accent)",
+                    }}
+                    onClick={() => moveChatToSidebar(sessionId)}
+                    title="Return to AI Panel"
+                >
+                    Return to Panel
+                </button>
+            </div>
+
+            <AIChatRuntimeBanner
+                connection={activeConnection}
+                runtimeName={activeRuntime?.runtime.name.replace(/ ACP$/, "")}
+            />
+
+            {!composerExpanded && (
+                <AIChatMessageList
+                    sessionId={sessionId}
+                    messages={session?.messages ?? []}
+                    status={session?.status ?? "idle"}
+                    hasOlderMessages={
+                        (session?.loadedPersistedMessageStart ?? 0) > 0
+                    }
+                    isLoadingOlderMessages={
+                        session?.isLoadingPersistedMessages ?? false
+                    }
+                    visibleWorkCycleId={session?.visibleWorkCycleId ?? null}
+                    chatFontSize={chatFontSize}
+                    chatFontFamily={chatFontFamily}
+                    onLoadOlderMessages={() => {
+                        void chatActions.loadOlderMessages(sessionId);
+                    }}
+                    onPermissionResponse={(requestId, optionId) => {
+                        void chatActions.respondPermissionForSession(
+                            sessionId,
+                            requestId,
+                            optionId,
+                        );
+                    }}
+                    onUserInputResponse={(requestId, answers) => {
+                        void chatActions.respondUserInput(
+                            requestId,
+                            answers,
+                            sessionId,
+                        );
+                    }}
+                />
+            )}
+
+            <EditedFilesBufferPanel sessionId={sessionId} />
+
+            <div
+                className={
+                    composerExpanded
+                        ? "flex min-h-0 flex-1 flex-col px-1.5 pb-1.5 pt-1.5"
+                        : "px-3 pb-3 pt-2"
+                }
+            >
+                <QueuedMessagesPanel
+                    items={queuedMessages}
+                    editingItem={queuedMessageEdit?.item ?? null}
+                    onCancel={(messageId) => {
+                        chatActions.removeQueuedMessage(sessionId, messageId);
+                    }}
+                    onClearAll={() => {
+                        chatActions.clearSessionQueue(sessionId);
+                    }}
+                    onEdit={(messageId) => {
+                        chatActions.editQueuedMessage(sessionId, messageId);
+                    }}
+                    onSendNow={(messageId) => {
+                        void chatActions.sendQueuedMessageNow(
+                            sessionId,
+                            messageId,
+                        );
+                    }}
+                    onCancelEdit={() => {
+                        chatActions.cancelQueuedMessageEdit(sessionId);
+                    }}
+                />
+                <AIChatComposer
+                    key={sessionId}
+                    parts={composerParts}
+                    notes={noteOptions}
+                    files={fileOptions}
+                    status={session?.status ?? "idle"}
+                    runtimeName={runtimeLabel}
+                    runtimeId={session?.runtimeId}
+                    autoContextEnabled={autoContextEnabled}
+                    hasActiveNote={activeNote !== null}
+                    requireCmdEnterToSend={requireCmdEnterToSend}
+                    composerFontSize={composerFontSize}
+                    composerFontFamily={composerFontFamily}
+                    availableCommands={session?.availableCommands}
+                    isStopping={Boolean(interruptedTurnState?.isStopping)}
+                    hasPendingSubmitAfterStop={Boolean(
+                        interruptedTurnState?.pendingManualSend,
+                    )}
+                    onToggleAutoContext={toggleAutoContext}
+                    expanded={composerExpanded}
+                    onToggleExpanded={() => setComposerExpanded((v) => !v)}
+                    disabled={
+                        !session ||
+                        activeConnection.status === "loading" ||
+                        Boolean(session.isResumingSession)
+                    }
+                    contextBar={
+                        <AIChatContextBar
+                            attachments={[
+                                ...(session?.attachments ?? [])
+                                    .filter(
+                                        (a) =>
+                                            !composerParts.some(
+                                                (p) =>
+                                                    (p.type === "mention" &&
+                                                        p.noteId ===
+                                                            a.noteId) ||
+                                                    (p.type ===
+                                                        "file_mention" &&
+                                                        a.type === "file" &&
+                                                        a.path === p.path) ||
+                                                    (p.type ===
+                                                        "folder_mention" &&
+                                                        a.type === "folder" &&
+                                                        p.folderPath ===
+                                                            a.noteId),
+                                            ),
+                                    )
+                                    .map((attachment) => ({
+                                        id: attachment.id,
+                                        noteId: attachment.noteId,
+                                        label: attachment.label,
+                                        path: attachment.path,
+                                        removable: true,
+                                        type: attachment.type,
+                                        status: attachment.status,
+                                        errorMessage: attachment.errorMessage,
+                                    })),
+                                ...autoContextAttachments,
+                            ]}
+                            onRemoveAttachment={handleRemoveAttachment}
+                            onClearAll={handleClearAttachments}
+                        />
+                    }
+                    footer={
+                        <AIChatAgentControls
+                            disabled={agentControlsDisabled}
+                            modelId={session?.modelId ?? ""}
+                            modeId={session?.modeId ?? ""}
+                            effortsByModel={session?.effortsByModel ?? {}}
+                            models={agentCatalog.models}
+                            modes={agentCatalog.modes}
+                            configOptions={agentCatalog.configOptions}
+                            onModelChange={(modelId) => {
+                                void chatActions.setModel(modelId, sessionId);
+                            }}
+                            onModeChange={(modeId) => {
+                                void chatActions.setMode(modeId, sessionId);
+                            }}
+                            onConfigOptionChange={(optionId, value) => {
+                                void chatActions.setConfigOption(
+                                    optionId,
+                                    value,
+                                    sessionId,
+                                );
+                            }}
+                        />
+                    }
+                    onChange={(parts) => {
+                        chatActions.setComposerParts(parts, sessionId);
+                    }}
+                    onAttachFile={handleAttachFile}
+                    onPasteImage={handlePasteImage}
+                    onMentionAttach={(note) => {
+                        chatActions.attachNote(note, sessionId);
+                    }}
+                    onFileMentionAttach={(file) => {
+                        chatActions.attachVaultFile(file, sessionId);
+                    }}
+                    onFolderAttach={(folderPath, name) => {
+                        chatActions.attachFolder(folderPath, name, sessionId);
+                    }}
+                    onSubmit={() => {
+                        void chatActions.sendMessage(sessionId);
+                    }}
+                    onStop={() => {
+                        void chatActions.stopStreaming(sessionId);
+                    }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -17,6 +17,7 @@ import {
     isNoteTab,
     selectEditorPaneActiveTab,
     selectFocusedEditorTab,
+    selectEditorWorkspaceTabs,
     useEditorStore,
 } from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
@@ -326,7 +327,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         if (!session || !sessionId) return;
         const title = getSessionTitle(session);
         const editorState = useEditorStore.getState();
-        const allTabs = editorState.panes.flatMap((p) => p.tabs);
+        const allTabs = selectEditorWorkspaceTabs(editorState);
         const chatTab = allTabs.find(
             (t) => isChatTab(t) && t.sessionId === sessionId,
         );

--- a/apps/desktop/src/features/ai/components/AIChatTabs.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatTabs.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../../test/test-utils";
 import type { AIChatSession, AIRuntimeOption } from "../types";
@@ -136,7 +136,7 @@ describe("AIChatTabs", () => {
         expect(screen.queryByText("Codex")).toBeNull();
     });
 
-    it("opens a context menu and exports the selected session", () => {
+    it("opens a context menu and exports the selected session", async () => {
         const onExportSession = vi.fn();
 
         renderComponent(
@@ -161,10 +161,12 @@ describe("AIChatTabs", () => {
         });
         fireEvent.click(screen.getByText("Export chat to Markdown"));
 
-        expect(onExportSession).toHaveBeenCalledWith("session-a");
+        await waitFor(() => {
+            expect(onExportSession).toHaveBeenCalledWith("session-a");
+        });
     });
 
-    it("renames a tab session from the context menu and cancels with Escape", () => {
+    it("renames a tab session from the context menu and cancels with Escape", async () => {
         const onRenameSession = vi.fn();
 
         renderComponent(
@@ -189,7 +191,7 @@ describe("AIChatTabs", () => {
         });
         fireEvent.click(screen.getByText("Rename chat"));
 
-        const input = screen.getByDisplayValue("First tab");
+        const input = await screen.findByDisplayValue("First tab");
         fireEvent.change(input, { target: { value: "Renamed tab" } });
         fireEvent.keyDown(input, { key: "Escape" });
         fireEvent.blur(input);
@@ -202,14 +204,16 @@ describe("AIChatTabs", () => {
         });
         fireEvent.click(screen.getByText("Rename chat"));
 
-        const secondInput = screen.getByDisplayValue("First tab");
+        const secondInput = await screen.findByDisplayValue("First tab");
         fireEvent.change(secondInput, { target: { value: "Renamed tab" } });
         fireEvent.keyDown(secondInput, { key: "Enter" });
 
-        expect(onRenameSession).toHaveBeenCalledWith(
-            "session-a",
-            "Renamed tab",
-        );
+        await waitFor(() => {
+            expect(onRenameSession).toHaveBeenCalledWith(
+                "session-a",
+                "Renamed tab",
+            );
+        });
     });
 
     it("uses the tab runtime as fallback metadata for restored tabs", () => {

--- a/apps/desktop/src/features/ai/components/AIChatTabs.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatTabs.tsx
@@ -15,6 +15,7 @@ import type {
     AIRuntimeOption,
 } from "../types";
 import type { ChatWorkspaceTab } from "../store/chatTabsStore";
+import { moveChatToWorkspace } from "../chatPaneMovement";
 import { useInlineRename } from "./useInlineRename";
 
 interface AIChatTabsProps {
@@ -470,6 +471,15 @@ export function AIChatTabs({
                             label: "Export chat to Markdown",
                             action: () =>
                                 onExportSession(contextMenu.payload.sessionId),
+                            disabled: !contextMenu.payload.hasSession,
+                        },
+                        { type: "separator" },
+                        {
+                            label: "Open in Editor Pane",
+                            action: () =>
+                                moveChatToWorkspace(
+                                    contextMenu.payload.sessionId,
+                                ),
                             disabled: !contextMenu.payload.hasSession,
                         },
                         { type: "separator" },

--- a/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
@@ -81,6 +81,24 @@ function makeSession(
 
 function setupReviewTab(sessionId: string) {
     useEditorStore.setState({
+        panes: [
+            {
+                id: "primary",
+                tabs: [
+                    {
+                        id: `review-${sessionId}`,
+                        kind: "ai-review" as const,
+                        sessionId,
+                        title: "Review",
+                    },
+                ],
+                activeTabId: `review-${sessionId}`,
+                activationHistory: [`review-${sessionId}`],
+                tabNavigationHistory: [`review-${sessionId}`],
+                tabNavigationIndex: 0,
+            },
+        ],
+        focusedPaneId: "primary",
         tabs: [
             {
                 id: `review-${sessionId}`,
@@ -90,6 +108,9 @@ function setupReviewTab(sessionId: string) {
             },
         ],
         activeTabId: `review-${sessionId}`,
+        activationHistory: [`review-${sessionId}`],
+        tabNavigationHistory: [`review-${sessionId}`],
+        tabNavigationIndex: 0,
     });
 }
 
@@ -125,6 +146,17 @@ describe("AIReviewView", () => {
         localStorage.clear();
         resetChatStore();
         useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: "primary",
             tabs: [],
             activeTabId: null,
             activationHistory: [],
@@ -138,6 +170,79 @@ describe("AIReviewView", () => {
     it("shows fallback when no review tab is active", () => {
         renderComponent(<AIReviewView />);
         expect(screen.getByText("No review tab active")).toBeInTheDocument();
+    });
+
+    it("renders the review session from the requested pane even when another pane is focused", () => {
+        const sessionId = "sess-pane-review";
+        const file = makeTrackedFile({
+            path: "/vault/notes/review.md",
+            originPath: "/vault/notes/review.md",
+            identityKey: "review-file",
+        });
+
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "note-primary",
+                            kind: "note",
+                            noteId: "notes/current",
+                            title: "Current",
+                            content: "body",
+                            history: [],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "note-primary",
+                    activationHistory: ["note-primary"],
+                    tabNavigationHistory: ["note-primary"],
+                    tabNavigationIndex: 0,
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: `review-${sessionId}`,
+                            kind: "ai-review",
+                            sessionId,
+                            title: "Review",
+                        },
+                    ],
+                    activeTabId: `review-${sessionId}`,
+                    activationHistory: [`review-${sessionId}`],
+                    tabNavigationHistory: [`review-${sessionId}`],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "primary",
+            tabs: [
+                {
+                    id: "note-primary",
+                    kind: "note",
+                    noteId: "notes/current",
+                    title: "Current",
+                    content: "body",
+                    history: [],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "note-primary",
+            activationHistory: ["note-primary"],
+            tabNavigationHistory: ["note-primary"],
+            tabNavigationIndex: 0,
+        });
+        useChatStore.setState({
+            sessionsById: {
+                [sessionId]: makeSession(sessionId, [file]),
+            },
+            activeSessionId: sessionId,
+        });
+
+        renderComponent(<AIReviewView paneId="secondary" />);
+
+        expect(screen.getByText("review.md")).toBeInTheDocument();
     });
 
     it("shows empty state when session has no buffer entries", () => {
@@ -487,7 +592,9 @@ describe("AIReviewView", () => {
 
         expect(diffContent).toHaveStyle({ fontSize: "0.76em" });
         expect(
-            JSON.parse(localStorage.getItem("neverwrite.ai.preferences") ?? "{}"),
+            JSON.parse(
+                localStorage.getItem("neverwrite.ai.preferences") ?? "{}",
+            ),
         ).toMatchObject({
             editDiffZoom: 0.76,
         });

--- a/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
@@ -15,6 +15,10 @@ import { emptyPatch, syncDerivedLinePatch } from "../store/actionLogModel";
 import { AIReviewView } from "./AIReviewView";
 import { readPersistedReviewViewState } from "./reviewTabPersistence";
 
+vi.mock("../../editor/useCodeLanguageSupport", () => ({
+    useCodeLanguageSupport: () => null,
+}));
+
 const DEFAULT_WORK_CYCLE = "default-wc";
 const defaultChatActions = {
     rejectEditedFile: useChatStore.getState().rejectEditedFile,

--- a/apps/desktop/src/features/ai/components/AIReviewView.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
     useEditorStore,
     isReviewTab,
+    selectEditorPaneActiveTab,
     type ReviewTab,
 } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
@@ -174,11 +175,13 @@ function StatChips({
 /*  Root                                                               */
 /* ------------------------------------------------------------------ */
 
-export function AIReviewView() {
+interface AIReviewViewProps {
+    paneId?: string;
+}
+
+export function AIReviewView({ paneId }: AIReviewViewProps) {
     const tab = useEditorStore((state) => {
-        const current = state.tabs.find(
-            (candidate) => candidate.id === state.activeTabId,
-        );
+        const current = selectEditorPaneActiveTab(state, paneId);
         return current && isReviewTab(current) ? current : null;
     });
 

--- a/apps/desktop/src/features/ai/hooks/useAutoOpenReviewTab.test.tsx
+++ b/apps/desktop/src/features/ai/hooks/useAutoOpenReviewTab.test.tsx
@@ -128,6 +128,82 @@ describe("useAutoOpenReviewTab", () => {
         ]);
     });
 
+    it("reopens existing review tabs on mount without stealing focus", () => {
+        const session = createSession("session-mounted-late", ["/vault/a.ts"]);
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "note-tab",
+                            kind: "note",
+                            noteId: "notes/current",
+                            title: "Current",
+                            content: "body",
+                            history: [
+                                {
+                                    kind: "note",
+                                    noteId: "notes/current",
+                                    title: "Current",
+                                    content: "body",
+                                },
+                            ],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "note-tab",
+                    activationHistory: ["note-tab"],
+                    tabNavigationHistory: ["note-tab"],
+                    tabNavigationIndex: 0,
+                },
+            ],
+            focusedPaneId: "primary",
+            tabs: [
+                {
+                    id: "note-tab",
+                    kind: "note",
+                    noteId: "notes/current",
+                    title: "Current",
+                    content: "body",
+                    history: [
+                        {
+                            kind: "note",
+                            noteId: "notes/current",
+                            title: "Current",
+                            content: "body",
+                        },
+                    ],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "note-tab",
+            activationHistory: ["note-tab"],
+            tabNavigationHistory: ["note-tab"],
+            tabNavigationIndex: 0,
+        });
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes,
+            activeSessionId: session.sessionId,
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+        }));
+
+        renderComponent(<AutoOpenReviewHarness />);
+
+        const state = useEditorStore.getState();
+        const reviewTab = state.tabs.find(
+            (tab) =>
+                isReviewTab(tab) && tab.sessionId === "session-mounted-late",
+        );
+
+        expect(reviewTab).toBeDefined();
+        expect(state.activeTabId).toBe("note-tab");
+        expect(state.focusedPaneId).toBe("primary");
+    });
+
     it("does not create duplicate review tabs for the same session", () => {
         renderComponent(<AutoOpenReviewHarness />);
 

--- a/apps/desktop/src/features/ai/hooks/useAutoOpenReviewTab.ts
+++ b/apps/desktop/src/features/ai/hooks/useAutoOpenReviewTab.ts
@@ -26,6 +26,22 @@ function getVisibleTrackedFilesCountForSession(
     return count;
 }
 
+function ensureReviewTabsForSessions(
+    sessionsById: Record<string, AIChatSession | undefined>,
+    runtimes: ReturnType<typeof useChatStore.getState>["runtimes"],
+) {
+    for (const [sessionId, session] of Object.entries(sessionsById)) {
+        if (getVisibleTrackedFilesCountForSession(session) <= 0) {
+            continue;
+        }
+
+        useEditorStore.getState().openReview(sessionId, {
+            background: true,
+            title: getReviewTabTitle(session, runtimes),
+        });
+    }
+}
+
 export function useAutoOpenReviewTab() {
     const prevCountsRef = useRef<Map<string, number>>(new Map());
     const prevSessionsByIdRef = useRef(useChatStore.getState().sessionsById);
@@ -41,6 +57,10 @@ export function useAutoOpenReviewTab() {
             ),
         );
         prevSessionsByIdRef.current = initialState.sessionsById;
+        ensureReviewTabsForSessions(
+            initialState.sessionsById,
+            initialState.runtimes,
+        );
 
         const unsubscribe = useChatStore.subscribe((state) => {
             const prevSessionsById = prevSessionsByIdRef.current;

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -827,7 +827,7 @@ describe("chatStore", () => {
         });
     });
 
-    it("keeps active note auto-context without auto-attaching the current selection", async () => {
+    it("does not synthesize legacy auto-context attachments when sending a plain composer message", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",
             notes: [
@@ -888,23 +888,7 @@ describe("chatStore", () => {
                 activeSessionId
             ]?.[0];
 
-        expect(queuedMessage).toMatchObject({
-            attachments: [
-                expect.objectContaining({
-                    type: "current_note",
-                    noteId: "notes/current",
-                    label: "Current",
-                }),
-            ],
-        });
-        expect(queuedMessage).not.toMatchObject({
-            attachments: expect.arrayContaining([
-                expect.objectContaining({
-                    type: "selection",
-                    noteId: "notes/current",
-                }),
-            ]),
-        });
+        expect(queuedMessage?.attachments).toEqual([]);
     });
 
     it("keeps the previous visible work cycle while its permission buffer is unresolved", async () => {
@@ -8226,7 +8210,8 @@ describe("chatStore", () => {
                     sessionId: "claude-session-2",
                     attachments: [
                         expect.objectContaining({
-                            filePath: "/home/user/projects/NeverWrite/README.md",
+                            filePath:
+                                "/home/user/projects/NeverWrite/README.md",
                         }),
                     ],
                 });

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -8326,6 +8326,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 );
             }
             useEditorStore.getState().closeReview(sessionId);
+            useEditorStore.getState().closeChat(sessionId);
             useChatTabsStore.getState().removeTabsForSession(sessionId);
             _queueDrainLocks.delete(sessionId);
             clearChatRowUiSession(sessionId);
@@ -8412,10 +8413,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (vaultPath) {
                 await aiDeleteAllSessionHistories(vaultPath).catch(() => {});
             }
-            // Close all review tabs before clearing sessions
+            // Close all review and chat tabs before clearing sessions
             const editor = useEditorStore.getState();
             for (const sessionId of Object.keys(get().sessionsById)) {
                 editor.closeReview(sessionId);
+                editor.closeChat(sessionId);
             }
             useChatTabsStore.getState().reset();
             _queueDrainLocks.clear();

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -35,7 +35,6 @@ import {
 import {
     isNoteTab,
     selectEditorWorkspaceTabs,
-    selectFocusedEditorTab,
     useEditorStore,
 } from "../../../app/store/editorStore";
 import {
@@ -1708,44 +1707,6 @@ function findMostRecentSessionIdForRuntime(
     );
 }
 
-function hasManualAttachment(
-    attachments: AIChatAttachment[],
-    type: AIChatAttachment["type"],
-    noteId: string,
-) {
-    return attachments.some(
-        (attachment) =>
-            attachment.type === type && attachment.noteId === noteId,
-    );
-}
-
-function getAutoContextAttachments(baseAttachments: AIChatAttachment[]) {
-    if (!useChatStore.getState().autoContextEnabled) return [];
-
-    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
-    const activeNoteId =
-        activeTab && isNoteTab(activeTab) ? activeTab.noteId : null;
-    const notes = useVaultStore.getState().notes;
-    const activeNote = activeNoteId
-        ? (notes.find((note) => note.id === activeNoteId) ?? null)
-        : null;
-
-    const autoAttachments: AIChatAttachment[] = [];
-
-    if (
-        activeNote &&
-        !hasManualAttachment(baseAttachments, "current_note", activeNote.id) &&
-        !hasManualAttachment(baseAttachments, "note", activeNote.id)
-    ) {
-        autoAttachments.push({
-            ...createAttachment("current_note", activeNote),
-            id: `auto:current_note:${activeNote.id}`,
-        });
-    }
-
-    return autoAttachments;
-}
-
 function buildPromptWithResumeContext(session: AIChatSession, prompt: string) {
     if (!session.resumeContextPending) {
         return prompt;
@@ -2125,7 +2086,6 @@ function buildQueuedMessage(
         ...selectionAttachments,
         ...screenshotAttachments,
         ...fileAttachments,
-        ...getAutoContextAttachments(session.attachments),
     ].map(cloneAttachment);
 
     return {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -32,7 +32,12 @@ import {
     aiUpdateSetup,
     aiRegisterFileBaseline,
 } from "../api";
-import { isNoteTab, useEditorStore } from "../../../app/store/editorStore";
+import {
+    isNoteTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
+    useEditorStore,
+} from "../../../app/store/editorStore";
 import {
     useVaultStore,
     type VaultNoteChange,
@@ -1717,8 +1722,7 @@ function hasManualAttachment(
 function getAutoContextAttachments(baseAttachments: AIChatAttachment[]) {
     if (!useChatStore.getState().autoContextEnabled) return [];
 
-    const { tabs, activeTabId } = useEditorStore.getState();
-    const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null;
+    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     const activeNoteId =
         activeTab && isNoteTab(activeTab) ? activeTab.noteId : null;
     const notes = useVaultStore.getState().notes;
@@ -2045,7 +2049,7 @@ function migrateSessionLocalState(
 }
 
 function registerOpenEditorBaselines(sessionId: string) {
-    const tabs = useEditorStore.getState().tabs;
+    const tabs = selectEditorWorkspaceTabs(useEditorStore.getState());
     for (const tab of tabs) {
         if (isNoteTab(tab) && tab.content != null) {
             aiRegisterFileBaseline(
@@ -2646,12 +2650,11 @@ function finalizeSessionStopping(sessionId: string) {
 
 function clearInterruptedTurnState(sessionId: string) {
     useChatStore.setState((state) => ({
-        interruptedTurnStateBySessionId:
-            cleanupInterruptedTurnStateBySessionId(
-                state.interruptedTurnStateBySessionId,
-                sessionId,
-                null,
-            ),
+        interruptedTurnStateBySessionId: cleanupInterruptedTurnStateBySessionId(
+            state.interruptedTurnStateBySessionId,
+            sessionId,
+            null,
+        ),
     }));
 }
 
@@ -5034,9 +5037,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
         if (get().pausedQueueBySessionId[sessionId]) {
             releasePausedQueueForManualSend(sessionId);
-            const nextQueuedMessageId = (
-                get().queuedMessagesBySessionId[sessionId] ?? []
-            )[0]?.id;
+            const nextQueuedMessageId = (get().queuedMessagesBySessionId[
+                sessionId
+            ] ?? [])[0]?.id;
             if (
                 nextQueuedMessageId &&
                 !get().activeQueuedMessageBySessionId[sessionId]
@@ -7137,9 +7140,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     );
                     if (queued) {
                         void pendingStop.finally(() => {
-                            void flushPendingInterruptedSend(
-                                resolvedSessionId,
-                            );
+                            void flushPendingInterruptedSend(resolvedSessionId);
                         });
                     }
                     return;

--- a/apps/desktop/src/features/ai/store/chatTabsStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatTabsStore.test.ts
@@ -114,6 +114,27 @@ describe("chatTabsStore", () => {
         ).toEqual(["session-b", "session-c", "session-a"]);
     });
 
+    it("creates hidden workspace metadata when moving a session without a sidebar tab", () => {
+        useChatTabsStore.getState().moveToWorkspace("session-a");
+
+        expect(useChatTabsStore.getState().tabs).toHaveLength(1);
+        expect(useChatTabsStore.getState().tabs[0]).toMatchObject({
+            sessionId: "session-a",
+            location: "workspace",
+        });
+        expect(useChatTabsStore.getState().activeTabId).toBeNull();
+    });
+
+    it("does not rewrite state when moving an already-workspace session again", () => {
+        useChatTabsStore.getState().moveToWorkspace("session-a");
+        const firstTab = useChatTabsStore.getState().tabs[0];
+
+        useChatTabsStore.getState().moveToWorkspace("session-a");
+
+        expect(useChatTabsStore.getState().tabs).toHaveLength(1);
+        expect(useChatTabsStore.getState().tabs[0]).toBe(firstTab);
+    });
+
     it("replaces persisted session ids with live ids", () => {
         useChatTabsStore.getState().openSessionTab("persisted:history-1");
         const originalTabId = useChatTabsStore.getState().tabs[0]?.id;

--- a/apps/desktop/src/features/ai/store/chatTabsStore.ts
+++ b/apps/desktop/src/features/ai/store/chatTabsStore.ts
@@ -383,11 +383,14 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
     },
 
     setActiveTab: (tabId) =>
-        set((state) =>
-            state.tabs.some((tab) => tab.id === tabId)
+        set((state) => {
+            if (state.activeTabId === tabId) {
+                return state;
+            }
+            return state.tabs.some((tab) => tab.id === tabId)
                 ? { activeTabId: tabId }
-                : state,
-        ),
+                : state;
+        }),
 
     ensureSessionTab: (
         sessionId,
@@ -656,23 +659,55 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
     },
 
     moveToWorkspace: (sessionId) => {
-        set((state) => ({
-            tabs: state.tabs.map((tab) =>
-                tab.sessionId === sessionId
-                    ? { ...tab, location: "workspace" as const }
-                    : tab,
-            ),
-        }));
+        if (!sessionId) return;
+
+        set((state) => {
+            const existing = state.tabs.find(
+                (tab) => tab.sessionId === sessionId,
+            );
+
+            if (!existing) {
+                return {
+                    tabs: [
+                        ...state.tabs,
+                        { ...createTab(sessionId), location: "workspace" },
+                    ],
+                };
+            }
+
+            if (existing.location === "workspace") {
+                return state;
+            }
+
+            return {
+                tabs: state.tabs.map((tab) =>
+                    tab.sessionId === sessionId
+                        ? { ...tab, location: "workspace" as const }
+                        : tab,
+                ),
+            };
+        });
     },
 
     moveToSidebar: (sessionId) => {
-        set((state) => ({
-            tabs: state.tabs.map((tab) =>
-                tab.sessionId === sessionId
-                    ? { ...tab, location: undefined }
-                    : tab,
-            ),
-        }));
+        if (!sessionId) return;
+
+        set((state) => {
+            const existing = state.tabs.find(
+                (tab) => tab.sessionId === sessionId,
+            );
+            if (!existing || existing.location === undefined) {
+                return state;
+            }
+
+            return {
+                tabs: state.tabs.map((tab) =>
+                    tab.sessionId === sessionId
+                        ? { ...tab, location: undefined }
+                        : tab,
+                ),
+            };
+        });
     },
 
     reset: () => {

--- a/apps/desktop/src/features/ai/store/chatTabsStore.ts
+++ b/apps/desktop/src/features/ai/store/chatTabsStore.ts
@@ -14,6 +14,8 @@ export interface ChatWorkspaceTab {
     historySessionId?: string;
     runtimeId?: string;
     pinned?: boolean;
+    /** Where this tab is currently displayed. undefined = "sidebar". */
+    location?: "sidebar" | "workspace";
 }
 
 export interface PersistedChatWorkspace {
@@ -60,6 +62,8 @@ interface ChatTabsStore {
         historySessionId?: string | null,
         runtimeId?: string | null,
     ) => void;
+    moveToWorkspace: (sessionId: string) => void;
+    moveToSidebar: (sessionId: string) => void;
     reset: () => void;
 }
 
@@ -514,8 +518,16 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
 
     hydrateForVault: (payload) => {
         const workspace = normalizeWorkspace(payload);
+        // Reset location: transient ChatTabs don't survive restarts
+        const tabs = (workspace?.tabs ?? []).map((tab) => {
+            if (tab.location) {
+                const { location: _, ...rest } = tab;
+                return rest;
+            }
+            return tab;
+        });
         set({
-            tabs: workspace?.tabs ?? [],
+            tabs,
             activeTabId: workspace?.activeTabId ?? null,
         });
     },
@@ -643,6 +655,26 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
         });
     },
 
+    moveToWorkspace: (sessionId) => {
+        set((state) => ({
+            tabs: state.tabs.map((tab) =>
+                tab.sessionId === sessionId
+                    ? { ...tab, location: "workspace" as const }
+                    : tab,
+            ),
+        }));
+    },
+
+    moveToSidebar: (sessionId) => {
+        set((state) => ({
+            tabs: state.tabs.map((tab) =>
+                tab.sessionId === sessionId
+                    ? { ...tab, location: undefined }
+                    : tab,
+            ),
+        }));
+    },
+
     reset: () => {
         set({
             tabs: [],
@@ -659,7 +691,7 @@ useChatTabsStore.subscribe((state) => {
     // Cheap fingerprint to skip expensive serialization when nothing relevant changed
     let sig = state.activeTabId ?? "";
     for (const t of state.tabs) {
-        sig += `|${t.id}|${t.sessionId ?? ""}|${t.historySessionId ?? ""}|${t.runtimeId ?? ""}|${t.pinned ? "1" : "0"}`;
+        sig += `|${t.id}|${t.sessionId ?? ""}|${t.historySessionId ?? ""}|${t.runtimeId ?? ""}|${t.pinned ? "1" : "0"}|${t.location ?? "s"}`;
     }
     if (sig === _lastChatTabsSig) return;
     _lastChatTabsSig = sig;
@@ -701,4 +733,13 @@ export function resetChatTabsStore() {
         tabs: [],
         activeTabId: null,
     });
+}
+
+export function isChatSessionInWorkspace(
+    tabs: ChatWorkspaceTab[],
+    sessionId: string,
+): boolean {
+    return tabs.some(
+        (tab) => tab.sessionId === sessionId && tab.location === "workspace",
+    );
 }

--- a/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
+++ b/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
@@ -9,6 +9,8 @@ import {
     isNoteTab,
     isPdfTab,
     isFileTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
     type NoteTab,
 } from "../../app/store/editorStore";
 import {
@@ -237,12 +239,12 @@ export function BookmarksPanel() {
     const fileTreeScale = useSettingsStore((s) => s.fileTreeScale);
 
     // Active tab info for highlight
-    const activeNoteId = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t?.id === s.activeTabId);
+    const activeNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return isNoteTab(tab) ? tab.noteId : null;
     });
-    const activeEntryPath = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t?.id === s.activeTabId);
+    const activeEntryPath = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return isPdfTab(tab) || isFileTab(tab) ? tab.path : null;
     });
 
@@ -331,8 +333,9 @@ export function BookmarksPanel() {
             if (item.kind === "note" && item.noteId) {
                 const note = resolveNote(item.noteId);
                 if (!note) return;
-                const { tabs } = useEditorStore.getState();
-                const existing = tabs.find(
+                const existing = selectEditorWorkspaceTabs(
+                    useEditorStore.getState(),
+                ).find(
                     (t): t is NoteTab =>
                         isNoteTab(t) && t.noteId === item.noteId,
                 );
@@ -368,8 +371,9 @@ export function BookmarksPanel() {
                 const note = resolveNote(item.noteId);
                 if (!note) return;
                 try {
-                    const { tabs } = useEditorStore.getState();
-                    const existing = tabs.find(
+                    const existing = selectEditorWorkspaceTabs(
+                        useEditorStore.getState(),
+                    ).find(
                         (t): t is NoteTab =>
                             isNoteTab(t) && t.noteId === item.noteId,
                     );
@@ -420,8 +424,9 @@ export function BookmarksPanel() {
             const note = resolveNote(item.noteId);
             if (!note || !vaultPath) return;
             try {
-                const { tabs } = useEditorStore.getState();
-                const existing = tabs.find(
+                const existing = selectEditorWorkspaceTabs(
+                    useEditorStore.getState(),
+                ).find(
                     (t): t is NoteTab =>
                         isNoteTab(t) && t.noteId === item.noteId,
                 );

--- a/apps/desktop/src/features/editor/CsvFileTabView.tsx
+++ b/apps/desktop/src/features/editor/CsvFileTabView.tsx
@@ -98,19 +98,22 @@ export function CsvFileTabView({ paneId }: CsvFileTabViewProps) {
     const [gridHeight, setGridHeight] = useState(420);
 
     const getCurrentContent = useCallback(() => contentRef.current, []);
-    const applyIncomingContent = useCallback((nextContent: string) => {
-        const nextState = buildCsvEditorState(
-            nextContent,
-            getActiveCsvTabMetadata(paneId),
-            getCsvIdentitySnapshot(editorStateRef.current),
-        );
-        contentRef.current = nextState.rawContent;
-        editorStateRef.current = nextState;
-        setEditorState(nextState);
-        setViewMode((currentMode) =>
-            nextState.isTableAvailable ? currentMode : "raw",
-        );
-    }, []);
+    const applyIncomingContent = useCallback(
+        (nextContent: string) => {
+            const nextState = buildCsvEditorState(
+                nextContent,
+                getActiveCsvTabMetadata(paneId),
+                getCsvIdentitySnapshot(editorStateRef.current),
+            );
+            contentRef.current = nextState.rawContent;
+            editorStateRef.current = nextState;
+            setEditorState(nextState);
+            setViewMode((currentMode) =>
+                nextState.isTableAvailable ? currentMode : "raw",
+            );
+        },
+        [paneId],
+    );
 
     const {
         tab,
@@ -185,7 +188,7 @@ export function CsvFileTabView({ paneId }: CsvFileTabViewProps) {
             setEditorState(nextState);
             handleLocalContentChange(nextRawContent);
         },
-        [handleLocalContentChange],
+        [handleLocalContentChange, paneId],
     );
 
     const handleGridChange = useCallback(

--- a/apps/desktop/src/features/editor/CsvFileTabView.tsx
+++ b/apps/desktop/src/features/editor/CsvFileTabView.tsx
@@ -18,6 +18,7 @@ import {
 import Papa, { type ParseError } from "papaparse";
 import {
     isFileTab,
+    selectEditorPaneState,
     useEditorStore,
     type FileTab,
 } from "../../app/store/editorStore";
@@ -82,7 +83,11 @@ const csvTextColumn = createTextColumn<string>({
     deletedValue: "",
 });
 
-export function CsvFileTabView() {
+interface CsvFileTabViewProps {
+    paneId?: string;
+}
+
+export function CsvFileTabView({ paneId }: CsvFileTabViewProps) {
     const initialEditorState = buildCsvEditorState("", null);
     const contentRef = useRef(initialEditorState.rawContent);
     const editorStateRef = useRef<CsvEditorState>(initialEditorState);
@@ -96,7 +101,7 @@ export function CsvFileTabView() {
     const applyIncomingContent = useCallback((nextContent: string) => {
         const nextState = buildCsvEditorState(
             nextContent,
-            getActiveCsvTabMetadata(),
+            getActiveCsvTabMetadata(paneId),
             getCsvIdentitySnapshot(editorStateRef.current),
         );
         contentRef.current = nextState.rawContent;
@@ -114,6 +119,7 @@ export function CsvFileTabView() {
         reloadFileFromDisk,
         keepLocalFileVersion,
     } = useEditableFileResource({
+        paneId,
         getCurrentContent,
         applyIncomingContent,
         acceptTab: (candidate) => candidate.viewer === "csv",
@@ -164,7 +170,7 @@ export function CsvFileTabView() {
             const nextState = buildCsvEditorState(
                 nextRawContent,
                 {
-                    ...getActiveCsvTabMetadata(),
+                    ...getActiveCsvTabMetadata(paneId),
                     sizeBytes: getContentByteLength(nextRawContent),
                     contentTruncated: false,
                 },
@@ -888,10 +894,11 @@ function createCsvEntityId(prefix: "column" | "row") {
     return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
-function getActiveCsvTabMetadata() {
+function getActiveCsvTabMetadata(paneId?: string) {
     const state = useEditorStore.getState();
-    const activeTab = state.tabs.find(
-        (candidate) => candidate.id === state.activeTabId,
+    const pane = selectEditorPaneState(state, paneId);
+    const activeTab = pane.tabs.find(
+        (candidate) => candidate.id === pane.activeTabId,
     );
     if (!activeTab || !isFileTab(activeTab) || activeTab.viewer !== "csv") {
         return null;

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -38,8 +38,10 @@ import {
 } from "../../components/context-menu/ContextMenu";
 import { findWikilinks } from "../../app/utils/wikilinks";
 import {
+    selectEditorWorkspaceTabs,
     useEditorStore,
     isNoteTab,
+    selectFocusedPaneId,
     selectEditorPaneState,
     type Tab,
     type NoteTab,
@@ -415,7 +417,7 @@ export function Editor({
     const activeTabId = paneState.activeTabId;
     const paneTabs = paneState.tabs;
     const isPaneFocused = useEditorStore((state) =>
-        paneId ? state.focusedPaneId === paneId : true,
+        paneId ? selectFocusedPaneId(state) === paneId : true,
     );
     const pendingReveal = useEditorStore((s) => s.pendingReveal);
     const clearPendingReveal = useEditorStore((s) => s.clearPendingReveal);
@@ -2942,11 +2944,9 @@ export function Editor({
             pruneNoteStateForOpenTabs(tabs);
         };
 
-        syncLiveNoteState(
-            useEditorStore.getState().panes.flatMap((pane) => pane.tabs),
-        );
+        syncLiveNoteState(selectEditorWorkspaceTabs(useEditorStore.getState()));
         const unsubscribe = useEditorStore.subscribe((state) => {
-            syncLiveNoteState(state.panes.flatMap((pane) => pane.tabs));
+            syncLiveNoteState(selectEditorWorkspaceTabs(state));
         });
         return unsubscribe;
     }, [pruneNoteStateForOpenTabs, getPaneSnapshot]);

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -40,6 +40,7 @@ import { findWikilinks } from "../../app/utils/wikilinks";
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorPaneState,
     type Tab,
     type NoteTab,
 } from "../../app/store/editorStore";
@@ -203,6 +204,7 @@ type TabScrollPosition = {
 };
 type EditorMode = "source" | "preview";
 interface EditorProps {
+    paneId?: string;
     emptyStateMessage?: string;
 }
 
@@ -274,6 +276,7 @@ function isNativeScrollbarMouseDown(view: EditorView, event: MouseEvent) {
 }
 
 export function Editor({
+    paneId,
     emptyStateMessage = "Open a note from the left panel",
 }: EditorProps) {
     const containerRef = useRef<HTMLDivElement>(null);
@@ -406,7 +409,14 @@ export function Editor({
         [syncFrontmatterFromContent],
     );
 
-    const activeTabId = useEditorStore((s) => s.activeTabId);
+    const paneState = useEditorStore(
+        useShallow((state) => selectEditorPaneState(state, paneId)),
+    );
+    const activeTabId = paneState.activeTabId;
+    const paneTabs = paneState.tabs;
+    const isPaneFocused = useEditorStore((state) =>
+        paneId ? state.focusedPaneId === paneId : true,
+    );
     const pendingReveal = useEditorStore((s) => s.pendingReveal);
     const clearPendingReveal = useEditorStore((s) => s.clearPendingReveal);
     const pendingSelectionReveal = useEditorStore(
@@ -448,11 +458,19 @@ export function Editor({
     const touchContent = useVaultStore((s) => s.touchContent);
     const openVault = useVaultStore((s) => s.openVault);
     const lastVaultPathRef = useRef<string | null>(vaultPath);
+    const getPaneSnapshot = useCallback(
+        () => selectEditorPaneState(useEditorStore.getState(), paneId),
+        [paneId],
+    );
 
     // Only re-renders when the active tab identity changes, not on content updates
     const activeTabInfo = useEditorStore(
-        useShallow((s) => {
-            const tab = s.tabs.find((t) => t.id === s.activeTabId) ?? null;
+        useShallow((state) => {
+            const pane = selectEditorPaneState(state, paneId);
+            const tab =
+                pane.tabs.find(
+                    (candidate) => candidate.id === pane.activeTabId,
+                ) ?? null;
             if (!tab || !isNoteTab(tab)) return null;
             return {
                 id: tab.id,
@@ -463,9 +481,7 @@ export function Editor({
     );
     const activeTab = ((): NoteTab | null => {
         if (activeTabId === null) return null;
-        const t = useEditorStore
-            .getState()
-            .tabs.find((t) => t.id === activeTabId);
+        const t = paneTabs.find((candidate) => candidate.id === activeTabId);
         return t && isNoteTab(t) ? t : null;
     })();
     activeTabRef.current = activeTab;
@@ -651,7 +667,8 @@ export function Editor({
     );
 
     const closeActiveTabWithSave = useCallback(() => {
-        const { tabs, activeTabId, closeTab } = useEditorStore.getState();
+        const { tabs, activeTabId } = getPaneSnapshot();
+        const { closeTab } = useEditorStore.getState();
         if (!activeTabId) return;
 
         const tab = tabs.find((item) => item.id === activeTabId);
@@ -676,7 +693,7 @@ export function Editor({
             deleteNoteStateForIds(noteIdsToClean);
             closeTab(activeTabId, { reason: "user" });
         })();
-    }, [deleteNoteStateForIds, saveNow]);
+    }, [deleteNoteStateForIds, getPaneSnapshot, saveNow]);
 
     const reloadNoteFromDisk = useCallback(async () => {
         const tab = activeTabRef.current;
@@ -2731,7 +2748,7 @@ export function Editor({
 
         const previousContent = currentView.state.doc.toString();
         const previousTab = prevTabId
-            ? (useEditorStore.getState().tabs.find((t) => t.id === prevTabId) ??
+            ? (getPaneSnapshot().tabs.find((tab) => tab.id === prevTabId) ??
               null)
             : null;
 
@@ -2925,12 +2942,14 @@ export function Editor({
             pruneNoteStateForOpenTabs(tabs);
         };
 
-        syncLiveNoteState(useEditorStore.getState().tabs);
+        syncLiveNoteState(
+            useEditorStore.getState().panes.flatMap((pane) => pane.tabs),
+        );
         const unsubscribe = useEditorStore.subscribe((state) => {
-            syncLiveNoteState(state.tabs);
+            syncLiveNoteState(state.panes.flatMap((pane) => pane.tabs));
         });
         return unsubscribe;
-    }, [pruneNoteStateForOpenTabs]);
+    }, [pruneNoteStateForOpenTabs, getPaneSnapshot]);
 
     useEffect(() => {
         if (activeTabInfo) return;
@@ -3078,11 +3097,15 @@ export function Editor({
         const unsub = useEditorStore.subscribe((state, prev) => {
             const view = viewRef.current;
             if (!view) return;
-            const tabId = state.activeTabId;
+            const pane = selectEditorPaneState(state, paneId);
+            const previousPane = selectEditorPaneState(prev, paneId);
+            const tabId = pane.activeTabId;
             if (!tabId) return;
 
-            const tab = state.tabs.find((t) => t.id === tabId);
-            const prevTab = prev.tabs.find((t) => t.id === tabId);
+            const tab = pane.tabs.find((candidate) => candidate.id === tabId);
+            const prevTab = previousPane.tabs.find(
+                (candidate) => candidate.id === tabId,
+            );
             if (!tab || !prevTab) return;
             if (!isNoteTab(tab) || !isNoteTab(prevTab)) return;
 
@@ -3203,9 +3226,9 @@ export function Editor({
                 externalReloadTimerRef.current = null;
 
                 const liveView = viewRef.current;
-                const liveTab = useEditorStore
-                    .getState()
-                    .tabs.find((candidate) => candidate.id === tabId);
+                const liveTab = getPaneSnapshot().tabs.find(
+                    (candidate) => candidate.id === tabId,
+                );
                 if (
                     !liveView ||
                     !liveTab ||
@@ -3277,7 +3300,9 @@ export function Editor({
         return unsub;
     }, [
         createEditorState,
+        getPaneSnapshot,
         markTabSaved,
+        paneId,
         replaceEditorView,
         scheduleMergeViewSync,
         serializePersistedContent,
@@ -3355,10 +3380,11 @@ export function Editor({
 
     // Keyboard shortcuts
     useEffect(() => {
+        if (!isPaneFocused) return;
         const handler = (e: KeyboardEvent) => {
             if (e.defaultPrevented) return;
             const platform = getDesktopPlatform();
-            const { tabs, activeTabId } = useEditorStore.getState();
+            const { tabs, activeTabId } = getPaneSnapshot();
 
             // Cmd+W / Ctrl+W: close active tab
             if (matchesShortcutAction(e, "close_tab", platform)) {
@@ -3417,9 +3443,10 @@ export function Editor({
 
         window.addEventListener("keydown", handler);
         return () => window.removeEventListener("keydown", handler);
-    }, [closeActiveTabWithSave, saveNow]);
+    }, [closeActiveTabWithSave, getPaneSnapshot, isPaneFocused, saveNow]);
 
     useEffect(() => {
+        if (!isPaneFocused) return;
         const handleCloseRequest = () => {
             closeActiveTabWithSave();
         };
@@ -3433,7 +3460,7 @@ export function Editor({
                 REQUEST_CLOSE_ACTIVE_TAB_EVENT,
                 handleCloseRequest,
             );
-    }, [closeActiveTabWithSave]);
+    }, [closeActiveTabWithSave, isPaneFocused]);
 
     const editorShellStyle = {
         "--editor-font-size": `${editorFontSize}px`,

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { renderComponent } from "../../test/test-utils";
+import { useEditorStore } from "../../app/store/editorStore";
+import { EditorPaneBar } from "./EditorPaneBar";
+
+describe("EditorPaneBar", () => {
+    beforeEach(() => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "tab-a",
+                            kind: "note",
+                            noteId: "notes/a",
+                            title: "Alpha",
+                            content: "Alpha",
+                        },
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "tab-b",
+                            kind: "note",
+                            noteId: "notes/b",
+                            title: "Beta",
+                            content: "Beta",
+                        },
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+    });
+
+    it("moves a tab to another pane from the tab context menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(tabButton).not.toBeNull();
+        fireEvent.contextMenu(tabButton!);
+        await user.click(
+            await screen.findByRole("button", { name: "Move to Pane 2" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().focusedPaneId).toBe("secondary");
+        });
+        expect(useEditorStore.getState().panes[0]?.tabs).toHaveLength(0);
+        expect(
+            useEditorStore.getState().panes[1]?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-b", "tab-a"]);
+    });
+
+    it("closes a pane explicitly from the pane actions menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="secondary" isFocused />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Pane 2 actions" }),
+        );
+        await user.click(
+            await screen.findByRole("button", { name: "Close Pane 2" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(1);
+        });
+        expect(useEditorStore.getState().focusedPaneId).toBe("primary");
+    });
+});

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -397,6 +397,30 @@ describe("EditorPaneBar", () => {
         ]);
     });
 
+    it("unifies all tabs into the current pane from the pane actions menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="secondary" isFocused />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Pane 2 actions" }),
+        );
+        await user.click(
+            await screen.findByRole("button", { name: "Unify All Tabs Here" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(1);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes.map((pane) => pane.id)).toEqual(["secondary"]);
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual([
+            "tab-b",
+            "tab-a",
+        ]);
+    });
+
     it("focuses a neighbor pane from the pane actions menu", async () => {
         const user = userEvent.setup();
         renderComponent(<EditorPaneBar paneId="secondary" isFocused />);

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -92,7 +92,7 @@ describe("EditorPaneBar", () => {
         });
 
         const state = useEditorStore.getState();
-        expect(state.focusedPaneId).toBe("tertiary");
+        expect(state.focusedPaneId).toBe("pane-3");
         expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
         expect(state.panes[2]?.tabs).toHaveLength(1);
         expect(state.panes[2]?.tabs[0]).toMatchObject({

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -7,6 +7,18 @@ import { EditorPaneBar } from "./EditorPaneBar";
 
 describe("EditorPaneBar", () => {
     beforeEach(() => {
+        Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+            configurable: true,
+            value: () => {},
+        });
+        Object.defineProperty(HTMLElement.prototype, "releasePointerCapture", {
+            configurable: true,
+            value: () => {},
+        });
+        Object.defineProperty(HTMLElement.prototype, "hasPointerCapture", {
+            configurable: true,
+            value: () => false,
+        });
         useEditorStore.getState().hydrateWorkspace(
             [
                 {
@@ -60,6 +72,52 @@ describe("EditorPaneBar", () => {
         expect(
             useEditorStore.getState().panes[1]?.tabs.map((tab) => tab.id),
         ).toEqual(["tab-b", "tab-a"]);
+    });
+
+    it("adds a duplicated tab to a new pane from the tab context menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(tabButton).not.toBeNull();
+        fireEvent.contextMenu(tabButton!);
+        await user.click(
+            await screen.findByRole("button", { name: "Add to New Pane" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(3);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("tertiary");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
+        expect(state.panes[2]?.tabs).toHaveLength(1);
+        expect(state.panes[2]?.tabs[0]).toMatchObject({
+            kind: "note",
+            noteId: "notes/a",
+            title: "Alpha",
+            content: "Alpha",
+        });
+        expect(state.panes[2]?.tabs[0]?.id).not.toBe("tab-a");
+    });
+
+    it("disables add to new pane when the workspace already has three panes", async () => {
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        useEditorStore.getState().createEmptyPane();
+
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(tabButton).not.toBeNull();
+        fireEvent.contextMenu(tabButton!);
+
+        expect(
+            await screen.findByRole("button", { name: "Add to New Pane" }),
+        ).toBeDisabled();
     });
 
     it("closes a pane explicitly from the pane actions menu", async () => {

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -4,7 +4,32 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { renderComponent } from "../../test/test-utils";
 import { useEditorStore } from "../../app/store/editorStore";
 import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
+import { useChatStore } from "../ai/store/chatStore";
 import { EditorPaneBar } from "./EditorPaneBar";
+
+function createChatSession(sessionId: string, title: string) {
+    return {
+        sessionId,
+        historySessionId: sessionId,
+        status: "idle" as const,
+        runtimeId: "codex-acp",
+        modelId: "test-model",
+        modeId: "default",
+        models: [],
+        modes: [],
+        configOptions: [],
+        messages: [
+            {
+                id: `${sessionId}-message`,
+                role: "user" as const,
+                kind: "text" as const,
+                content: title,
+                timestamp: 10,
+            },
+        ],
+        attachments: [],
+    };
+}
 
 describe("EditorPaneBar", () => {
     beforeEach(() => {
@@ -287,5 +312,35 @@ describe("EditorPaneBar", () => {
             expect(useEditorStore.getState().panes).toHaveLength(1);
         });
         expect(useEditorStore.getState().focusedPaneId).toBe("primary");
+    });
+
+    it("renames workspace chat tabs with a double click on the title", async () => {
+        useChatStore.setState({
+            sessionsById: {
+                "session-a": createChatSession("session-a", "Workspace chat"),
+            },
+        });
+        useEditorStore.getState().openChat("session-a", {
+            title: "Stale title",
+            paneId: "primary",
+        });
+
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        fireEvent.doubleClick(screen.getByText("Workspace chat"));
+
+        const input = screen.getByDisplayValue("Workspace chat");
+        fireEvent.change(input, {
+            target: { value: "Renamed workspace chat" },
+        });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().sessionsById["session-a"]?.customTitle,
+            ).toBe("Renamed workspace chat");
+        });
+
+        expect(screen.getByText("Renamed workspace chat")).toBeInTheDocument();
     });
 });

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -69,10 +69,109 @@ describe("EditorPaneBar", () => {
         await waitFor(() => {
             expect(useEditorStore.getState().focusedPaneId).toBe("secondary");
         });
-        expect(useEditorStore.getState().panes[0]?.tabs).toHaveLength(0);
+        expect(useEditorStore.getState().panes.map((pane) => pane.id)).toEqual([
+            "secondary",
+        ]);
         expect(
-            useEditorStore.getState().panes[1]?.tabs.map((tab) => tab.id),
+            useEditorStore.getState().panes[0]?.tabs.map((tab) => tab.id),
         ).toEqual(["tab-b", "tab-a"]);
+    });
+
+    it("does not move tabs between panes via drag gestures", () => {
+        renderComponent(
+            <div>
+                <div data-editor-pane-id="primary">
+                    <EditorPaneBar paneId="primary" isFocused />
+                </div>
+                <div data-editor-pane-id="secondary">
+                    <EditorPaneBar paneId="secondary" isFocused={false} />
+                </div>
+            </div>,
+        );
+
+        const primaryPane = document.querySelector(
+            '[data-editor-pane-id="primary"]',
+        ) as HTMLElement | null;
+        const secondaryPane = document.querySelector(
+            '[data-editor-pane-id="secondary"]',
+        ) as HTMLElement | null;
+        const secondaryStrip = document.querySelector(
+            '[data-pane-tab-strip="secondary"]',
+        ) as HTMLElement | null;
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+
+        expect(primaryPane).not.toBeNull();
+        expect(secondaryPane).not.toBeNull();
+        expect(secondaryStrip).not.toBeNull();
+        expect(tabButton).not.toBeNull();
+
+        primaryPane!.getBoundingClientRect = () =>
+            ({
+                left: 0,
+                top: 0,
+                right: 180,
+                bottom: 80,
+                width: 180,
+                height: 80,
+                x: 0,
+                y: 0,
+                toJSON: () => ({}),
+            }) as DOMRect;
+        secondaryPane!.getBoundingClientRect = () =>
+            ({
+                left: 200,
+                top: 0,
+                right: 380,
+                bottom: 80,
+                width: 180,
+                height: 80,
+                x: 200,
+                y: 0,
+                toJSON: () => ({}),
+            }) as DOMRect;
+        secondaryStrip!.getBoundingClientRect = () =>
+            ({
+                left: 200,
+                top: 0,
+                right: 380,
+                bottom: 38,
+                width: 180,
+                height: 38,
+                x: 200,
+                y: 0,
+                toJSON: () => ({}),
+            }) as DOMRect;
+
+        fireEvent.pointerDown(tabButton!, {
+            pointerId: 1,
+            button: 0,
+            clientX: 20,
+            clientY: 20,
+            screenX: 20,
+            screenY: 20,
+        });
+        fireEvent.pointerMove(tabButton!, {
+            pointerId: 1,
+            buttons: 1,
+            clientX: 240,
+            clientY: 20,
+            screenX: 240,
+            screenY: 20,
+        });
+        fireEvent.pointerUp(tabButton!, {
+            pointerId: 1,
+            clientX: 240,
+            clientY: 20,
+            screenX: 240,
+            screenY: 20,
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
+        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual(["tab-b"]);
+        expect(state.focusedPaneId).toBe("primary");
     });
 
     it("moves a tab into a new right split from the tab context menu", async () => {
@@ -91,14 +190,15 @@ describe("EditorPaneBar", () => {
         );
 
         await waitFor(() => {
-            expect(useEditorStore.getState().panes).toHaveLength(3);
+            expect(useEditorStore.getState().panes).toHaveLength(2);
         });
 
         const state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("pane-3");
-        expect(
-            state.panes.find((pane) => pane.id === "primary")?.tabs,
-        ).toHaveLength(0);
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "secondary",
+            "pane-3",
+        ]);
         expect(
             state.panes.find((pane) => pane.id === "pane-3")?.tabs[0],
         ).toMatchObject({

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -222,8 +222,8 @@ describe("EditorPaneBar", () => {
         const state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("pane-3");
         expect(state.panes.map((pane) => pane.id)).toEqual([
-            "secondary",
             "pane-3",
+            "secondary",
         ]);
         expect(
             state.panes.find((pane) => pane.id === "pane-3")?.tabs[0],
@@ -233,6 +233,99 @@ describe("EditorPaneBar", () => {
             title: "Alpha",
             content: "Alpha",
         });
+    });
+
+    it("moves a tab into a new down split under the current pane without flattening sibling panes", async () => {
+        const user = userEvent.setup();
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "tab-a",
+                            kind: "note",
+                            noteId: "notes/a",
+                            title: "Alpha",
+                            content: "Alpha",
+                        },
+                        {
+                            id: "tab-c",
+                            kind: "note",
+                            noteId: "notes/c",
+                            title: "Gamma",
+                            content: "Gamma",
+                        },
+                    ],
+                    activeTabId: "tab-a",
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "tab-b",
+                            kind: "note",
+                            noteId: "notes/b",
+                            title: "Beta",
+                            content: "Beta",
+                        },
+                    ],
+                    activeTabId: "tab-b",
+                },
+            ],
+            "primary",
+        );
+
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-c"]',
+        ) as HTMLElement | null;
+        expect(tabButton).not.toBeNull();
+        fireEvent.contextMenu(tabButton!);
+        await user.click(
+            await screen.findByRole("button", {
+                name: "Move to New Down Split",
+            }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(3);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("pane-3");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "pane-3",
+            "secondary",
+        ]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "primary")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-a"]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "pane-3")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-c"]);
+        expect(
+            state.panes
+                .find((pane) => pane.id === "secondary")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-b"]);
+        expect(state.layoutTree.type).toBe("split");
+        if (state.layoutTree.type !== "split") {
+            throw new Error("Expected root split layout");
+        }
+        expect(state.layoutTree.direction).toBe("row");
+        const nestedSplit = state.layoutTree.children[0];
+        expect(nestedSplit?.type).toBe("split");
+        if (!nestedSplit || nestedSplit.type !== "split") {
+            throw new Error("Expected nested split on the left branch");
+        }
+        expect(nestedSplit.direction).toBe("column");
     });
 
     it("disables creating a new split when the workspace already reached the cap", async () => {

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -1,8 +1,9 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it } from "vitest";
 import { renderComponent } from "../../test/test-utils";
 import { useEditorStore } from "../../app/store/editorStore";
+import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
 import { EditorPaneBar } from "./EditorPaneBar";
 
 describe("EditorPaneBar", () => {
@@ -74,7 +75,7 @@ describe("EditorPaneBar", () => {
         ).toEqual(["tab-b", "tab-a"]);
     });
 
-    it("adds a duplicated tab to a new pane from the tab context menu", async () => {
+    it("moves a tab into a new right split from the tab context menu", async () => {
         const user = userEvent.setup();
         renderComponent(<EditorPaneBar paneId="primary" isFocused />);
 
@@ -84,7 +85,9 @@ describe("EditorPaneBar", () => {
         expect(tabButton).not.toBeNull();
         fireEvent.contextMenu(tabButton!);
         await user.click(
-            await screen.findByRole("button", { name: "Add to New Pane" }),
+            await screen.findByRole("button", {
+                name: "Move to New Right Split",
+            }),
         );
 
         await waitFor(() => {
@@ -93,21 +96,28 @@ describe("EditorPaneBar", () => {
 
         const state = useEditorStore.getState();
         expect(state.focusedPaneId).toBe("pane-3");
-        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
-        expect(state.panes[2]?.tabs).toHaveLength(1);
-        expect(state.panes[2]?.tabs[0]).toMatchObject({
+        expect(
+            state.panes.find((pane) => pane.id === "primary")?.tabs,
+        ).toHaveLength(0);
+        expect(
+            state.panes.find((pane) => pane.id === "pane-3")?.tabs[0],
+        ).toMatchObject({
             kind: "note",
             noteId: "notes/a",
             title: "Alpha",
             content: "Alpha",
         });
-        expect(state.panes[2]?.tabs[0]?.id).not.toBe("tab-a");
     });
 
-    it("disables add to new pane when the workspace already has three panes", async () => {
+    it("disables creating a new split when the workspace already reached the cap", async () => {
         renderComponent(<EditorPaneBar paneId="primary" isFocused />);
 
-        useEditorStore.getState().createEmptyPane();
+        await act(async () => {
+            Array.from({ length: MAX_EDITOR_PANES - 2 }, () =>
+                useEditorStore.getState().createEmptyPane(),
+            );
+            await Promise.resolve();
+        });
 
         const tabButton = document.querySelector(
             '[data-pane-tab-id="tab-a"]',
@@ -116,8 +126,50 @@ describe("EditorPaneBar", () => {
         fireEvent.contextMenu(tabButton!);
 
         expect(
-            await screen.findByRole("button", { name: "Add to New Pane" }),
+            await screen.findByRole("button", {
+                name: "Move to New Right Split",
+            }),
         ).toBeDisabled();
+    });
+
+    it("splits the current pane down from the pane actions menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="secondary" isFocused />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Pane 2 actions" }),
+        );
+        await user.click(
+            await screen.findByRole("button", { name: "Split Down" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(3);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("pane-3");
+        expect(state.panes.map((pane) => pane.id)).toEqual([
+            "primary",
+            "secondary",
+            "pane-3",
+        ]);
+    });
+
+    it("focuses a neighbor pane from the pane actions menu", async () => {
+        const user = userEvent.setup();
+        renderComponent(<EditorPaneBar paneId="secondary" isFocused />);
+
+        await user.click(
+            screen.getByRole("button", { name: "Pane 2 actions" }),
+        );
+        await user.click(
+            await screen.findByRole("button", { name: "Focus Pane Left" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().focusedPaneId).toBe("primary");
+        });
     });
 
     it("closes a pane explicitly from the pane actions menu", async () => {

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -405,7 +405,7 @@ describe("EditorPaneBar", () => {
             screen.getByRole("button", { name: "Pane 2 actions" }),
         );
         await user.click(
-            await screen.findByRole("button", { name: "Unify All Tabs Here" }),
+            await screen.findByRole("button", { name: "Unify All Tabs" }),
         );
 
         await waitFor(() => {

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -328,6 +328,28 @@ describe("EditorPaneBar", () => {
         expect(nestedSplit.direction).toBe("column");
     });
 
+    it("scrolls the pane tab strip horizontally with the mouse wheel", () => {
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const tabStrip = document.querySelector(
+            '[data-pane-tab-strip="primary"]',
+        ) as HTMLDivElement | null;
+        expect(tabStrip).not.toBeNull();
+
+        let scrollLeft = 12;
+        Object.defineProperty(tabStrip!, "scrollLeft", {
+            configurable: true,
+            get: () => scrollLeft,
+            set: (value: number) => {
+                scrollLeft = value;
+            },
+        });
+
+        fireEvent.wheel(tabStrip!, { deltaY: 28 });
+
+        expect(scrollLeft).toBe(40);
+    });
+
     it("disables creating a new split when the workspace already reached the cap", async () => {
         renderComponent(<EditorPaneBar paneId="primary" isFocused />);
 

--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -1,9 +1,10 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../test/test-utils";
 import { useEditorStore } from "../../app/store/editorStore";
 import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { useChatStore } from "../ai/store/chatStore";
 import { EditorPaneBar } from "./EditorPaneBar";
 
@@ -342,5 +343,52 @@ describe("EditorPaneBar", () => {
         });
 
         expect(screen.getByText("Renamed workspace chat")).toBeInTheDocument();
+    });
+
+    it("creates a new note from the pane plus-button context menu in the current pane", async () => {
+        const createNote = vi.fn().mockResolvedValue({
+            id: "notes/from-menu.md",
+            path: "/vault/notes/from-menu.md",
+            title: "From Menu",
+            modified_at: 1,
+            created_at: 1,
+        });
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            createNote,
+        });
+
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const newTabButton = document.querySelector(
+            '[data-pane-tab-strip="primary"] [data-new-tab-button="true"]',
+        ) as HTMLElement | null;
+        expect(newTabButton).not.toBeNull();
+
+        fireEvent.contextMenu(newTabButton!);
+        fireEvent.click(
+            await screen.findByRole("button", { name: "New Note" }),
+        );
+
+        await waitFor(() => {
+            const primaryPane = useEditorStore
+                .getState()
+                .panes.find((pane) => pane.id === "primary");
+            expect(
+                primaryPane?.tabs.some(
+                    (tab) =>
+                        tab.kind === "note" &&
+                        tab.noteId === "notes/from-menu.md",
+                ),
+            ).toBe(true);
+        });
+
+        expect(createNote).toHaveBeenCalledTimes(1);
+        expect(
+            useEditorStore
+                .getState()
+                .panes.find((pane) => pane.id === "secondary")
+                ?.tabs.map((tab) => tab.id),
+        ).toEqual(["tab-b"]);
     });
 });

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -59,117 +59,7 @@ import {
     buildTabFileDragDetail,
     isPointOverAiComposerDropZone,
 } from "./tabDragAttachments";
-
-function renderTabLeadingIcon(tab: Tab): ReactNode {
-    if (tab.kind === "pdf") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background: "color-mix(in srgb, #e24b3b 12%, transparent)",
-                    color: "#e24b3b",
-                }}
-            >
-                PDF
-            </span>
-        );
-    }
-
-    if (tab.kind === "file") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background:
-                        "color-mix(in srgb, var(--text-secondary) 12%, transparent)",
-                    color: "var(--text-secondary)",
-                }}
-            >
-                F
-            </span>
-        );
-    }
-
-    if (tab.kind === "ai-review") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background:
-                        "color-mix(in srgb, var(--accent) 12%, transparent)",
-                    color: "var(--accent)",
-                }}
-            >
-                AI
-            </span>
-        );
-    }
-
-    if (tab.kind === "ai-chat") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background:
-                        "color-mix(in srgb, var(--accent) 12%, transparent)",
-                    color: "var(--accent)",
-                }}
-            >
-                C
-            </span>
-        );
-    }
-
-    if (tab.kind === "map") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background:
-                        "color-mix(in srgb, var(--accent) 12%, transparent)",
-                    color: "var(--accent)",
-                }}
-            >
-                M
-            </span>
-        );
-    }
-
-    if (tab.kind === "graph") {
-        return (
-            <span
-                aria-hidden="true"
-                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-                style={{
-                    background:
-                        "color-mix(in srgb, var(--accent) 12%, transparent)",
-                    color: "var(--accent)",
-                }}
-            >
-                G
-            </span>
-        );
-    }
-
-    return (
-        <span
-            aria-hidden="true"
-            className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
-            style={{
-                background:
-                    "color-mix(in srgb, var(--text-secondary) 10%, transparent)",
-                color: "var(--text-secondary)",
-            }}
-        >
-            N
-        </span>
-    );
-}
+import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 
 function getTabLabel(
     tab: Tab,
@@ -212,6 +102,9 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const splitEditorPane = useEditorStore((state) => state.splitEditorPane);
     const balancePaneLayout = useEditorStore(
         (state) => state.balancePaneLayout,
+    );
+    const unifyAllPanesInto = useEditorStore(
+        (state) => state.unifyAllPanesInto,
     );
     const focusPaneNeighbor = useEditorStore(
         (state) => state.focusPaneNeighbor,
@@ -743,7 +636,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                     cursor: isDragging ? "grabbing" : "pointer",
                                 }}
                             >
-                                {renderTabLeadingIcon(tab)}
+                                {renderEditorTabLeadingIcon(tab)}
                                 {isEditing ? (
                                     <input
                                         ref={inputRef}
@@ -1032,6 +925,11 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             action: () => balancePaneLayout(),
                             disabled: paneCount <= 1,
                         },
+                        {
+                            label: "Unify All Tabs Here",
+                            action: () => unifyAllPanesInto(paneId),
+                            disabled: paneCount <= 1,
+                        },
                         { type: "separator" },
                         {
                             label: `Close Pane ${paneIndex + 1}`,
@@ -1069,7 +967,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                               willChange: "transform",
                           }}
                       >
-                          {renderTabLeadingIcon(draggedPreviewTab)}
+                          {renderEditorTabLeadingIcon(draggedPreviewTab)}
                           <span
                               style={{
                                   minWidth: 0,

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -626,6 +626,12 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                         ? "color-mix(in srgb, var(--bg-secondary) 96%, var(--accent) 4%)"
                         : "var(--bg-secondary)",
                 }}
+                onWheel={(event) => {
+                    if (event.deltaY !== 0) {
+                        event.currentTarget.scrollLeft += event.deltaY;
+                        event.preventDefault();
+                    }
+                }}
             >
                 {insertionIndicatorIndex === 0 && (
                     <div

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -1,7 +1,20 @@
-import { useMemo, useState, type ReactNode } from "react";
+import {
+    Fragment,
+    useEffect,
+    useLayoutEffect,
+    useCallback,
+    useMemo,
+    useRef,
+    useState,
+    type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import type { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
     type Tab,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     selectEditorPaneState,
     useEditorStore,
 } from "../../app/store/editorStore";
@@ -12,6 +25,27 @@ import {
     type ContextMenuEntry,
     type ContextMenuState,
 } from "../../components/context-menu/ContextMenu";
+import {
+    ATTACH_EXTERNAL_TAB_EVENT,
+    type AttachExternalTabPayload,
+    createDetachedWindowPayload,
+    createGhostWindow,
+    destroyGhostWindow,
+    findWindowTabDropTarget,
+    getCurrentWindowLabel,
+    getDetachedWindowPosition,
+    getWindowMode,
+    isPointerOutsideCurrentWindow,
+    moveGhostWindow,
+    openDetachedNoteWindow,
+} from "../../app/detachedWindows";
+import { emitFileTreeNoteDrag } from "../ai/dragEvents";
+import { useTabDragReorder } from "./useTabDragReorder";
+import {
+    buildTabFileDragDetail,
+    isPointOverAiComposerDropZone,
+} from "./tabDragAttachments";
+import { getTabStripInsertIndex } from "./tabStrip";
 
 function renderTabLeadingIcon(tab: Tab): ReactNode {
     if (tab.kind === "pdf") {
@@ -121,17 +155,90 @@ interface EditorPaneBarProps {
     isFocused: boolean;
 }
 
+interface CrossPaneTabDropPreview {
+    sourcePaneId: string;
+    targetPaneId: string;
+    insertIndex: number;
+    tabId: string;
+}
+
+const CROSS_PANE_TAB_DROP_PREVIEW_EVENT =
+    "neverwrite:cross-pane-tab-drop-preview";
+
+function duplicateTabForNewPane(tab: Tab): Tab | null {
+    if (tab.kind === "ai-review" || tab.kind === "graph") {
+        return null;
+    }
+
+    return {
+        ...tab,
+        id: crypto.randomUUID(),
+    };
+}
+
+function getAppWindow() {
+    return getCurrentWindow();
+}
+
+function isPointInsideRect(
+    clientX: number,
+    clientY: number,
+    rect: DOMRect | Pick<DOMRect, "left" | "right" | "top" | "bottom">,
+) {
+    return (
+        clientX >= rect.left &&
+        clientX <= rect.right &&
+        clientY >= rect.top &&
+        clientY <= rect.bottom
+    );
+}
+
+function getPaneTabStripDropIndex(strip: HTMLElement | null, clientX: number) {
+    if (!strip) {
+        return 0;
+    }
+
+    const tabRects = Array.from(
+        strip.querySelectorAll<HTMLElement>("[data-pane-tab-id]"),
+    ).map((tab) => {
+        const rect = tab.getBoundingClientRect();
+        return {
+            left: rect.left,
+            width: rect.width,
+        };
+    });
+
+    return getTabStripInsertIndex(clientX, tabRects);
+}
+
+function dispatchCrossPaneTabDropPreview(
+    detail: CrossPaneTabDropPreview | null,
+) {
+    window.dispatchEvent(
+        new CustomEvent<CrossPaneTabDropPreview | null>(
+            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+            {
+                detail,
+            },
+        ),
+    );
+}
+
 export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const pane = useEditorStore((state) =>
         selectEditorPaneState(state, paneId),
     );
     const panes = useEditorStore((state) => state.panes);
+    const reorderPaneTabs = useEditorStore((state) => state.reorderPaneTabs);
     const switchTab = useEditorStore((state) => state.switchTab);
     const closeTab = useEditorStore((state) => state.closeTab);
     const closePane = useEditorStore((state) => state.closePane);
     const moveTabToPane = useEditorStore((state) => state.moveTabToPane);
     const insertExternalTabInPane = useEditorStore(
         (state) => state.insertExternalTabInPane,
+    );
+    const insertExternalTabInNewPane = useEditorStore(
+        (state) => state.insertExternalTabInNewPane,
     );
     const fileTreeShowExtensions = useSettingsStore(
         (state) => state.fileTreeShowExtensions,
@@ -143,6 +250,20 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const [paneContextMenu, setPaneContextMenu] = useState<ContextMenuState<{
         paneId: string;
     }> | null>(null);
+    const [dragPreviewTabId, setDragPreviewTabId] = useState<string | null>(
+        null,
+    );
+    const [crossPaneDropPreview, setCrossPaneDropPreview] =
+        useState<CrossPaneTabDropPreview | null>(null);
+    const dragPreviewNodeRef = useRef<HTMLDivElement | null>(null);
+    const dragPreviewPosRef = useRef({ clientX: 0, clientY: 0 });
+    const dragPreviewFrameRef = useRef<number | null>(null);
+    const crossPaneDropPreviewRef = useRef<CrossPaneTabDropPreview | null>(
+        null,
+    );
+    const ghostRef = useRef<WebviewWindow | null>(null);
+    const ghostCancelledRef = useRef(false);
+    const windowMode = getWindowMode();
 
     const paneIndex = panes.findIndex((candidate) => candidate.id === paneId);
     const movableTargets = useMemo(
@@ -155,78 +276,584 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 .filter((candidate) => candidate.id !== paneId),
         [paneId, panes],
     );
+    const emitTabDragDetail = useCallback(
+        (
+            tabId: string,
+            phase: "start" | "move" | "end" | "cancel" | "attach",
+            coords?: { clientX: number; clientY: number },
+        ) => {
+            if (phase === "cancel") {
+                emitFileTreeNoteDrag({
+                    phase: "cancel",
+                    x: 0,
+                    y: 0,
+                    notes: [],
+                });
+                return;
+            }
+
+            if (!coords) {
+                return;
+            }
+
+            const tab =
+                pane.tabs.find((candidate) => candidate.id === tabId) ?? null;
+            if (!tab) {
+                return;
+            }
+
+            const detail = buildTabFileDragDetail(tab, phase, coords, {
+                resolveNotePath: (noteId) =>
+                    useVaultStore
+                        .getState()
+                        .notes.find((note) => note.id === noteId)?.path ?? null,
+            });
+            if (!detail) {
+                return;
+            }
+
+            emitFileTreeNoteDrag({
+                ...detail,
+                origin: {
+                    kind: "unified-bar-tab",
+                    tabId,
+                },
+            });
+        },
+        [pane.tabs],
+    );
+    const updateCrossPaneDropPreview = useCallback(
+        (detail: CrossPaneTabDropPreview | null) => {
+            crossPaneDropPreviewRef.current = detail;
+            dispatchCrossPaneTabDropPreview(detail);
+        },
+        [],
+    );
+    const resolveCrossPaneDropTarget = useCallback(
+        (tabId: string, clientX: number, clientY: number) => {
+            const workspacePanes = useEditorStore.getState().panes;
+            const paneNodes = document.querySelectorAll<HTMLElement>(
+                "[data-editor-pane-id]",
+            );
+
+            for (const paneNode of paneNodes) {
+                const targetPaneId = paneNode.dataset.editorPaneId;
+                if (!targetPaneId || targetPaneId === paneId) {
+                    continue;
+                }
+
+                const paneRect = paneNode.getBoundingClientRect();
+                if (!isPointInsideRect(clientX, clientY, paneRect)) {
+                    continue;
+                }
+
+                const targetPane =
+                    workspacePanes.find((pane) => pane.id === targetPaneId) ??
+                    null;
+                if (!targetPane) {
+                    continue;
+                }
+
+                const targetStrip = paneNode.querySelector<HTMLElement>(
+                    "[data-pane-tab-strip]",
+                );
+                const insertIndex =
+                    targetStrip &&
+                    isPointInsideRect(
+                        clientX,
+                        clientY,
+                        targetStrip.getBoundingClientRect(),
+                    )
+                        ? getPaneTabStripDropIndex(targetStrip, clientX)
+                        : targetPane.tabs.length;
+
+                return {
+                    sourcePaneId: paneId,
+                    targetPaneId,
+                    insertIndex,
+                    tabId,
+                } satisfies CrossPaneTabDropPreview;
+            }
+
+            return null;
+        },
+        [paneId],
+    );
+    const handleDetachStart = useCallback(
+        async (tabId: string, coords: { screenX: number; screenY: number }) => {
+            updateCrossPaneDropPreview(null);
+            const currentTabs = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            );
+            const tab = currentTabs.find((candidate) => candidate.id === tabId);
+            if (!tab) {
+                return;
+            }
+
+            ghostCancelledRef.current = false;
+
+            try {
+                const ghost = await createGhostWindow(
+                    tab.title,
+                    coords.screenX,
+                    coords.screenY,
+                );
+                if (ghostCancelledRef.current) {
+                    void destroyGhostWindow(ghost);
+                    return;
+                }
+                ghostRef.current = ghost;
+            } catch (error) {
+                console.error("Failed to create ghost window:", error);
+            }
+        },
+        [updateCrossPaneDropPreview],
+    );
+    const handleDetachMove = useCallback(
+        (coords: { screenX: number; screenY: number }) => {
+            const ghost = ghostRef.current;
+            if (!ghost) {
+                return;
+            }
+
+            void moveGhostWindow(ghost, coords.screenX, coords.screenY);
+        },
+        [],
+    );
+    const handleDetachCancel = useCallback(() => {
+        updateCrossPaneDropPreview(null);
+        ghostCancelledRef.current = true;
+        if (ghostRef.current) {
+            void destroyGhostWindow(ghostRef.current);
+            ghostRef.current = null;
+        }
+    }, [updateCrossPaneDropPreview]);
+    const handleDetachEnd = useCallback(
+        async (tabId: string, coords: { screenX: number; screenY: number }) => {
+            updateCrossPaneDropPreview(null);
+            ghostCancelledRef.current = true;
+            if (ghostRef.current) {
+                await destroyGhostWindow(ghostRef.current);
+                ghostRef.current = null;
+            }
+
+            const state = useEditorStore.getState();
+            const currentTabs = selectEditorWorkspaceTabs(state);
+            const tab = currentTabs.find((candidate) => candidate.id === tabId);
+            if (!tab) {
+                return;
+            }
+
+            const targetWindowLabel = await findWindowTabDropTarget(
+                coords.screenX,
+                coords.screenY,
+                getCurrentWindowLabel(),
+                vaultPath,
+            );
+
+            if (targetWindowLabel) {
+                const appWindow = getAppWindow();
+                await appWindow.emitTo(
+                    targetWindowLabel,
+                    ATTACH_EXTERNAL_TAB_EVENT,
+                    { tab } satisfies AttachExternalTabPayload,
+                );
+
+                if (windowMode === "note" && currentTabs.length === 1) {
+                    await appWindow.close();
+                    return;
+                }
+
+                closeTab(tabId, { reason: "detach" });
+                return;
+            }
+
+            await openDetachedNoteWindow(
+                createDetachedWindowPayload(tab, vaultPath),
+                {
+                    title: tab.title,
+                    position: getDetachedWindowPosition(
+                        coords.screenX,
+                        coords.screenY,
+                    ),
+                },
+            );
+
+            if (windowMode === "note" && currentTabs.length === 1) {
+                const appWindow = getAppWindow();
+                await appWindow.close();
+                return;
+            }
+
+            closeTab(tabId, { reason: "detach" });
+        },
+        [closeTab, updateCrossPaneDropPreview, vaultPath, windowMode],
+    );
+    const applyDragPreviewPosition = useCallback(() => {
+        dragPreviewFrameRef.current = null;
+        const node = dragPreviewNodeRef.current;
+        if (!node) {
+            return;
+        }
+
+        const { clientX, clientY } = dragPreviewPosRef.current;
+        node.style.transform = `translate3d(${clientX + 12}px, ${clientY + 12}px, 0) scale(1.02)`;
+    }, []);
+    const scheduleDragPreviewPosition = useCallback(() => {
+        if (dragPreviewFrameRef.current !== null) {
+            return;
+        }
+
+        dragPreviewFrameRef.current = window.requestAnimationFrame(
+            applyDragPreviewPosition,
+        );
+    }, [applyDragPreviewPosition]);
+    const updateTabDragPreview = useCallback(
+        (tabId: string, clientX: number, clientY: number) => {
+            dragPreviewPosRef.current = { clientX, clientY };
+            setDragPreviewTabId((current) =>
+                current === tabId ? current : tabId,
+            );
+            scheduleDragPreviewPosition();
+        },
+        [scheduleDragPreviewPosition],
+    );
+
+    useLayoutEffect(() => {
+        if (dragPreviewTabId !== null) {
+            applyDragPreviewPosition();
+        }
+    }, [applyDragPreviewPosition, dragPreviewTabId]);
+
+    useEffect(() => {
+        const handleCrossPaneDropPreview = (event: Event) => {
+            const detail = (
+                event as CustomEvent<CrossPaneTabDropPreview | null>
+            ).detail;
+            crossPaneDropPreviewRef.current = detail;
+            setCrossPaneDropPreview(detail);
+        };
+
+        window.addEventListener(
+            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+            handleCrossPaneDropPreview,
+        );
+
+        return () => {
+            if (dragPreviewFrameRef.current !== null) {
+                window.cancelAnimationFrame(dragPreviewFrameRef.current);
+                dragPreviewFrameRef.current = null;
+            }
+            if (ghostRef.current) {
+                void destroyGhostWindow(ghostRef.current);
+                ghostRef.current = null;
+            }
+            window.removeEventListener(
+                CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+                handleCrossPaneDropPreview,
+            );
+        };
+    }, []);
+
+    const {
+        draggingTabId,
+        projectedDropIndex,
+        tabStripRef,
+        visualTabs,
+        registerTabNode,
+        handlePointerDown,
+        handlePointerMove,
+        handlePointerUp,
+        handleLostPointerCapture,
+        consumeSuppressedClick,
+    } = useTabDragReorder({
+        tabs: pane.tabs,
+        onCommitReorder: (fromIndex, toIndex) =>
+            reorderPaneTabs(paneId, fromIndex, toIndex),
+        onActivate: switchTab,
+        liveReorder: false,
+        shouldDetach: isPointerOutsideCurrentWindow,
+        shouldCommitDrag: (tabId, coords) => {
+            const crossPaneTarget = resolveCrossPaneDropTarget(
+                tabId,
+                coords.clientX,
+                coords.clientY,
+            );
+            if (
+                crossPaneTarget ??
+                (crossPaneDropPreviewRef.current?.tabId === tabId
+                    ? crossPaneDropPreviewRef.current
+                    : null)
+            ) {
+                return false;
+            }
+
+            const tab =
+                pane.tabs.find((candidate) => candidate.id === tabId) ?? null;
+            if (!tab) {
+                return true;
+            }
+
+            const canAttachToComposer =
+                buildTabFileDragDetail(
+                    tab,
+                    "end",
+                    {
+                        clientX: coords.clientX,
+                        clientY: coords.clientY,
+                    },
+                    {
+                        resolveNotePath: (noteId) =>
+                            useVaultStore
+                                .getState()
+                                .notes.find((note) => note.id === noteId)
+                                ?.path ?? null,
+                    },
+                ) !== null;
+
+            if (!canAttachToComposer) {
+                return true;
+            }
+
+            return !isPointOverAiComposerDropZone(
+                coords.clientX,
+                coords.clientY,
+            );
+        },
+        onDetachStart: handleDetachStart,
+        onDetachMove: handleDetachMove,
+        onDetachEnd: handleDetachEnd,
+        onDetachCancel: handleDetachCancel,
+        onDragStart: (tabId, coords) => {
+            updateTabDragPreview(tabId, coords.clientX, coords.clientY);
+            updateCrossPaneDropPreview(null);
+            emitTabDragDetail(tabId, "start", {
+                clientX: coords.clientX,
+                clientY: coords.clientY,
+            });
+        },
+        onDragMove: (tabId, coords) => {
+            updateTabDragPreview(tabId, coords.clientX, coords.clientY);
+            updateCrossPaneDropPreview(
+                resolveCrossPaneDropTarget(
+                    tabId,
+                    coords.clientX,
+                    coords.clientY,
+                ),
+            );
+            emitTabDragDetail(tabId, "move", {
+                clientX: coords.clientX,
+                clientY: coords.clientY,
+            });
+        },
+        onDragEnd: (tabId, coords) => {
+            const crossPaneTarget =
+                resolveCrossPaneDropTarget(
+                    tabId,
+                    coords.clientX,
+                    coords.clientY,
+                ) ??
+                (crossPaneDropPreviewRef.current?.tabId === tabId
+                    ? crossPaneDropPreviewRef.current
+                    : null);
+            emitTabDragDetail(tabId, "end", {
+                clientX: coords.clientX,
+                clientY: coords.clientY,
+            });
+            if (crossPaneTarget) {
+                moveTabToPane(
+                    tabId,
+                    crossPaneTarget.targetPaneId,
+                    crossPaneTarget.insertIndex,
+                );
+            }
+            updateCrossPaneDropPreview(null);
+            setDragPreviewTabId(null);
+        },
+        onDragCancel: (tabId) => {
+            emitTabDragDetail(tabId, "cancel");
+            updateCrossPaneDropPreview(null);
+            setDragPreviewTabId(null);
+        },
+    });
+    const draggedPreviewTab =
+        dragPreviewTabId === null
+            ? null
+            : (pane.tabs.find((tab) => tab.id === dragPreviewTabId) ?? null);
+    const draggingOriginalIndex = draggingTabId
+        ? pane.tabs.findIndex((tab) => tab.id === draggingTabId)
+        : -1;
+    const externalInsertionIndicatorIndex =
+        crossPaneDropPreview?.targetPaneId === paneId
+            ? crossPaneDropPreview.insertIndex
+            : null;
+    const suppressLocalInsertionIndicator =
+        crossPaneDropPreview?.sourcePaneId === paneId &&
+        crossPaneDropPreview.targetPaneId !== paneId;
+    const insertionIndicatorIndex =
+        externalInsertionIndicatorIndex ??
+        (suppressLocalInsertionIndicator
+            ? null
+            : draggingOriginalIndex === -1 || projectedDropIndex == null
+              ? null
+              : projectedDropIndex > draggingOriginalIndex
+                ? projectedDropIndex + 1
+                : projectedDropIndex);
+    const handleTabPointerDownCapture = useCallback(
+        (tabId: string, event: React.PointerEvent<HTMLDivElement>) => {
+            if (event.button !== 0) return;
+            if ((event.target as HTMLElement).closest("button")) return;
+            switchTab(tabId);
+        },
+        [switchTab],
+    );
+    const handleTabClick = useCallback(
+        (tabId: string) => {
+            if (consumeSuppressedClick(tabId)) return;
+            switchTab(tabId);
+        },
+        [consumeSuppressedClick, switchTab],
+    );
 
     return (
         <>
             <div
+                ref={tabStripRef}
+                data-pane-tab-strip={paneId}
                 className="flex items-center gap-1 px-2 py-1 shrink-0 overflow-x-auto scrollbar-hidden"
                 style={{
                     minHeight: 38,
                     borderBottom: "1px solid var(--border)",
                     background: isFocused
                         ? "color-mix(in srgb, var(--bg-secondary) 96%, var(--accent) 4%)"
-                        : "var(--bg-secondary)",
+                        : crossPaneDropPreview?.targetPaneId === paneId
+                          ? "color-mix(in srgb, var(--bg-secondary) 92%, var(--accent) 8%)"
+                          : "var(--bg-secondary)",
                 }}
             >
-                {pane.tabs.map((tab) => {
+                {insertionIndicatorIndex === 0 && (
+                    <div
+                        aria-hidden="true"
+                        className="shrink-0 rounded-full"
+                        style={{
+                            width: 3,
+                            height: 20,
+                            marginRight: 4,
+                            backgroundColor: "var(--accent)",
+                            boxShadow:
+                                "0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent)",
+                        }}
+                    />
+                )}
+                {visualTabs.map((tab, index) => {
                     const isActive = tab.id === pane.activeTabId;
+                    const isDragging = tab.id === draggingTabId;
                     return (
-                        <button
-                            key={tab.id}
-                            type="button"
-                            data-pane-tab-id={tab.id}
-                            onClick={() => switchTab(tab.id)}
-                            onContextMenu={(event) => {
-                                event.preventDefault();
-                                setTabContextMenu({
-                                    x: event.clientX,
-                                    y: event.clientY,
-                                    payload: { tabId: tab.id },
-                                });
-                            }}
-                            className="group inline-flex min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left"
-                            style={{
-                                border: isActive
-                                    ? "1px solid color-mix(in srgb, var(--accent) 18%, var(--border))"
-                                    : "1px solid color-mix(in srgb, var(--border) 46%, transparent)",
-                                background: isActive
-                                    ? "var(--bg-primary)"
-                                    : "color-mix(in srgb, var(--bg-primary) 38%, transparent)",
-                                color: isActive
-                                    ? "var(--text-primary)"
-                                    : "var(--text-secondary)",
-                                boxShadow: isActive
-                                    ? "0 10px 24px rgba(15, 23, 42, 0.08)"
-                                    : "none",
-                            }}
-                        >
-                            {renderTabLeadingIcon(tab)}
-                            <span className="truncate text-[12px] font-medium">
-                                {getTabLabel(tab, fileTreeShowExtensions)}
-                            </span>
-                            <span
-                                title={`Close ${tab.title}`}
-                                onClick={(event) => {
-                                    event.stopPropagation();
-                                    closeTab(tab.id);
+                        <Fragment key={tab.id}>
+                            <div
+                                ref={(node) => registerTabNode(tab.id, node)}
+                                data-pane-tab-id={tab.id}
+                                role="tab"
+                                tabIndex={0}
+                                aria-selected={isActive}
+                                className="group inline-flex min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left"
+                                onPointerDownCapture={(event) =>
+                                    handleTabPointerDownCapture(tab.id, event)
+                                }
+                                onPointerDown={(event) =>
+                                    handlePointerDown(tab.id, index, event)
+                                }
+                                onPointerMove={(event) =>
+                                    handlePointerMove(tab.id, event)
+                                }
+                                onPointerUp={(event) =>
+                                    handlePointerUp(event.pointerId, {
+                                        clientX: event.clientX,
+                                        clientY: event.clientY,
+                                        screenX: event.screenX,
+                                        screenY: event.screenY,
+                                    })
+                                }
+                                onPointerCancel={(event) =>
+                                    handlePointerUp(event.pointerId, {
+                                        clientX: event.clientX,
+                                        clientY: event.clientY,
+                                        screenX: event.screenX,
+                                        screenY: event.screenY,
+                                    })
+                                }
+                                onLostPointerCapture={(event) =>
+                                    handleLostPointerCapture(event.pointerId)
+                                }
+                                onClick={() => handleTabClick(tab.id)}
+                                onContextMenu={(event) => {
+                                    event.preventDefault();
+                                    setTabContextMenu({
+                                        x: event.clientX,
+                                        y: event.clientY,
+                                        payload: { tabId: tab.id },
+                                    });
                                 }}
-                                className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded opacity-45 transition group-hover:opacity-100"
-                                style={{ color: "inherit" }}
+                                style={{
+                                    border: isActive
+                                        ? "1px solid color-mix(in srgb, var(--accent) 18%, var(--border))"
+                                        : "1px solid color-mix(in srgb, var(--border) 46%, transparent)",
+                                    background: isActive
+                                        ? "var(--bg-primary)"
+                                        : "color-mix(in srgb, var(--bg-primary) 38%, transparent)",
+                                    color: isActive
+                                        ? "var(--text-primary)"
+                                        : "var(--text-secondary)",
+                                    boxShadow: isActive
+                                        ? "0 10px 24px rgba(15, 23, 42, 0.08)"
+                                        : "none",
+                                    opacity: isDragging ? 0.72 : 1,
+                                    cursor: isDragging ? "grabbing" : "pointer",
+                                }}
                             >
-                                <svg
-                                    width="10"
-                                    height="10"
-                                    viewBox="0 0 16 16"
-                                    fill="none"
-                                    stroke="currentColor"
-                                    strokeWidth="1.8"
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
+                                {renderTabLeadingIcon(tab)}
+                                <span className="truncate text-[12px] font-medium">
+                                    {getTabLabel(tab, fileTreeShowExtensions)}
+                                </span>
+                                <button
+                                    type="button"
+                                    title={`Close ${tab.title}`}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        closeTab(tab.id);
+                                    }}
+                                    className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded opacity-45 transition group-hover:opacity-100"
+                                    style={{ color: "inherit" }}
                                 >
-                                    <path d="M4 4l8 8M4 12l8-8" />
-                                </svg>
-                            </span>
-                        </button>
+                                    <svg
+                                        width="10"
+                                        height="10"
+                                        viewBox="0 0 16 16"
+                                        fill="none"
+                                        stroke="currentColor"
+                                        strokeWidth="1.8"
+                                        strokeLinecap="round"
+                                        strokeLinejoin="round"
+                                    >
+                                        <path d="M4 4l8 8M4 12l8-8" />
+                                    </svg>
+                                </button>
+                            </div>
+                            {insertionIndicatorIndex === index + 1 && (
+                                <div
+                                    aria-hidden="true"
+                                    className="shrink-0 rounded-full"
+                                    style={{
+                                        width: 3,
+                                        height: 20,
+                                        marginLeft: 4,
+                                        backgroundColor: "var(--accent)",
+                                        boxShadow:
+                                            "0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent)",
+                                    }}
+                                />
+                            )}
+                        </Fragment>
                     );
                 })}
 
@@ -322,8 +949,21 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             },
                         ];
 
+                        const duplicatedTab = duplicateTabForNewPane(targetTab);
+                        entries.push({ type: "separator" });
+                        entries.push({
+                            label: "Add to New Pane",
+                            disabled:
+                                duplicatedTab === null || panes.length >= 3,
+                            action: () => {
+                                if (!duplicatedTab) {
+                                    return;
+                                }
+                                insertExternalTabInNewPane(duplicatedTab);
+                            },
+                        });
+
                         if (movableTargets.length > 0) {
-                            entries.push({ type: "separator" });
                             entries.push(
                                 ...movableTargets.map((target) => ({
                                     label: `Move to Pane ${target.index + 1}`,
@@ -351,6 +991,54 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                     ]}
                 />
             )}
+
+            {draggedPreviewTab
+                ? createPortal(
+                      <div
+                          ref={dragPreviewNodeRef}
+                          data-pane-tab-drag-preview="true"
+                          style={{
+                              position: "fixed",
+                              left: 0,
+                              top: 0,
+                              display: "flex",
+                              alignItems: "center",
+                              gap: 8,
+                              minWidth: 140,
+                              maxWidth: 220,
+                              height: 34,
+                              padding: "0 12px",
+                              borderRadius: 10,
+                              border: "1px solid color-mix(in srgb, var(--accent) 16%, var(--border))",
+                              background:
+                                  "color-mix(in srgb, var(--bg-primary) 94%, white 6%)",
+                              color: "var(--text-primary)",
+                              boxShadow: "0 14px 32px rgba(15, 23, 42, 0.18)",
+                              pointerEvents: "none",
+                              zIndex: 9999,
+                              willChange: "transform",
+                          }}
+                      >
+                          {renderTabLeadingIcon(draggedPreviewTab)}
+                          <span
+                              style={{
+                                  minWidth: 0,
+                                  overflow: "hidden",
+                                  textOverflow: "ellipsis",
+                                  whiteSpace: "nowrap",
+                                  fontSize: 12,
+                                  fontWeight: 600,
+                              }}
+                          >
+                              {getTabLabel(
+                                  draggedPreviewTab,
+                                  fileTreeShowExtensions,
+                              )}
+                          </span>
+                      </div>,
+                      document.body,
+                  )
+                : null}
         </>
     );
 }

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -21,7 +21,6 @@ import {
     selectLeafPaneIds,
     selectPaneCount,
     selectPaneNeighbor,
-    selectPaneState,
     useEditorStore,
 } from "../../app/store/editorStore";
 import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
@@ -53,13 +52,6 @@ import {
     buildTabFileDragDetail,
     isPointOverAiComposerDropZone,
 } from "./tabDragAttachments";
-import { getTabStripInsertIndex } from "./tabStrip";
-import {
-    CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
-    dispatchCrossPaneTabDropPreview,
-    type CrossPaneTabDropPreview,
-    resolvePaneDropPosition,
-} from "./workspaceTabDropPreview";
 
 function renderTabLeadingIcon(tab: Tab): ReactNode {
     if (tab.kind === "pdf") {
@@ -189,37 +181,6 @@ function getAppWindow() {
     return getCurrentWindow();
 }
 
-function isPointInsideRect(
-    clientX: number,
-    clientY: number,
-    rect: DOMRect | Pick<DOMRect, "left" | "right" | "top" | "bottom">,
-) {
-    return (
-        clientX >= rect.left &&
-        clientX <= rect.right &&
-        clientY >= rect.top &&
-        clientY <= rect.bottom
-    );
-}
-
-function getPaneTabStripDropIndex(strip: HTMLElement | null, clientX: number) {
-    if (!strip) {
-        return 0;
-    }
-
-    const tabRects = Array.from(
-        strip.querySelectorAll<HTMLElement>("[data-pane-tab-id]"),
-    ).map((tab) => {
-        const rect = tab.getBoundingClientRect();
-        return {
-            left: rect.left,
-            width: rect.width,
-        };
-    });
-
-    return getTabStripInsertIndex(clientX, tabRects);
-}
-
 export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const pane = useEditorStore((state) =>
         selectEditorPaneState(state, paneId),
@@ -240,9 +201,6 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const moveTabToNewSplit = useEditorStore(
         (state) => state.moveTabToNewSplit,
     );
-    const moveTabToPaneDropTarget = useEditorStore(
-        (state) => state.moveTabToPaneDropTarget,
-    );
     const moveTabToPane = useEditorStore((state) => state.moveTabToPane);
     const insertExternalTabInPane = useEditorStore(
         (state) => state.insertExternalTabInPane,
@@ -260,14 +218,9 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const [dragPreviewTabId, setDragPreviewTabId] = useState<string | null>(
         null,
     );
-    const [crossPaneDropPreview, setCrossPaneDropPreview] =
-        useState<CrossPaneTabDropPreview | null>(null);
     const dragPreviewNodeRef = useRef<HTMLDivElement | null>(null);
     const dragPreviewPosRef = useRef({ clientX: 0, clientY: 0 });
     const dragPreviewFrameRef = useRef<number | null>(null);
-    const crossPaneDropPreviewRef = useRef<CrossPaneTabDropPreview | null>(
-        null,
-    );
     const ghostRef = useRef<WebviewWindow | null>(null);
     const ghostCancelledRef = useRef(false);
     const windowMode = getWindowMode();
@@ -342,73 +295,8 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         },
         [pane.tabs],
     );
-    const updateCrossPaneDropPreview = useCallback(
-        (detail: CrossPaneTabDropPreview | null) => {
-            crossPaneDropPreviewRef.current = detail;
-            dispatchCrossPaneTabDropPreview(detail);
-        },
-        [],
-    );
-    const resolveCrossPaneDropTarget = useCallback(
-        (tabId: string, clientX: number, clientY: number) => {
-            const editorState = useEditorStore.getState();
-            const paneNodes = document.querySelectorAll<HTMLElement>(
-                "[data-editor-pane-id]",
-            );
-
-            for (const paneNode of paneNodes) {
-                const targetPaneId = paneNode.dataset.editorPaneId;
-                if (!targetPaneId || targetPaneId === paneId) {
-                    continue;
-                }
-
-                const paneRect = paneNode.getBoundingClientRect();
-                if (!isPointInsideRect(clientX, clientY, paneRect)) {
-                    continue;
-                }
-
-                const targetPane = selectPaneState(editorState, targetPaneId);
-                if (!targetPane) {
-                    continue;
-                }
-
-                const targetStrip = paneNode.querySelector<HTMLElement>(
-                    "[data-pane-tab-strip]",
-                );
-                const canCreateDropSplit =
-                    selectPaneCount(editorState) < MAX_EDITOR_PANES;
-                const position = canCreateDropSplit
-                    ? resolvePaneDropPosition(clientX, clientY, paneRect)
-                    : "center";
-                const insertIndex =
-                    position === "center" &&
-                    targetStrip &&
-                    isPointInsideRect(
-                        clientX,
-                        clientY,
-                        targetStrip.getBoundingClientRect(),
-                    )
-                        ? getPaneTabStripDropIndex(targetStrip, clientX)
-                        : position === "center"
-                          ? targetPane.tabs.length
-                          : null;
-
-                return {
-                    sourcePaneId: paneId,
-                    targetPaneId,
-                    position,
-                    insertIndex,
-                    tabId,
-                } satisfies CrossPaneTabDropPreview;
-            }
-
-            return null;
-        },
-        [paneId],
-    );
     const handleDetachStart = useCallback(
         async (tabId: string, coords: { screenX: number; screenY: number }) => {
-            updateCrossPaneDropPreview(null);
             const currentTabs = selectEditorWorkspaceTabs(
                 useEditorStore.getState(),
             );
@@ -434,7 +322,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 console.error("Failed to create ghost window:", error);
             }
         },
-        [updateCrossPaneDropPreview],
+        [],
     );
     const handleDetachMove = useCallback(
         (coords: { screenX: number; screenY: number }) => {
@@ -448,16 +336,14 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         [],
     );
     const handleDetachCancel = useCallback(() => {
-        updateCrossPaneDropPreview(null);
         ghostCancelledRef.current = true;
         if (ghostRef.current) {
             void destroyGhostWindow(ghostRef.current);
             ghostRef.current = null;
         }
-    }, [updateCrossPaneDropPreview]);
+    }, []);
     const handleDetachEnd = useCallback(
         async (tabId: string, coords: { screenX: number; screenY: number }) => {
-            updateCrossPaneDropPreview(null);
             ghostCancelledRef.current = true;
             if (ghostRef.current) {
                 await destroyGhostWindow(ghostRef.current);
@@ -514,7 +400,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
 
             closeTab(tabId, { reason: "detach" });
         },
-        [closeTab, updateCrossPaneDropPreview, vaultPath, windowMode],
+        [closeTab, vaultPath, windowMode],
     );
     const applyDragPreviewPosition = useCallback(() => {
         dragPreviewFrameRef.current = null;
@@ -553,19 +439,6 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     }, [applyDragPreviewPosition, dragPreviewTabId]);
 
     useEffect(() => {
-        const handleCrossPaneDropPreview = (event: Event) => {
-            const detail = (
-                event as CustomEvent<CrossPaneTabDropPreview | null>
-            ).detail;
-            crossPaneDropPreviewRef.current = detail;
-            setCrossPaneDropPreview(detail);
-        };
-
-        window.addEventListener(
-            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
-            handleCrossPaneDropPreview,
-        );
-
         return () => {
             if (dragPreviewFrameRef.current !== null) {
                 window.cancelAnimationFrame(dragPreviewFrameRef.current);
@@ -575,10 +448,6 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 void destroyGhostWindow(ghostRef.current);
                 ghostRef.current = null;
             }
-            window.removeEventListener(
-                CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
-                handleCrossPaneDropPreview,
-            );
         };
     }, []);
 
@@ -601,20 +470,6 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         liveReorder: false,
         shouldDetach: isPointerOutsideCurrentWindow,
         shouldCommitDrag: (tabId, coords) => {
-            const crossPaneTarget = resolveCrossPaneDropTarget(
-                tabId,
-                coords.clientX,
-                coords.clientY,
-            );
-            if (
-                crossPaneTarget ??
-                (crossPaneDropPreviewRef.current?.tabId === tabId
-                    ? crossPaneDropPreviewRef.current
-                    : null)
-            ) {
-                return false;
-            }
-
             const tab =
                 pane.tabs.find((candidate) => candidate.id === tabId) ?? null;
             if (!tab) {
@@ -653,7 +508,6 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         onDetachCancel: handleDetachCancel,
         onDragStart: (tabId, coords) => {
             updateTabDragPreview(tabId, coords.clientX, coords.clientY);
-            updateCrossPaneDropPreview(null);
             emitTabDragDetail(tabId, "start", {
                 clientX: coords.clientX,
                 clientY: coords.clientY,
@@ -661,54 +515,20 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         },
         onDragMove: (tabId, coords) => {
             updateTabDragPreview(tabId, coords.clientX, coords.clientY);
-            updateCrossPaneDropPreview(
-                resolveCrossPaneDropTarget(
-                    tabId,
-                    coords.clientX,
-                    coords.clientY,
-                ),
-            );
             emitTabDragDetail(tabId, "move", {
                 clientX: coords.clientX,
                 clientY: coords.clientY,
             });
         },
         onDragEnd: (tabId, coords) => {
-            const crossPaneTarget =
-                resolveCrossPaneDropTarget(
-                    tabId,
-                    coords.clientX,
-                    coords.clientY,
-                ) ??
-                (crossPaneDropPreviewRef.current?.tabId === tabId
-                    ? crossPaneDropPreviewRef.current
-                    : null);
             emitTabDragDetail(tabId, "end", {
                 clientX: coords.clientX,
                 clientY: coords.clientY,
             });
-            if (crossPaneTarget) {
-                if (crossPaneTarget.position === "center") {
-                    moveTabToPane(
-                        tabId,
-                        crossPaneTarget.targetPaneId,
-                        crossPaneTarget.insertIndex ?? undefined,
-                    );
-                } else {
-                    moveTabToPaneDropTarget(
-                        tabId,
-                        crossPaneTarget.targetPaneId,
-                        crossPaneTarget.position,
-                        crossPaneTarget.insertIndex ?? undefined,
-                    );
-                }
-            }
-            updateCrossPaneDropPreview(null);
             setDragPreviewTabId(null);
         },
         onDragCancel: (tabId) => {
             emitTabDragDetail(tabId, "cancel");
-            updateCrossPaneDropPreview(null);
             setDragPreviewTabId(null);
         },
     });
@@ -719,23 +539,12 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const draggingOriginalIndex = draggingTabId
         ? pane.tabs.findIndex((tab) => tab.id === draggingTabId)
         : -1;
-    const externalInsertionIndicatorIndex =
-        crossPaneDropPreview?.targetPaneId === paneId &&
-        crossPaneDropPreview.position === "center"
-            ? crossPaneDropPreview.insertIndex
-            : null;
-    const suppressLocalInsertionIndicator =
-        crossPaneDropPreview?.sourcePaneId === paneId &&
-        crossPaneDropPreview.targetPaneId !== paneId;
     const insertionIndicatorIndex =
-        externalInsertionIndicatorIndex ??
-        (suppressLocalInsertionIndicator
+        draggingOriginalIndex === -1 || projectedDropIndex == null
             ? null
-            : draggingOriginalIndex === -1 || projectedDropIndex == null
-              ? null
-              : projectedDropIndex > draggingOriginalIndex
-                ? projectedDropIndex + 1
-                : projectedDropIndex);
+            : projectedDropIndex > draggingOriginalIndex
+              ? projectedDropIndex + 1
+              : projectedDropIndex;
     const handleTabPointerDownCapture = useCallback(
         (tabId: string, event: React.PointerEvent<HTMLDivElement>) => {
             if (event.button !== 0) return;
@@ -763,9 +572,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                     borderBottom: "1px solid var(--border)",
                     background: isFocused
                         ? "color-mix(in srgb, var(--bg-secondary) 96%, var(--accent) 4%)"
-                        : crossPaneDropPreview?.targetPaneId === paneId
-                          ? "color-mix(in srgb, var(--bg-secondary) 92%, var(--accent) 8%)"
-                          : "var(--bg-secondary)",
+                        : "var(--bg-secondary)",
                 }}
             >
                 {insertionIndicatorIndex === 0 && (

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -13,11 +13,13 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { WebviewWindow } from "@tauri-apps/api/webviewWindow";
 import {
     type Tab,
+    isChatTab,
     isNoteTab,
     selectEditorWorkspaceTabs,
     selectEditorPaneState,
     useEditorStore,
 } from "../../app/store/editorStore";
+import { moveChatToSidebar } from "../ai/chatPaneMovement";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
@@ -95,6 +97,22 @@ function renderTabLeadingIcon(tab: Tab): ReactNode {
         );
     }
 
+    if (tab.kind === "ai-chat") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background:
+                        "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    color: "var(--accent)",
+                }}
+            >
+                C
+            </span>
+        );
+    }
+
     if (tab.kind === "map") {
         return (
             <span
@@ -166,7 +184,11 @@ const CROSS_PANE_TAB_DROP_PREVIEW_EVENT =
     "neverwrite:cross-pane-tab-drop-preview";
 
 function duplicateTabForNewPane(tab: Tab): Tab | null {
-    if (tab.kind === "ai-review" || tab.kind === "graph") {
+    if (
+        tab.kind === "ai-review" ||
+        tab.kind === "ai-chat" ||
+        tab.kind === "graph"
+    ) {
         return null;
     }
 
@@ -820,7 +842,11 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                     title={`Close ${tab.title}`}
                                     onClick={(event) => {
                                         event.stopPropagation();
-                                        closeTab(tab.id);
+                                        if (isChatTab(tab)) {
+                                            moveChatToSidebar(tab.sessionId);
+                                        } else {
+                                            closeTab(tab.id);
+                                        }
                                     }}
                                     className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded opacity-45 transition group-hover:opacity-100"
                                     style={{ color: "inherit" }}
@@ -945,9 +971,23 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                         const entries: ContextMenuEntry[] = [
                             {
                                 label: "Close",
-                                action: () => closeTab(targetTab.id),
+                                action: () => {
+                                    if (isChatTab(targetTab)) {
+                                        moveChatToSidebar(targetTab.sessionId);
+                                    } else {
+                                        closeTab(targetTab.id);
+                                    }
+                                },
                             },
                         ];
+
+                        if (isChatTab(targetTab)) {
+                            entries.push({
+                                label: "Return to AI Panel",
+                                action: () =>
+                                    moveChatToSidebar(targetTab.sessionId),
+                            });
+                        }
 
                         const duplicatedTab = duplicateTabForNewPane(targetTab);
                         entries.push({ type: "separator" });

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -25,6 +25,9 @@ import {
 } from "../../app/store/editorStore";
 import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
 import { moveChatToSidebar } from "../ai/chatPaneMovement";
+import { getSessionTitle } from "../ai/sessionPresentation";
+import { useChatStore } from "../ai/store/chatStore";
+import { useInlineRename } from "../ai/components/useInlineRename";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
@@ -164,7 +167,16 @@ function renderTabLeadingIcon(tab: Tab): ReactNode {
     );
 }
 
-function getTabLabel(tab: Tab, fileTreeShowExtensions: boolean) {
+function getTabLabel(
+    tab: Tab,
+    fileTreeShowExtensions: boolean,
+    chatSessionsById: ReturnType<typeof useChatStore.getState>["sessionsById"],
+) {
+    if (isChatTab(tab)) {
+        const session = chatSessionsById[tab.sessionId];
+        return session ? getSessionTitle(session) : tab.title;
+    }
+
     if (fileTreeShowExtensions && isNoteTab(tab)) {
         const baseName = tab.noteId.split("/").pop() || tab.title;
         return tab.noteId ? `${baseName}.md` : baseName;
@@ -185,6 +197,8 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const pane = useEditorStore((state) =>
         selectEditorPaneState(state, paneId),
     );
+    const chatSessionsById = useChatStore((state) => state.sessionsById);
+    const renameChatSession = useChatStore((state) => state.renameSession);
     const paneIds = useEditorStore(useShallow(selectLeafPaneIds));
     const paneCount = useEditorStore(selectPaneCount);
     const reorderPaneTabs = useEditorStore((state) => state.reorderPaneTabs);
@@ -224,6 +238,15 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const ghostRef = useRef<WebviewWindow | null>(null);
     const ghostCancelledRef = useRef(false);
     const windowMode = getWindowMode();
+    const {
+        editingKey,
+        editValue,
+        inputRef,
+        setEditValue,
+        startEditing,
+        cancelEditing,
+        commitEditing,
+    } = useInlineRename<string>();
 
     const paneIndex = paneIds.indexOf(paneId);
     const canCreateSplit = paneCount < MAX_EDITOR_PANES;
@@ -555,10 +578,31 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     );
     const handleTabClick = useCallback(
         (tabId: string) => {
+            if (editingKey === tabId) return;
             if (consumeSuppressedClick(tabId)) return;
             switchTab(tabId);
         },
-        [consumeSuppressedClick, switchTab],
+        [consumeSuppressedClick, editingKey, switchTab],
+    );
+    const beginChatRename = useCallback(
+        (tab: Tab) => {
+            if (!isChatTab(tab)) return;
+            const session = chatSessionsById[tab.sessionId];
+            if (!session) return;
+            switchTab(tab.id);
+            startEditing(tab.id, getSessionTitle(session));
+        },
+        [chatSessionsById, startEditing, switchTab],
+    );
+    const commitChatRename = useCallback(
+        (tabId: string, value: string | null) => {
+            const tab = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find((candidate) => candidate.id === tabId);
+            if (!tab || !isChatTab(tab)) return;
+            renameChatSession(tab.sessionId, value);
+        },
+        [renameChatSession],
     );
 
     return (
@@ -594,6 +638,13 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 {visualTabs.map((tab, index) => {
                     const isActive = tab.id === pane.activeTabId;
                     const isDragging = tab.id === draggingTabId;
+                    const isEditing = editingKey === tab.id;
+                    const canRename = isChatTab(tab);
+                    const tabLabel = getTabLabel(
+                        tab,
+                        fileTreeShowExtensions,
+                        chatSessionsById,
+                    );
                     return (
                         <Fragment key={tab.id}>
                             <div
@@ -604,35 +655,57 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                 aria-selected={isActive}
                                 className="group inline-flex h-8 min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 text-left"
                                 onPointerDownCapture={(event) =>
-                                    handleTabPointerDownCapture(tab.id, event)
+                                    isEditing
+                                        ? undefined
+                                        : handleTabPointerDownCapture(
+                                              tab.id,
+                                              event,
+                                          )
                                 }
                                 onPointerDown={(event) =>
-                                    handlePointerDown(tab.id, index, event)
+                                    isEditing
+                                        ? undefined
+                                        : handlePointerDown(
+                                              tab.id,
+                                              index,
+                                              event,
+                                          )
                                 }
                                 onPointerMove={(event) =>
-                                    handlePointerMove(tab.id, event)
+                                    isEditing
+                                        ? undefined
+                                        : handlePointerMove(tab.id, event)
                                 }
                                 onPointerUp={(event) =>
-                                    handlePointerUp(event.pointerId, {
-                                        clientX: event.clientX,
-                                        clientY: event.clientY,
-                                        screenX: event.screenX,
-                                        screenY: event.screenY,
-                                    })
+                                    isEditing
+                                        ? undefined
+                                        : handlePointerUp(event.pointerId, {
+                                              clientX: event.clientX,
+                                              clientY: event.clientY,
+                                              screenX: event.screenX,
+                                              screenY: event.screenY,
+                                          })
                                 }
                                 onPointerCancel={(event) =>
-                                    handlePointerUp(event.pointerId, {
-                                        clientX: event.clientX,
-                                        clientY: event.clientY,
-                                        screenX: event.screenX,
-                                        screenY: event.screenY,
-                                    })
+                                    isEditing
+                                        ? undefined
+                                        : handlePointerUp(event.pointerId, {
+                                              clientX: event.clientX,
+                                              clientY: event.clientY,
+                                              screenX: event.screenX,
+                                              screenY: event.screenY,
+                                          })
                                 }
                                 onLostPointerCapture={(event) =>
-                                    handleLostPointerCapture(event.pointerId)
+                                    isEditing
+                                        ? undefined
+                                        : handleLostPointerCapture(
+                                              event.pointerId,
+                                          )
                                 }
                                 onClick={() => handleTabClick(tab.id)}
                                 onContextMenu={(event) => {
+                                    if (isEditing) return;
                                     event.preventDefault();
                                     setTabContextMenu({
                                         x: event.clientX,
@@ -659,12 +732,59 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                 }}
                             >
                                 {renderTabLeadingIcon(tab)}
-                                <span className="truncate text-[12px] font-medium">
-                                    {getTabLabel(tab, fileTreeShowExtensions)}
-                                </span>
+                                {isEditing ? (
+                                    <input
+                                        ref={inputRef}
+                                        value={editValue}
+                                        onChange={(event) =>
+                                            setEditValue(event.target.value)
+                                        }
+                                        onKeyDown={(event) => {
+                                            if (event.key === "Enter") {
+                                                commitEditing(commitChatRename);
+                                            } else if (event.key === "Escape") {
+                                                cancelEditing();
+                                            }
+                                        }}
+                                        onBlur={() =>
+                                            commitEditing(commitChatRename)
+                                        }
+                                        onPointerDown={(event) =>
+                                            event.stopPropagation()
+                                        }
+                                        onClick={(event) =>
+                                            event.stopPropagation()
+                                        }
+                                        className="min-w-0 flex-1 truncate bg-transparent text-[12px] font-medium outline-none"
+                                        style={{
+                                            color: "var(--text-primary)",
+                                            border: "none",
+                                            padding: 0,
+                                            minHeight: 0,
+                                            boxSizing: "border-box",
+                                            boxShadow:
+                                                "inset 0 -1px 0 var(--accent)",
+                                        }}
+                                    />
+                                ) : (
+                                    <span
+                                        className="truncate text-[12px] font-medium"
+                                        onDoubleClick={() => {
+                                            if (!canRename) return;
+                                            beginChatRename(tab);
+                                        }}
+                                        title={
+                                            canRename
+                                                ? "Double-click to rename"
+                                                : undefined
+                                        }
+                                    >
+                                        {tabLabel}
+                                    </span>
+                                )}
                                 <button
                                     type="button"
-                                    title={`Close ${tab.title}`}
+                                    title={`Close ${tabLabel}`}
                                     onClick={(event) => {
                                         event.stopPropagation();
                                         if (isChatTab(tab)) {
@@ -808,6 +928,10 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
 
                         if (isChatTab(targetTab)) {
                             entries.push({
+                                label: "Rename chat",
+                                action: () => beginChatRename(targetTab),
+                            });
+                            entries.push({
                                 label: "Return to AI Panel",
                                 action: () =>
                                     moveChatToSidebar(targetTab.sessionId),
@@ -938,6 +1062,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                               {getTabLabel(
                                   draggedPreviewTab,
                                   fileTreeShowExtensions,
+                                  chatSessionsById,
                               )}
                           </span>
                       </div>,

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -926,7 +926,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             disabled: paneCount <= 1,
                         },
                         {
-                            label: "Unify All Tabs Here",
+                            label: "Unify All Tabs",
                             action: () => unifyAllPanesInto(paneId),
                             disabled: paneCount <= 1,
                         },

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -50,6 +50,10 @@ import {
     openDetachedNoteWindow,
 } from "../../app/detachedWindows";
 import { emitFileTreeNoteDrag } from "../ai/dragEvents";
+import {
+    buildNewTabContextMenuEntries,
+    openBlankDraftTabFromPlusButton,
+} from "./newTabMenuActions";
 import { useTabDragReorder } from "./useTabDragReorder";
 import {
     buildTabFileDragDetail,
@@ -216,11 +220,11 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         (state) => state.moveTabToNewSplit,
     );
     const moveTabToPane = useEditorStore((state) => state.moveTabToPane);
-    const insertExternalTabInPane = useEditorStore(
-        (state) => state.insertExternalTabInPane,
-    );
     const fileTreeShowExtensions = useSettingsStore(
         (state) => state.fileTreeShowExtensions,
+    );
+    const developerModeEnabled = useSettingsStore(
+        (state) => state.developerModeEnabled,
     );
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const [tabContextMenu, setTabContextMenu] = useState<ContextMenuState<{
@@ -229,6 +233,8 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const [paneContextMenu, setPaneContextMenu] = useState<ContextMenuState<{
         paneId: string;
     }> | null>(null);
+    const [newTabContextMenu, setNewTabContextMenu] =
+        useState<ContextMenuState<void> | null>(null);
     const [dragPreviewTabId, setDragPreviewTabId] = useState<string | null>(
         null,
     );
@@ -831,18 +837,16 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 {vaultPath && (
                     <button
                         type="button"
-                        onClick={() =>
-                            insertExternalTabInPane(
-                                {
-                                    id: crypto.randomUUID(),
-                                    kind: "note",
-                                    noteId: "",
-                                    title: "New Tab",
-                                    content: "",
-                                },
-                                paneId,
-                            )
-                        }
+                        data-new-tab-button="true"
+                        onClick={() => openBlankDraftTabFromPlusButton(paneId)}
+                        onContextMenu={(event) => {
+                            event.preventDefault();
+                            setNewTabContextMenu({
+                                x: event.clientX,
+                                y: event.clientY,
+                                payload: undefined,
+                            });
+                        }}
                         className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
                         aria-label="New tab"
                         title="New tab"
@@ -966,6 +970,17 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
 
                         return entries;
                     })()}
+                />
+            )}
+
+            {newTabContextMenu && (
+                <ContextMenu
+                    menu={newTabContextMenu}
+                    onClose={() => setNewTabContextMenu(null)}
+                    entries={buildNewTabContextMenuEntries({
+                        paneId,
+                        developerModeEnabled,
+                    })}
                 />
             )}
 

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -1,0 +1,356 @@
+import { useMemo, useState, type ReactNode } from "react";
+import {
+    type Tab,
+    isNoteTab,
+    selectEditorPaneState,
+    useEditorStore,
+} from "../../app/store/editorStore";
+import { useSettingsStore } from "../../app/store/settingsStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import {
+    ContextMenu,
+    type ContextMenuEntry,
+    type ContextMenuState,
+} from "../../components/context-menu/ContextMenu";
+
+function renderTabLeadingIcon(tab: Tab): ReactNode {
+    if (tab.kind === "pdf") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background: "color-mix(in srgb, #e24b3b 12%, transparent)",
+                    color: "#e24b3b",
+                }}
+            >
+                PDF
+            </span>
+        );
+    }
+
+    if (tab.kind === "file") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background:
+                        "color-mix(in srgb, var(--text-secondary) 12%, transparent)",
+                    color: "var(--text-secondary)",
+                }}
+            >
+                F
+            </span>
+        );
+    }
+
+    if (tab.kind === "ai-review") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background:
+                        "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    color: "var(--accent)",
+                }}
+            >
+                AI
+            </span>
+        );
+    }
+
+    if (tab.kind === "map") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background:
+                        "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    color: "var(--accent)",
+                }}
+            >
+                M
+            </span>
+        );
+    }
+
+    if (tab.kind === "graph") {
+        return (
+            <span
+                aria-hidden="true"
+                className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+                style={{
+                    background:
+                        "color-mix(in srgb, var(--accent) 12%, transparent)",
+                    color: "var(--accent)",
+                }}
+            >
+                G
+            </span>
+        );
+    }
+
+    return (
+        <span
+            aria-hidden="true"
+            className="inline-flex h-4 w-4 items-center justify-center rounded text-[8px] font-semibold"
+            style={{
+                background:
+                    "color-mix(in srgb, var(--text-secondary) 10%, transparent)",
+                color: "var(--text-secondary)",
+            }}
+        >
+            N
+        </span>
+    );
+}
+
+function getTabLabel(tab: Tab, fileTreeShowExtensions: boolean) {
+    if (fileTreeShowExtensions && isNoteTab(tab)) {
+        const baseName = tab.noteId.split("/").pop() || tab.title;
+        return tab.noteId ? `${baseName}.md` : baseName;
+    }
+    return tab.title;
+}
+
+interface EditorPaneBarProps {
+    paneId: string;
+    isFocused: boolean;
+}
+
+export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
+    const pane = useEditorStore((state) =>
+        selectEditorPaneState(state, paneId),
+    );
+    const panes = useEditorStore((state) => state.panes);
+    const switchTab = useEditorStore((state) => state.switchTab);
+    const closeTab = useEditorStore((state) => state.closeTab);
+    const closePane = useEditorStore((state) => state.closePane);
+    const moveTabToPane = useEditorStore((state) => state.moveTabToPane);
+    const insertExternalTabInPane = useEditorStore(
+        (state) => state.insertExternalTabInPane,
+    );
+    const fileTreeShowExtensions = useSettingsStore(
+        (state) => state.fileTreeShowExtensions,
+    );
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+    const [tabContextMenu, setTabContextMenu] = useState<ContextMenuState<{
+        tabId: string;
+    }> | null>(null);
+    const [paneContextMenu, setPaneContextMenu] = useState<ContextMenuState<{
+        paneId: string;
+    }> | null>(null);
+
+    const paneIndex = panes.findIndex((candidate) => candidate.id === paneId);
+    const movableTargets = useMemo(
+        () =>
+            panes
+                .map((candidate, index) => ({
+                    id: candidate.id,
+                    index,
+                }))
+                .filter((candidate) => candidate.id !== paneId),
+        [paneId, panes],
+    );
+
+    return (
+        <>
+            <div
+                className="flex items-center gap-1 px-2 py-1 shrink-0 overflow-x-auto scrollbar-hidden"
+                style={{
+                    minHeight: 38,
+                    borderBottom: "1px solid var(--border)",
+                    background: isFocused
+                        ? "color-mix(in srgb, var(--bg-secondary) 96%, var(--accent) 4%)"
+                        : "var(--bg-secondary)",
+                }}
+            >
+                {pane.tabs.map((tab) => {
+                    const isActive = tab.id === pane.activeTabId;
+                    return (
+                        <button
+                            key={tab.id}
+                            type="button"
+                            data-pane-tab-id={tab.id}
+                            onClick={() => switchTab(tab.id)}
+                            onContextMenu={(event) => {
+                                event.preventDefault();
+                                setTabContextMenu({
+                                    x: event.clientX,
+                                    y: event.clientY,
+                                    payload: { tabId: tab.id },
+                                });
+                            }}
+                            className="group inline-flex min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left"
+                            style={{
+                                border: isActive
+                                    ? "1px solid color-mix(in srgb, var(--accent) 18%, var(--border))"
+                                    : "1px solid color-mix(in srgb, var(--border) 46%, transparent)",
+                                background: isActive
+                                    ? "var(--bg-primary)"
+                                    : "color-mix(in srgb, var(--bg-primary) 38%, transparent)",
+                                color: isActive
+                                    ? "var(--text-primary)"
+                                    : "var(--text-secondary)",
+                                boxShadow: isActive
+                                    ? "0 10px 24px rgba(15, 23, 42, 0.08)"
+                                    : "none",
+                            }}
+                        >
+                            {renderTabLeadingIcon(tab)}
+                            <span className="truncate text-[12px] font-medium">
+                                {getTabLabel(tab, fileTreeShowExtensions)}
+                            </span>
+                            <span
+                                title={`Close ${tab.title}`}
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    closeTab(tab.id);
+                                }}
+                                className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded opacity-45 transition group-hover:opacity-100"
+                                style={{ color: "inherit" }}
+                            >
+                                <svg
+                                    width="10"
+                                    height="10"
+                                    viewBox="0 0 16 16"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="1.8"
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                >
+                                    <path d="M4 4l8 8M4 12l8-8" />
+                                </svg>
+                            </span>
+                        </button>
+                    );
+                })}
+
+                {vaultPath && (
+                    <button
+                        type="button"
+                        onClick={() =>
+                            insertExternalTabInPane(
+                                {
+                                    id: crypto.randomUUID(),
+                                    kind: "note",
+                                    noteId: "",
+                                    title: "New Tab",
+                                    content: "",
+                                },
+                                paneId,
+                            )
+                        }
+                        className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                        aria-label="New tab"
+                        title="New tab"
+                        style={{
+                            border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
+                            color: "var(--text-secondary)",
+                            background: "transparent",
+                        }}
+                    >
+                        <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.8"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M8 3.5v9M3.5 8h9" />
+                        </svg>
+                    </button>
+                )}
+
+                <button
+                    type="button"
+                    onClick={(event) =>
+                        setPaneContextMenu({
+                            x: event.clientX,
+                            y: event.clientY,
+                            payload: { paneId },
+                        })
+                    }
+                    className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                    aria-label={`Pane ${paneIndex + 1} actions`}
+                    title={`Pane ${paneIndex + 1} actions`}
+                    style={{
+                        border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
+                        color: "var(--text-secondary)",
+                        background: "transparent",
+                    }}
+                >
+                    <svg
+                        width="12"
+                        height="12"
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                    >
+                        <circle cx="8" cy="3.5" r="1.25" />
+                        <circle cx="8" cy="8" r="1.25" />
+                        <circle cx="8" cy="12.5" r="1.25" />
+                    </svg>
+                </button>
+            </div>
+
+            {tabContextMenu && (
+                <ContextMenu
+                    menu={tabContextMenu}
+                    onClose={() => setTabContextMenu(null)}
+                    entries={(() => {
+                        const targetTab =
+                            pane.tabs.find(
+                                (candidate) =>
+                                    candidate.id ===
+                                    tabContextMenu.payload.tabId,
+                            ) ?? null;
+                        if (!targetTab) {
+                            return [];
+                        }
+
+                        const entries: ContextMenuEntry[] = [
+                            {
+                                label: "Close",
+                                action: () => closeTab(targetTab.id),
+                            },
+                        ];
+
+                        if (movableTargets.length > 0) {
+                            entries.push({ type: "separator" });
+                            entries.push(
+                                ...movableTargets.map((target) => ({
+                                    label: `Move to Pane ${target.index + 1}`,
+                                    action: () =>
+                                        moveTabToPane(targetTab.id, target.id),
+                                })),
+                            );
+                        }
+
+                        return entries;
+                    })()}
+                />
+            )}
+
+            {paneContextMenu && (
+                <ContextMenu
+                    menu={paneContextMenu}
+                    onClose={() => setPaneContextMenu(null)}
+                    entries={[
+                        {
+                            label: `Close Pane ${paneIndex + 1}`,
+                            action: () => closePane(paneId),
+                            disabled: panes.length <= 1,
+                        },
+                    ]}
+                />
+            )}
+        </>
+    );
+}

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -8,6 +8,7 @@ import {
     useState,
     type ReactNode,
 } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { createPortal } from "react-dom";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import type { WebviewWindow } from "@tauri-apps/api/webviewWindow";
@@ -15,10 +16,15 @@ import {
     type Tab,
     isChatTab,
     isNoteTab,
-    selectEditorWorkspaceTabs,
     selectEditorPaneState,
+    selectEditorWorkspaceTabs,
+    selectLeafPaneIds,
+    selectPaneCount,
+    selectPaneNeighbor,
+    selectPaneState,
     useEditorStore,
 } from "../../app/store/editorStore";
+import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
 import { moveChatToSidebar } from "../ai/chatPaneMovement";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -48,6 +54,12 @@ import {
     isPointOverAiComposerDropZone,
 } from "./tabDragAttachments";
 import { getTabStripInsertIndex } from "./tabStrip";
+import {
+    CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+    dispatchCrossPaneTabDropPreview,
+    type CrossPaneTabDropPreview,
+    resolvePaneDropPosition,
+} from "./workspaceTabDropPreview";
 
 function renderTabLeadingIcon(tab: Tab): ReactNode {
     if (tab.kind === "pdf") {
@@ -173,31 +185,6 @@ interface EditorPaneBarProps {
     isFocused: boolean;
 }
 
-interface CrossPaneTabDropPreview {
-    sourcePaneId: string;
-    targetPaneId: string;
-    insertIndex: number;
-    tabId: string;
-}
-
-const CROSS_PANE_TAB_DROP_PREVIEW_EVENT =
-    "neverwrite:cross-pane-tab-drop-preview";
-
-function duplicateTabForNewPane(tab: Tab): Tab | null {
-    if (
-        tab.kind === "ai-review" ||
-        tab.kind === "ai-chat" ||
-        tab.kind === "graph"
-    ) {
-        return null;
-    }
-
-    return {
-        ...tab,
-        id: crypto.randomUUID(),
-    };
-}
-
 function getAppWindow() {
     return getCurrentWindow();
 }
@@ -233,34 +220,32 @@ function getPaneTabStripDropIndex(strip: HTMLElement | null, clientX: number) {
     return getTabStripInsertIndex(clientX, tabRects);
 }
 
-function dispatchCrossPaneTabDropPreview(
-    detail: CrossPaneTabDropPreview | null,
-) {
-    window.dispatchEvent(
-        new CustomEvent<CrossPaneTabDropPreview | null>(
-            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
-            {
-                detail,
-            },
-        ),
-    );
-}
-
 export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const pane = useEditorStore((state) =>
         selectEditorPaneState(state, paneId),
     );
-    const panes = useEditorStore((state) => state.panes);
+    const paneIds = useEditorStore(useShallow(selectLeafPaneIds));
+    const paneCount = useEditorStore(selectPaneCount);
     const reorderPaneTabs = useEditorStore((state) => state.reorderPaneTabs);
     const switchTab = useEditorStore((state) => state.switchTab);
     const closeTab = useEditorStore((state) => state.closeTab);
     const closePane = useEditorStore((state) => state.closePane);
+    const splitEditorPane = useEditorStore((state) => state.splitEditorPane);
+    const balancePaneLayout = useEditorStore(
+        (state) => state.balancePaneLayout,
+    );
+    const focusPaneNeighbor = useEditorStore(
+        (state) => state.focusPaneNeighbor,
+    );
+    const moveTabToNewSplit = useEditorStore(
+        (state) => state.moveTabToNewSplit,
+    );
+    const moveTabToPaneDropTarget = useEditorStore(
+        (state) => state.moveTabToPaneDropTarget,
+    );
     const moveTabToPane = useEditorStore((state) => state.moveTabToPane);
     const insertExternalTabInPane = useEditorStore(
         (state) => state.insertExternalTabInPane,
-    );
-    const insertExternalTabInNewPane = useEditorStore(
-        (state) => state.insertExternalTabInNewPane,
     );
     const fileTreeShowExtensions = useSettingsStore(
         (state) => state.fileTreeShowExtensions,
@@ -287,16 +272,29 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     const ghostCancelledRef = useRef(false);
     const windowMode = getWindowMode();
 
-    const paneIndex = panes.findIndex((candidate) => candidate.id === paneId);
+    const paneIndex = paneIds.indexOf(paneId);
+    const canCreateSplit = paneCount < MAX_EDITOR_PANES;
+    const leftNeighborPaneId = useEditorStore((state) =>
+        selectPaneNeighbor(state, paneId, "left"),
+    );
+    const rightNeighborPaneId = useEditorStore((state) =>
+        selectPaneNeighbor(state, paneId, "right"),
+    );
+    const upNeighborPaneId = useEditorStore((state) =>
+        selectPaneNeighbor(state, paneId, "up"),
+    );
+    const downNeighborPaneId = useEditorStore((state) =>
+        selectPaneNeighbor(state, paneId, "down"),
+    );
     const movableTargets = useMemo(
         () =>
-            panes
+            paneIds
                 .map((candidate, index) => ({
-                    id: candidate.id,
+                    id: candidate,
                     index,
                 }))
                 .filter((candidate) => candidate.id !== paneId),
-        [paneId, panes],
+        [paneId, paneIds],
     );
     const emitTabDragDetail = useCallback(
         (
@@ -353,7 +351,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     );
     const resolveCrossPaneDropTarget = useCallback(
         (tabId: string, clientX: number, clientY: number) => {
-            const workspacePanes = useEditorStore.getState().panes;
+            const editorState = useEditorStore.getState();
             const paneNodes = document.querySelectorAll<HTMLElement>(
                 "[data-editor-pane-id]",
             );
@@ -369,9 +367,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                     continue;
                 }
 
-                const targetPane =
-                    workspacePanes.find((pane) => pane.id === targetPaneId) ??
-                    null;
+                const targetPane = selectPaneState(editorState, targetPaneId);
                 if (!targetPane) {
                     continue;
                 }
@@ -379,7 +375,13 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 const targetStrip = paneNode.querySelector<HTMLElement>(
                     "[data-pane-tab-strip]",
                 );
+                const canCreateDropSplit =
+                    selectPaneCount(editorState) < MAX_EDITOR_PANES;
+                const position = canCreateDropSplit
+                    ? resolvePaneDropPosition(clientX, clientY, paneRect)
+                    : "center";
                 const insertIndex =
+                    position === "center" &&
                     targetStrip &&
                     isPointInsideRect(
                         clientX,
@@ -387,11 +389,14 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                         targetStrip.getBoundingClientRect(),
                     )
                         ? getPaneTabStripDropIndex(targetStrip, clientX)
-                        : targetPane.tabs.length;
+                        : position === "center"
+                          ? targetPane.tabs.length
+                          : null;
 
                 return {
                     sourcePaneId: paneId,
                     targetPaneId,
+                    position,
                     insertIndex,
                     tabId,
                 } satisfies CrossPaneTabDropPreview;
@@ -683,11 +688,20 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 clientY: coords.clientY,
             });
             if (crossPaneTarget) {
-                moveTabToPane(
-                    tabId,
-                    crossPaneTarget.targetPaneId,
-                    crossPaneTarget.insertIndex,
-                );
+                if (crossPaneTarget.position === "center") {
+                    moveTabToPane(
+                        tabId,
+                        crossPaneTarget.targetPaneId,
+                        crossPaneTarget.insertIndex ?? undefined,
+                    );
+                } else {
+                    moveTabToPaneDropTarget(
+                        tabId,
+                        crossPaneTarget.targetPaneId,
+                        crossPaneTarget.position,
+                        crossPaneTarget.insertIndex ?? undefined,
+                    );
+                }
             }
             updateCrossPaneDropPreview(null);
             setDragPreviewTabId(null);
@@ -706,7 +720,8 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         ? pane.tabs.findIndex((tab) => tab.id === draggingTabId)
         : -1;
     const externalInsertionIndicatorIndex =
-        crossPaneDropPreview?.targetPaneId === paneId
+        crossPaneDropPreview?.targetPaneId === paneId &&
+        crossPaneDropPreview.position === "center"
             ? crossPaneDropPreview.insertIndex
             : null;
     const suppressLocalInsertionIndicator =
@@ -989,17 +1004,19 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             });
                         }
 
-                        const duplicatedTab = duplicateTabForNewPane(targetTab);
                         entries.push({ type: "separator" });
                         entries.push({
-                            label: "Add to New Pane",
-                            disabled:
-                                duplicatedTab === null || panes.length >= 3,
+                            label: "Move to New Right Split",
+                            disabled: !canCreateSplit,
                             action: () => {
-                                if (!duplicatedTab) {
-                                    return;
-                                }
-                                insertExternalTabInNewPane(duplicatedTab);
+                                moveTabToNewSplit(targetTab.id, "row");
+                            },
+                        });
+                        entries.push({
+                            label: "Move to New Down Split",
+                            disabled: !canCreateSplit,
+                            action: () => {
+                                moveTabToNewSplit(targetTab.id, "column");
                             },
                         });
 
@@ -1024,9 +1041,47 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                     onClose={() => setPaneContextMenu(null)}
                     entries={[
                         {
+                            label: "Split Right",
+                            action: () => splitEditorPane("row", paneId),
+                            disabled: !canCreateSplit,
+                        },
+                        {
+                            label: "Split Down",
+                            action: () => splitEditorPane("column", paneId),
+                            disabled: !canCreateSplit,
+                        },
+                        { type: "separator" },
+                        {
+                            label: "Focus Pane Left",
+                            action: () => focusPaneNeighbor("left", paneId),
+                            disabled: !leftNeighborPaneId,
+                        },
+                        {
+                            label: "Focus Pane Right",
+                            action: () => focusPaneNeighbor("right", paneId),
+                            disabled: !rightNeighborPaneId,
+                        },
+                        {
+                            label: "Focus Pane Up",
+                            action: () => focusPaneNeighbor("up", paneId),
+                            disabled: !upNeighborPaneId,
+                        },
+                        {
+                            label: "Focus Pane Down",
+                            action: () => focusPaneNeighbor("down", paneId),
+                            disabled: !downNeighborPaneId,
+                        },
+                        { type: "separator" },
+                        {
+                            label: "Balance Layout",
+                            action: () => balancePaneLayout(),
+                            disabled: paneCount <= 1,
+                        },
+                        { type: "separator" },
+                        {
                             label: `Close Pane ${paneIndex + 1}`,
                             action: () => closePane(paneId),
-                            disabled: panes.length <= 1,
+                            disabled: paneCount <= 1,
                         },
                     ]}
                 />

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -6,7 +6,6 @@ import {
     useMemo,
     useRef,
     useState,
-    type ReactNode,
 } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { createPortal } from "react-dom";

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -566,9 +566,11 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
             <div
                 ref={tabStripRef}
                 data-pane-tab-strip={paneId}
-                className="flex items-center gap-1 px-2 py-1 shrink-0 overflow-x-auto scrollbar-hidden"
+                className="flex items-center gap-1 px-2 py-0.5 shrink-0 overflow-x-auto scrollbar-hidden"
                 style={{
+                    height: 38,
                     minHeight: 38,
+                    boxSizing: "border-box",
                     borderBottom: "1px solid var(--border)",
                     background: isFocused
                         ? "color-mix(in srgb, var(--bg-secondary) 96%, var(--accent) 4%)"
@@ -600,7 +602,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                 role="tab"
                                 tabIndex={0}
                                 aria-selected={isActive}
-                                className="group inline-flex min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 py-1.5 text-left"
+                                className="group inline-flex h-8 min-w-0 max-w-55 shrink-0 items-center gap-2 rounded-lg px-2.5 text-left"
                                 onPointerDownCapture={(event) =>
                                     handleTabPointerDownCapture(tab.id, event)
                                 }
@@ -639,6 +641,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                     });
                                 }}
                                 style={{
+                                    boxSizing: "border-box",
                                     border: isActive
                                         ? "1px solid color-mix(in srgb, var(--accent) 18%, var(--border))"
                                         : "1px solid color-mix(in srgb, var(--border) 46%, transparent)",

--- a/apps/desktop/src/features/editor/EditorPaneContent.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneContent.tsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from "react";
+import {
+    useEditorStore,
+    isFileTab,
+    isGraphTab,
+    isMapTab,
+    isNoteTab,
+    isPdfTab,
+    isReviewTab,
+    selectEditorPaneActiveTab,
+    selectEditorPaneState,
+} from "../../app/store/editorStore";
+import { perfCount } from "../../app/utils/perfInstrumentation";
+import { canUseExcalidrawRuntime } from "../../app/utils/safeBrowser";
+import { Editor } from "./Editor";
+import { FileTabView } from "./FileTabView";
+import { NewTabView } from "./NewTabView";
+import { SearchView } from "../search/SearchView";
+import { PdfTabView } from "../pdf/PdfTabView";
+import { AIReviewView } from "../ai/components/AIReviewView";
+
+type EditorPanelView =
+    | "pdf"
+    | "file"
+    | "new"
+    | "search"
+    | "ai-review"
+    | "editor"
+    | "map"
+    | "graph";
+
+const LazyExcalidrawTabView = React.lazy(() =>
+    import("../maps/ExcalidrawTabView").then((m) => ({
+        default: m.ExcalidrawTabView,
+    })),
+);
+
+const LazyGraphTabView = React.lazy(() =>
+    import("../graph/GraphTabView").then((m) => ({
+        default: m.GraphTabView,
+    })),
+);
+
+const GRAPH_KEEP_ALIVE_MS = 15 * 60 * 1000;
+const EXCALIDRAW_RUNTIME_SUPPORTED = canUseExcalidrawRuntime();
+
+function UnsupportedMapView() {
+    return (
+        <div
+            className="h-full flex items-center justify-center p-6"
+            style={{ color: "var(--text-secondary)" }}
+        >
+            <div
+                className="max-w-xl rounded-xl p-5"
+                style={{
+                    border: "1px solid var(--border)",
+                    background: "var(--bg-secondary)",
+                }}
+            >
+                <div
+                    className="text-sm font-semibold"
+                    style={{ color: "var(--text-primary)" }}
+                >
+                    Map view is unavailable in this hardened build
+                </div>
+                <div className="mt-2 text-sm leading-6">
+                    The current release disables dynamic code execution required
+                    by Excalidraw. Existing map tabs are preserved in session
+                    data, but they are not restored automatically and cannot be
+                    rendered until a CSP-compatible runtime is wired in.
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function renderEditorPanelView(
+    view: EditorPanelView,
+    paneId?: string,
+    emptyStateMessage?: string,
+) {
+    switch (view) {
+        case "pdf":
+            return <PdfTabView paneId={paneId} />;
+        case "file":
+            return <FileTabView paneId={paneId} />;
+        case "ai-review":
+            return <AIReviewView paneId={paneId} />;
+        case "map":
+            if (!EXCALIDRAW_RUNTIME_SUPPORTED) {
+                return <UnsupportedMapView />;
+            }
+            return (
+                <React.Suspense fallback={null}>
+                    <LazyExcalidrawTabView />
+                </React.Suspense>
+            );
+        case "new":
+            return <NewTabView />;
+        case "search":
+            return <SearchView />;
+        case "graph":
+            return null;
+        default:
+            return <Editor paneId={paneId} emptyStateMessage={emptyStateMessage} />;
+    }
+}
+
+interface EditorPaneContentProps {
+    paneId?: string;
+    emptyStateMessage?: string;
+}
+
+export function EditorPaneContent({
+    paneId,
+    emptyStateMessage,
+}: EditorPaneContentProps) {
+    const view = useEditorStore((state): EditorPanelView => {
+        const tab = selectEditorPaneActiveTab(state, paneId);
+        if (!tab) return "editor";
+        if (isPdfTab(tab)) return "pdf";
+        if (isFileTab(tab)) return "file";
+        if (isReviewTab(tab)) return "ai-review";
+        if (isMapTab(tab)) return "map";
+        if (isGraphTab(tab)) return "graph";
+        if (!isNoteTab(tab)) return "editor";
+        if (tab.noteId === "") return "new";
+        if (tab.noteId === "__search__") return "search";
+        return "editor";
+    });
+    const paneTabs = useEditorStore((state) =>
+        selectEditorPaneState(state, paneId).tabs,
+    );
+    const hasGraphTab = paneTabs.some((tab) => isGraphTab(tab));
+    const isGraphActive = view === "graph";
+    const [keepAlive, setKeepAlive] = useState(false);
+    const [prevIsGraphActive, setPrevIsGraphActive] = useState(isGraphActive);
+    const [prevHasGraphTab, setPrevHasGraphTab] = useState(hasGraphTab);
+
+    if (
+        prevIsGraphActive !== isGraphActive ||
+        prevHasGraphTab !== hasGraphTab
+    ) {
+        setPrevIsGraphActive(isGraphActive);
+        setPrevHasGraphTab(hasGraphTab);
+        if (!hasGraphTab) {
+            if (keepAlive) setKeepAlive(false);
+        } else if (prevIsGraphActive && !isGraphActive) {
+            if (!keepAlive) setKeepAlive(true);
+        } else if (isGraphActive && keepAlive) {
+            setKeepAlive(false);
+        }
+    }
+
+    useEffect(() => {
+        if (!keepAlive) return;
+        const timeoutId = window.setTimeout(() => {
+            perfCount("graph.lifecycle.keepAliveExpired");
+            setKeepAlive(false);
+        }, GRAPH_KEEP_ALIVE_MS);
+        return () => window.clearTimeout(timeoutId);
+    }, [keepAlive]);
+
+    const keepGraphMounted = hasGraphTab && (isGraphActive || keepAlive);
+
+    return (
+        <div className="relative flex-1 min-h-0 min-w-0 w-full overflow-hidden">
+            {keepGraphMounted && (
+                <div
+                    style={{
+                        position: "absolute",
+                        inset: 0,
+                        visibility: isGraphActive ? "visible" : "hidden",
+                        pointerEvents: isGraphActive ? "auto" : "none",
+                    }}
+                >
+                    <React.Suspense fallback={null}>
+                        <LazyGraphTabView isVisible={isGraphActive} />
+                    </React.Suspense>
+                </div>
+            )}
+            {!isGraphActive &&
+                renderEditorPanelView(view, paneId, emptyStateMessage)}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/editor/EditorPaneContent.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneContent.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import {
     useEditorStore,
+    isChatTab,
     isFileTab,
     isGraphTab,
     isMapTab,
@@ -25,6 +26,7 @@ type EditorPanelView =
     | "new"
     | "search"
     | "ai-review"
+    | "ai-chat"
     | "editor"
     | "map"
     | "graph";
@@ -38,6 +40,12 @@ const LazyExcalidrawTabView = React.lazy(() =>
 const LazyGraphTabView = React.lazy(() =>
     import("../graph/GraphTabView").then((m) => ({
         default: m.GraphTabView,
+    })),
+);
+
+const LazyAIChatSessionView = React.lazy(() =>
+    import("../ai/components/AIChatSessionView").then((m) => ({
+        default: m.AIChatSessionView,
     })),
 );
 
@@ -86,6 +94,12 @@ function renderEditorPanelView(
             return <FileTabView paneId={paneId} />;
         case "ai-review":
             return <AIReviewView paneId={paneId} />;
+        case "ai-chat":
+            return (
+                <React.Suspense fallback={null}>
+                    <LazyAIChatSessionView paneId={paneId} />
+                </React.Suspense>
+            );
         case "map":
             if (!EXCALIDRAW_RUNTIME_SUPPORTED) {
                 return <UnsupportedMapView />;
@@ -102,7 +116,9 @@ function renderEditorPanelView(
         case "graph":
             return null;
         default:
-            return <Editor paneId={paneId} emptyStateMessage={emptyStateMessage} />;
+            return (
+                <Editor paneId={paneId} emptyStateMessage={emptyStateMessage} />
+            );
     }
 }
 
@@ -121,6 +137,7 @@ export function EditorPaneContent({
         if (isPdfTab(tab)) return "pdf";
         if (isFileTab(tab)) return "file";
         if (isReviewTab(tab)) return "ai-review";
+        if (isChatTab(tab)) return "ai-chat";
         if (isMapTab(tab)) return "map";
         if (isGraphTab(tab)) return "graph";
         if (!isNoteTab(tab)) return "editor";
@@ -128,8 +145,8 @@ export function EditorPaneContent({
         if (tab.noteId === "__search__") return "search";
         return "editor";
     });
-    const paneTabs = useEditorStore((state) =>
-        selectEditorPaneState(state, paneId).tabs,
+    const paneTabs = useEditorStore(
+        (state) => selectEditorPaneState(state, paneId).tabs,
     );
     const hasGraphTab = paneTabs.some((tab) => isGraphTab(tab));
     const isGraphActive = view === "graph";

--- a/apps/desktop/src/features/editor/EditorPaneContent.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneContent.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
     useEditorStore,
     isChatTab,
@@ -11,7 +11,6 @@ import {
     selectEditorPaneActiveTab,
     selectEditorPaneState,
 } from "../../app/store/editorStore";
-import { perfCount } from "../../app/utils/perfInstrumentation";
 import { canUseExcalidrawRuntime } from "../../app/utils/safeBrowser";
 import { Editor } from "./Editor";
 import { FileTabView } from "./FileTabView";
@@ -49,7 +48,6 @@ const LazyAIChatSessionView = React.lazy(() =>
     })),
 );
 
-const GRAPH_KEEP_ALIVE_MS = 15 * 60 * 1000;
 const EXCALIDRAW_RUNTIME_SUPPORTED = canUseExcalidrawRuntime();
 
 function UnsupportedMapView() {
@@ -150,35 +148,7 @@ export function EditorPaneContent({
     );
     const hasGraphTab = paneTabs.some((tab) => isGraphTab(tab));
     const isGraphActive = view === "graph";
-    const [keepAlive, setKeepAlive] = useState(false);
-    const [prevIsGraphActive, setPrevIsGraphActive] = useState(isGraphActive);
-    const [prevHasGraphTab, setPrevHasGraphTab] = useState(hasGraphTab);
-
-    if (
-        prevIsGraphActive !== isGraphActive ||
-        prevHasGraphTab !== hasGraphTab
-    ) {
-        setPrevIsGraphActive(isGraphActive);
-        setPrevHasGraphTab(hasGraphTab);
-        if (!hasGraphTab) {
-            if (keepAlive) setKeepAlive(false);
-        } else if (prevIsGraphActive && !isGraphActive) {
-            if (!keepAlive) setKeepAlive(true);
-        } else if (isGraphActive && keepAlive) {
-            setKeepAlive(false);
-        }
-    }
-
-    useEffect(() => {
-        if (!keepAlive) return;
-        const timeoutId = window.setTimeout(() => {
-            perfCount("graph.lifecycle.keepAliveExpired");
-            setKeepAlive(false);
-        }, GRAPH_KEEP_ALIVE_MS);
-        return () => window.clearTimeout(timeoutId);
-    }, [keepAlive]);
-
-    const keepGraphMounted = hasGraphTab && (isGraphActive || keepAlive);
+    const keepGraphMounted = hasGraphTab;
 
     return (
         <div className="relative flex-1 min-h-0 min-w-0 w-full overflow-hidden">

--- a/apps/desktop/src/features/editor/FileTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.tsx
@@ -11,6 +11,7 @@ import {
     fileViewerNeedsTextContent,
     useEditorStore,
     isFileTab,
+    selectEditorPaneActiveTab,
     type FileTab,
 } from "../../app/store/editorStore";
 import {
@@ -32,11 +33,13 @@ function clampScrollOffset(offset: number) {
     return Number.isFinite(offset) ? Math.max(0, offset) : 0;
 }
 
-export function FileTabView() {
+interface FileTabViewProps {
+    paneId?: string;
+}
+
+export function FileTabView({ paneId }: FileTabViewProps) {
     const tab = useEditorStore((state) => {
-        const current = state.tabs.find(
-            (candidate) => candidate.id === state.activeTabId,
-        );
+        const current = selectEditorPaneActiveTab(state, paneId);
         return current && isFileTab(current) ? current : null;
     });
 
@@ -56,11 +59,11 @@ export function FileTabView() {
     }
 
     if (tab.viewer === "csv") {
-        return <CsvFileTabView key={tab.id} />;
+        return <CsvFileTabView key={tab.id} paneId={paneId} />;
     }
 
     if (fileViewerNeedsTextContent(tab.viewer)) {
-        return <FileTextTabView key={tab.id} />;
+        return <FileTextTabView key={tab.id} paneId={paneId} />;
     }
 
     return (

--- a/apps/desktop/src/features/editor/FileTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.tsx
@@ -81,7 +81,7 @@ function FileHeader({ tab, children }: { tab: FileTab; children?: ReactNode }) {
         <div
             className="flex items-center justify-between gap-2 px-3 shrink-0"
             style={{
-                height: 34,
+                height: 39,
                 borderBottom: "1px solid var(--border)",
                 backgroundColor: "var(--bg-secondary)",
             }}

--- a/apps/desktop/src/features/editor/FileTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.tsx
@@ -79,7 +79,7 @@ export function FileTabView({ paneId }: FileTabViewProps) {
 function FileHeader({ tab, children }: { tab: FileTab; children?: ReactNode }) {
     return (
         <div
-            className="flex items-center justify-between gap-2 px-3 shrink-0"
+            className="flex min-w-0 items-center justify-between gap-2 px-3 shrink-0 overflow-x-auto"
             style={{
                 height: 39,
                 borderBottom: "1px solid var(--border)",
@@ -222,7 +222,7 @@ function ImageFileViewer({ tab }: { tab: FileTab }) {
     const zoomPercent = formatZoomPercentage(zoom);
 
     return (
-        <div className="h-full flex flex-col overflow-hidden">
+        <div className="h-full min-w-0 flex flex-col overflow-hidden">
             <FileHeader tab={tab}>
                 <button
                     type="button"
@@ -260,7 +260,7 @@ function ImageFileViewer({ tab }: { tab: FileTab }) {
 
             <div
                 ref={containerRef}
-                className="flex-1 overflow-auto"
+                className="min-w-0 flex-1 overflow-auto"
                 style={{
                     background:
                         "radial-gradient(circle at top, color-mix(in srgb, var(--bg-secondary) 92%, white) 0%, var(--bg-primary) 72%)",
@@ -295,7 +295,7 @@ function ImageFileViewer({ tab }: { tab: FileTab }) {
                 )}
                 {isFit ? (
                     <div
-                        className="h-full w-full flex items-center justify-center p-6"
+                        className="h-full min-w-0 w-full flex items-center justify-center p-6"
                         style={{
                             display: status === "error" ? "none" : undefined,
                         }}
@@ -319,7 +319,7 @@ function ImageFileViewer({ tab }: { tab: FileTab }) {
                     </div>
                 ) : (
                     <div
-                        className="inline-flex min-w-full min-h-full items-start justify-center p-6"
+                        className="flex min-w-full min-h-full items-start justify-center p-6"
                         style={{
                             display: status === "error" ? "none" : undefined,
                         }}

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -48,7 +48,11 @@ import { shouldEnableInlineReviewMergeView } from "./editorReviewGate";
 import { useEditableFileResource } from "./useEditableFileResource";
 import { logError } from "../../app/utils/runtimeLog";
 
-export function FileTextTabView() {
+interface FileTextTabViewProps {
+    paneId?: string;
+}
+
+export function FileTextTabView({ paneId }: FileTextTabViewProps) {
     const containerRef = useRef<HTMLDivElement>(null);
     const viewRef = useRef<EditorView | null>(null);
     const syntaxCompartmentRef = useRef(new Compartment());
@@ -109,9 +113,13 @@ export function FileTextTabView() {
         keepLocalFileVersion,
         flushCurrentSave,
     } = useEditableFileResource({
+        paneId,
         getCurrentContent,
         applyIncomingContent: replaceEditorDocument,
     });
+    const isPaneFocused = useEditorStore(
+        (state) => state.focusedPaneId === paneId,
+    );
     const languagePath = tab?.path ?? null;
     const languageMimeType = tab?.mimeType ?? null;
     const trackedFileMatch = tab
@@ -125,6 +133,7 @@ export function FileTextTabView() {
         : null;
 
     useEffect(() => {
+        if (paneId && !isPaneFocused) return;
         const handler = (event: KeyboardEvent) => {
             if (event.defaultPrevented) return;
             if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
@@ -145,7 +154,7 @@ export function FileTextTabView() {
 
         window.addEventListener("keydown", handler);
         return () => window.removeEventListener("keydown", handler);
-    }, []);
+    }, [isPaneFocused, paneId]);
 
     const copySelectedText = useCallback(async () => {
         const view = viewRef.current;

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -600,7 +600,7 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
             <div
                 className="flex items-center justify-between gap-2 px-3 shrink-0"
                 style={{
-                    height: 34,
+                    height: 39,
                     borderBottom: "1px solid var(--border)",
                     backgroundColor: "var(--bg-secondary)",
                 }}

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -25,7 +25,10 @@ import {
     ContextMenu,
     type ContextMenuState,
 } from "../../components/context-menu/ContextMenu";
-import { useEditorStore } from "../../app/store/editorStore";
+import {
+    selectFocusedPaneId,
+    useEditorStore,
+} from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useThemeStore } from "../../app/store/themeStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -118,7 +121,7 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
         applyIncomingContent: replaceEditorDocument,
     });
     const isPaneFocused = useEditorStore(
-        (state) => state.focusedPaneId === paneId,
+        (state) => selectFocusedPaneId(state) === paneId,
     );
     const languagePath = tab?.path ?? null;
     const languageMimeType = tab?.mimeType ?? null;

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -275,6 +275,18 @@ describe("MultiPaneWorkspace", () => {
         ).not.toBeNull();
     });
 
+    it("stretches pane containers to fill their split slots", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        const primaryPane = screen
+            .getByTestId("pane-content-primary")
+            .closest('[data-editor-pane-id="primary"]');
+
+        expect(primaryPane).not.toBeNull();
+        expect(primaryPane?.className).toContain("w-full");
+        expect(primaryPane?.className).toContain("flex-1");
+    });
+
     it("renders independent resize handles for each split branch", () => {
         renderComponent(<MultiPaneWorkspace />);
 

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { renderComponent } from "../../test/test-utils";
+import { useEditorStore } from "../../app/store/editorStore";
+import { useLayoutStore } from "../../app/store/layoutStore";
+import { MultiPaneWorkspace } from "./MultiPaneWorkspace";
+
+vi.mock("./EditorPaneBar", () => ({
+    EditorPaneBar: ({
+        paneId,
+        isFocused,
+    }: {
+        paneId: string;
+        isFocused: boolean;
+    }) => (
+        <div
+            data-testid={`pane-bar-${paneId}`}
+            data-focused={isFocused || undefined}
+        >
+            {paneId}
+        </div>
+    ),
+}));
+
+vi.mock("./EditorPaneContent", () => ({
+    EditorPaneContent: ({
+        paneId,
+        emptyStateMessage,
+    }: {
+        paneId?: string;
+        emptyStateMessage?: string;
+    }) => (
+        <div data-testid={`pane-content-${paneId ?? "focused"}`}>
+            {paneId}
+            {emptyStateMessage ? `:${emptyStateMessage}` : ""}
+        </div>
+    ),
+}));
+
+describe("MultiPaneWorkspace", () => {
+    beforeEach(() => {
+        class MockResizeObserver {
+            private readonly callback: ResizeObserverCallback;
+
+            constructor(callback: ResizeObserverCallback) {
+                this.callback = callback;
+            }
+
+            observe(target: Element) {
+                this.callback(
+                    [
+                        {
+                            target,
+                            contentRect: {
+                                width: 900,
+                                height: 600,
+                                x: 0,
+                                y: 0,
+                                top: 0,
+                                left: 0,
+                                right: 900,
+                                bottom: 600,
+                                toJSON: () => ({}),
+                            },
+                        } as ResizeObserverEntry,
+                    ],
+                    this,
+                );
+            }
+
+            disconnect() {}
+
+            unobserve() {}
+        }
+
+        Object.defineProperty(globalThis, "ResizeObserver", {
+            configurable: true,
+            value: MockResizeObserver,
+        });
+        Object.defineProperty(HTMLElement.prototype, "setPointerCapture", {
+            configurable: true,
+            value: vi.fn(),
+        });
+        Object.defineProperty(HTMLElement.prototype, "getBoundingClientRect", {
+            configurable: true,
+            value: () => ({
+                width: 900,
+                height: 600,
+                x: 0,
+                y: 0,
+                top: 0,
+                left: 0,
+                right: 900,
+                bottom: 600,
+                toJSON: () => ({}),
+            }),
+        });
+
+        useEditorStore.setState({
+            panes: [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "secondary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+                {
+                    id: "tertiary",
+                    tabs: [],
+                    activeTabId: null,
+                    activationHistory: [],
+                    tabNavigationHistory: [],
+                    tabNavigationIndex: -1,
+                },
+            ],
+            focusedPaneId: "primary",
+        });
+        useLayoutStore.setState({
+            editorPaneSizes: [1 / 3, 1 / 3, 1 / 3],
+        });
+    });
+
+    it("focuses the clicked pane", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        const targetPane = screen
+            .getByTestId("pane-content-secondary")
+            .closest('[data-editor-pane-id="secondary"]');
+        expect(targetPane).not.toBeNull();
+
+        fireEvent.pointerDown(targetPane!, { pointerId: 1, button: 0 });
+
+        expect(useEditorStore.getState().focusedPaneId).toBe("secondary");
+    });
+
+    it("renders a divider between each adjacent pane", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        expect(screen.getAllByRole("separator")).toHaveLength(2);
+    });
+
+    it("passes an explicit empty-state message to each pane content", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        expect(
+            screen.getAllByText((content) =>
+                content.includes("This pane is empty. Open a note here"),
+            ),
+        ).toHaveLength(3);
+    });
+});

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -1,9 +1,37 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { fireEvent, screen } from "@testing-library/react";
-import { renderComponent } from "../../test/test-utils";
+import { flushPromises, renderComponent } from "../../test/test-utils";
+import { publishWindowTabDropZone } from "../../app/detachedWindows";
 import { useEditorStore } from "../../app/store/editorStore";
 import { useLayoutStore } from "../../app/store/layoutStore";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { MultiPaneWorkspace } from "./MultiPaneWorkspace";
+
+const innerPositionMock = vi.fn();
+const scaleFactorMock = vi.fn();
+
+vi.mock("@tauri-apps/api/window", () => ({
+    getCurrentWindow: () => ({
+        listen: vi.fn(),
+        once: vi.fn(),
+        onCloseRequested: vi.fn(),
+        onMoved: vi.fn().mockResolvedValue(vi.fn()),
+        onResized: vi.fn().mockResolvedValue(vi.fn()),
+        onScaleChanged: vi.fn().mockResolvedValue(vi.fn()),
+        innerPosition: innerPositionMock,
+        scaleFactor: scaleFactorMock,
+        setFocus: vi.fn(),
+        startDragging: vi.fn(),
+        emitTo: vi.fn(),
+        close: vi.fn(),
+        label: "main",
+    }),
+}));
+
+vi.mock("../../app/detachedWindows", () => ({
+    getCurrentWindowLabel: vi.fn(() => "main"),
+    publishWindowTabDropZone: vi.fn(),
+}));
 
 vi.mock("./EditorPaneBar", () => ({
     EditorPaneBar: ({
@@ -128,6 +156,27 @@ describe("MultiPaneWorkspace", () => {
         useLayoutStore.setState({
             editorPaneSizes: [1 / 3, 1 / 3, 1 / 3],
         });
+        useVaultStore.setState((state) => ({
+            ...state,
+            vaultPath: "/vaults/main",
+        }));
+        Object.defineProperty(window, "screenX", {
+            value: 900,
+            configurable: true,
+        });
+        Object.defineProperty(window, "screenY", {
+            value: 700,
+            configurable: true,
+        });
+        scaleFactorMock.mockResolvedValue(2);
+        innerPositionMock.mockResolvedValue({
+            x: 240,
+            y: 80,
+            toLogical: () => ({
+                x: 120,
+                y: 40,
+            }),
+        });
     });
 
     it("focuses the clicked pane", () => {
@@ -157,5 +206,22 @@ describe("MultiPaneWorkspace", () => {
                 content.includes("This pane is empty. Open a note here"),
             ),
         ).toHaveLength(3);
+    });
+
+    it("publishes a drop zone for detached tab reattachment in split view", async () => {
+        renderComponent(<MultiPaneWorkspace />);
+        await flushPromises();
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+
+        expect(vi.mocked(publishWindowTabDropZone)).toHaveBeenCalledWith(
+            "main",
+            expect.objectContaining({
+                left: 120,
+                top: 40,
+                right: 1020,
+                bottom: 640,
+                vaultPath: "/vaults/main",
+            }),
+        );
     });
 });

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -287,6 +287,18 @@ describe("MultiPaneWorkspace", () => {
         expect(primaryPane?.className).toContain("flex-1");
     });
 
+    it("stretches the root split container to fill the workspace width", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        const rootSplit = document.querySelector(
+            `[data-workspace-split-id="${useEditorStore.getState().layoutTree.id}"]`,
+        );
+
+        expect(rootSplit).not.toBeNull();
+        expect(rootSplit?.className).toContain("w-full");
+        expect(rootSplit?.className).toContain("flex-1");
+    });
+
     it("renders independent resize handles for each split branch", () => {
         renderComponent(<MultiPaneWorkspace />);
 

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -1,11 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import { flushPromises, renderComponent } from "../../test/test-utils";
 import { publishWindowTabDropZone } from "../../app/detachedWindows";
 import { useEditorStore } from "../../app/store/editorStore";
-import { useLayoutStore } from "../../app/store/layoutStore";
+import {
+    createInitialLayout,
+    splitPane,
+} from "../../app/store/workspaceLayoutTree";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { MultiPaneWorkspace } from "./MultiPaneWorkspace";
+import { CROSS_PANE_TAB_DROP_PREVIEW_EVENT } from "./workspaceTabDropPreview";
 
 const innerPositionMock = vi.fn();
 const scaleFactorMock = vi.fn();
@@ -66,6 +70,20 @@ vi.mock("./EditorPaneContent", () => ({
 }));
 
 describe("MultiPaneWorkspace", () => {
+    function createThreePaneLayout() {
+        return splitPane(
+            splitPane(
+                createInitialLayout("primary"),
+                "primary",
+                "row",
+                "secondary",
+            ),
+            "secondary",
+            "column",
+            "tertiary",
+        );
+    }
+
     beforeEach(() => {
         class MockResizeObserver {
             private readonly callback: ResizeObserverCallback;
@@ -124,6 +142,7 @@ describe("MultiPaneWorkspace", () => {
             }),
         });
 
+        const layoutTree = createThreePaneLayout();
         useEditorStore.setState({
             panes: [
                 {
@@ -152,9 +171,7 @@ describe("MultiPaneWorkspace", () => {
                 },
             ],
             focusedPaneId: "primary",
-        });
-        useLayoutStore.setState({
-            editorPaneSizes: [1 / 3, 1 / 3, 1 / 3],
+            layoutTree,
         });
         useVaultStore.setState((state) => ({
             ...state,
@@ -196,6 +213,11 @@ describe("MultiPaneWorkspace", () => {
         renderComponent(<MultiPaneWorkspace />);
 
         expect(screen.getAllByRole("separator")).toHaveLength(2);
+        expect(
+            screen
+                .getAllByRole("separator")
+                .map((separator) => separator.getAttribute("aria-orientation")),
+        ).toEqual(["vertical", "horizontal"]);
     });
 
     it("passes an explicit empty-state message to each pane content", () => {
@@ -223,5 +245,104 @@ describe("MultiPaneWorkspace", () => {
                 vaultPath: "/vaults/main",
             }),
         );
+    });
+
+    it("renders mixed layouts like A | (B over C)", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        const primaryPane = screen
+            .getByTestId("pane-content-primary")
+            .closest('[data-editor-pane-id="primary"]');
+        const secondaryPane = screen
+            .getByTestId("pane-content-secondary")
+            .closest('[data-editor-pane-id="secondary"]');
+        const tertiaryPane = screen
+            .getByTestId("pane-content-tertiary")
+            .closest('[data-editor-pane-id="tertiary"]');
+
+        expect(primaryPane).not.toBeNull();
+        expect(secondaryPane).not.toBeNull();
+        expect(tertiaryPane).not.toBeNull();
+        expect(
+            screen
+                .getByTestId("pane-bar-primary")
+                .closest('[data-workspace-split-direction="row"]'),
+        ).not.toBeNull();
+        expect(
+            screen
+                .getByTestId("pane-bar-secondary")
+                .closest('[data-workspace-split-direction="column"]'),
+        ).not.toBeNull();
+    });
+
+    it("renders independent resize handles for each split branch", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        const separators = screen.getAllByRole("separator");
+        const verticalDivider = separators.find(
+            (separator) =>
+                separator.getAttribute("aria-orientation") === "vertical",
+        );
+        const horizontalDivider = separators.find(
+            (separator) =>
+                separator.getAttribute("aria-orientation") === "horizontal",
+        );
+
+        expect(verticalDivider).toBeDefined();
+        expect(horizontalDivider).toBeDefined();
+        expect(verticalDivider).toHaveAttribute(
+            "aria-label",
+            "Resize split split-1 sections 1 and 2",
+        );
+        expect(horizontalDivider).toHaveAttribute(
+            "aria-label",
+            "Resize split split-2 sections 1 and 2",
+        );
+    });
+
+    it("renders pane drop overlays for center and edge previews", () => {
+        renderComponent(<MultiPaneWorkspace />);
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(CROSS_PANE_TAB_DROP_PREVIEW_EVENT, {
+                    detail: {
+                        sourcePaneId: "primary",
+                        targetPaneId: "secondary",
+                        position: "center",
+                        insertIndex: 0,
+                        tabId: "tab-a",
+                    },
+                }),
+            );
+        });
+
+        expect(
+            screen
+                .getByTestId("pane-content-secondary")
+                .closest('[data-editor-pane-id="secondary"]')
+                ?.querySelector('[data-pane-drop-overlay-position="center"]'),
+        ).not.toBeNull();
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(CROSS_PANE_TAB_DROP_PREVIEW_EVENT, {
+                    detail: {
+                        sourcePaneId: "primary",
+                        targetPaneId: "secondary",
+                        position: "left",
+                        insertIndex: null,
+                        tabId: "tab-a",
+                    },
+                }),
+            );
+        });
+
+        expect(
+            screen
+                .getByTestId("pane-content-secondary")
+                .closest('[data-editor-pane-id="secondary"]')
+                ?.querySelector('[data-pane-drop-overlay-position="left"]'),
+        ).not.toBeNull();
     });
 });

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
@@ -1,47 +1,27 @@
 import {
-    Fragment,
     useCallback,
     useEffect,
     useLayoutEffect,
-    useMemo,
     useRef,
     useState,
-    type PointerEvent as ReactPointerEvent,
 } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
     getCurrentWindowLabel,
     publishWindowTabDropZone,
 } from "../../app/detachedWindows";
-import { useEditorStore } from "../../app/store/editorStore";
-import { useLayoutStore } from "../../app/store/layoutStore";
+import {
+    selectFocusedPaneId,
+    selectLeafPaneIds,
+    useEditorStore,
+} from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
-import { EditorPaneBar } from "./EditorPaneBar";
-import { EditorPaneContent } from "./EditorPaneContent";
-
-const RESIZER_HITBOX_WIDTH = 10;
-const RESIZER_VISIBLE_WIDTH = 1;
-const MIN_PANE_WIDTH = 280;
-const MIN_PANE_WIDTH_FALLBACK = 180;
-
-interface ResizeSession {
-    pointerId: number;
-    dividerIndex: number;
-    startX: number;
-    startSizes: number[];
-    containerWidth: number;
-}
-
-function getEffectiveMinPaneWidth(containerWidth: number, paneCount: number) {
-    const evenWidth = Math.floor(containerWidth / Math.max(1, paneCount));
-    return Math.max(
-        MIN_PANE_WIDTH_FALLBACK,
-        Math.min(
-            MIN_PANE_WIDTH,
-            Math.max(MIN_PANE_WIDTH_FALLBACK, evenWidth - 12),
-        ),
-    );
-}
+import { WorkspaceSplitContainer } from "./WorkspaceSplitContainer";
+import {
+    CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+    type CrossPaneTabDropPreview,
+} from "./workspaceTabDropPreview";
 
 function getAppWindow() {
     return getCurrentWindow();
@@ -79,39 +59,35 @@ async function getWindowContentScreenOrigin() {
 }
 
 export function MultiPaneWorkspace() {
-    const allPanes = useEditorStore((state) => state.panes);
-    const focusedPaneId = useEditorStore((state) => state.focusedPaneId);
+    const leafPaneIds = useEditorStore(useShallow(selectLeafPaneIds));
+    const layoutTree = useEditorStore((state) => state.layoutTree);
+    const focusedPaneId = useEditorStore(selectFocusedPaneId);
     const focusPane = useEditorStore((state) => state.focusPane);
-    const editorPaneSizes = useLayoutStore((state) => state.editorPaneSizes);
-    const ensureEditorPaneSizeCount = useLayoutStore(
-        (state) => state.ensureEditorPaneSizeCount,
-    );
-    const setEditorPaneSizes = useLayoutStore(
-        (state) => state.setEditorPaneSizes,
-    );
+    const resizePaneSplit = useEditorStore((state) => state.resizePaneSplit);
     const containerRef = useRef<HTMLDivElement | null>(null);
-    const resizeSessionRef = useRef<ResizeSession | null>(null);
-    const [containerWidth, setContainerWidth] = useState(0);
-    const [isResizing, setIsResizing] = useState(false);
-    const panes = useMemo(() => allPanes.slice(0, 3), [allPanes]);
-    const paneCount = Math.max(1, panes.length);
+    const [crossPaneDropPreview, setCrossPaneDropPreview] =
+        useState<CrossPaneTabDropPreview | null>(null);
+    const visiblePaneCount = Math.max(1, leafPaneIds.length);
 
     useEffect(() => {
-        ensureEditorPaneSizeCount(paneCount);
-    }, [ensureEditorPaneSizeCount, paneCount]);
-
-    useEffect(() => {
-        const node = containerRef.current;
-        if (!node) return;
-
-        const syncWidth = () => {
-            setContainerWidth(node.getBoundingClientRect().width);
+        const handleCrossPaneDropPreview = (event: Event) => {
+            const detail = (
+                event as CustomEvent<CrossPaneTabDropPreview | null>
+            ).detail;
+            setCrossPaneDropPreview(detail);
         };
 
-        syncWidth();
-        const observer = new ResizeObserver(() => syncWidth());
-        observer.observe(node);
-        return () => observer.disconnect();
+        window.addEventListener(
+            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+            handleCrossPaneDropPreview,
+        );
+
+        return () => {
+            window.removeEventListener(
+                CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+                handleCrossPaneDropPreview,
+            );
+        };
     }, []);
 
     useLayoutEffect(() => {
@@ -123,7 +99,9 @@ export function MultiPaneWorkspace() {
         const cleanupListeners: Array<() => void> = [];
 
         const schedulePublish = () => {
-            if (disposed) return;
+            if (disposed) {
+                return;
+            }
             if (frame !== null) {
                 window.cancelAnimationFrame(frame);
             }
@@ -152,7 +130,9 @@ export function MultiPaneWorkspace() {
                 };
 
                 void getWindowContentScreenOrigin().then((origin) => {
-                    if (disposed || publishVersion !== nextVersion) return;
+                    if (disposed || publishVersion !== nextVersion) {
+                        return;
+                    }
 
                     const left = origin.x + nextRect.left;
                     const top = origin.y + nextRect.top;
@@ -181,44 +161,44 @@ export function MultiPaneWorkspace() {
 
         const appWindow = getAppWindow();
 
-        void Promise.resolve(
-            appWindow.onMoved(() => {
-                schedulePublish();
-            }),
-        ).then((unlisten) => {
-            if (typeof unlisten !== "function") return;
-            if (disposed) {
-                void unlisten();
-                return;
-            }
-            cleanupListeners.push(unlisten);
-        });
+        void Promise.resolve(appWindow.onMoved(schedulePublish)).then(
+            (unlisten) => {
+                if (typeof unlisten !== "function") {
+                    return;
+                }
+                if (disposed) {
+                    void unlisten();
+                    return;
+                }
+                cleanupListeners.push(unlisten);
+            },
+        );
 
-        void Promise.resolve(
-            appWindow.onResized(() => {
-                schedulePublish();
-            }),
-        ).then((unlisten) => {
-            if (typeof unlisten !== "function") return;
-            if (disposed) {
-                void unlisten();
-                return;
-            }
-            cleanupListeners.push(unlisten);
-        });
+        void Promise.resolve(appWindow.onResized(schedulePublish)).then(
+            (unlisten) => {
+                if (typeof unlisten !== "function") {
+                    return;
+                }
+                if (disposed) {
+                    void unlisten();
+                    return;
+                }
+                cleanupListeners.push(unlisten);
+            },
+        );
 
-        void Promise.resolve(
-            appWindow.onScaleChanged(() => {
-                schedulePublish();
-            }),
-        ).then((unlisten) => {
-            if (typeof unlisten !== "function") return;
-            if (disposed) {
-                void unlisten();
-                return;
-            }
-            cleanupListeners.push(unlisten);
-        });
+        void Promise.resolve(appWindow.onScaleChanged(schedulePublish)).then(
+            (unlisten) => {
+                if (typeof unlisten !== "function") {
+                    return;
+                }
+                if (disposed) {
+                    void unlisten();
+                    return;
+                }
+                cleanupListeners.push(unlisten);
+            },
+        );
 
         return () => {
             disposed = true;
@@ -233,14 +213,7 @@ export function MultiPaneWorkspace() {
             });
             publishWindowTabDropZone(label, null);
         };
-    }, [paneCount]);
-
-    const paneSizes = useMemo(() => {
-        if (editorPaneSizes.length === paneCount) {
-            return editorPaneSizes;
-        }
-        return Array.from({ length: paneCount }, () => 1 / paneCount);
-    }, [editorPaneSizes, paneCount]);
+    }, [visiblePaneCount]);
 
     const handlePaneFocus = useCallback(
         (paneId: string) => {
@@ -249,161 +222,25 @@ export function MultiPaneWorkspace() {
         [focusPane],
     );
 
-    const stopResize = useCallback((pointerId?: number) => {
-        const session = resizeSessionRef.current;
-        if (!session) return;
-        if (pointerId !== undefined && session.pointerId !== pointerId) {
-            return;
-        }
-        resizeSessionRef.current = null;
-        document.body.classList.remove("resizing-editor-pane");
-        setIsResizing(false);
-    }, []);
-
-    useEffect(() => {
-        if (!isResizing) return;
-
-        const handlePointerMove = (event: PointerEvent) => {
-            const session = resizeSessionRef.current;
-            if (!session) {
-                return;
-            }
-
-            const effectiveMinWidth = getEffectiveMinPaneWidth(
-                session.containerWidth,
-                paneCount,
-            );
-            const leftIndex = session.dividerIndex;
-            const rightIndex = leftIndex + 1;
-            const startLeftPx =
-                session.startSizes[leftIndex] * session.containerWidth;
-            const startRightPx =
-                session.startSizes[rightIndex] * session.containerWidth;
-            const pairWidth = startLeftPx + startRightPx;
-            const deltaPx = event.clientX - session.startX;
-            const nextLeftPx = Math.max(
-                effectiveMinWidth,
-                Math.min(pairWidth - effectiveMinWidth, startLeftPx + deltaPx),
-            );
-            const nextRightPx = pairWidth - nextLeftPx;
-            const nextSizes = [...session.startSizes];
-            nextSizes[leftIndex] = nextLeftPx / session.containerWidth;
-            nextSizes[rightIndex] = nextRightPx / session.containerWidth;
-            setEditorPaneSizes(paneCount, nextSizes);
-        };
-        const handlePointerUp = () => stopResize();
-
-        window.addEventListener("pointermove", handlePointerMove);
-        window.addEventListener("pointerup", handlePointerUp);
-        window.addEventListener("pointercancel", handlePointerUp);
-        window.addEventListener("blur", handlePointerUp);
-        return () => {
-            window.removeEventListener("pointermove", handlePointerMove);
-            window.removeEventListener("pointerup", handlePointerUp);
-            window.removeEventListener("pointercancel", handlePointerUp);
-            window.removeEventListener("blur", handlePointerUp);
-        };
-    }, [isResizing, paneCount, setEditorPaneSizes, stopResize]);
-
-    const handleDividerPointerDown = useCallback(
-        (dividerIndex: number, event: ReactPointerEvent<HTMLDivElement>) => {
-            if (event.button !== 0) return;
-            const node = containerRef.current;
-            if (!node) return;
-            resizeSessionRef.current = {
-                pointerId: event.pointerId,
-                dividerIndex,
-                startX: event.clientX,
-                startSizes: paneSizes,
-                containerWidth: node.getBoundingClientRect().width,
-            };
-            event.currentTarget.setPointerCapture(event.pointerId);
-            document.body.classList.add("resizing-editor-pane");
-            setIsResizing(true);
-            event.preventDefault();
+    const handleResizeSplit = useCallback(
+        (splitId: string, sizes: readonly number[]) => {
+            resizePaneSplit(splitId, sizes);
         },
-        [paneSizes],
+        [resizePaneSplit],
     );
-
-    const effectiveMinWidth =
-        containerWidth > 0
-            ? getEffectiveMinPaneWidth(containerWidth, paneCount)
-            : MIN_PANE_WIDTH_FALLBACK;
 
     return (
         <div
             ref={containerRef}
             className="flex h-full min-h-0 min-w-0 overflow-hidden"
         >
-            {panes.map((pane, index) => {
-                const isFocused = pane.id === focusedPaneId;
-                return (
-                    <Fragment key={pane.id}>
-                        <div
-                            className="flex min-h-0 min-w-0 flex-col overflow-hidden"
-                            style={{
-                                flexBasis: 0,
-                                flexGrow: paneSizes[index] ?? 1,
-                                minWidth: effectiveMinWidth,
-                                border: isFocused
-                                    ? "1px solid color-mix(in srgb, var(--accent) 26%, var(--border))"
-                                    : "1px solid transparent",
-                                borderRadius: 14,
-                                background: "var(--bg-primary)",
-                                boxShadow: isFocused
-                                    ? "0 14px 32px rgba(15, 23, 42, 0.08)"
-                                    : "none",
-                            }}
-                            onPointerDownCapture={() =>
-                                handlePaneFocus(pane.id)
-                            }
-                            onFocusCapture={() => handlePaneFocus(pane.id)}
-                            data-editor-pane-id={pane.id}
-                            data-editor-pane-focused={isFocused || undefined}
-                        >
-                            <EditorPaneBar
-                                paneId={pane.id}
-                                isFocused={isFocused}
-                            />
-                            <EditorPaneContent
-                                paneId={pane.id}
-                                emptyStateMessage="This pane is empty. Open a note here or close the pane from its menu."
-                            />
-                        </div>
-                        {index < panes.length - 1 && (
-                            <div
-                                role="separator"
-                                aria-orientation="vertical"
-                                aria-label={`Resize panes ${index + 1} and ${index + 2}`}
-                                className="relative shrink-0"
-                                style={{
-                                    width: RESIZER_HITBOX_WIDTH,
-                                    cursor: "col-resize",
-                                }}
-                                onPointerDown={(event) =>
-                                    handleDividerPointerDown(index, event)
-                                }
-                                onPointerUp={(event) =>
-                                    stopResize(event.pointerId)
-                                }
-                                onPointerCancel={(event) =>
-                                    stopResize(event.pointerId)
-                                }
-                            >
-                                <div
-                                    aria-hidden="true"
-                                    className="absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full"
-                                    style={{
-                                        width: RESIZER_VISIBLE_WIDTH,
-                                        background:
-                                            "color-mix(in srgb, var(--border) 90%, transparent)",
-                                    }}
-                                />
-                            </div>
-                        )}
-                    </Fragment>
-                );
-            })}
+            <WorkspaceSplitContainer
+                node={layoutTree}
+                focusedPaneId={focusedPaneId}
+                onPaneFocus={handlePaneFocus}
+                onResizeSplit={handleResizeSplit}
+                dropPreview={crossPaneDropPreview}
+            />
         </div>
     );
 }

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
@@ -1,0 +1,246 @@
+import {
+    Fragment,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type PointerEvent as ReactPointerEvent,
+} from "react";
+import { useEditorStore } from "../../app/store/editorStore";
+import { useLayoutStore } from "../../app/store/layoutStore";
+import { EditorPaneBar } from "./EditorPaneBar";
+import { EditorPaneContent } from "./EditorPaneContent";
+
+const RESIZER_HITBOX_WIDTH = 10;
+const RESIZER_VISIBLE_WIDTH = 1;
+const MIN_PANE_WIDTH = 280;
+const MIN_PANE_WIDTH_FALLBACK = 180;
+
+interface ResizeSession {
+    pointerId: number;
+    dividerIndex: number;
+    startX: number;
+    startSizes: number[];
+    containerWidth: number;
+}
+
+function getEffectiveMinPaneWidth(containerWidth: number, paneCount: number) {
+    const evenWidth = Math.floor(containerWidth / Math.max(1, paneCount));
+    return Math.max(
+        MIN_PANE_WIDTH_FALLBACK,
+        Math.min(
+            MIN_PANE_WIDTH,
+            Math.max(MIN_PANE_WIDTH_FALLBACK, evenWidth - 12),
+        ),
+    );
+}
+
+export function MultiPaneWorkspace() {
+    const allPanes = useEditorStore((state) => state.panes);
+    const focusedPaneId = useEditorStore((state) => state.focusedPaneId);
+    const focusPane = useEditorStore((state) => state.focusPane);
+    const editorPaneSizes = useLayoutStore((state) => state.editorPaneSizes);
+    const ensureEditorPaneSizeCount = useLayoutStore(
+        (state) => state.ensureEditorPaneSizeCount,
+    );
+    const setEditorPaneSizes = useLayoutStore(
+        (state) => state.setEditorPaneSizes,
+    );
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const resizeSessionRef = useRef<ResizeSession | null>(null);
+    const [containerWidth, setContainerWidth] = useState(0);
+    const [isResizing, setIsResizing] = useState(false);
+    const panes = useMemo(() => allPanes.slice(0, 3), [allPanes]);
+    const paneCount = Math.max(1, panes.length);
+
+    useEffect(() => {
+        ensureEditorPaneSizeCount(paneCount);
+    }, [ensureEditorPaneSizeCount, paneCount]);
+
+    useEffect(() => {
+        const node = containerRef.current;
+        if (!node) return;
+
+        const syncWidth = () => {
+            setContainerWidth(node.getBoundingClientRect().width);
+        };
+
+        syncWidth();
+        const observer = new ResizeObserver(() => syncWidth());
+        observer.observe(node);
+        return () => observer.disconnect();
+    }, []);
+
+    const paneSizes = useMemo(() => {
+        if (editorPaneSizes.length === paneCount) {
+            return editorPaneSizes;
+        }
+        return Array.from({ length: paneCount }, () => 1 / paneCount);
+    }, [editorPaneSizes, paneCount]);
+
+    const handlePaneFocus = useCallback(
+        (paneId: string) => {
+            focusPane(paneId);
+        },
+        [focusPane],
+    );
+
+    const stopResize = useCallback((pointerId?: number) => {
+        const session = resizeSessionRef.current;
+        if (!session) return;
+        if (pointerId !== undefined && session.pointerId !== pointerId) {
+            return;
+        }
+        resizeSessionRef.current = null;
+        document.body.classList.remove("resizing-editor-pane");
+        setIsResizing(false);
+    }, []);
+
+    useEffect(() => {
+        if (!isResizing) return;
+
+        const handlePointerMove = (event: PointerEvent) => {
+            const session = resizeSessionRef.current;
+            if (!session) {
+                return;
+            }
+
+            const effectiveMinWidth = getEffectiveMinPaneWidth(
+                session.containerWidth,
+                paneCount,
+            );
+            const leftIndex = session.dividerIndex;
+            const rightIndex = leftIndex + 1;
+            const startLeftPx =
+                session.startSizes[leftIndex] * session.containerWidth;
+            const startRightPx =
+                session.startSizes[rightIndex] * session.containerWidth;
+            const pairWidth = startLeftPx + startRightPx;
+            const deltaPx = event.clientX - session.startX;
+            const nextLeftPx = Math.max(
+                effectiveMinWidth,
+                Math.min(pairWidth - effectiveMinWidth, startLeftPx + deltaPx),
+            );
+            const nextRightPx = pairWidth - nextLeftPx;
+            const nextSizes = [...session.startSizes];
+            nextSizes[leftIndex] = nextLeftPx / session.containerWidth;
+            nextSizes[rightIndex] = nextRightPx / session.containerWidth;
+            setEditorPaneSizes(paneCount, nextSizes);
+        };
+        const handlePointerUp = () => stopResize();
+
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", handlePointerUp);
+        window.addEventListener("blur", handlePointerUp);
+        return () => {
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("pointerup", handlePointerUp);
+            window.removeEventListener("pointercancel", handlePointerUp);
+            window.removeEventListener("blur", handlePointerUp);
+        };
+    }, [isResizing, paneCount, setEditorPaneSizes, stopResize]);
+
+    const handleDividerPointerDown = useCallback(
+        (dividerIndex: number, event: ReactPointerEvent<HTMLDivElement>) => {
+            if (event.button !== 0) return;
+            const node = containerRef.current;
+            if (!node) return;
+            resizeSessionRef.current = {
+                pointerId: event.pointerId,
+                dividerIndex,
+                startX: event.clientX,
+                startSizes: paneSizes,
+                containerWidth: node.getBoundingClientRect().width,
+            };
+            event.currentTarget.setPointerCapture(event.pointerId);
+            document.body.classList.add("resizing-editor-pane");
+            setIsResizing(true);
+            event.preventDefault();
+        },
+        [paneSizes],
+    );
+
+    const effectiveMinWidth =
+        containerWidth > 0
+            ? getEffectiveMinPaneWidth(containerWidth, paneCount)
+            : MIN_PANE_WIDTH_FALLBACK;
+
+    return (
+        <div
+            ref={containerRef}
+            className="flex h-full min-h-0 min-w-0 overflow-hidden"
+        >
+            {panes.map((pane, index) => {
+                const isFocused = pane.id === focusedPaneId;
+                return (
+                    <Fragment key={pane.id}>
+                        <div
+                            className="flex min-h-0 min-w-0 flex-col overflow-hidden"
+                            style={{
+                                flexBasis: 0,
+                                flexGrow: paneSizes[index] ?? 1,
+                                minWidth: effectiveMinWidth,
+                                border: isFocused
+                                    ? "1px solid color-mix(in srgb, var(--accent) 26%, var(--border))"
+                                    : "1px solid transparent",
+                                borderRadius: 14,
+                                background: "var(--bg-primary)",
+                                boxShadow: isFocused
+                                    ? "0 14px 32px rgba(15, 23, 42, 0.08)"
+                                    : "none",
+                            }}
+                            onPointerDownCapture={() =>
+                                handlePaneFocus(pane.id)
+                            }
+                            onFocusCapture={() => handlePaneFocus(pane.id)}
+                            data-editor-pane-id={pane.id}
+                            data-editor-pane-focused={isFocused || undefined}
+                        >
+                            <EditorPaneBar
+                                paneId={pane.id}
+                                isFocused={isFocused}
+                            />
+                            <EditorPaneContent
+                                paneId={pane.id}
+                                emptyStateMessage="This pane is empty. Open a note here or close the pane from its menu."
+                            />
+                        </div>
+                        {index < panes.length - 1 && (
+                            <div
+                                role="separator"
+                                aria-orientation="vertical"
+                                aria-label={`Resize panes ${index + 1} and ${index + 2}`}
+                                className="relative shrink-0"
+                                style={{
+                                    width: RESIZER_HITBOX_WIDTH,
+                                    cursor: "col-resize",
+                                }}
+                                onPointerDown={(event) =>
+                                    handleDividerPointerDown(index, event)
+                                }
+                                onPointerUp={(event) =>
+                                    stopResize(event.pointerId)
+                                }
+                                onPointerCancel={(event) =>
+                                    stopResize(event.pointerId)
+                                }
+                            >
+                                <div
+                                    aria-hidden="true"
+                                    className="absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full"
+                                    style={{
+                                        width: RESIZER_VISIBLE_WIDTH,
+                                        background:
+                                            "color-mix(in srgb, var(--border) 90%, transparent)",
+                                    }}
+                                />
+                            </div>
+                        )}
+                    </Fragment>
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
@@ -2,13 +2,20 @@ import {
     Fragment,
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
     type PointerEvent as ReactPointerEvent,
 } from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+    getCurrentWindowLabel,
+    publishWindowTabDropZone,
+} from "../../app/detachedWindows";
 import { useEditorStore } from "../../app/store/editorStore";
 import { useLayoutStore } from "../../app/store/layoutStore";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { EditorPaneBar } from "./EditorPaneBar";
 import { EditorPaneContent } from "./EditorPaneContent";
 
@@ -34,6 +41,41 @@ function getEffectiveMinPaneWidth(containerWidth: number, paneCount: number) {
             Math.max(MIN_PANE_WIDTH_FALLBACK, evenWidth - 12),
         ),
     );
+}
+
+function getAppWindow() {
+    return getCurrentWindow();
+}
+
+async function getWindowContentScreenOrigin() {
+    const appWindow = getAppWindow();
+    if (
+        typeof appWindow.innerPosition !== "function" ||
+        typeof appWindow.scaleFactor !== "function"
+    ) {
+        return { x: window.screenX, y: window.screenY };
+    }
+
+    try {
+        const [innerPosition, scaleFactor] = await Promise.all([
+            appWindow.innerPosition(),
+            appWindow.scaleFactor(),
+        ]);
+        const logicalPosition =
+            typeof innerPosition.toLogical === "function"
+                ? innerPosition.toLogical(scaleFactor)
+                : {
+                      x: innerPosition.x / scaleFactor,
+                      y: innerPosition.y / scaleFactor,
+                  };
+
+        return {
+            x: logicalPosition.x,
+            y: logicalPosition.y,
+        };
+    } catch {
+        return { x: window.screenX, y: window.screenY };
+    }
 }
 
 export function MultiPaneWorkspace() {
@@ -71,6 +113,127 @@ export function MultiPaneWorkspace() {
         observer.observe(node);
         return () => observer.disconnect();
     }, []);
+
+    useLayoutEffect(() => {
+        const label = getCurrentWindowLabel();
+        let disposed = false;
+        let frame: number | null = null;
+        let publishVersion = 0;
+        let resizeObserver: ResizeObserver | null = null;
+        const cleanupListeners: Array<() => void> = [];
+
+        const schedulePublish = () => {
+            if (disposed) return;
+            if (frame !== null) {
+                window.cancelAnimationFrame(frame);
+            }
+
+            frame = window.requestAnimationFrame(() => {
+                frame = null;
+                const dropZone = containerRef.current;
+                if (!dropZone) {
+                    publishWindowTabDropZone(label, null);
+                    return;
+                }
+
+                const rect = dropZone.getBoundingClientRect();
+                if (rect.width <= 0 || rect.height <= 0) {
+                    publishWindowTabDropZone(label, null);
+                    return;
+                }
+
+                const nextVersion = publishVersion + 1;
+                publishVersion = nextVersion;
+                const nextRect = {
+                    left: rect.left,
+                    top: rect.top,
+                    width: rect.width,
+                    height: rect.height,
+                };
+
+                void getWindowContentScreenOrigin().then((origin) => {
+                    if (disposed || publishVersion !== nextVersion) return;
+
+                    const left = origin.x + nextRect.left;
+                    const top = origin.y + nextRect.top;
+                    publishWindowTabDropZone(label, {
+                        left: Math.round(left),
+                        top: Math.round(top),
+                        right: Math.round(left + nextRect.width),
+                        bottom: Math.round(top + nextRect.height),
+                        vaultPath: useVaultStore.getState().vaultPath,
+                    });
+                });
+            });
+        };
+
+        schedulePublish();
+        window.addEventListener("resize", schedulePublish);
+        window.addEventListener("focus", schedulePublish);
+
+        const node = containerRef.current;
+        if (node && typeof ResizeObserver !== "undefined") {
+            resizeObserver = new ResizeObserver(() => {
+                schedulePublish();
+            });
+            resizeObserver.observe(node);
+        }
+
+        const appWindow = getAppWindow();
+
+        void Promise.resolve(
+            appWindow.onMoved(() => {
+                schedulePublish();
+            }),
+        ).then((unlisten) => {
+            if (typeof unlisten !== "function") return;
+            if (disposed) {
+                void unlisten();
+                return;
+            }
+            cleanupListeners.push(unlisten);
+        });
+
+        void Promise.resolve(
+            appWindow.onResized(() => {
+                schedulePublish();
+            }),
+        ).then((unlisten) => {
+            if (typeof unlisten !== "function") return;
+            if (disposed) {
+                void unlisten();
+                return;
+            }
+            cleanupListeners.push(unlisten);
+        });
+
+        void Promise.resolve(
+            appWindow.onScaleChanged(() => {
+                schedulePublish();
+            }),
+        ).then((unlisten) => {
+            if (typeof unlisten !== "function") return;
+            if (disposed) {
+                void unlisten();
+                return;
+            }
+            cleanupListeners.push(unlisten);
+        });
+
+        return () => {
+            disposed = true;
+            if (frame !== null) {
+                window.cancelAnimationFrame(frame);
+            }
+            resizeObserver?.disconnect();
+            window.removeEventListener("resize", schedulePublish);
+            window.removeEventListener("focus", schedulePublish);
+            cleanupListeners.forEach((unlisten) => {
+                void unlisten();
+            });
+            publishWindowTabDropZone(label, null);
+        };
+    }, [paneCount]);
 
     const paneSizes = useMemo(() => {
         if (editorPaneSizes.length === paneCount) {

--- a/apps/desktop/src/features/editor/NewTabView.tsx
+++ b/apps/desktop/src/features/editor/NewTabView.tsx
@@ -16,6 +16,7 @@ import {
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
@@ -291,10 +292,9 @@ export function NewTabView() {
     ];
 
     const handleOpen = async (id: string, title: string) => {
-        const tabs = useEditorStore.getState().tabs;
-        const existing = tabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === id,
-        );
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === id);
         if (existing) {
             openNote(id, title, existing.content);
             return;

--- a/apps/desktop/src/features/editor/UnifiedBar.test.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.test.tsx
@@ -436,6 +436,24 @@ describe("UnifiedBar tab strip drop", () => {
         expect(useEditorStore.getState().activeTabId).toBeNull();
     });
 
+    it("does not render the ACP chat button next to the new-tab button", async () => {
+        setEditorTabs([
+            {
+                id: "tab-a",
+                kind: "note",
+                noteId: "notes/alpha.md",
+                title: "Alpha",
+                content: "alpha",
+            },
+        ]);
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        const { container } = renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        expect(container.querySelector('button[title="New ACP"]')).toBeNull();
+    });
+
     it("shrinks editor tabs continuously and expands them again when space returns", async () => {
         const resizeCallbacks: ResizeObserverCallback[] = [];
         const originalResizeObserver = globalThis.ResizeObserver;

--- a/apps/desktop/src/features/editor/UnifiedBar.test.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.test.tsx
@@ -1,6 +1,7 @@
-import { act, fireEvent, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { useState } from "react";
+import userEvent from "@testing-library/user-event";
 import {
     renderComponent,
     flushPromises,
@@ -208,6 +209,106 @@ describe("UnifiedBar tab strip drop", () => {
 
         fireEvent.click(targetTab!);
         expect(useEditorStore.getState().activeTabId).toBe("tab-b");
+    });
+
+    it("opens a tab in a new left pane from the context menu when split view is inactive", async () => {
+        const user = userEvent.setup();
+        setEditorTabs(
+            [
+                {
+                    id: "tab-a",
+                    kind: "note",
+                    noteId: "notes/alpha.md",
+                    title: "Alpha",
+                    content: "alpha",
+                },
+                {
+                    id: "tab-b",
+                    kind: "note",
+                    noteId: "notes/beta.md",
+                    title: "Beta",
+                    content: "beta",
+                },
+            ],
+            "tab-a",
+        );
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        const targetTab = document.querySelector(
+            '[data-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(targetTab).not.toBeNull();
+
+        fireEvent.contextMenu(targetTab!);
+        await user.click(
+            await screen.findByRole("button", {
+                name: "Open in New Left Pane",
+            }),
+        );
+
+        await waitFor(() => {
+            expect(
+                useEditorStore.getState().panes.map((pane) => pane.id),
+            ).toEqual(["pane-2", "primary"]);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("pane-2");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
+        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual(["tab-b"]);
+    });
+
+    it("opens a tab in a new down pane from the context menu when split view is inactive", async () => {
+        const user = userEvent.setup();
+        setEditorTabs(
+            [
+                {
+                    id: "tab-a",
+                    kind: "note",
+                    noteId: "notes/alpha.md",
+                    title: "Alpha",
+                    content: "alpha",
+                },
+                {
+                    id: "tab-b",
+                    kind: "note",
+                    noteId: "notes/beta.md",
+                    title: "Beta",
+                    content: "beta",
+                },
+            ],
+            "tab-a",
+        );
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        const targetTab = document.querySelector(
+            '[data-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(targetTab).not.toBeNull();
+
+        fireEvent.contextMenu(targetTab!);
+        await user.click(
+            await screen.findByRole("button", {
+                name: "Open in New Down Pane",
+            }),
+        );
+
+        await waitFor(() => {
+            expect(
+                useEditorStore.getState().panes.map((pane) => pane.id),
+            ).toEqual(["primary", "pane-2"]);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("pane-2");
+        expect(state.panes[0]?.tabs.map((tab) => tab.id)).toEqual(["tab-b"]);
+        expect(state.panes[1]?.tabs.map((tab) => tab.id)).toEqual(["tab-a"]);
     });
 
     it("opens a file tree drag drop in the strip at the requested position", async () => {

--- a/apps/desktop/src/features/editor/UnifiedBar.test.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.test.tsx
@@ -5,13 +5,16 @@ import userEvent from "@testing-library/user-event";
 import {
     renderComponent,
     flushPromises,
+    mockInvoke,
     setEditorTabs,
     setVaultEntries,
     setVaultNotes,
 } from "../../test/test-utils";
 import { useEditorStore } from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { FILE_TREE_NOTE_DRAG_EVENT } from "../ai/dragEvents";
+import { useChatStore } from "../ai/store/chatStore";
 import type { AIComposerPart } from "../ai/types";
 
 const innerPositionMock = vi.fn();
@@ -175,6 +178,33 @@ describe("UnifiedBar tab strip drop", () => {
         });
 
         useSettingsStore.setState({ fileTreeShowExtensions: false });
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: {
+                        id: "codex-acp",
+                        name: "Codex ACP",
+                        description: "Codex provider",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+                {
+                    runtime: {
+                        id: "claude-acp",
+                        name: "Claude ACP",
+                        description: "Claude provider",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            selectedRuntimeId: "codex-acp",
+        });
     });
 
     it("switches tabs when clicking another tab", async () => {
@@ -553,6 +583,179 @@ describe("UnifiedBar tab strip drop", () => {
         await flushPromises();
 
         expect(container.querySelector('button[title="New ACP"]')).toBeNull();
+    });
+
+    it("shows the plus-button context menu and hides blank files outside developer mode", async () => {
+        setEditorTabs([
+            {
+                id: "tab-a",
+                kind: "note",
+                noteId: "notes/alpha.md",
+                title: "Alpha",
+                content: "alpha",
+            },
+        ]);
+        setVaultEntries([]);
+        useSettingsStore.setState({ developerModeEnabled: false });
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        const { container } = renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        const newTabButton = container.querySelector(
+            '[data-new-tab-button="true"]',
+        ) as HTMLElement | null;
+        expect(newTabButton).not.toBeNull();
+
+        fireEvent.contextMenu(newTabButton!);
+
+        expect(
+            await screen.findByRole("button", { name: "New Note" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "New Agent" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "New blank file" }),
+        ).toBeNull();
+    });
+
+    it("opens the New Agent submenu and creates a chat for the selected provider", async () => {
+        const user = userEvent.setup();
+        setEditorTabs([
+            {
+                id: "tab-a",
+                kind: "note",
+                noteId: "notes/alpha.md",
+                title: "Alpha",
+                content: "alpha",
+            },
+        ]);
+        setVaultEntries([]);
+        useChatStore.setState((state) => ({
+            ...state,
+            newSession: vi.fn(async (runtimeId?: string) => {
+                const sessionId = `session-${runtimeId ?? "default"}`;
+                useChatStore.setState((current) => ({
+                    ...current,
+                    sessionsById: {
+                        ...current.sessionsById,
+                        [sessionId]: {
+                            sessionId,
+                            historySessionId: sessionId,
+                            status: "idle",
+                            runtimeId: runtimeId ?? "codex-acp",
+                            modelId: "test-model",
+                            modeId: "default",
+                            models: [],
+                            modes: [],
+                            configOptions: [],
+                            messages: [],
+                            attachments: [],
+                        },
+                    },
+                    sessionOrder: [sessionId, ...current.sessionOrder],
+                    activeSessionId: sessionId,
+                }));
+            }),
+        }));
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        const { container } = renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        const newTabButton = container.querySelector(
+            '[data-new-tab-button="true"]',
+        ) as HTMLElement | null;
+        expect(newTabButton).not.toBeNull();
+
+        fireEvent.contextMenu(newTabButton!);
+        const newAgentButton = await screen.findByRole("button", {
+            name: "New Agent",
+        });
+        fireEvent.mouseEnter(newAgentButton);
+        await user.click(await screen.findByRole("button", { name: "Claude" }));
+
+        await waitFor(() => {
+            expect(
+                useEditorStore
+                    .getState()
+                    .tabs.some((tab) => tab.kind === "ai-chat"),
+            ).toBe(true);
+        });
+
+        const chatSessionId = useEditorStore
+            .getState()
+            .tabs.find(
+                (tab) =>
+                    tab.kind === "ai-chat" &&
+                    tab.id === useEditorStore.getState().activeTabId,
+            );
+        expect(chatSessionId).not.toBeNull();
+        if (chatSessionId && chatSessionId.kind === "ai-chat") {
+            expect(
+                useChatStore.getState().sessionsById[chatSessionId.sessionId]
+                    ?.runtimeId,
+            ).toBe("claude-acp");
+        }
+    });
+
+    it("creates a blank file from the plus-button context menu in developer mode", async () => {
+        const user = userEvent.setup();
+        setEditorTabs([
+            {
+                id: "tab-a",
+                kind: "note",
+                noteId: "notes/alpha.md",
+                title: "Alpha",
+                content: "alpha",
+            },
+        ]);
+        setVaultEntries([]);
+        useSettingsStore.setState({ developerModeEnabled: true });
+        useVaultStore.setState({
+            refreshEntries: vi.fn().mockResolvedValue(undefined),
+        });
+        mockInvoke().mockResolvedValue({
+            relative_path: "untitled",
+            file_name: "untitled",
+            path: "/vault/untitled",
+            mime_type: "text/plain",
+            content: "",
+            size_bytes: 0,
+            content_truncated: false,
+        });
+
+        const { UnifiedBar } = await import("./UnifiedBar");
+        const { container } = renderComponent(<UnifiedBar windowMode="main" />);
+        await flushPromises();
+
+        const newTabButton = container.querySelector(
+            '[data-new-tab-button="true"]',
+        ) as HTMLElement | null;
+        expect(newTabButton).not.toBeNull();
+
+        fireEvent.contextMenu(newTabButton!);
+        await user.click(
+            await screen.findByRole("button", { name: "New blank file" }),
+        );
+
+        await waitFor(() => {
+            expect(
+                useEditorStore
+                    .getState()
+                    .tabs.some(
+                        (tab) =>
+                            tab.kind === "file" && tab.title === "untitled",
+                    ),
+            ).toBe(true);
+        });
+
+        expect(mockInvoke()).toHaveBeenCalledWith("save_vault_file", {
+            vaultPath: "/vault",
+            relativePath: "untitled",
+            content: "",
+        });
     });
 
     it("shrinks editor tabs continuously and expands them again when space returns", async () => {

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -36,8 +36,11 @@ import {
     isReviewTab,
     isFileTab,
     isPdfTab,
+    selectFocusedPaneId,
+    selectPaneCount,
     type Tab,
 } from "../../app/store/editorStore";
+import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
 import { moveChatToSidebar } from "../ai/chatPaneMovement";
 import { useLayoutStore } from "../../app/store/layoutStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
@@ -412,6 +415,9 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const switchTab = useEditorStore((s) => s.switchTab);
     const closeTab = useEditorStore((s) => s.closeTab);
     const reorderTabs = useEditorStore((s) => s.reorderTabs);
+    const moveTabToPaneDropTarget = useEditorStore(
+        (s) => s.moveTabToPaneDropTarget,
+    );
     const goBack = useEditorStore((s) => s.goBack);
     const goForward = useEditorStore((s) => s.goForward);
     const navigateToHistoryIndex = useEditorStore(
@@ -453,6 +459,8 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const rightPanelCollapsed = useLayoutStore((s) => s.rightPanelCollapsed);
     const rightPanelView = useLayoutStore((s) => s.rightPanelView);
     const activateRightView = useLayoutStore((s) => s.activateRightView);
+    const focusedPaneId = useEditorStore(selectFocusedPaneId);
+    const paneCount = useEditorStore(selectPaneCount);
     const vaultPath = useVaultStore((s) => s.vaultPath);
     const refreshEntries = useVaultStore((s) => s.refreshEntries);
     const [tabContextMenu, setTabContextMenu] = useState<ContextMenuState<{
@@ -471,6 +479,7 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const dragPreviewPosRef = useRef({ clientX: 0, clientY: 0 });
     const dragPreviewFrameRef = useRef<number | null>(null);
     const internalDragActiveRef = useRef(false);
+    const canCreateSplit = paneCount < MAX_EDITOR_PANES;
 
     const handleMoveTabFileToTrash = useCallback(
         async (path: string, title: string) => {
@@ -2286,6 +2295,31 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                         const tabIndex = tabs.findIndex(
                             (entry) => entry.id === tab.id,
                         );
+                        const splitEntries = focusedPaneId
+                            ? [
+                                  { type: "separator" as const },
+                                  {
+                                      label: "Open in New Left Pane",
+                                      action: () =>
+                                          moveTabToPaneDropTarget(
+                                              tab.id,
+                                              focusedPaneId,
+                                              "left",
+                                          ),
+                                      disabled: !canCreateSplit,
+                                  },
+                                  {
+                                      label: "Open in New Down Pane",
+                                      action: () =>
+                                          moveTabToPaneDropTarget(
+                                              tab.id,
+                                              focusedPaneId,
+                                              "down",
+                                          ),
+                                      disabled: !canCreateSplit,
+                                  },
+                              ]
+                            : [];
 
                         if (isChatTab(tab)) {
                             return [
@@ -2303,6 +2337,7 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                     action: () => closeOtherTabs(tab.id),
                                     disabled: tabs.length <= 1,
                                 },
+                                ...splitEntries,
                             ];
                         }
 
@@ -2317,6 +2352,7 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                     action: () => closeOtherTabs(tab.id),
                                     disabled: tabs.length <= 1,
                                 },
+                                ...splitEntries,
                             ];
                         }
 
@@ -2342,6 +2378,7 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                 action: () => closeTabsToTheLeft(tab.id),
                                 disabled: tabIndex <= 0,
                             },
+                            ...splitEntries,
                             { type: "separator" as const },
                             ...(!isPdf && !isFile
                                 ? [

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -75,6 +75,7 @@ import { getTabStripDropIndex, getTabStripScrollTarget } from "./tabStrip";
 import { WindowChrome } from "../../components/layout/WindowChrome";
 import { getDesktopPlatform } from "../../app/utils/platform";
 import { REQUEST_CLOSE_ACTIVE_TAB_EVENT } from "./Editor";
+import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 
 const DRAGGING_TAB_PLACEHOLDER_OPACITY = 0.18;
 const TAB_STRIP_FADE_WIDTH = 18;
@@ -164,247 +165,6 @@ const controlsGroupStyle: CSSProperties = {
     background: "color-mix(in srgb, var(--bg-primary) 52%, var(--bg-tertiary))",
     boxShadow: "inset 0 1px 0 rgba(255,255,255,0.05)",
 };
-
-function renderTabLeadingIcon(tab: Tab): ReactNode {
-    if (tab.kind === "pdf") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                className="shrink-0 opacity-65"
-            >
-                <path
-                    d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
-                    stroke="#e24b3b"
-                    strokeWidth="1"
-                />
-                <path
-                    d="M9.5 1.5V5H13"
-                    stroke="#e24b3b"
-                    strokeWidth="0.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                />
-                <text
-                    x="5"
-                    y="12"
-                    fontSize="4.5"
-                    fontWeight="700"
-                    fill="#e24b3b"
-                    fontFamily="sans-serif"
-                >
-                    PDF
-                </text>
-            </svg>
-        );
-    }
-
-    if (tab.kind === "file") {
-        if (tab.mimeType?.startsWith("image/")) {
-            return (
-                <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    className="shrink-0 opacity-55"
-                >
-                    <rect
-                        x="2"
-                        y="2.5"
-                        width="12"
-                        height="11"
-                        rx="1.5"
-                        stroke="currentColor"
-                        strokeWidth="1"
-                    />
-                    <circle
-                        cx="5.5"
-                        cy="5.8"
-                        r="1.2"
-                        stroke="currentColor"
-                        strokeWidth="0.8"
-                    />
-                    <path
-                        d="M2.5 11l3-3.5 2.5 2.5 1.5-1.5 4 3.5"
-                        stroke="currentColor"
-                        strokeWidth="0.8"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    />
-                </svg>
-            );
-        }
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                className="shrink-0 opacity-55"
-            >
-                <path
-                    d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                />
-                <path
-                    d="M9.5 1.5V5H13"
-                    stroke="currentColor"
-                    strokeWidth="0.8"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                />
-            </svg>
-        );
-    }
-
-    if (tab.kind === "ai-review") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="shrink-0 opacity-60"
-            >
-                <path d="M3 8h10M6 4l-4 4 4 4M10 4l4 4-4 4" />
-            </svg>
-        );
-    }
-
-    if (tab.kind === "ai-chat") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                className="shrink-0 opacity-60"
-            >
-                <path d="M2 3h12v8H5l-3 3V3z" />
-            </svg>
-        );
-    }
-
-    if (tab.kind === "map") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                className="shrink-0 opacity-55"
-            >
-                <rect
-                    x="2"
-                    y="2"
-                    width="12"
-                    height="12"
-                    rx="1.5"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                />
-                <circle cx="8" cy="5.5" r="1.3" fill="currentColor" />
-                <circle cx="5" cy="10.5" r="1.3" fill="currentColor" />
-                <circle cx="11" cy="10.5" r="1.3" fill="currentColor" />
-                <path
-                    d="M7.15 6.65 5.7 9.3M8.85 6.65l1.45 2.65"
-                    stroke="currentColor"
-                    strokeWidth="0.85"
-                    strokeLinecap="round"
-                />
-            </svg>
-        );
-    }
-
-    if (tab.kind === "graph") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                className="shrink-0 opacity-55"
-            >
-                <circle
-                    cx="8"
-                    cy="8"
-                    r="2"
-                    stroke="currentColor"
-                    strokeWidth="1"
-                />
-                <circle
-                    cx="3"
-                    cy="4"
-                    r="1.5"
-                    stroke="currentColor"
-                    strokeWidth="0.8"
-                />
-                <circle
-                    cx="13"
-                    cy="4"
-                    r="1.5"
-                    stroke="currentColor"
-                    strokeWidth="0.8"
-                />
-                <circle
-                    cx="4"
-                    cy="13"
-                    r="1.5"
-                    stroke="currentColor"
-                    strokeWidth="0.8"
-                />
-                <circle
-                    cx="12"
-                    cy="12"
-                    r="1.5"
-                    stroke="currentColor"
-                    strokeWidth="0.8"
-                />
-                <path
-                    d="M6.3 6.8l-2-1.8M9.7 6.8l2-1.8M6.5 9.5l-1.5 2.5M9.5 9.5l1.5 1.5"
-                    stroke="currentColor"
-                    strokeWidth="0.7"
-                    strokeLinecap="round"
-                />
-            </svg>
-        );
-    }
-
-    // Note tab (kind is "note" or undefined) — document with text lines
-    return (
-        <svg
-            width="12"
-            height="12"
-            viewBox="0 0 16 16"
-            fill="none"
-            className="shrink-0 opacity-50"
-        >
-            <path
-                d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
-                stroke="currentColor"
-                strokeWidth="1"
-            />
-            <path
-                d="M6 8h4M6 10.5h3"
-                stroke="currentColor"
-                strokeWidth="0.8"
-                strokeLinecap="round"
-            />
-        </svg>
-    );
-}
 
 interface UnifiedBarProps {
     windowMode: "main" | "note";
@@ -1748,7 +1508,9 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                                             : undefined,
                                                     }}
                                                 >
-                                                    {renderTabLeadingIcon(tab)}
+                                                    {renderEditorTabLeadingIcon(
+                                                        tab,
+                                                    )}
                                                     <span
                                                         className="flex-1 truncate font-medium"
                                                         style={{
@@ -1925,7 +1687,9 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                           willChange: "transform",
                                       }}
                                   >
-                                      {renderTabLeadingIcon(draggedPreviewTab)}
+                                      {renderEditorTabLeadingIcon(
+                                          draggedPreviewTab,
+                                      )}
                                       <span
                                           style={{
                                               flex: 1,

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -38,8 +38,7 @@ import {
     isPdfTab,
     type Tab,
 } from "../../app/store/editorStore";
-import { moveChatToSidebar, newChatInWorkspace } from "../ai/chatPaneMovement";
-import { useChatStore } from "../ai/store/chatStore";
+import { moveChatToSidebar } from "../ai/chatPaneMovement";
 import { useLayoutStore } from "../../app/store/layoutStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -472,35 +471,6 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const dragPreviewPosRef = useRef({ clientX: 0, clientY: 0 });
     const dragPreviewFrameRef = useRef<number | null>(null);
     const internalDragActiveRef = useRef(false);
-    const [acpMenuOpen, setAcpMenuOpen] = useState(false);
-    const acpButtonRef = useRef<HTMLButtonElement | null>(null);
-    const acpMenuRef = useRef<HTMLDivElement | null>(null);
-    const aiRuntimeDescriptors = useChatStore((s) => s.runtimes);
-    const aiRuntimes = aiRuntimeDescriptors.map((d) => d.runtime);
-
-    // Close ACP menu on click outside or Escape
-    useEffect(() => {
-        if (!acpMenuOpen) return;
-        const handleDown = (e: globalThis.MouseEvent) => {
-            if (
-                acpMenuRef.current &&
-                !acpMenuRef.current.contains(e.target as Node) &&
-                acpButtonRef.current &&
-                !acpButtonRef.current.contains(e.target as Node)
-            ) {
-                setAcpMenuOpen(false);
-            }
-        };
-        const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setAcpMenuOpen(false);
-        };
-        document.addEventListener("mousedown", handleDown);
-        document.addEventListener("keydown", handleKey);
-        return () => {
-            document.removeEventListener("mousedown", handleDown);
-            document.removeEventListener("keydown", handleKey);
-        };
-    }, [acpMenuOpen]);
 
     const handleMoveTabFileToTrash = useCallback(
         async (path: string, title: string) => {
@@ -1869,113 +1839,6 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                     >
                                         +
                                     </button>
-
-                                    {/* New ACP button — opens a runtime picker dropdown */}
-                                    <div style={{ position: "relative" }}>
-                                        <button
-                                            ref={acpButtonRef}
-                                            onMouseDown={(e) =>
-                                                e.stopPropagation()
-                                            }
-                                            onClick={() =>
-                                                setAcpMenuOpen((v) => !v)
-                                            }
-                                            title="New ACP"
-                                            className="no-drag flex items-center justify-center shrink-0 ub-chrome-btn"
-                                            style={{
-                                                alignSelf: "center",
-                                                marginLeft: 2,
-                                                flexShrink: 0,
-                                                ...getChromeButtonStyle(
-                                                    acpMenuOpen,
-                                                ),
-                                            }}
-                                        >
-                                            <svg
-                                                width="14"
-                                                height="14"
-                                                viewBox="0 0 16 16"
-                                                fill="none"
-                                                stroke="currentColor"
-                                                strokeWidth="1.3"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                            >
-                                                <path d="M2 3h12v8H5l-3 3V3z" />
-                                            </svg>
-                                        </button>
-                                        {acpMenuOpen &&
-                                            createPortal(
-                                                <div
-                                                    ref={acpMenuRef}
-                                                    style={{
-                                                        position: "fixed",
-                                                        top:
-                                                            (acpButtonRef.current?.getBoundingClientRect()
-                                                                .bottom ?? 0) +
-                                                            4,
-                                                        left:
-                                                            acpButtonRef.current?.getBoundingClientRect()
-                                                                .left ?? 0,
-                                                        zIndex: 10010,
-                                                        minWidth: 160,
-                                                        background:
-                                                            "var(--bg-elevated)",
-                                                        border: "1px solid var(--border)",
-                                                        borderRadius: 8,
-                                                        padding: "4px 0",
-                                                        boxShadow:
-                                                            "0 4px 16px rgba(0,0,0,0.18)",
-                                                    }}
-                                                    onMouseDown={(e) =>
-                                                        e.stopPropagation()
-                                                    }
-                                                >
-                                                    {aiRuntimes.map(
-                                                        (runtime) => (
-                                                            <button
-                                                                key={runtime.id}
-                                                                type="button"
-                                                                onClick={() => {
-                                                                    setAcpMenuOpen(
-                                                                        false,
-                                                                    );
-                                                                    void newChatInWorkspace(
-                                                                        runtime.id,
-                                                                    );
-                                                                }}
-                                                                className="flex w-full items-center rounded px-2.5 py-1.5 text-left text-xs"
-                                                                style={{
-                                                                    color: "var(--text-primary)",
-                                                                    cursor: "pointer",
-                                                                    background:
-                                                                        "transparent",
-                                                                    border: "none",
-                                                                }}
-                                                                onMouseEnter={(
-                                                                    e,
-                                                                ) => {
-                                                                    e.currentTarget.style.background =
-                                                                        "var(--bg-hover)";
-                                                                }}
-                                                                onMouseLeave={(
-                                                                    e,
-                                                                ) => {
-                                                                    e.currentTarget.style.background =
-                                                                        "transparent";
-                                                                }}
-                                                            >
-                                                                {runtime.name.replace(
-                                                                    / ACP$/,
-                                                                    "",
-                                                                )}
-                                                            </button>
-                                                        ),
-                                                    )}
-                                                </div>,
-                                                document.body,
-                                            )}
-                                    </div>
                                 </div>
 
                                 <div

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -31,12 +31,15 @@ import {
 } from "../../app/detachedWindows";
 import {
     useEditorStore,
+    isChatTab,
     isNoteTab,
     isReviewTab,
     isFileTab,
     isPdfTab,
     type Tab,
 } from "../../app/store/editorStore";
+import { moveChatToSidebar, newChatInWorkspace } from "../ai/chatPaneMovement";
+import { useChatStore } from "../ai/store/chatStore";
 import { useLayoutStore } from "../../app/store/layoutStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -270,6 +273,24 @@ function renderTabLeadingIcon(tab: Tab): ReactNode {
         );
     }
 
+    if (tab.kind === "ai-chat") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0 opacity-60"
+            >
+                <path d="M2 3h12v8H5l-3 3V3z" />
+            </svg>
+        );
+    }
+
     if (tab.kind === "map") {
         return (
             <svg
@@ -451,6 +472,35 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const dragPreviewPosRef = useRef({ clientX: 0, clientY: 0 });
     const dragPreviewFrameRef = useRef<number | null>(null);
     const internalDragActiveRef = useRef(false);
+    const [acpMenuOpen, setAcpMenuOpen] = useState(false);
+    const acpButtonRef = useRef<HTMLButtonElement | null>(null);
+    const acpMenuRef = useRef<HTMLDivElement | null>(null);
+    const aiRuntimeDescriptors = useChatStore((s) => s.runtimes);
+    const aiRuntimes = aiRuntimeDescriptors.map((d) => d.runtime);
+
+    // Close ACP menu on click outside or Escape
+    useEffect(() => {
+        if (!acpMenuOpen) return;
+        const handleDown = (e: globalThis.MouseEvent) => {
+            if (
+                acpMenuRef.current &&
+                !acpMenuRef.current.contains(e.target as Node) &&
+                acpButtonRef.current &&
+                !acpButtonRef.current.contains(e.target as Node)
+            ) {
+                setAcpMenuOpen(false);
+            }
+        };
+        const handleKey = (e: KeyboardEvent) => {
+            if (e.key === "Escape") setAcpMenuOpen(false);
+        };
+        document.addEventListener("mousedown", handleDown);
+        document.addEventListener("keydown", handleKey);
+        return () => {
+            document.removeEventListener("mousedown", handleDown);
+            document.removeEventListener("keydown", handleKey);
+        };
+    }, [acpMenuOpen]);
 
     const handleMoveTabFileToTrash = useCallback(
         async (path: string, title: string) => {
@@ -873,6 +923,15 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
         async (tabId: string) => {
             const { tabs: currentTabs, activeTabId } =
                 useEditorStore.getState();
+
+            // ChatTab close returns the session to the sidebar
+            const chatTab = currentTabs.find(
+                (t) => t.id === tabId && isChatTab(t),
+            );
+            if (chatTab && isChatTab(chatTab)) {
+                moveChatToSidebar(chatTab.sessionId);
+                return;
+            }
 
             if (windowMode === "note" && currentTabs.length === 1) {
                 const appWindow = getAppWindow();
@@ -1810,6 +1869,113 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                     >
                                         +
                                     </button>
+
+                                    {/* New ACP button — opens a runtime picker dropdown */}
+                                    <div style={{ position: "relative" }}>
+                                        <button
+                                            ref={acpButtonRef}
+                                            onMouseDown={(e) =>
+                                                e.stopPropagation()
+                                            }
+                                            onClick={() =>
+                                                setAcpMenuOpen((v) => !v)
+                                            }
+                                            title="New ACP"
+                                            className="no-drag flex items-center justify-center shrink-0 ub-chrome-btn"
+                                            style={{
+                                                alignSelf: "center",
+                                                marginLeft: 2,
+                                                flexShrink: 0,
+                                                ...getChromeButtonStyle(
+                                                    acpMenuOpen,
+                                                ),
+                                            }}
+                                        >
+                                            <svg
+                                                width="14"
+                                                height="14"
+                                                viewBox="0 0 16 16"
+                                                fill="none"
+                                                stroke="currentColor"
+                                                strokeWidth="1.3"
+                                                strokeLinecap="round"
+                                                strokeLinejoin="round"
+                                            >
+                                                <path d="M2 3h12v8H5l-3 3V3z" />
+                                            </svg>
+                                        </button>
+                                        {acpMenuOpen &&
+                                            createPortal(
+                                                <div
+                                                    ref={acpMenuRef}
+                                                    style={{
+                                                        position: "fixed",
+                                                        top:
+                                                            (acpButtonRef.current?.getBoundingClientRect()
+                                                                .bottom ?? 0) +
+                                                            4,
+                                                        left:
+                                                            acpButtonRef.current?.getBoundingClientRect()
+                                                                .left ?? 0,
+                                                        zIndex: 10010,
+                                                        minWidth: 160,
+                                                        background:
+                                                            "var(--bg-elevated)",
+                                                        border: "1px solid var(--border)",
+                                                        borderRadius: 8,
+                                                        padding: "4px 0",
+                                                        boxShadow:
+                                                            "0 4px 16px rgba(0,0,0,0.18)",
+                                                    }}
+                                                    onMouseDown={(e) =>
+                                                        e.stopPropagation()
+                                                    }
+                                                >
+                                                    {aiRuntimes.map(
+                                                        (runtime) => (
+                                                            <button
+                                                                key={runtime.id}
+                                                                type="button"
+                                                                onClick={() => {
+                                                                    setAcpMenuOpen(
+                                                                        false,
+                                                                    );
+                                                                    void newChatInWorkspace(
+                                                                        runtime.id,
+                                                                    );
+                                                                }}
+                                                                className="flex w-full items-center rounded px-2.5 py-1.5 text-left text-xs"
+                                                                style={{
+                                                                    color: "var(--text-primary)",
+                                                                    cursor: "pointer",
+                                                                    background:
+                                                                        "transparent",
+                                                                    border: "none",
+                                                                }}
+                                                                onMouseEnter={(
+                                                                    e,
+                                                                ) => {
+                                                                    e.currentTarget.style.background =
+                                                                        "var(--bg-hover)";
+                                                                }}
+                                                                onMouseLeave={(
+                                                                    e,
+                                                                ) => {
+                                                                    e.currentTarget.style.background =
+                                                                        "transparent";
+                                                                }}
+                                                            >
+                                                                {runtime.name.replace(
+                                                                    / ACP$/,
+                                                                    "",
+                                                                )}
+                                                            </button>
+                                                        ),
+                                                    )}
+                                                </div>,
+                                                document.body,
+                                            )}
+                                    </div>
                                 </div>
 
                                 <div
@@ -2257,6 +2423,25 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                         const tabIndex = tabs.findIndex(
                             (entry) => entry.id === tab.id,
                         );
+
+                        if (isChatTab(tab)) {
+                            return [
+                                {
+                                    label: "Return to AI Panel",
+                                    action: () =>
+                                        moveChatToSidebar(tab.sessionId),
+                                },
+                                {
+                                    label: "Close",
+                                    action: () => void handleCloseTab(tab.id),
+                                },
+                                {
+                                    label: "Close Others",
+                                    action: () => closeOtherTabs(tab.id),
+                                    disabled: tabs.length <= 1,
+                                },
+                            ];
+                        }
 
                         if (isReview || tab.kind === "graph") {
                             return [

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -5,7 +5,6 @@ import {
     useLayoutEffect,
     useRef,
     useState,
-    type ReactNode,
     type CSSProperties,
     type MouseEvent as ReactMouseEvent,
 } from "react";
@@ -38,7 +37,6 @@ import {
     isPdfTab,
     selectFocusedPaneId,
     selectPaneCount,
-    type Tab,
 } from "../../app/store/editorStore";
 import { MAX_EDITOR_PANES } from "../../app/store/workspaceLayoutTree";
 import { moveChatToSidebar } from "../ai/chatPaneMovement";

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -66,6 +66,10 @@ import {
     isPointOverAiComposerDropZone,
 } from "./tabDragAttachments";
 import { useResponsiveEditorTabLayout } from "./editorTabStripLayout";
+import {
+    buildNewTabContextMenuEntries,
+    openBlankDraftTabFromPlusButton,
+} from "./newTabMenuActions";
 import { useTabDragReorder } from "./useTabDragReorder";
 import { getTabStripDropIndex, getTabStripScrollTarget } from "./tabStrip";
 import { WindowChrome } from "../../components/layout/WindowChrome";
@@ -424,6 +428,9 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
         (s) => s.navigateToHistoryIndex,
     );
     const tabOpenBehavior = useSettingsStore((s) => s.tabOpenBehavior);
+    const developerModeEnabled = useSettingsStore(
+        (s) => s.developerModeEnabled,
+    );
     const fileTreeShowExtensions = useSettingsStore(
         (s) => s.fileTreeShowExtensions,
     );
@@ -467,6 +474,8 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
         tabId: string;
     }> | null>(null);
     const [historyContextMenu, setHistoryContextMenu] =
+        useState<ContextMenuState<void> | null>(null);
+    const [newTabContextMenu, setNewTabContextMenu] =
         useState<ContextMenuState<void> | null>(null);
     const [dragPreviewTabId, setDragPreviewTabId] = useState<string | null>(
         null,
@@ -1818,22 +1827,21 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                     })}
 
                                     <button
+                                        data-new-tab-button="true"
                                         onMouseDown={(e) => e.stopPropagation()}
                                         onClick={() => {
-                                            if (
-                                                !useVaultStore.getState()
-                                                    .vaultPath
-                                            )
-                                                return;
-                                            useEditorStore
-                                                .getState()
-                                                .insertExternalTab({
-                                                    id: crypto.randomUUID(),
-                                                    kind: "note",
-                                                    noteId: "",
-                                                    title: "New Tab",
-                                                    content: "",
-                                                });
+                                            openBlankDraftTabFromPlusButton(
+                                                focusedPaneId ?? undefined,
+                                            );
+                                        }}
+                                        onContextMenu={(event) => {
+                                            event.preventDefault();
+                                            event.stopPropagation();
+                                            setNewTabContextMenu({
+                                                x: event.clientX,
+                                                y: event.clientY,
+                                                payload: undefined,
+                                            });
                                         }}
                                         title="New tab"
                                         className="no-drag flex items-center justify-center shrink-0 ub-chrome-btn"
@@ -2268,6 +2276,16 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                         />
                     );
                 })()}
+            {newTabContextMenu && (
+                <ContextMenu
+                    menu={newTabContextMenu}
+                    onClose={() => setNewTabContextMenu(null)}
+                    entries={buildNewTabContextMenuEntries({
+                        paneId: focusedPaneId ?? undefined,
+                        developerModeEnabled,
+                    })}
+                />
+            )}
             {tabContextMenu && (
                 <ContextMenu
                     menu={tabContextMenu}

--- a/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
@@ -39,6 +39,11 @@ function getIconButtonStyle(active = false): CSSProperties {
     return {
         width: 30,
         height: 30,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        cursor: "pointer",
         borderRadius: 9,
         border: active
             ? "1px solid color-mix(in srgb, var(--accent) 20%, var(--border))"
@@ -100,8 +105,20 @@ export function WorkspaceChromeBar() {
 
     return (
         <WindowChrome
+            showLeadingInset
+            showWindowControls
             onBackgroundMouseDown={handleBackgroundMouseDown}
             onBackgroundDoubleClick={() => toggleWindowMaximize()}
+            onLeadingInsetMouseDown={handleBackgroundMouseDown}
+            onLeadingInsetDoubleClick={() => toggleWindowMaximize()}
+            shellStyle={{
+                background:
+                    "color-mix(in srgb, var(--bg-tertiary) 92%, transparent)",
+                borderBottom: "1px solid var(--border)",
+                backdropFilter: "blur(18px)",
+                boxShadow: "0 1px 0 rgba(255,255,255,0.04)",
+            }}
+            barStyle={{ padding: "0 6px" }}
         >
             <div
                 className="flex min-w-0 flex-1 items-center gap-2 px-2"
@@ -113,7 +130,11 @@ export function WorkspaceChromeBar() {
                     onClick={toggleSidebar}
                     title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
                     className="no-drag flex items-center justify-center shrink-0"
-                    style={getIconButtonStyle(!sidebarCollapsed)}
+                    style={{
+                        ...getIconButtonStyle(!sidebarCollapsed),
+                        marginLeft: 10,
+                        marginRight: 2,
+                    }}
                 >
                     <svg
                         width="14"
@@ -186,43 +207,113 @@ export function WorkspaceChromeBar() {
                 </div>
 
                 <div
-                    className="min-w-0 flex-1 px-2 text-xs font-medium uppercase tracking-[0.14em]"
+                    className="min-w-0 flex-1 truncate px-2 text-xs font-medium uppercase tracking-[0.14em]"
                     style={{ color: "var(--text-secondary)" }}
                 >
                     Multi-pane workspace
                 </div>
 
-                <div className="no-drag flex items-center gap-1">
+                <div className="no-drag flex shrink-0 items-center gap-1">
                     <button
                         type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
                         onClick={() => activateRightView("chat")}
                         title="AI Chat"
+                        className="no-drag"
                         style={getIconButtonStyle(
                             !rightPanelCollapsed && rightPanelView === "chat",
                         )}
                     >
-                        Chat
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M14 10a2 2 0 0 1-2 2H5l-3 3V4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2z" />
+                        </svg>
                     </button>
                     <button
                         type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
                         onClick={() => activateRightView("outline")}
                         title="Outline"
+                        className="no-drag"
                         style={getIconButtonStyle(
                             !rightPanelCollapsed &&
                                 rightPanelView === "outline",
                         )}
                     >
-                        Outline
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.5"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M3 3.5h10" />
+                            <path d="M5.5 8h7.5" />
+                            <path d="M8 12.5h5" />
+                            <path d="M3 8h.01" />
+                            <path d="M5.5 12.5h.01" />
+                        </svg>
                     </button>
                     <button
                         type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
                         onClick={() => activateRightView("links")}
                         title="Links"
+                        className="no-drag"
                         style={getIconButtonStyle(
                             !rightPanelCollapsed && rightPanelView === "links",
                         )}
                     >
-                        Links
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                        >
+                            <rect
+                                x="11"
+                                y="2"
+                                width="4"
+                                height="12"
+                                rx="1"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="1"
+                                y="2"
+                                width="8"
+                                height="2"
+                                rx="1"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="1"
+                                y="7"
+                                width="8"
+                                height="2"
+                                rx="1"
+                                fill="currentColor"
+                            />
+                            <rect
+                                x="1"
+                                y="12"
+                                width="8"
+                                height="2"
+                                rx="1"
+                                fill="currentColor"
+                            />
+                        </svg>
                     </button>
                 </div>
             </div>

--- a/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
@@ -1,0 +1,231 @@
+import {
+    useCallback,
+    type CSSProperties,
+    type MouseEvent as ReactMouseEvent,
+} from "react";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import { WindowChrome } from "../../components/layout/WindowChrome";
+import {
+    isFileTab,
+    isNoteTab,
+    isPdfTab,
+    selectFocusedEditorTab,
+    useEditorStore,
+} from "../../app/store/editorStore";
+import { useLayoutStore } from "../../app/store/layoutStore";
+import { useSettingsStore } from "../../app/store/settingsStore";
+import { getDesktopPlatform } from "../../app/utils/platform";
+
+function getAppWindow() {
+    return getCurrentWindow();
+}
+
+function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
+    if (event.button !== 0) return;
+    event.preventDefault();
+    void getAppWindow()
+        .startDragging()
+        .catch(() => {});
+}
+
+function toggleWindowMaximize() {
+    if (getDesktopPlatform() !== "windows") return;
+    const appWindow = getAppWindow();
+    if (typeof appWindow.toggleMaximize !== "function") return;
+    void appWindow.toggleMaximize().catch(() => {});
+}
+
+function getIconButtonStyle(active = false): CSSProperties {
+    return {
+        width: 30,
+        height: 30,
+        borderRadius: 9,
+        border: active
+            ? "1px solid color-mix(in srgb, var(--accent) 20%, var(--border))"
+            : "1px solid transparent",
+        backgroundColor: active
+            ? "color-mix(in srgb, var(--accent) 12%, var(--bg-primary))"
+            : "transparent",
+        color: active ? "var(--text-primary)" : "var(--text-secondary)",
+        opacity: active ? 1 : 0.82,
+    };
+}
+
+export function WorkspaceChromeBar() {
+    const toggleSidebar = useLayoutStore((state) => state.toggleSidebar);
+    const sidebarCollapsed = useLayoutStore((state) => state.sidebarCollapsed);
+    const rightPanelCollapsed = useLayoutStore(
+        (state) => state.rightPanelCollapsed,
+    );
+    const rightPanelView = useLayoutStore((state) => state.rightPanelView);
+    const activateRightView = useLayoutStore(
+        (state) => state.activateRightView,
+    );
+    const goBack = useEditorStore((state) => state.goBack);
+    const goForward = useEditorStore((state) => state.goForward);
+    const tabOpenBehavior = useSettingsStore((state) => state.tabOpenBehavior);
+    const canGoBack = useEditorStore((state) => {
+        if (tabOpenBehavior === "history") {
+            const tab = selectFocusedEditorTab(state);
+            return tab && (isNoteTab(tab) || isFileTab(tab) || isPdfTab(tab))
+                ? tab.historyIndex > 0
+                : false;
+        }
+        if (state.tabNavigationIndex <= 0) return false;
+        return state.tabNavigationHistory
+            .slice(0, state.tabNavigationIndex)
+            .some((tabId) => state.tabs.some((tab) => tab.id === tabId));
+    });
+    const canGoForward = useEditorStore((state) => {
+        if (tabOpenBehavior === "history") {
+            const tab = selectFocusedEditorTab(state);
+            return tab && (isNoteTab(tab) || isFileTab(tab) || isPdfTab(tab))
+                ? tab.historyIndex < tab.history.length - 1
+                : false;
+        }
+        if (state.tabNavigationIndex >= state.tabNavigationHistory.length - 1) {
+            return false;
+        }
+        return state.tabNavigationHistory
+            .slice(state.tabNavigationIndex + 1)
+            .some((tabId) => state.tabs.some((tab) => tab.id === tabId));
+    });
+
+    const handleBackgroundMouseDown = useCallback(
+        (event: ReactMouseEvent<HTMLElement>) => {
+            startWindowDrag(event);
+        },
+        [],
+    );
+
+    return (
+        <WindowChrome
+            onBackgroundMouseDown={handleBackgroundMouseDown}
+            onBackgroundDoubleClick={() => toggleWindowMaximize()}
+        >
+            <div
+                className="flex min-w-0 flex-1 items-center gap-2 px-2"
+                onMouseDown={startWindowDrag}
+            >
+                <button
+                    type="button"
+                    onMouseDown={(event) => event.stopPropagation()}
+                    onClick={toggleSidebar}
+                    title={sidebarCollapsed ? "Show sidebar" : "Hide sidebar"}
+                    className="no-drag flex items-center justify-center shrink-0"
+                    style={getIconButtonStyle(!sidebarCollapsed)}
+                >
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <rect x="2.5" y="2.5" width="11" height="11" rx="2" />
+                        <path d="M6 2.5v11" />
+                    </svg>
+                </button>
+
+                <div className="flex items-center">
+                    <button
+                        type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={goBack}
+                        disabled={!canGoBack}
+                        title="Go back"
+                        className="no-drag flex items-center justify-center shrink-0"
+                        style={{
+                            ...getIconButtonStyle(false),
+                            borderRadius: "9px 0 0 9px",
+                            opacity: canGoBack ? 0.82 : 0.34,
+                        }}
+                    >
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.8"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M9.5 3L4.5 8l5 5" />
+                        </svg>
+                    </button>
+                    <button
+                        type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={goForward}
+                        disabled={!canGoForward}
+                        title="Go forward"
+                        className="no-drag flex items-center justify-center shrink-0"
+                        style={{
+                            ...getIconButtonStyle(false),
+                            borderRadius: "0 9px 9px 0",
+                            opacity: canGoForward ? 0.82 : 0.34,
+                        }}
+                    >
+                        <svg
+                            width="14"
+                            height="14"
+                            viewBox="0 0 16 16"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="1.8"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <path d="M6.5 3L11.5 8l-5 5" />
+                        </svg>
+                    </button>
+                </div>
+
+                <div
+                    className="min-w-0 flex-1 px-2 text-xs font-medium uppercase tracking-[0.14em]"
+                    style={{ color: "var(--text-secondary)" }}
+                >
+                    Multi-pane workspace
+                </div>
+
+                <div className="no-drag flex items-center gap-1">
+                    <button
+                        type="button"
+                        onClick={() => activateRightView("chat")}
+                        title="AI Chat"
+                        style={getIconButtonStyle(
+                            !rightPanelCollapsed && rightPanelView === "chat",
+                        )}
+                    >
+                        Chat
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => activateRightView("outline")}
+                        title="Outline"
+                        style={getIconButtonStyle(
+                            !rightPanelCollapsed &&
+                                rightPanelView === "outline",
+                        )}
+                    >
+                        Outline
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => activateRightView("links")}
+                        title="Links"
+                        style={getIconButtonStyle(
+                            !rightPanelCollapsed && rightPanelView === "links",
+                        )}
+                    >
+                        Links
+                    </button>
+                </div>
+            </div>
+        </WindowChrome>
+    );
+}

--- a/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceChromeBar.tsx
@@ -206,12 +206,7 @@ export function WorkspaceChromeBar() {
                     </button>
                 </div>
 
-                <div
-                    className="min-w-0 flex-1 truncate px-2 text-xs font-medium uppercase tracking-[0.14em]"
-                    style={{ color: "var(--text-secondary)" }}
-                >
-                    Multi-pane workspace
-                </div>
+                <div aria-hidden="true" className="min-w-0 flex-1" />
 
                 <div className="no-drag flex shrink-0 items-center gap-1">
                     <button

--- a/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
@@ -173,7 +173,7 @@ function WorkspacePane({
 
     return (
         <div
-            className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden"
+            className="relative flex h-full min-h-0 min-w-0 w-full flex-1 flex-col overflow-hidden"
             style={{
                 minWidth: MIN_PANE_WIDTH,
                 minHeight: MIN_PANE_HEIGHT,

--- a/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
@@ -46,9 +46,9 @@ function getDropOverlayLabel(position: CrossPaneTabDropPreview["position"]) {
             return "Split left";
         case "right":
             return "Split right";
-        case "top":
+        case "up":
             return "Split up";
-        case "bottom":
+        case "down":
             return "Split down";
         default:
             return "Add as tab";
@@ -83,7 +83,7 @@ function getDropOverlayStyle(position: CrossPaneTabDropPreview["position"]) {
                 bottom: 8,
                 width: "34%",
             };
-        case "top":
+        case "up":
             return {
                 ...base,
                 left: 8,
@@ -91,7 +91,7 @@ function getDropOverlayStyle(position: CrossPaneTabDropPreview["position"]) {
                 top: 8,
                 height: "34%",
             };
-        case "bottom":
+        case "down":
             return {
                 ...base,
                 left: 8,

--- a/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
@@ -180,7 +180,7 @@ function WorkspacePane({
                 border: isFocused
                     ? "1px solid color-mix(in srgb, var(--accent) 26%, var(--border))"
                     : "1px solid transparent",
-                borderRadius: 14,
+                borderRadius: 0,
                 background: "var(--bg-primary)",
                 boxShadow: isFocused
                     ? "0 14px 32px rgba(15, 23, 42, 0.08)"
@@ -404,67 +404,100 @@ export function WorkspaceSplitContainer({
                         </div>
                         {index < node.children.length - 1 ? (
                             <div
-                                role="separator"
-                                aria-orientation={orientation}
-                                aria-label={`Resize split ${node.id} sections ${index + 1} and ${index + 2}`}
                                 className="relative shrink-0"
                                 style={{
                                     width:
                                         node.direction === "row"
-                                            ? RESIZER_HITBOX_SIZE
+                                            ? RESIZER_VISIBLE_SIZE
                                             : "100%",
                                     height:
                                         node.direction === "column"
-                                            ? RESIZER_HITBOX_SIZE
+                                            ? RESIZER_VISIBLE_SIZE
                                             : "100%",
-                                    cursor,
+                                    background:
+                                        "color-mix(in srgb, var(--border) 40%, transparent)",
+                                    zIndex: 10,
                                 }}
-                                onPointerDown={(event) =>
-                                    handleDividerPointerDown(index, event)
-                                }
-                                onPointerUp={(event) =>
-                                    stopResize(event.pointerId)
-                                }
-                                onPointerCancel={(event) =>
-                                    stopResize(event.pointerId)
-                                }
                             >
+                                {/* Drag hitbox — overlaps adjacent panes for a comfortable grab area */}
                                 <div
-                                    aria-hidden="true"
-                                    className="absolute rounded-full"
+                                    role="separator"
+                                    aria-orientation={orientation}
+                                    aria-label={`Resize split ${node.id} sections ${index + 1} and ${index + 2}`}
+                                    className="group/resizer absolute"
                                     style={{
                                         left:
                                             node.direction === "row"
-                                                ? "50%"
+                                                ? -(
+                                                      RESIZER_HITBOX_SIZE -
+                                                      RESIZER_VISIBLE_SIZE
+                                                  ) / 2
                                                 : 0,
                                         top:
                                             node.direction === "column"
-                                                ? "50%"
+                                                ? -(
+                                                      RESIZER_HITBOX_SIZE -
+                                                      RESIZER_VISIBLE_SIZE
+                                                  ) / 2
                                                 : 0,
-                                        bottom:
-                                            node.direction === "row"
-                                                ? 0
-                                                : "auto",
-                                        right:
-                                            node.direction === "column"
-                                                ? 0
-                                                : "auto",
                                         width:
                                             node.direction === "row"
-                                                ? RESIZER_VISIBLE_SIZE
+                                                ? RESIZER_HITBOX_SIZE
                                                 : "100%",
                                         height:
                                             node.direction === "column"
-                                                ? RESIZER_VISIBLE_SIZE
+                                                ? RESIZER_HITBOX_SIZE
                                                 : "100%",
-                                        transform:
-                                            node.direction === "row"
-                                                ? "translateX(-50%)"
-                                                : "translateY(-50%)",
-                                        background:
-                                            "color-mix(in srgb, var(--border) 90%, transparent)",
+                                        cursor,
                                     }}
-                                />
+                                    onPointerDown={(event) =>
+                                        handleDividerPointerDown(index, event)
+                                    }
+                                    onPointerUp={(event) =>
+                                        stopResize(event.pointerId)
+                                    }
+                                    onPointerCancel={(event) =>
+                                        stopResize(event.pointerId)
+                                    }
+                                >
+                                    {/* Hover indicator */}
+                                    <div
+                                        aria-hidden="true"
+                                        className="absolute rounded-full opacity-0 transition-opacity duration-150 group-hover/resizer:opacity-100"
+                                        style={{
+                                            left:
+                                                node.direction === "row"
+                                                    ? "50%"
+                                                    : 0,
+                                            top:
+                                                node.direction === "column"
+                                                    ? "50%"
+                                                    : 0,
+                                            bottom:
+                                                node.direction === "row"
+                                                    ? 0
+                                                    : "auto",
+                                            right:
+                                                node.direction === "column"
+                                                    ? 0
+                                                    : "auto",
+                                            width:
+                                                node.direction === "row"
+                                                    ? 3
+                                                    : "100%",
+                                            height:
+                                                node.direction === "column"
+                                                    ? 3
+                                                    : "100%",
+                                            transform:
+                                                node.direction === "row"
+                                                    ? "translateX(-50%)"
+                                                    : "translateY(-50%)",
+                                            background:
+                                                "color-mix(in srgb, var(--accent) 40%, var(--border))",
+                                        }}
+                                    />
+                                </div>
                             </div>
                         ) : null}
                     </Fragment>

--- a/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
@@ -367,7 +367,7 @@ export function WorkspaceSplitContainer({
     return (
         <div
             ref={containerRef}
-            className={`flex h-full min-h-0 min-w-0 overflow-hidden ${
+            className={`flex h-full min-h-0 min-w-0 w-full flex-1 overflow-hidden ${
                 node.direction === "row" ? "flex-row" : "flex-col"
             }`}
             data-workspace-split-id={node.id}

--- a/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
+++ b/apps/desktop/src/features/editor/WorkspaceSplitContainer.tsx
@@ -1,0 +1,475 @@
+import {
+    Fragment,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type PointerEvent as ReactPointerEvent,
+} from "react";
+import type { WorkspaceLayoutNode } from "../../app/store/workspaceLayoutTree";
+import { EditorPaneBar } from "./EditorPaneBar";
+import { EditorPaneContent } from "./EditorPaneContent";
+import type { CrossPaneTabDropPreview } from "./workspaceTabDropPreview";
+
+const RESIZER_HITBOX_SIZE = 10;
+const RESIZER_VISIBLE_SIZE = 1;
+const MIN_PANE_WIDTH = 180;
+const MIN_PANE_HEIGHT = 140;
+
+interface ResizeSession {
+    pointerId: number;
+    dividerIndex: number;
+    direction: "row" | "column";
+    startPointerOffset: number;
+    startSizes: number[];
+    containerMainAxisSize: number;
+    minSizes: number[];
+}
+
+interface NodeConstraints {
+    minWidth: number;
+    minHeight: number;
+}
+
+interface WorkspaceSplitContainerProps {
+    node: WorkspaceLayoutNode;
+    focusedPaneId: string | null;
+    onPaneFocus: (paneId: string) => void;
+    onResizeSplit: (splitId: string, sizes: readonly number[]) => void;
+    dropPreview: CrossPaneTabDropPreview | null;
+}
+
+function getDropOverlayLabel(position: CrossPaneTabDropPreview["position"]) {
+    switch (position) {
+        case "left":
+            return "Split left";
+        case "right":
+            return "Split right";
+        case "top":
+            return "Split up";
+        case "bottom":
+            return "Split down";
+        default:
+            return "Add as tab";
+    }
+}
+
+function getDropOverlayStyle(position: CrossPaneTabDropPreview["position"]) {
+    const base = {
+        position: "absolute" as const,
+        pointerEvents: "none" as const,
+        borderRadius: 12,
+        background: "color-mix(in srgb, var(--accent) 14%, transparent)",
+        border: "1px solid color-mix(in srgb, var(--accent) 28%, transparent)",
+        boxShadow:
+            "0 0 0 1px color-mix(in srgb, var(--accent) 10%, transparent)",
+    };
+
+    switch (position) {
+        case "left":
+            return {
+                ...base,
+                left: 8,
+                top: 8,
+                bottom: 8,
+                width: "34%",
+            };
+        case "right":
+            return {
+                ...base,
+                right: 8,
+                top: 8,
+                bottom: 8,
+                width: "34%",
+            };
+        case "top":
+            return {
+                ...base,
+                left: 8,
+                right: 8,
+                top: 8,
+                height: "34%",
+            };
+        case "bottom":
+            return {
+                ...base,
+                left: 8,
+                right: 8,
+                bottom: 8,
+                height: "34%",
+            };
+        default:
+            return {
+                ...base,
+                inset: 8,
+            };
+    }
+}
+
+function getNodeConstraints(node: WorkspaceLayoutNode): NodeConstraints {
+    if (node.type === "pane") {
+        return {
+            minWidth: MIN_PANE_WIDTH,
+            minHeight: MIN_PANE_HEIGHT,
+        };
+    }
+
+    const childConstraints = node.children.map((child) =>
+        getNodeConstraints(child),
+    );
+
+    if (node.direction === "row") {
+        return {
+            minWidth: childConstraints.reduce(
+                (sum, child) => sum + child.minWidth,
+                0,
+            ),
+            minHeight: childConstraints.reduce(
+                (max, child) => Math.max(max, child.minHeight),
+                MIN_PANE_HEIGHT,
+            ),
+        };
+    }
+
+    return {
+        minWidth: childConstraints.reduce(
+            (max, child) => Math.max(max, child.minWidth),
+            MIN_PANE_WIDTH,
+        ),
+        minHeight: childConstraints.reduce(
+            (sum, child) => sum + child.minHeight,
+            0,
+        ),
+    };
+}
+
+function clampSplitResize(
+    pairSize: number,
+    proposedLeadingSize: number,
+    leadingMinSize: number,
+    trailingMinSize: number,
+) {
+    const maxLeadingSize = Math.max(leadingMinSize, pairSize - trailingMinSize);
+    return Math.max(
+        leadingMinSize,
+        Math.min(maxLeadingSize, proposedLeadingSize),
+    );
+}
+
+function WorkspacePane({
+    paneId,
+    isFocused,
+    onPaneFocus,
+    dropPreview,
+}: {
+    paneId: string;
+    isFocused: boolean;
+    onPaneFocus: (paneId: string) => void;
+    dropPreview: CrossPaneTabDropPreview | null;
+}) {
+    const activeDropPreview =
+        dropPreview?.targetPaneId === paneId ? dropPreview : null;
+
+    return (
+        <div
+            className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden"
+            style={{
+                minWidth: MIN_PANE_WIDTH,
+                minHeight: MIN_PANE_HEIGHT,
+                border: isFocused
+                    ? "1px solid color-mix(in srgb, var(--accent) 26%, var(--border))"
+                    : "1px solid transparent",
+                borderRadius: 14,
+                background: "var(--bg-primary)",
+                boxShadow: isFocused
+                    ? "0 14px 32px rgba(15, 23, 42, 0.08)"
+                    : "none",
+            }}
+            onPointerDownCapture={() => onPaneFocus(paneId)}
+            onFocusCapture={() => onPaneFocus(paneId)}
+            data-editor-pane-id={paneId}
+            data-editor-pane-focused={isFocused || undefined}
+        >
+            {activeDropPreview ? (
+                <div
+                    aria-hidden="true"
+                    data-pane-drop-overlay-position={activeDropPreview.position}
+                    style={getDropOverlayStyle(activeDropPreview.position)}
+                >
+                    <div
+                        style={{
+                            position: "absolute",
+                            left: 10,
+                            top: 10,
+                            padding: "4px 8px",
+                            borderRadius: 999,
+                            background:
+                                "color-mix(in srgb, var(--bg-primary) 90%, white 10%)",
+                            color: "var(--text-primary)",
+                            fontSize: 11,
+                            fontWeight: 600,
+                            letterSpacing: "0.01em",
+                        }}
+                    >
+                        {getDropOverlayLabel(activeDropPreview.position)}
+                    </div>
+                </div>
+            ) : null}
+            <EditorPaneBar paneId={paneId} isFocused={isFocused} />
+            <EditorPaneContent
+                paneId={paneId}
+                emptyStateMessage="This pane is empty. Open a note here or close the pane from its menu."
+            />
+        </div>
+    );
+}
+
+export function WorkspaceSplitContainer({
+    node,
+    focusedPaneId,
+    onPaneFocus,
+    onResizeSplit,
+    dropPreview,
+}: WorkspaceSplitContainerProps) {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const resizeSessionRef = useRef<ResizeSession | null>(null);
+    const [isResizing, setIsResizing] = useState(false);
+
+    const childConstraints = useMemo(
+        () =>
+            node.type === "split"
+                ? node.children.map((child) => getNodeConstraints(child))
+                : [],
+        [node],
+    );
+
+    const stopResize = useCallback((pointerId?: number) => {
+        const session = resizeSessionRef.current;
+        if (!session) {
+            return;
+        }
+        if (pointerId !== undefined && session.pointerId !== pointerId) {
+            return;
+        }
+
+        resizeSessionRef.current = null;
+        document.body.classList.remove("resizing-editor-pane");
+        setIsResizing(false);
+    }, []);
+
+    useEffect(() => {
+        if (!isResizing) {
+            return;
+        }
+
+        const handlePointerMove = (event: PointerEvent) => {
+            const session = resizeSessionRef.current;
+            if (!session) {
+                return;
+            }
+
+            const leadingIndex = session.dividerIndex;
+            const trailingIndex = leadingIndex + 1;
+            const startLeadingSize =
+                session.startSizes[leadingIndex] *
+                session.containerMainAxisSize;
+            const startTrailingSize =
+                session.startSizes[trailingIndex] *
+                session.containerMainAxisSize;
+            const pairSize = startLeadingSize + startTrailingSize;
+            const pointerOffset =
+                session.direction === "row" ? event.clientX : event.clientY;
+            const delta = pointerOffset - session.startPointerOffset;
+            const nextLeadingSize = clampSplitResize(
+                pairSize,
+                startLeadingSize + delta,
+                session.minSizes[leadingIndex] ?? 0,
+                session.minSizes[trailingIndex] ?? 0,
+            );
+            const nextTrailingSize = pairSize - nextLeadingSize;
+            const nextSizes = [...session.startSizes];
+            nextSizes[leadingIndex] =
+                nextLeadingSize / session.containerMainAxisSize;
+            nextSizes[trailingIndex] =
+                nextTrailingSize / session.containerMainAxisSize;
+            onResizeSplit(node.id, nextSizes);
+        };
+
+        const handlePointerUp = () => stopResize();
+
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", handlePointerUp);
+        window.addEventListener("blur", handlePointerUp);
+        return () => {
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("pointerup", handlePointerUp);
+            window.removeEventListener("pointercancel", handlePointerUp);
+            window.removeEventListener("blur", handlePointerUp);
+        };
+    }, [isResizing, node.id, onResizeSplit, stopResize]);
+
+    const handleDividerPointerDown = useCallback(
+        (dividerIndex: number, event: ReactPointerEvent<HTMLDivElement>) => {
+            const isPrimaryMouseButton =
+                event.pointerType !== "mouse" || event.button === 0;
+
+            if (node.type !== "split" || !isPrimaryMouseButton) {
+                return;
+            }
+
+            const container = containerRef.current;
+            if (!container) {
+                return;
+            }
+
+            const rect = container.getBoundingClientRect();
+            const containerMainAxisSize =
+                node.direction === "row" ? rect.width : rect.height;
+            if (containerMainAxisSize <= 0) {
+                return;
+            }
+
+            resizeSessionRef.current = {
+                pointerId: event.pointerId,
+                dividerIndex,
+                direction: node.direction,
+                startPointerOffset:
+                    node.direction === "row" ? event.clientX : event.clientY,
+                startSizes: node.sizes,
+                containerMainAxisSize,
+                minSizes: childConstraints.map((constraints) =>
+                    node.direction === "row"
+                        ? constraints.minWidth
+                        : constraints.minHeight,
+                ),
+            };
+            event.currentTarget.setPointerCapture(event.pointerId);
+            document.body.classList.add("resizing-editor-pane");
+            setIsResizing(true);
+            event.preventDefault();
+        },
+        [childConstraints, node],
+    );
+
+    if (node.type === "pane") {
+        return (
+            <WorkspacePane
+                paneId={node.paneId}
+                isFocused={node.paneId === focusedPaneId}
+                onPaneFocus={onPaneFocus}
+                dropPreview={dropPreview}
+            />
+        );
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            className={`flex h-full min-h-0 min-w-0 overflow-hidden ${
+                node.direction === "row" ? "flex-row" : "flex-col"
+            }`}
+            data-workspace-split-id={node.id}
+            data-workspace-split-direction={node.direction}
+        >
+            {node.children.map((child, index) => {
+                const constraints = childConstraints[index] ?? {
+                    minWidth: MIN_PANE_WIDTH,
+                    minHeight: MIN_PANE_HEIGHT,
+                };
+                const orientation =
+                    node.direction === "row" ? "vertical" : "horizontal";
+                const cursor =
+                    node.direction === "row" ? "col-resize" : "row-resize";
+
+                return (
+                    <Fragment key={child.id}>
+                        <div
+                            className="flex min-h-0 min-w-0 overflow-hidden"
+                            style={{
+                                flexBasis: 0,
+                                flexGrow: node.sizes[index] ?? 1,
+                                minWidth: constraints.minWidth,
+                                minHeight: constraints.minHeight,
+                            }}
+                        >
+                            <WorkspaceSplitContainer
+                                node={child}
+                                focusedPaneId={focusedPaneId}
+                                onPaneFocus={onPaneFocus}
+                                onResizeSplit={onResizeSplit}
+                                dropPreview={dropPreview}
+                            />
+                        </div>
+                        {index < node.children.length - 1 ? (
+                            <div
+                                role="separator"
+                                aria-orientation={orientation}
+                                aria-label={`Resize split ${node.id} sections ${index + 1} and ${index + 2}`}
+                                className="relative shrink-0"
+                                style={{
+                                    width:
+                                        node.direction === "row"
+                                            ? RESIZER_HITBOX_SIZE
+                                            : "100%",
+                                    height:
+                                        node.direction === "column"
+                                            ? RESIZER_HITBOX_SIZE
+                                            : "100%",
+                                    cursor,
+                                }}
+                                onPointerDown={(event) =>
+                                    handleDividerPointerDown(index, event)
+                                }
+                                onPointerUp={(event) =>
+                                    stopResize(event.pointerId)
+                                }
+                                onPointerCancel={(event) =>
+                                    stopResize(event.pointerId)
+                                }
+                            >
+                                <div
+                                    aria-hidden="true"
+                                    className="absolute rounded-full"
+                                    style={{
+                                        left:
+                                            node.direction === "row"
+                                                ? "50%"
+                                                : 0,
+                                        top:
+                                            node.direction === "column"
+                                                ? "50%"
+                                                : 0,
+                                        bottom:
+                                            node.direction === "row"
+                                                ? 0
+                                                : "auto",
+                                        right:
+                                            node.direction === "column"
+                                                ? 0
+                                                : "auto",
+                                        width:
+                                            node.direction === "row"
+                                                ? RESIZER_VISIBLE_SIZE
+                                                : "100%",
+                                        height:
+                                            node.direction === "column"
+                                                ? RESIZER_VISIBLE_SIZE
+                                                : "100%",
+                                        transform:
+                                            node.direction === "row"
+                                                ? "translateX(-50%)"
+                                                : "translateY(-50%)",
+                                        background:
+                                            "color-mix(in srgb, var(--border) 90%, transparent)",
+                                    }}
+                                />
+                            </div>
+                        ) : null}
+                    </Fragment>
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/editor/editorTabIcons.tsx
+++ b/apps/desktop/src/features/editor/editorTabIcons.tsx
@@ -1,0 +1,242 @@
+import type { ReactNode } from "react";
+import type { Tab } from "../../app/store/editorStore";
+
+export function renderEditorTabLeadingIcon(tab: Tab): ReactNode {
+    if (tab.kind === "pdf") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                className="shrink-0 opacity-65"
+            >
+                <path
+                    d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
+                    stroke="#e24b3b"
+                    strokeWidth="1"
+                />
+                <path
+                    d="M9.5 1.5V5H13"
+                    stroke="#e24b3b"
+                    strokeWidth="0.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+                <text
+                    x="5"
+                    y="12"
+                    fontSize="4.5"
+                    fontWeight="700"
+                    fill="#e24b3b"
+                    fontFamily="sans-serif"
+                >
+                    PDF
+                </text>
+            </svg>
+        );
+    }
+
+    if (tab.kind === "file") {
+        if (tab.mimeType?.startsWith("image/")) {
+            return (
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 16 16"
+                    fill="none"
+                    className="shrink-0 opacity-55"
+                >
+                    <rect
+                        x="2"
+                        y="2.5"
+                        width="12"
+                        height="11"
+                        rx="1.5"
+                        stroke="currentColor"
+                        strokeWidth="1"
+                    />
+                    <circle
+                        cx="5.5"
+                        cy="5.8"
+                        r="1.2"
+                        stroke="currentColor"
+                        strokeWidth="0.8"
+                    />
+                    <path
+                        d="M2.5 11l3-3.5 2.5 2.5 1.5-1.5 4 3.5"
+                        stroke="currentColor"
+                        strokeWidth="0.8"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    />
+                </svg>
+            );
+        }
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                className="shrink-0 opacity-55"
+            >
+                <path
+                    d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                />
+                <path
+                    d="M9.5 1.5V5H13"
+                    stroke="currentColor"
+                    strokeWidth="0.8"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                />
+            </svg>
+        );
+    }
+
+    if (tab.kind === "ai-review") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0 opacity-60"
+            >
+                <path d="M3 8h10M6 4l-4 4 4 4M10 4l4 4-4 4" />
+            </svg>
+        );
+    }
+
+    if (tab.kind === "ai-chat") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="shrink-0 opacity-60"
+            >
+                <path d="M2 3h12v8H5l-3 3V3z" />
+            </svg>
+        );
+    }
+
+    if (tab.kind === "map") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                className="shrink-0 opacity-55"
+            >
+                <rect
+                    x="2"
+                    y="2"
+                    width="12"
+                    height="12"
+                    rx="1.5"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                />
+                <circle cx="8" cy="5.5" r="1.3" fill="currentColor" />
+                <circle cx="5" cy="10.5" r="1.3" fill="currentColor" />
+                <circle cx="11" cy="10.5" r="1.3" fill="currentColor" />
+                <path
+                    d="M7.15 6.65 5.7 9.3M8.85 6.65l1.45 2.65"
+                    stroke="currentColor"
+                    strokeWidth="0.85"
+                    strokeLinecap="round"
+                />
+            </svg>
+        );
+    }
+
+    if (tab.kind === "graph") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 16 16"
+                fill="none"
+                className="shrink-0 opacity-55"
+            >
+                <circle
+                    cx="8"
+                    cy="8"
+                    r="2"
+                    stroke="currentColor"
+                    strokeWidth="1"
+                />
+                <circle
+                    cx="3"
+                    cy="4"
+                    r="1.5"
+                    stroke="currentColor"
+                    strokeWidth="0.8"
+                />
+                <circle
+                    cx="13"
+                    cy="4"
+                    r="1.5"
+                    stroke="currentColor"
+                    strokeWidth="0.8"
+                />
+                <circle
+                    cx="4"
+                    cy="13"
+                    r="1.5"
+                    stroke="currentColor"
+                    strokeWidth="0.8"
+                />
+                <circle
+                    cx="12"
+                    cy="12"
+                    r="1.5"
+                    stroke="currentColor"
+                    strokeWidth="0.8"
+                />
+                <path
+                    d="M6.3 6.8l-2-1.8M9.7 6.8l2-1.8M6.5 9.5l-1.5 2.5M9.5 9.5l1.5 1.5"
+                    stroke="currentColor"
+                    strokeWidth="0.7"
+                    strokeLinecap="round"
+                />
+            </svg>
+        );
+    }
+
+    return (
+        <svg
+            width="12"
+            height="12"
+            viewBox="0 0 16 16"
+            fill="none"
+            className="shrink-0 opacity-50"
+        >
+            <path
+                d="M4 1.5h5.5L13 5v9a1.5 1.5 0 0 1-1.5 1.5h-7A1.5 1.5 0 0 1 3 14V3A1.5 1.5 0 0 1 4 1.5Z"
+                stroke="currentColor"
+                strokeWidth="1"
+            />
+            <path
+                d="M6 8h4M6 10.5h3"
+                stroke="currentColor"
+                strokeWidth="0.8"
+                strokeLinecap="round"
+            />
+        </svg>
+    );
+}

--- a/apps/desktop/src/features/editor/editorTargetResolver.test.ts
+++ b/apps/desktop/src/features/editor/editorTargetResolver.test.ts
@@ -206,4 +206,90 @@ describe("editorTargetResolver", () => {
             openTab: null,
         });
     });
+
+    it("finds an open note target in a non-focused pane", () => {
+        useVaultStore.setState({
+            notes: [
+                {
+                    id: "notes/reference",
+                    path: "/vault/notes/reference.md",
+                    title: "Reference",
+                    modified_at: 0,
+                    created_at: 0,
+                },
+            ],
+        });
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "tab-secondary-note",
+                            kind: "note",
+                            noteId: "notes/reference",
+                            title: "Reference",
+                            content: "from secondary pane",
+                            history: [],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "tab-secondary-note",
+                },
+            ],
+            "primary",
+        );
+
+        expect(findOpenNoteTarget("/vault/notes/reference.md")).toMatchObject({
+            kind: "note",
+            noteId: "notes/reference",
+            openTab: {
+                id: "tab-secondary-note",
+            },
+        });
+    });
+
+    it("finds an open file target in a non-focused pane", () => {
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [],
+                    activeTabId: null,
+                },
+                {
+                    id: "secondary",
+                    tabs: [
+                        {
+                            id: "tab-secondary-file",
+                            kind: "file",
+                            relativePath: "src/worker.rs",
+                            path: "/vault/src/worker.rs",
+                            title: "worker.rs",
+                            content: "fn worker() {}",
+                            mimeType: "text/rust",
+                            viewer: "text",
+                            history: [],
+                            historyIndex: 0,
+                        },
+                    ],
+                    activeTabId: "tab-secondary-file",
+                },
+            ],
+            "primary",
+        );
+
+        expect(findOpenFileTarget("/vault/src/worker.rs")).toMatchObject({
+            kind: "file",
+            relativePath: "src/worker.rs",
+            openTab: {
+                id: "tab-secondary-file",
+            },
+        });
+    });
 });

--- a/apps/desktop/src/features/editor/editorTargetResolver.ts
+++ b/apps/desktop/src/features/editor/editorTargetResolver.ts
@@ -1,6 +1,7 @@
 import {
     isFileTab,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type FileTab,
     type NoteTab,
     useEditorStore,
@@ -42,8 +43,7 @@ export function resolveMarkdownNoteIdForPath(path: string): string | null {
         return null;
     }
 
-    const { tabs } = useEditorStore.getState();
-    const openTab = tabs.find(
+    const openTab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
         (tab) =>
             isNoteTab(tab) &&
             normalizeVaultPathMatch(tab.noteId) === normalizedPath,
@@ -96,8 +96,7 @@ function resolveAbsoluteNotePathForNoteId(noteId: string): string {
 
 export function findOpenNoteTarget(path: string): NoteEditorTarget | null {
     const noteId = resolveNoteIdCandidate(path);
-    const { tabs } = useEditorStore.getState();
-    const openTab = tabs.find(
+    const openTab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
         (tab) =>
             isNoteTab(tab) &&
             normalizeVaultPathMatch(tab.noteId) ===
@@ -125,8 +124,7 @@ export function findOpenFileTarget(path: string): FileEditorTarget | null {
     const normalizedRelativePath = relativePath
         ? normalizeVaultPathMatch(relativePath)
         : null;
-    const { tabs } = useEditorStore.getState();
-    const openTab = tabs.find(
+    const openTab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
         (tab) =>
             isFileTab(tab) &&
             (normalizeVaultPathMatch(tab.path) === normalizedPath ||

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -26,7 +26,12 @@ import {
     getYouTubeThumbnailUrl,
 } from "../youtube";
 
-import { useEditorStore, isNoteTab } from "../../../app/store/editorStore";
+import {
+    useEditorStore,
+    isNoteTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
+} from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { emitFileTreeNoteDrag } from "../../ai/dragEvents";
 import {
@@ -95,12 +100,7 @@ export function invalidateLivePreviewNoteCache(
 }
 
 function getActiveNotePath() {
-    const activeTabId = useEditorStore.getState().activeTabId;
-    if (!activeTabId) return null;
-
-    const activeTab = useEditorStore
-        .getState()
-        .tabs.find((tab) => tab.id === activeTabId);
+    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     if (!activeTab || !isNoteTab(activeTab)) return null;
 
     return (
@@ -903,14 +903,14 @@ class NoteEmbedWidget extends WidgetType {
                     entry.title === this.target ||
                     entry.id.replace(/\.md$/i, "") === this.target,
             );
-        const openTab = useEditorStore
-            .getState()
-            .tabs.find(
-                (tab) =>
-                    (isNoteTab(tab) && tab.noteId === note?.id) ||
-                    (isNoteTab(tab) && tab.noteId === this.target) ||
-                    tab.title === this.target,
-            );
+        const openTab = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find(
+            (tab) =>
+                (isNoteTab(tab) && tab.noteId === note?.id) ||
+                (isNoteTab(tab) && tab.noteId === this.target) ||
+                tab.title === this.target,
+        );
 
         const title = document.createElement("div");
         title.className = "cm-note-embed-title";

--- a/apps/desktop/src/features/editor/mergeViewSync.ts
+++ b/apps/desktop/src/features/editor/mergeViewSync.ts
@@ -18,6 +18,7 @@ import type { AIChatSession } from "../ai/types";
 import {
     isFileTab,
     isNoteTab,
+    selectFocusedEditorTab,
     useEditorStore,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -919,8 +920,7 @@ function getMergeTargetId(target: EditorTarget | null) {
 }
 
 function getActiveEditorTargetDebugInfo() {
-    const { tabs, activeTabId } = useEditorStore.getState();
-    const activeTab = tabs.find((tab) => tab.id === activeTabId) ?? null;
+    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     const editorTab =
         activeTab && (isNoteTab(activeTab) || isFileTab(activeTab))
             ? activeTab

--- a/apps/desktop/src/features/editor/newTabMenuActions.ts
+++ b/apps/desktop/src/features/editor/newTabMenuActions.ts
@@ -1,0 +1,243 @@
+import type { ContextMenuEntry } from "../../components/context-menu/ContextMenu";
+import { inferFileViewer } from "../../app/store/editorTabs";
+import { useEditorStore } from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import { vaultInvoke } from "../../app/utils/vaultInvoke";
+import { moveChatToWorkspace } from "../ai/chatPaneMovement";
+import { useChatStore } from "../ai/store/chatStore";
+
+interface SavedVaultFileDetail {
+    path: string;
+    relative_path: string;
+    file_name: string;
+    mime_type: string | null;
+    content: string;
+    size_bytes?: number | null;
+    content_truncated?: boolean | null;
+}
+
+function insertBlankDraftTab(paneId?: string) {
+    if (!useVaultStore.getState().vaultPath) return;
+
+    const tab = {
+        id: crypto.randomUUID(),
+        kind: "note" as const,
+        noteId: "",
+        title: "New Tab",
+        content: "",
+    };
+    const editor = useEditorStore.getState();
+
+    if (paneId) {
+        editor.insertExternalTabInPane(tab, paneId);
+        return;
+    }
+
+    editor.insertExternalTab(tab);
+}
+
+function getNextUntitledNoteName() {
+    const notes = useVaultStore.getState().notes;
+    let name = "Untitled";
+    let index = 1;
+
+    while (
+        notes.some((note) => note.id === name || note.id.endsWith(`/${name}`))
+    ) {
+        name = `Untitled ${index++}`;
+    }
+
+    return name;
+}
+
+function getNextBlankFilePath() {
+    const entries = useVaultStore.getState().entries;
+    const usedPaths = new Set(
+        entries.map((entry) => entry.relative_path.toLowerCase()),
+    );
+
+    let relativePath = "untitled";
+    let index = 1;
+
+    while (usedPaths.has(relativePath.toLowerCase())) {
+        relativePath = `untitled-${index++}`;
+    }
+
+    return relativePath;
+}
+
+async function createNewNote(paneId?: string) {
+    const vault = useVaultStore.getState();
+    if (!vault.vaultPath) return;
+
+    try {
+        const note = await vault.createNote(getNextUntitledNoteName());
+        if (!note) return;
+
+        const editor = useEditorStore.getState();
+        if (paneId) {
+            editor.insertExternalTabInPane(
+                {
+                    id: crypto.randomUUID(),
+                    kind: "note",
+                    noteId: note.id,
+                    title: note.title,
+                    content: "",
+                },
+                paneId,
+            );
+            return;
+        }
+
+        editor.openNote(note.id, note.title, "");
+    } catch (error) {
+        console.error("Failed to create a new note from the tab menu:", error);
+    }
+}
+
+function getRuntimeMenuLabel(name: string) {
+    const trimmed = name.trim();
+    return trimmed.replace(/ ACP$/, "");
+}
+
+async function createNewChat(runtimeId?: string, paneId?: string) {
+    const beforeSessionIds = new Set(
+        Object.keys(useChatStore.getState().sessionsById),
+    );
+
+    try {
+        await useChatStore.getState().newSession(runtimeId);
+        const nextState = useChatStore.getState();
+        const createdSessionId =
+            Object.keys(nextState.sessionsById).find(
+                (sessionId) => !beforeSessionIds.has(sessionId),
+            ) ??
+            (nextState.activeSessionId &&
+            !beforeSessionIds.has(nextState.activeSessionId)
+                ? nextState.activeSessionId
+                : null);
+
+        if (!createdSessionId) return;
+        moveChatToWorkspace(createdSessionId, paneId ? { paneId } : undefined);
+    } catch (error) {
+        console.error("Failed to create a new chat from the tab menu:", error);
+    }
+}
+
+async function createNewBlankFile(paneId?: string) {
+    const vault = useVaultStore.getState();
+    if (!vault.vaultPath) return;
+
+    try {
+        const detail = await vaultInvoke<SavedVaultFileDetail>(
+            "save_vault_file",
+            {
+                relativePath: getNextBlankFilePath(),
+                content: "",
+            },
+        );
+
+        try {
+            await vault.refreshEntries();
+        } catch (error) {
+            console.error(
+                "Failed to refresh entries after creating a blank file:",
+                error,
+            );
+        }
+
+        const editor = useEditorStore.getState();
+        const nextTab = {
+            id: crypto.randomUUID(),
+            kind: "file" as const,
+            relativePath: detail.relative_path,
+            title: detail.file_name,
+            path: detail.path,
+            mimeType: detail.mime_type,
+            viewer: inferFileViewer(detail.path, detail.mime_type),
+            content: detail.content,
+            sizeBytes: detail.size_bytes ?? null,
+            contentTruncated: Boolean(detail.content_truncated),
+        };
+
+        if (paneId) {
+            editor.insertExternalTabInPane(nextTab, paneId);
+            return;
+        }
+
+        editor.openFile(
+            detail.relative_path,
+            detail.file_name,
+            detail.path,
+            detail.content,
+            detail.mime_type,
+            inferFileViewer(detail.path, detail.mime_type),
+            {
+                sizeBytes: detail.size_bytes ?? null,
+                contentTruncated: Boolean(detail.content_truncated),
+            },
+        );
+    } catch (error) {
+        console.error(
+            "Failed to create a new blank file from the tab menu:",
+            error,
+        );
+    }
+}
+
+export function buildNewTabContextMenuEntries(options?: {
+    paneId?: string;
+    developerModeEnabled?: boolean;
+}): ContextMenuEntry[] {
+    const paneId = options?.paneId;
+    const developerModeEnabled = options?.developerModeEnabled ?? false;
+    const chatState = useChatStore.getState();
+    const runtimes = [...chatState.runtimes];
+    const selectedRuntimeId = chatState.selectedRuntimeId;
+    runtimes.sort((left, right) => {
+        if (left.runtime.id === selectedRuntimeId) return -1;
+        if (right.runtime.id === selectedRuntimeId) return 1;
+        return left.runtime.name.localeCompare(right.runtime.name);
+    });
+    const entries: ContextMenuEntry[] = [
+        {
+            label: "New Note",
+            action: () => {
+                void createNewNote(paneId);
+            },
+        },
+        {
+            label: "New Agent",
+            disabled: runtimes.length === 0,
+            children:
+                runtimes.length > 0
+                    ? runtimes.map((runtime) => ({
+                          label: getRuntimeMenuLabel(runtime.runtime.name),
+                          action: () => {
+                              void createNewChat(runtime.runtime.id, paneId);
+                          },
+                      }))
+                    : [
+                          {
+                              label: "No providers available",
+                              disabled: true,
+                          },
+                      ],
+        },
+    ];
+
+    if (developerModeEnabled) {
+        entries.push({
+            label: "New blank file",
+            action: () => {
+                void createNewBlankFile(paneId);
+            },
+        });
+    }
+
+    return entries;
+}
+
+export function openBlankDraftTabFromPlusButton(paneId?: string) {
+    insertBlankDraftTab(paneId);
+}

--- a/apps/desktop/src/features/editor/useEditableFileResource.ts
+++ b/apps/desktop/src/features/editor/useEditableFileResource.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import {
     fileViewerNeedsTextContent,
     isFileTab,
+    selectEditorPaneState,
     useEditorStore,
     type FileTab,
     type Tab,
@@ -34,6 +35,7 @@ type FileReloadMetadata = {
 type EditableFileTab = NonNullable<ReturnType<typeof getActiveEditableFileTab>>;
 
 interface UseEditableFileResourceOptions {
+    paneId?: string;
     getCurrentContent: () => string | null;
     applyIncomingContent: (nextContent: string) => void;
     acceptTab?: (tab: FileTab) => boolean;
@@ -43,6 +45,7 @@ interface UseEditableFileResourceOptions {
 // Shared file-editing orchestration so multiple viewers can reuse the same
 // autosave, reload and external-conflict behavior without diverging.
 export function useEditableFileResource({
+    paneId,
     getCurrentContent,
     applyIncomingContent,
     acceptTab = defaultAcceptEditableFileTab,
@@ -60,7 +63,7 @@ export function useEditableFileResource({
     const lastVaultPathRef = useRef<string | null>(vaultPath);
 
     const tab = useEditorStore((state) =>
-        getActiveEditableFileTab(state, acceptTab),
+        getActiveEditableFileTab(state, paneId, acceptTab),
     );
     const hasExternalConflict = useEditorStore((state) => {
         const relativePath = tab?.relativePath;
@@ -105,9 +108,11 @@ export function useEditableFileResource({
             pruneFilePathStateForOpenTabs(tabs);
         };
 
-        syncLiveFilePathState(useEditorStore.getState().tabs);
+        syncLiveFilePathState(
+            useEditorStore.getState().panes.flatMap((pane) => pane.tabs),
+        );
         const unsubscribe = useEditorStore.subscribe((state) => {
-            syncLiveFilePathState(state.tabs);
+            syncLiveFilePathState(state.panes.flatMap((pane) => pane.tabs));
         });
         return unsubscribe;
     }, [pruneFilePathStateForOpenTabs]);
@@ -291,13 +296,15 @@ export function useEditableFileResource({
 
     useEffect(() => {
         const unsubscribe = useEditorStore.subscribe((state, prev) => {
-            const activeTabId = state.activeTabId;
+            const paneState = selectEditorPaneState(state, paneId);
+            const previousPaneState = selectEditorPaneState(prev, paneId);
+            const activeTabId = paneState.activeTabId;
             if (!activeTabId) return;
 
-            const currentTab = state.tabs.find(
+            const currentTab = paneState.tabs.find(
                 (candidate) => candidate.id === activeTabId,
             );
-            const previousTab = prev.tabs.find(
+            const previousTab = previousPaneState.tabs.find(
                 (candidate) => candidate.id === activeTabId,
             );
             if (!currentTab || !previousTab) return;
@@ -418,7 +425,7 @@ export function useEditableFileResource({
         });
 
         return unsubscribe;
-    }, [acceptTab, applyIncomingContent, getCurrentContent]);
+    }, [acceptTab, applyIncomingContent, getCurrentContent, paneId]);
 
     useEffect(() => {
         return () => {
@@ -485,10 +492,12 @@ function defaultAcceptEditableFileTab(tab: FileTab) {
 
 function getActiveEditableFileTab(
     state: ReturnType<typeof useEditorStore.getState>,
+    paneId: string | undefined,
     acceptTab: (tab: FileTab) => boolean,
 ) {
-    const current = state.tabs.find(
-        (candidate) => candidate.id === state.activeTabId,
+    const pane = selectEditorPaneState(state, paneId);
+    const current = pane.tabs.find(
+        (candidate) => candidate.id === pane.activeTabId,
     );
 
     return current && isFileTab(current) && acceptTab(current) ? current : null;

--- a/apps/desktop/src/features/editor/useEditableFileResource.ts
+++ b/apps/desktop/src/features/editor/useEditableFileResource.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from "react";
 import {
     fileViewerNeedsTextContent,
     isFileTab,
+    selectEditorWorkspaceTabs,
     selectEditorPaneState,
     useEditorStore,
     type FileTab,
@@ -109,10 +110,10 @@ export function useEditableFileResource({
         };
 
         syncLiveFilePathState(
-            useEditorStore.getState().panes.flatMap((pane) => pane.tabs),
+            selectEditorWorkspaceTabs(useEditorStore.getState()),
         );
         const unsubscribe = useEditorStore.subscribe((state) => {
-            syncLiveFilePathState(state.panes.flatMap((pane) => pane.tabs));
+            syncLiveFilePathState(selectEditorWorkspaceTabs(state));
         });
         return unsubscribe;
     }, [pruneFilePathStateForOpenTabs]);

--- a/apps/desktop/src/features/editor/wikilinkNavigation.ts
+++ b/apps/desktop/src/features/editor/wikilinkNavigation.ts
@@ -3,6 +3,8 @@ import {
     useEditorStore,
     isNoteTab,
     type NoteTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { openVaultFileEntry } from "../../app/utils/vaultEntries";
@@ -11,10 +13,10 @@ import { findWikilinkResource } from "./wikilinkResolution";
 export async function navigateWikilink(target: string) {
     const resource = await findWikilinkResource(target);
     if (resource?.kind === "note") {
-        const { tabs, openNote } = useEditorStore.getState();
-        const existing = tabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === resource.id,
-        );
+        const { openNote } = useEditorStore.getState();
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === resource.id);
         if (existing) {
             openNote(resource.id, resource.title ?? target, existing.content);
             return;
@@ -74,8 +76,8 @@ export async function openWikilinkInNewTab(target: string) {
         return;
     }
 
-    const { tabs, insertExternalTab } = useEditorStore.getState();
-    const existing = tabs.find(
+    const { insertExternalTab } = useEditorStore.getState();
+    const existing = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
         (tab): tab is NoteTab => isNoteTab(tab) && tab.noteId === resource.id,
     );
 
@@ -142,10 +144,7 @@ export function getNoteLinkTarget(href: string): string | null {
 
     if (!normalizedTarget) return null;
 
-    const activeTabId = useEditorStore.getState().activeTabId;
-    const activeTab = useEditorStore
-        .getState()
-        .tabs.find((tab) => tab.id === activeTabId);
+    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     const activeNoteId =
         activeTab && isNoteTab(activeTab) ? activeTab.noteId : null;
 

--- a/apps/desktop/src/features/editor/wikilinkResolution.ts
+++ b/apps/desktop/src/features/editor/wikilinkResolution.ts
@@ -1,4 +1,8 @@
-import { useEditorStore, isNoteTab } from "../../app/store/editorStore";
+import {
+    useEditorStore,
+    isNoteTab,
+    selectFocusedEditorTab,
+} from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { isTextLikeVaultEntry } from "../../app/utils/vaultEntries";
 import {
@@ -53,10 +57,7 @@ let cachedVaultPath: string | null = null;
 let cachedResolverRevision: number | null = null;
 
 function getActiveNoteId() {
-    const activeTabId = useEditorStore.getState().activeTabId;
-    const activeTab = useEditorStore
-        .getState()
-        .tabs.find((tab) => tab.id === activeTabId);
+    const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     return activeTab && isNoteTab(activeTab) ? activeTab.noteId : null;
 }
 

--- a/apps/desktop/src/features/editor/workspaceTabDropPreview.test.ts
+++ b/apps/desktop/src/features/editor/workspaceTabDropPreview.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { resolvePaneDropPosition } from "./workspaceTabDropPreview";
+
+describe("workspaceTabDropPreview", () => {
+    const paneRect = {
+        left: 100,
+        right: 500,
+        top: 40,
+        bottom: 340,
+    };
+
+    it("classifies the center region as add-as-tab", () => {
+        expect(resolvePaneDropPosition(300, 180, paneRect)).toBe("center");
+    });
+
+    it("classifies each edge as a split target", () => {
+        expect(resolvePaneDropPosition(112, 180, paneRect)).toBe("left");
+        expect(resolvePaneDropPosition(488, 180, paneRect)).toBe("right");
+        expect(resolvePaneDropPosition(300, 52, paneRect)).toBe("top");
+        expect(resolvePaneDropPosition(300, 328, paneRect)).toBe("bottom");
+    });
+});

--- a/apps/desktop/src/features/editor/workspaceTabDropPreview.test.ts
+++ b/apps/desktop/src/features/editor/workspaceTabDropPreview.test.ts
@@ -16,7 +16,7 @@ describe("workspaceTabDropPreview", () => {
     it("classifies each edge as a split target", () => {
         expect(resolvePaneDropPosition(112, 180, paneRect)).toBe("left");
         expect(resolvePaneDropPosition(488, 180, paneRect)).toBe("right");
-        expect(resolvePaneDropPosition(300, 52, paneRect)).toBe("top");
-        expect(resolvePaneDropPosition(300, 328, paneRect)).toBe("bottom");
+        expect(resolvePaneDropPosition(300, 52, paneRect)).toBe("up");
+        expect(resolvePaneDropPosition(300, 328, paneRect)).toBe("down");
     });
 });

--- a/apps/desktop/src/features/editor/workspaceTabDropPreview.ts
+++ b/apps/desktop/src/features/editor/workspaceTabDropPreview.ts
@@ -49,8 +49,8 @@ export function resolvePaneDropPosition(
     const distances = [
         { position: "left" as const, distance: clientX - rect.left },
         { position: "right" as const, distance: rect.right - clientX },
-        { position: "top" as const, distance: clientY - rect.top },
-        { position: "bottom" as const, distance: rect.bottom - clientY },
+        { position: "up" as const, distance: clientY - rect.top },
+        { position: "down" as const, distance: rect.bottom - clientY },
     ].filter(({ position, distance }) => {
         if (distance < 0) {
             return false;

--- a/apps/desktop/src/features/editor/workspaceTabDropPreview.ts
+++ b/apps/desktop/src/features/editor/workspaceTabDropPreview.ts
@@ -1,0 +1,72 @@
+import type { WorkspaceMovePosition } from "../../app/store/workspaceLayoutTree";
+
+export type WorkspaceTabDropPosition = "center" | WorkspaceMovePosition;
+
+export interface CrossPaneTabDropPreview {
+    sourcePaneId: string;
+    targetPaneId: string;
+    position: WorkspaceTabDropPosition;
+    insertIndex: number | null;
+    tabId: string;
+}
+
+export const CROSS_PANE_TAB_DROP_PREVIEW_EVENT =
+    "neverwrite:cross-pane-tab-drop-preview";
+
+const EDGE_DROP_ZONE_RATIO = 0.22;
+const MIN_EDGE_DROP_ZONE_SIZE = 56;
+const MAX_EDGE_DROP_ZONE_SIZE = 96;
+
+export function dispatchCrossPaneTabDropPreview(
+    detail: CrossPaneTabDropPreview | null,
+) {
+    window.dispatchEvent(
+        new CustomEvent<CrossPaneTabDropPreview | null>(
+            CROSS_PANE_TAB_DROP_PREVIEW_EVENT,
+            {
+                detail,
+            },
+        ),
+    );
+}
+
+function getEdgeDropZoneSize(size: number) {
+    return Math.min(
+        MAX_EDGE_DROP_ZONE_SIZE,
+        Math.max(MIN_EDGE_DROP_ZONE_SIZE, size * EDGE_DROP_ZONE_RATIO),
+    );
+}
+
+export function resolvePaneDropPosition(
+    clientX: number,
+    clientY: number,
+    rect: DOMRect | Pick<DOMRect, "left" | "right" | "top" | "bottom">,
+): WorkspaceTabDropPosition {
+    const width = Math.max(0, rect.right - rect.left);
+    const height = Math.max(0, rect.bottom - rect.top);
+    const horizontalEdgeZone = getEdgeDropZoneSize(width);
+    const verticalEdgeZone = getEdgeDropZoneSize(height);
+    const distances = [
+        { position: "left" as const, distance: clientX - rect.left },
+        { position: "right" as const, distance: rect.right - clientX },
+        { position: "top" as const, distance: clientY - rect.top },
+        { position: "bottom" as const, distance: rect.bottom - clientY },
+    ].filter(({ position, distance }) => {
+        if (distance < 0) {
+            return false;
+        }
+
+        if (position === "left" || position === "right") {
+            return distance <= horizontalEdgeZone;
+        }
+
+        return distance <= verticalEdgeZone;
+    });
+
+    if (distances.length === 0) {
+        return "center";
+    }
+
+    distances.sort((left, right) => left.distance - right.distance);
+    return distances[0]?.position ?? "center";
+}

--- a/apps/desktop/src/features/graph/GraphViewController.tsx
+++ b/apps/desktop/src/features/graph/GraphViewController.tsx
@@ -9,6 +9,8 @@ import {
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useThemeStore } from "../../app/store/themeStore";
@@ -111,8 +113,8 @@ export function GraphViewController({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isVisible]);
 
-    const activeNoteId = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
+    const activeNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return tab && isNoteTab(tab) ? tab.noteId : null;
     });
     const vaultPath = useVaultStore((s) => s.vaultPath);
@@ -371,10 +373,10 @@ export function GraphViewController({
     );
 
     const openNoteById = useCallback(async (noteId: string, title: string) => {
-        const { openNote, tabs } = useEditorStore.getState();
-        const existing = tabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === noteId,
-        );
+        const { openNote } = useEditorStore.getState();
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === noteId);
         if (existing) {
             openNote(noteId, title, existing.content);
             return;

--- a/apps/desktop/src/features/maps/MapsPanel.test.tsx
+++ b/apps/desktop/src/features/maps/MapsPanel.test.tsx
@@ -4,10 +4,13 @@ import { describe, expect, it } from "vitest";
 import { isMapTab, useEditorStore } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
+    createInitialLayout,
+    splitPane,
+} from "../../app/store/workspaceLayoutTree";
+import {
     flushPromises,
     mockInvoke,
     renderComponent,
-    setEditorTabs,
 } from "../../test/test-utils";
 import { MapsPanel } from "./MapsPanel";
 
@@ -36,25 +39,74 @@ function buildMovedMapEntry(relativePath: string, title: string) {
     };
 }
 
+function setFocusedPrimaryWorkspaceWithMapInSecondary() {
+    const homeTab = {
+        id: "note-1",
+        kind: "note" as const,
+        noteId: "notes/home",
+        title: "Home",
+        content: "# Home",
+        history: [
+            {
+                kind: "note" as const,
+                noteId: "notes/home",
+                title: "Home",
+                content: "# Home",
+            },
+        ],
+        historyIndex: 0,
+    };
+    const mapTab = {
+        id: "map-1",
+        kind: "map" as const,
+        title: "Map 2026-04-05",
+        relativePath: "Excalidraw/Map 2026-04-05.excalidraw",
+        history: [],
+        historyIndex: -1,
+    };
+    const layoutTree = splitPane(
+        createInitialLayout("primary"),
+        "primary",
+        "row",
+        "secondary",
+    );
+
+    useEditorStore.setState({
+        panes: [
+            {
+                id: "primary",
+                tabs: [homeTab],
+                activeTabId: homeTab.id,
+                activationHistory: [homeTab.id],
+                tabNavigationHistory: [homeTab.id],
+                tabNavigationIndex: 0,
+            },
+            {
+                id: "secondary",
+                tabs: [mapTab],
+                activeTabId: mapTab.id,
+                activationHistory: [mapTab.id],
+                tabNavigationHistory: [mapTab.id],
+                tabNavigationIndex: 0,
+            },
+        ],
+        focusedPaneId: "primary",
+        layoutTree,
+        tabs: [homeTab],
+        activeTabId: homeTab.id,
+        activationHistory: [homeTab.id],
+        tabNavigationHistory: [homeTab.id],
+        tabNavigationIndex: 0,
+    });
+}
+
 describe("MapsPanel", () => {
-    it("renames a map from the context menu while preserving the map tab linkage", async () => {
+    it("renames a map from the context menu while preserving the map tab linkage in another pane", async () => {
         const user = userEvent.setup();
         const invokeMock = mockInvoke();
 
         useVaultStore.setState({ vaultPath: "/vault" });
-        setEditorTabs(
-            [
-                {
-                    id: "map-1",
-                    kind: "map",
-                    title: "Map 2026-04-05",
-                    relativePath: "Excalidraw/Map 2026-04-05.excalidraw",
-                    history: [],
-                    historyIndex: -1,
-                },
-            ],
-            "map-1",
-        );
+        setFocusedPrimaryWorkspaceWithMapInSecondary();
 
         invokeMock.mockImplementation(async (command) => {
             if (command === "list_maps") {
@@ -105,32 +157,22 @@ describe("MapsPanel", () => {
         expect(await screen.findByText("Architecture")).toBeInTheDocument();
         const mapTabs = useEditorStore
             .getState()
-            .tabs.filter((tab) => isMapTab(tab));
+            .panes.flatMap((pane) => pane.tabs)
+            .filter((tab) => isMapTab(tab));
         expect(mapTabs).toHaveLength(1);
         expect(mapTabs[0]).toMatchObject({
             relativePath: "Excalidraw/Architecture.excalidraw",
             title: "Architecture",
         });
+        expect(useEditorStore.getState().focusedPaneId).toBe("primary");
     });
 
-    it("deletes a map from the context menu and closes its open tab", async () => {
+    it("deletes a map from the context menu and closes its open tab in another pane", async () => {
         const user = userEvent.setup();
         const invokeMock = mockInvoke();
 
         useVaultStore.setState({ vaultPath: "/vault" });
-        setEditorTabs(
-            [
-                {
-                    id: "map-1",
-                    kind: "map",
-                    title: "Map 2026-04-05",
-                    relativePath: "Excalidraw/Map 2026-04-05.excalidraw",
-                    history: [],
-                    historyIndex: -1,
-                },
-            ],
-            "map-1",
-        );
+        setFocusedPrimaryWorkspaceWithMapInSecondary();
 
         invokeMock.mockImplementation(async (command) => {
             if (command === "list_maps") {
@@ -174,7 +216,11 @@ describe("MapsPanel", () => {
             ).not.toBeInTheDocument();
         });
         expect(
-            useEditorStore.getState().tabs.some((tab) => isMapTab(tab)),
+            useEditorStore
+                .getState()
+                .panes.flatMap((pane) => pane.tabs)
+                .some((tab) => isMapTab(tab)),
         ).toBe(false);
+        expect(useEditorStore.getState().focusedPaneId).toBe("primary");
     });
 });

--- a/apps/desktop/src/features/maps/MapsPanel.tsx
+++ b/apps/desktop/src/features/maps/MapsPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { openPath, revealItemInDir } from "@tauri-apps/plugin-opener";
-import { useEditorStore, isMapTab } from "../../app/store/editorStore";
+import { useEditorStore } from "../../app/store/editorStore";
 import { resolveVaultAbsolutePath } from "../../app/utils/vaultPaths";
 import { useVaultStore, type VaultEntryDto } from "../../app/store/vaultStore";
 import { emitFileTreeNoteDrag } from "../ai/dragEvents";
@@ -79,9 +79,11 @@ export function MapsPanel() {
     const [renameValue, setRenameValue] = useState("");
     const vaultPath = useVaultStore((s) => s.vaultPath);
     const openMap = useEditorStore((s) => s.openMap);
+    const handleMapDeleted = useEditorStore((s) => s.handleMapDeleted);
+    const handleMapRenamed = useEditorStore((s) => s.handleMapRenamed);
     const activeMapRelativePath = useEditorStore((s) => {
         const tab = s.tabs.find((t) => t.id === s.activeTabId);
-        return tab && isMapTab(tab) ? tab.relativePath : null;
+        return tab?.kind === "map" ? tab.relativePath : null;
     });
 
     const dragStateRef = useRef<DragState | null>(null);
@@ -243,27 +245,25 @@ export function MapsPanel() {
         openMap(nextEntry.relativePath, nextEntry.title);
     };
 
-    const handleDeleteMap = async (map: MapEntry) => {
-        if (!vaultPath) return;
-        setContextMenu(null);
-        if (renamingMapPath === map.relativePath) {
-            setRenamingMapPath(null);
-            setRenameValue("");
-        }
-        await invoke("delete_map", {
-            vaultPath,
-            relativePath: map.relativePath,
-        });
-        setMaps((prev) =>
-            prev.filter((m) => m.relativePath !== map.relativePath),
-        );
-        // Close any open tab for this map
-        const { tabs, closeTab } = useEditorStore.getState();
-        const openTab = tabs.find(
-            (t) => isMapTab(t) && t.relativePath === map.relativePath,
-        );
-        if (openTab) closeTab(openTab.id, { reason: "delete" });
-    };
+    const handleDeleteMap = useCallback(
+        async (map: MapEntry) => {
+            if (!vaultPath) return;
+            setContextMenu(null);
+            if (renamingMapPath === map.relativePath) {
+                setRenamingMapPath(null);
+                setRenameValue("");
+            }
+            await invoke("delete_map", {
+                vaultPath,
+                relativePath: map.relativePath,
+            });
+            setMaps((prev) =>
+                prev.filter((entry) => entry.relativePath !== map.relativePath),
+            );
+            handleMapDeleted(map.relativePath);
+        },
+        [handleMapDeleted, renamingMapPath, vaultPath],
+    );
 
     const handleMapContextMenu = useCallback(
         (event: React.MouseEvent, map: MapEntry) => {
@@ -328,24 +328,18 @@ export function MapsPanel() {
                     ),
                 );
 
-                useEditorStore.setState((state) => ({
-                    tabs: state.tabs.map((tab) =>
-                        isMapTab(tab) && tab.relativePath === map.relativePath
-                            ? {
-                                  ...tab,
-                                  relativePath: updated.relative_path,
-                                  title: nextTitle,
-                              }
-                            : tab,
-                    ),
-                }));
+                handleMapRenamed(
+                    map.relativePath,
+                    updated.relative_path,
+                    nextTitle,
+                );
             } catch (error) {
                 logError("maps-panel", "Failed to rename map", error);
             } finally {
                 handleRenameCancel();
             }
         },
-        [handleRenameCancel, renameValue],
+        [handleMapRenamed, handleRenameCancel, renameValue],
     );
 
     const contextMenuEntries = useMemo<ContextMenuEntry[]>(() => {

--- a/apps/desktop/src/features/notes/LinksPanel.tsx
+++ b/apps/desktop/src/features/notes/LinksPanel.tsx
@@ -12,6 +12,8 @@ import {
     type PendingReveal,
     isNoteTab,
     type NoteTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
 } from "../../app/store/editorStore";
 import { useShallow } from "zustand/react/shallow";
 import { getViewportSafeMenuPosition } from "../../app/utils/menuPosition";
@@ -392,7 +394,7 @@ export function LinksPanel() {
     // `tabs` is NOT subscribed here — event handlers use getState() instead.
     const { activeNoteId, activeTitle, activeContent } = useEditorStore(
         useShallow((s) => {
-            const tab = s.tabs.find((t) => t.id === s.activeTabId);
+            const tab = selectFocusedEditorTab(s);
             return {
                 activeNoteId: tab && isNoteTab(tab) ? tab.noteId : null,
                 activeTitle: tab?.title ?? null,
@@ -516,9 +518,9 @@ export function LinksPanel() {
     ];
 
     const openNoteById = async (id: string, title: string) => {
-        const existing = useEditorStore
-            .getState()
-            .tabs.find((t): t is NoteTab => isNoteTab(t) && t.noteId === id);
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === id);
         if (existing) {
             openNote(id, title, existing.content);
             return;
@@ -535,11 +537,9 @@ export function LinksPanel() {
 
     const openBacklinkInNewTab = async (bl: BacklinkDto) => {
         try {
-            const existing = useEditorStore
-                .getState()
-                .tabs.find(
-                    (t): t is NoteTab => isNoteTab(t) && t.noteId === bl.id,
-                );
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === bl.id);
             const content =
                 existing?.content ??
                 (
@@ -598,12 +598,11 @@ export function LinksPanel() {
 
     const openOutgoingInNewTab = async (link: ResolvedOutgoingLink) => {
         try {
-            const existing = useEditorStore
-                .getState()
-                .tabs.find(
-                    (t): t is NoteTab =>
-                        isNoteTab(t) && t.noteId === link.note.id,
-                );
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find(
+                (t): t is NoteTab => isNoteTab(t) && t.noteId === link.note.id,
+            );
             const content =
                 existing?.content ??
                 (

--- a/apps/desktop/src/features/pdf/PdfTabView.test.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.test.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { act } from "react";
 import { PdfTabView } from "./PdfTabView";
 import {
     createDeferred,
@@ -292,7 +291,8 @@ describe("PdfTabView", () => {
         expect(screen.getByRole("button", { name: "Copy" })).toBeEnabled();
     });
 
-    it("handles pinch-style wheel zoom on first load before toolbar zoom is used", async () => {
+    it("blocks pinch-style wheel zoom and keeps toolbar controls as the only zoom path", async () => {
+        const user = userEvent.setup();
         const pdfDocument = {
             destroy: vi.fn(),
             getPage: vi.fn().mockImplementation(async () => createMockPage()),
@@ -330,98 +330,24 @@ describe("PdfTabView", () => {
 
         expect(scrollSurface).toBeTruthy();
 
-        fireEvent.wheel(scrollSurface!, {
+        const pinchWheelEvent = new WheelEvent("wheel", {
+            bubbles: true,
+            cancelable: true,
             ctrlKey: true,
             deltaY: -100,
         });
 
-        await act(async () => {
-            await new Promise((resolve) => window.setTimeout(resolve, 200));
-        });
+        scrollSurface!.dispatchEvent(pinchWheelEvent);
 
-        await waitFor(() => {
-            expect(screen.getByText("125%")).toBeInTheDocument();
-        });
-    });
+        expect(pinchWheelEvent.defaultPrevented).toBe(true);
+        expect(screen.getByText("100%")).toBeInTheDocument();
 
-    it("anchors wheel zoom to the pointer instead of drifting the viewport", async () => {
-        const pdfDocument = {
-            destroy: vi.fn(),
-            getPage: vi.fn().mockImplementation(async () => createMockPage()),
-            numPages: 1,
-        };
+        await user.click(screen.getByTitle("Zoom in"));
 
-        getDocumentMock.mockReturnValue({
-            destroy: vi.fn(),
-            promise: Promise.resolve(pdfDocument),
-        });
-
-        setEditorTabs([
-            {
-                kind: "pdf",
-                id: "pdf-tab",
-                entryId: "entry-1",
-                title: "Doc",
-                path: "/vault/docs/doc.pdf",
-                page: 1,
-                zoom: 1,
-                viewMode: "single",
-            },
-        ]);
-
-        const { container } = renderComponent(<PdfTabView />);
-
-        await waitFor(() => {
-            expect(container.querySelector("canvas")).toBeInTheDocument();
-        });
-
-        const scrollSurface = container.querySelector(
-            "div[class*='overflow-auto']",
-        ) as HTMLDivElement | null;
-        const content =
-            scrollSurface?.firstElementChild as HTMLDivElement | null;
-
-        expect(scrollSurface).toBeTruthy();
-        expect(content).toBeTruthy();
-
-        Object.defineProperty(scrollSurface!, "scrollTop", {
-            configurable: true,
-            writable: true,
-            value: 300,
-        });
-        Object.defineProperty(scrollSurface!, "scrollLeft", {
-            configurable: true,
-            writable: true,
-            value: 40,
-        });
-        scrollSurface!.getBoundingClientRect = () =>
-            ({
-                left: 0,
-                top: 0,
-                right: 900,
-                bottom: 700,
-                width: 900,
-                height: 700,
-                x: 0,
-                y: 0,
-                toJSON: () => ({}),
-            }) as DOMRect;
-
-        fireEvent.wheel(scrollSurface!, {
-            ctrlKey: true,
-            clientX: 180,
-            clientY: 200,
-            deltaY: -100,
-        });
-
-        expect(scrollSurface!.scrollTop).toBe(425);
-        expect(scrollSurface!.scrollLeft).toBe(95);
         expect(screen.getByText("125%")).toBeInTheDocument();
-        expect(content!.style.transformOrigin).toBe("");
-        expect(content!.style.transform).toBe("");
     });
 
-    it("allows native pan gestures on the PDF surface", async () => {
+    it("preserves pan gestures while suppressing gesture-based pinch zoom on the PDF surface", async () => {
         const pdfDocument = {
             destroy: vi.fn(),
             getPage: vi.fn().mockImplementation(async () => createMockPage()),
@@ -459,7 +385,23 @@ describe("PdfTabView", () => {
             "canvas",
         ) as HTMLCanvasElement | null;
 
-        expect(scrollSurface?.style.touchAction).toBe("pan-x pan-y pinch-zoom");
+        expect(scrollSurface?.style.touchAction).toBe("pan-x pan-y");
         expect(canvas?.style.touchAction).not.toBe("none");
+
+        const panWheelEvent = new WheelEvent("wheel", {
+            bubbles: true,
+            cancelable: true,
+            deltaY: 120,
+        });
+        scrollSurface!.dispatchEvent(panWheelEvent);
+
+        const pinchGestureEvent = new Event("gesturestart", {
+            bubbles: true,
+            cancelable: true,
+        });
+        scrollSurface!.dispatchEvent(pinchGestureEvent);
+
+        expect(panWheelEvent.defaultPrevented).toBe(false);
+        expect(pinchGestureEvent.defaultPrevented).toBe(true);
     });
 });

--- a/apps/desktop/src/features/pdf/PdfTabView.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.tsx
@@ -825,11 +825,11 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
 
     return (
         <div
-            className="h-full flex flex-col"
+            className="h-full min-w-0 flex flex-col overflow-hidden"
             style={{ background: "var(--bg-primary)" }}
         >
             <div
-                className="flex items-center gap-2 px-3 shrink-0"
+                className="flex min-w-0 items-center gap-2 overflow-x-auto px-3 shrink-0"
                 style={{
                     height: 39,
                     borderBottom: "1px solid var(--border)",
@@ -954,7 +954,7 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
 
             <div
                 ref={registerContainerElement}
-                className={`flex-1 overflow-auto ${tab.viewMode === "continuous" ? "" : "flex justify-center"}`}
+                className={`min-w-0 flex-1 overflow-auto ${tab.viewMode === "continuous" ? "" : "flex justify-center"}`}
                 style={{
                     padding: 24,
                     background:
@@ -967,7 +967,7 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
                 {tab.viewMode === "continuous" ? (
                     <div
                         ref={contentRef}
-                        className="w-full"
+                        className="min-w-0 w-full"
                         style={{
                             filter: activeFilter.css,
                             position:
@@ -1009,7 +1009,7 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
                 ) : (
                     <div
                         ref={contentRef}
-                        className="w-full flex justify-center"
+                        className="min-w-0 w-full flex justify-center"
                         style={{
                             filter: activeFilter.css,
                         }}

--- a/apps/desktop/src/features/pdf/PdfTabView.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.tsx
@@ -831,7 +831,7 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
             <div
                 className="flex items-center gap-2 px-3 shrink-0"
                 style={{
-                    height: 34,
+                    height: 39,
                     borderBottom: "1px solid var(--border)",
                     background: "var(--bg-secondary)",
                     color: "var(--text-secondary)",

--- a/apps/desktop/src/features/pdf/PdfTabView.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.tsx
@@ -17,6 +17,7 @@ import {
 import {
     useEditorStore,
     isPdfTab,
+    selectEditorPaneActiveTab,
     type PdfTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -225,11 +226,13 @@ function clampContinuousWindow(
     return layouts.slice(nextStart, nextEnd);
 }
 
-export function PdfTabView() {
+interface PdfTabViewProps {
+    paneId?: string;
+}
+
+export function PdfTabView({ paneId }: PdfTabViewProps) {
     const tab = useEditorStore((s) => {
-        const current = s.tabs.find(
-            (candidate) => candidate.id === s.activeTabId,
-        );
+        const current = selectEditorPaneActiveTab(s, paneId);
         return current && isPdfTab(current) ? current : null;
     });
 

--- a/apps/desktop/src/features/pdf/PdfTabView.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.tsx
@@ -19,13 +19,9 @@ import {
     isPdfTab,
     type PdfTab,
 } from "../../app/store/editorStore";
-import {
-    isWheelZoomGesture,
-    useWheelZoomModifier,
-} from "../../app/hooks/useWheelZoomModifier";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { buildVaultPreviewUrlFromAbsolutePath } from "../../app/utils/filePreviewUrl";
-import { formatZoomPercentage, persistWheelZoom } from "../../app/utils/zoom";
+import { formatZoomPercentage } from "../../app/utils/zoom";
 
 pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
     "pdfjs-dist/legacy/build/pdf.worker.min.mjs",
@@ -33,10 +29,6 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 ).toString();
 
 const ZOOM_STEPS = [0.5, 0.75, 1, 1.25, 1.5, 2];
-const MIN_ZOOM = 0.25;
-const MAX_ZOOM = 4;
-const WHEEL_ZOOM_SENSITIVITY = 0.0025;
-const WHEEL_ZOOM_COMMIT_DELAY = 150;
 const CONTINUOUS_PAGE_GAP = 20;
 const CONTINUOUS_OVERSCAN_PX = 1200;
 const CONTINUOUS_MAX_RENDERED_PAGES = 15;
@@ -62,10 +54,6 @@ const PDF_DOCUMENT_OPTIONS = {
     verbosity: pdfjsLib.VerbosityLevel.ERRORS,
 };
 
-function clampScrollOffset(offset: number) {
-    return Number.isFinite(offset) ? Math.max(0, offset) : 0;
-}
-
 function getPixelRatio() {
     if (typeof window === "undefined") return 1;
     return window.devicePixelRatio || 1;
@@ -87,6 +75,12 @@ function clampZoom(zoom: number, direction: "in" | "out"): number {
     }
     return ZOOM_STEPS[ZOOM_STEPS.length - 1];
 }
+
+const PINCH_GESTURE_EVENTS = [
+    "gesturestart",
+    "gesturechange",
+    "gestureend",
+] as const;
 
 function classifyPdfError(raw: string): string {
     const lower = raw.toLowerCase();
@@ -260,8 +254,6 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
     const pageRefs = useRef<Record<number, HTMLDivElement | null>>({});
     const previousViewModeRef = useRef(tab.viewMode);
     const pendingProgrammaticPageRef = useRef<number | null>(null);
-    const wheelZoomTimerRef = useRef(0);
-    const wheelZoomModifierRef = useWheelZoomModifier();
     const [contextMenu, setContextMenu] = useState<ContextMenuState<{
         pageNumber: number;
         selectedText: string;
@@ -275,7 +267,6 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
         null,
     );
     const [retryCount, setRetryCount] = useState(0);
-    const [liveZoom, setLiveZoom] = useState<number | null>(null);
     const [scrollTop, setScrollTop] = useState(0);
     const [scrollContainer, setScrollContainer] =
         useState<HTMLDivElement | null>(null);
@@ -302,8 +293,7 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
     const loading = !error && !activePdf;
     const pdf = activePdf?.pdf ?? null;
     const numPages = activePdf?.numPages ?? 0;
-    const effectiveZoom = liveZoom ?? tab.zoom;
-    const effectiveZoomRef = useRef(effectiveZoom);
+    const effectiveZoom = tab.zoom;
     const continuousLayouts = useMemo(
         () => (pageMetrics ? buildPageLayouts(pageMetrics, effectiveZoom) : []),
         [effectiveZoom, pageMetrics],
@@ -398,28 +388,6 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
     useEffect(() => {
         pageRefs.current = {};
     }, [effectiveZoom, retryCount, tab.path, tab.viewMode]);
-
-    useEffect(() => {
-        effectiveZoomRef.current = effectiveZoom;
-    }, [effectiveZoom]);
-
-    useEffect(() => {
-        if (liveZoom === null) return;
-        if (Math.abs(tab.zoom - liveZoom) > 0.0001) return;
-        setLiveZoom(null);
-    }, [liveZoom, tab.zoom]);
-
-    useEffect(() => {
-        return () => {
-            window.clearTimeout(wheelZoomTimerRef.current);
-        };
-    }, []);
-
-    useEffect(() => {
-        window.clearTimeout(wheelZoomTimerRef.current);
-        setLiveZoom(null);
-        effectiveZoomRef.current = tab.zoom;
-    }, [tab.id, tab.path]);
 
     useEffect(() => {
         queueMicrotask(() => setPageMetrics(null));
@@ -637,14 +605,10 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
     }, [numPages, scrollToPage, tab.id, tab.page, tab.viewMode, updatePdfPage]);
 
     const zoomIn = useCallback(() => {
-        window.clearTimeout(wheelZoomTimerRef.current);
-        setLiveZoom(null);
         updatePdfZoom(tab.id, clampZoom(effectiveZoom, "in"));
     }, [effectiveZoom, tab.id, updatePdfZoom]);
 
     const zoomOut = useCallback(() => {
-        window.clearTimeout(wheelZoomTimerRef.current);
-        setLiveZoom(null);
         updatePdfZoom(tab.id, clampZoom(effectiveZoom, "out"));
     }, [effectiveZoom, tab.id, updatePdfZoom]);
 
@@ -707,55 +671,32 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
         if (!scrollContainer) return;
 
         function handleWheel(event: WheelEvent) {
-            if (!scrollContainer) return;
-            if (!isWheelZoomGesture(event, wheelZoomModifierRef)) return;
+            if (!event.metaKey && !event.ctrlKey) return;
             event.preventDefault();
-
-            const prev = effectiveZoomRef.current;
-            const next = Math.min(
-                MAX_ZOOM,
-                Math.max(
-                    MIN_ZOOM,
-                    prev * (1 - event.deltaY * WHEEL_ZOOM_SENSITIVITY),
-                ),
-            );
-            if (Math.abs(next - prev) < 0.0001) return;
-
-            const containerRect = scrollContainer.getBoundingClientRect();
-            const pointerOffsetX = event.clientX - containerRect.left;
-            const pointerOffsetY = event.clientY - containerRect.top;
-            const scrollScaleRatio = next / prev;
-            const nextScrollLeft = clampScrollOffset(
-                (scrollContainer.scrollLeft + pointerOffsetX) *
-                    scrollScaleRatio -
-                    pointerOffsetX,
-            );
-            const nextScrollTop = clampScrollOffset(
-                (scrollContainer.scrollTop + pointerOffsetY) *
-                    scrollScaleRatio -
-                    pointerOffsetY,
-            );
-
-            setLiveZoom(next);
-            effectiveZoomRef.current = next;
-            scrollContainer.scrollLeft = nextScrollLeft;
-            scrollContainer.scrollTop = nextScrollTop;
-            setScrollTop(nextScrollTop);
-
-            window.clearTimeout(wheelZoomTimerRef.current);
-            wheelZoomTimerRef.current = window.setTimeout(() => {
-                updatePdfZoom(tab.id, persistWheelZoom(next));
-            }, WHEEL_ZOOM_COMMIT_DELAY);
         }
+
+        const suppressPinchGesture = (event: Event) => {
+            event.preventDefault();
+        };
 
         scrollContainer.addEventListener("wheel", handleWheel, {
             passive: false,
         });
+        for (const eventName of PINCH_GESTURE_EVENTS) {
+            scrollContainer.addEventListener(eventName, suppressPinchGesture, {
+                passive: false,
+            });
+        }
         return () => {
             scrollContainer.removeEventListener("wheel", handleWheel);
-            window.clearTimeout(wheelZoomTimerRef.current);
+            for (const eventName of PINCH_GESTURE_EVENTS) {
+                scrollContainer.removeEventListener(
+                    eventName,
+                    suppressPinchGesture,
+                );
+            }
         };
-    }, [scrollContainer, tab.id, updatePdfZoom, wheelZoomModifierRef]);
+    }, [scrollContainer]);
 
     useEffect(() => {
         function handleKeyDown(event: KeyboardEvent) {
@@ -1015,7 +956,9 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
                     padding: 24,
                     background:
                         "color-mix(in srgb, var(--bg-primary) 92%, #000)",
-                    touchAction: "pan-x pan-y pinch-zoom",
+                    // Preserve native panning in both axes while requiring
+                    // explicit toolbar controls for zoom changes.
+                    touchAction: "pan-x pan-y",
                 }}
             >
                 {tab.viewMode === "continuous" ? (

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
@@ -6,6 +6,7 @@ import {
     useMemo,
     useDeferredValue,
 } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import {
     useVaultStore,
@@ -84,7 +85,6 @@ function QuickSwitcherDialog() {
     const closeModal = useCommandStore((s) => s.closeModal);
     const notes = useVaultStore((s) => s.notes);
     const entries = useVaultStore((s) => s.entries);
-    const panes = useEditorStore((s) => s.panes);
     const openNote = useEditorStore((s) => s.openNote);
     const openPdf = useEditorStore((s) => s.openPdf);
     const showExtensions = useSettingsStore((s) => s.fileTreeShowExtensions);
@@ -97,7 +97,7 @@ function QuickSwitcherDialog() {
         () => new Map(entries.map((entry) => [entry.path, entry])),
         [entries],
     );
-    const tabs = useMemo(() => panes.flatMap((pane) => pane.tabs), [panes]);
+    const tabs = useEditorStore(useShallow(selectEditorWorkspaceTabs));
 
     const buildNoteItem = useCallback(
         (note: NoteDto): QuickSwitcherItem => ({

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
@@ -17,6 +17,7 @@ import {
     isFileTab,
     isPdfTab,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useCommandStore } from "../command-palette/store/commandStore";
@@ -83,7 +84,7 @@ function QuickSwitcherDialog() {
     const closeModal = useCommandStore((s) => s.closeModal);
     const notes = useVaultStore((s) => s.notes);
     const entries = useVaultStore((s) => s.entries);
-    const tabs = useEditorStore((s) => s.tabs);
+    const panes = useEditorStore((s) => s.panes);
     const openNote = useEditorStore((s) => s.openNote);
     const openPdf = useEditorStore((s) => s.openPdf);
     const showExtensions = useSettingsStore((s) => s.fileTreeShowExtensions);
@@ -96,6 +97,7 @@ function QuickSwitcherDialog() {
         () => new Map(entries.map((entry) => [entry.path, entry])),
         [entries],
     );
+    const tabs = useMemo(() => panes.flatMap((pane) => pane.tabs), [panes]);
 
     const buildNoteItem = useCallback(
         (note: NoteDto): QuickSwitcherItem => ({
@@ -274,11 +276,9 @@ function QuickSwitcherDialog() {
 
             if (item.kind !== "note") return;
             const note = item.note;
-            const existing = useEditorStore
-                .getState()
-                .tabs.find(
-                    (t): t is NoteTab => isNoteTab(t) && t.noteId === note.id,
-                );
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === note.id);
             if (existing) {
                 openNote(note.id, note.title, existing.content);
                 return;

--- a/apps/desktop/src/features/search/SearchPanel.test.tsx
+++ b/apps/desktop/src/features/search/SearchPanel.test.tsx
@@ -206,14 +206,37 @@ describe("SearchPanel", () => {
         vi.useFakeTimers();
         const invokeMock = mockInvoke();
 
-        setEditorTabs([
-            {
-                id: "tab-existing",
-                noteId: "notes/roadmap",
-                title: "Roadmap",
-                content: "cached",
-            },
-        ]);
+        act(() => {
+            useEditorStore.getState().hydrateWorkspace(
+                [
+                    {
+                        id: "primary",
+                        tabs: [
+                            {
+                                id: "tab-current",
+                                noteId: "notes/current",
+                                title: "Current",
+                                content: "current",
+                            },
+                        ],
+                        activeTabId: "tab-current",
+                    },
+                    {
+                        id: "secondary",
+                        tabs: [
+                            {
+                                id: "tab-existing",
+                                noteId: "notes/roadmap",
+                                title: "Roadmap",
+                                content: "cached",
+                            },
+                        ],
+                        activeTabId: "tab-existing",
+                    },
+                ],
+                "primary",
+            );
+        });
 
         invokeMock.mockImplementation(async (command) => {
             if (command === "search_notes") {

--- a/apps/desktop/src/features/search/SearchPanel.test.tsx
+++ b/apps/desktop/src/features/search/SearchPanel.test.tsx
@@ -142,6 +142,7 @@ describe("SearchPanel", () => {
         });
 
         fireEvent.click(screen.getByText("Copy Note Path"));
+        await flushPromises();
 
         expect(getClipboardMock().writeText).toHaveBeenCalledWith(
             "notes/roadmap",

--- a/apps/desktop/src/features/search/SearchPanel.tsx
+++ b/apps/desktop/src/features/search/SearchPanel.tsx
@@ -9,6 +9,7 @@ import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -150,10 +151,9 @@ export function SearchPanel({ autoFocus }: { autoFocus?: boolean }) {
         }
 
         const { id, title } = result;
-        const tabs = useEditorStore.getState().tabs;
-        const existing = tabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === id,
-        );
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === id);
         if (existing) {
             openNote(id, title, existing.content);
             return;
@@ -181,8 +181,9 @@ export function SearchPanel({ autoFocus }: { autoFocus?: boolean }) {
         }
 
         try {
-            const tabs = useEditorStore.getState().tabs;
-            const existing = tabs.find(
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find(
                 (tab): tab is NoteTab =>
                     isNoteTab(tab) && tab.noteId === result.id,
             );
@@ -268,9 +269,11 @@ export function SearchPanel({ autoFocus }: { autoFocus?: boolean }) {
                 </div>
                 <button
                     onClick={() => {
-                        const { tabs, insertExternalTab, openNote } =
+                        const { insertExternalTab, openNote } =
                             useEditorStore.getState();
-                        const existing = tabs.find(
+                        const existing = selectEditorWorkspaceTabs(
+                            useEditorStore.getState(),
+                        ).find(
                             (t): t is NoteTab =>
                                 isNoteTab(t) && t.noteId === "__search__",
                         );

--- a/apps/desktop/src/features/search/SearchView.tsx
+++ b/apps/desktop/src/features/search/SearchView.tsx
@@ -3,6 +3,7 @@ import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -158,10 +159,9 @@ export function SearchView() {
             await openVaultFileEntry(entry);
             return;
         }
-        const tabs = useEditorStore.getState().tabs;
-        const existing = tabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === result.id,
-        );
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === result.id);
         if (existing) {
             openNote(result.id, result.title, existing.content);
             return;
@@ -188,10 +188,9 @@ export function SearchView() {
             return;
         }
         try {
-            const tabs = useEditorStore.getState().tabs;
-            const existing = tabs.find(
-                (t): t is NoteTab => isNoteTab(t) && t.noteId === result.id,
-            );
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === result.id);
             const content =
                 existing?.content ??
                 (
@@ -520,7 +519,7 @@ export function SearchView() {
                                                     "var(--bg-secondary)")
                                             }
                                         >
-                                            <span className="truncate max-w-[200px]">
+                                            <span className="max-w-50 truncate">
                                                 {h}
                                             </span>
                                             <span
@@ -531,7 +530,7 @@ export function SearchView() {
                                                         getSearchHistory(),
                                                     );
                                                 }}
-                                                className="opacity-0 group-hover:opacity-60 hover:!opacity-100 ml-0.5"
+                                                className="ml-0.5 opacity-0 group-hover:opacity-60 hover:opacity-100!"
                                             >
                                                 <svg
                                                     width="10"
@@ -723,7 +722,7 @@ export function SearchView() {
                                             void handleOpenInNewTab(r)
                                         }
                                         title="Open in new tab"
-                                        className="shrink-0 px-2.5 py-2.5 opacity-0 group-hover:opacity-60 hover:!opacity-100"
+                                        className="shrink-0 px-2.5 py-2.5 opacity-0 group-hover:opacity-60 hover:opacity-100!"
                                         style={{
                                             color: "var(--text-secondary)",
                                         }}

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -2385,8 +2385,6 @@ function ShortcutsSettings() {
 function AISettings() {
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
     const setSetting = useSettingsStore((s) => s.setSetting);
-    const autoContextEnabled = useChatStore((s) => s.autoContextEnabled);
-    const toggleAutoContext = useChatStore((s) => s.toggleAutoContext);
     const requireCmdEnterToSend = useChatStore((s) => s.requireCmdEnterToSend);
     const toggleRequireCmdEnterToSend = useChatStore(
         (s) => s.toggleRequireCmdEnterToSend,
@@ -2414,16 +2412,6 @@ function AISettings() {
     return (
         <div>
             <SectionLabel>Context</SectionLabel>
-            <Row
-                label="Include current note"
-                description="Automatically include the active note as context when sending messages."
-                control={
-                    <Toggle
-                        value={autoContextEnabled}
-                        onChange={() => toggleAutoContext()}
-                    />
-                }
-            />
             <Row
                 label="Inline review in editor"
                 description="Show AI file changes inline in editors with accept and reject controls. Available only in source mode. This preference is saved per vault."

--- a/apps/desktop/src/features/tags/TagsPanel.tsx
+++ b/apps/desktop/src/features/tags/TagsPanel.tsx
@@ -4,6 +4,7 @@ import { useVaultStore } from "../../app/store/vaultStore";
 import {
     useEditorStore,
     isNoteTab,
+    selectEditorWorkspaceTabs,
     type NoteTab,
 } from "../../app/store/editorStore";
 import {
@@ -136,10 +137,9 @@ export function TagsPanel() {
     const handleNoteClick = async (noteId: string) => {
         const note = noteMap.get(noteId);
         if (!note) return;
-        const { tabs: currentTabs } = useEditorStore.getState();
-        const existing = currentTabs.find(
-            (t): t is NoteTab => isNoteTab(t) && t.noteId === noteId,
-        );
+        const existing = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).find((t): t is NoteTab => isNoteTab(t) && t.noteId === noteId);
         if (existing) {
             openNote(note.id, note.title, existing.content);
             return;
@@ -158,8 +158,9 @@ export function TagsPanel() {
         const note = noteMap.get(noteId);
         if (!note) return;
         try {
-            const currentTabs = useEditorStore.getState().tabs;
-            const existing = currentTabs.find(
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find(
                 (tab): tab is NoteTab =>
                     isNoteTab(tab) && tab.noteId === noteId,
             );

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -790,6 +790,58 @@ describe("FileTree", () => {
         ).toBe("Beta body");
     });
 
+    it("adds a note to a new pane from the context menu", async () => {
+        const user = userEvent.setup();
+        vi.mocked(invoke).mockResolvedValue({ content: "Beta body" });
+
+        setVaultNotes([
+            {
+                id: "notes/alpha",
+                path: "/vault/notes/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "notes/beta",
+                path: "/vault/notes/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-alpha",
+                    noteId: "notes/alpha",
+                    title: "Alpha",
+                    content: "Alpha",
+                },
+            ],
+            "tab-alpha",
+        );
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "notes");
+
+        fireEvent.contextMenu(getNoteRow("Beta"));
+        await user.click(
+            await screen.findByRole("button", { name: "Add to New Pane" }),
+        );
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().panes).toHaveLength(2);
+        });
+
+        const state = useEditorStore.getState();
+        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.panes[1]?.tabs[0]).toMatchObject({
+            noteId: "notes/beta",
+            content: "Beta body",
+        });
+    });
+
     it("opens a file in a new tab on middle click", async () => {
         const user = userEvent.setup();
         vi.mocked(invoke).mockImplementation(async (command, args) => {

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -835,7 +835,7 @@ describe("FileTree", () => {
         });
 
         const state = useEditorStore.getState();
-        expect(state.focusedPaneId).toBe("secondary");
+        expect(state.focusedPaneId).toBe("pane-2");
         expect(state.panes[1]?.tabs[0]).toMatchObject({
             noteId: "notes/beta",
             content: "Beta body",

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -790,7 +790,7 @@ describe("FileTree", () => {
         ).toBe("Beta body");
     });
 
-    it("adds a note to a new pane from the context menu", async () => {
+    it("opens a note in a right split from the context menu", async () => {
         const user = userEvent.setup();
         vi.mocked(invoke).mockResolvedValue({ content: "Beta body" });
 
@@ -827,7 +827,7 @@ describe("FileTree", () => {
 
         fireEvent.contextMenu(getNoteRow("Beta"));
         await user.click(
-            await screen.findByRole("button", { name: "Add to New Pane" }),
+            await screen.findByRole("button", { name: "Open in Right Split" }),
         );
 
         await waitFor(() => {

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -1683,7 +1683,7 @@ export function FileTree() {
             basePadding: Math.round(8 * treeScale),
             smallIcon: Math.max(13, Math.round(13 * treeScale)),
             mediumIcon: Math.max(15, Math.round(15 * treeScale)),
-            toolbarHeight: Math.max(29, Math.round(29 * treeScale)),
+            toolbarHeight: Math.max(34, Math.round(34 * treeScale)),
             toolbarButton: Math.max(24, Math.round(24 * treeScale)),
             toolbarIconScale: treeScale,
             inputFontSize: Math.max(12, Math.round(12 * treeScale)),

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -24,8 +24,13 @@ import {
     isPdfTab,
     selectEditorWorkspaceTabs,
     selectFocusedEditorTab,
+    selectPaneCount,
     type NoteTab,
 } from "../../app/store/editorStore";
+import {
+    MAX_EDITOR_PANES,
+    type WorkspaceSplitDirection,
+} from "../../app/store/workspaceLayoutTree";
 import {
     buildEntryMovePath,
     buildNoteMoveOperations,
@@ -1499,10 +1504,10 @@ export function FileTree() {
     const openNote = useEditorStore((s) => s.openNote);
     const closeTab = useEditorStore((s) => s.closeTab);
     const insertExternalTab = useEditorStore((s) => s.insertExternalTab);
-    const insertExternalTabInNewPane = useEditorStore(
-        (s) => s.insertExternalTabInNewPane,
+    const insertExternalTabInNewSplit = useEditorStore(
+        (s) => s.insertExternalTabInNewSplit,
     );
-    const paneCount = useEditorStore((s) => s.panes.length);
+    const paneCount = useEditorStore(selectPaneCount);
     const bookmarkItems = useBookmarkStore((s) => s.items);
     const fileTreeScale = useSettingsStore((s) => s.fileTreeScale);
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
@@ -2925,8 +2930,8 @@ export function FileTree() {
         [insertExternalTab, readNoteContent],
     );
 
-    const handleAddNoteToNewPane = useCallback(
-        async (note: NoteDto) => {
+    const handleOpenNoteInSplit = useCallback(
+        async (note: NoteDto, direction: WorkspaceSplitDirection) => {
             try {
                 const existing = selectEditorWorkspaceTabs(
                     useEditorStore.getState(),
@@ -2938,21 +2943,24 @@ export function FileTree() {
                     existing?.content ??
                     (await readNoteContent(note.id)).content;
 
-                insertExternalTabInNewPane({
-                    id: crypto.randomUUID(),
-                    noteId: note.id,
-                    title: note.title,
-                    content,
-                });
+                insertExternalTabInNewSplit(
+                    {
+                        id: crypto.randomUUID(),
+                        noteId: note.id,
+                        title: note.title,
+                        content,
+                    },
+                    direction,
+                );
             } catch (error) {
                 logError(
                     "file-tree",
-                    "Failed to add tree note to new pane",
+                    "Failed to open tree note in split",
                     error,
                 );
             }
         },
-        [insertExternalTabInNewPane, readNoteContent],
+        [insertExternalTabInNewSplit, readNoteContent],
     );
 
     const handleNoteClick = async (
@@ -3666,9 +3674,15 @@ export function FileTree() {
                         action: () => void handleOpenNoteInNewTab(note),
                     },
                     {
-                        label: "Add to New Pane",
-                        action: () => void handleAddNoteToNewPane(note),
-                        disabled: paneCount >= 3,
+                        label: "Open in Right Split",
+                        action: () => void handleOpenNoteInSplit(note, "row"),
+                        disabled: paneCount >= MAX_EDITOR_PANES,
+                    },
+                    {
+                        label: "Open in Bottom Split",
+                        action: () =>
+                            void handleOpenNoteInSplit(note, "column"),
+                        disabled: paneCount >= MAX_EDITOR_PANES,
                     },
                     { type: "separator" },
                     {
@@ -3935,7 +3949,7 @@ export function FileTree() {
         handleEntryRenameStart,
         handleFolderRenameStart,
         handleAddFileToChat,
-        handleAddNoteToNewPane,
+        handleOpenNoteInSplit,
         handleAddPdfToChat,
         handleMoveEntryToTrash,
         handlePdfClick,

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -22,6 +22,8 @@ import {
     isFileTab,
     isNoteTab,
     isPdfTab,
+    selectEditorWorkspaceTabs,
+    selectFocusedEditorTab,
     type NoteTab,
 } from "../../app/store/editorStore";
 import {
@@ -1483,12 +1485,12 @@ export function FileTree() {
     const refreshStructure = useVaultStore((s) => s.refreshStructure);
     const updateNoteMetadata = useVaultStore((s) => s.updateNoteMetadata);
     const touchContent = useVaultStore((s) => s.touchContent);
-    const activeNoteId = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
+    const activeNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         return tab && isNoteTab(tab) ? tab.noteId : null;
     });
-    const activeEntryPath = useEditorStore((s) => {
-        const tab = s.tabs.find((t) => t.id === s.activeTabId);
+    const activeEntryPath = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
         if (tab && (isPdfTab(tab) || isFileTab(tab))) {
             return tab.path;
         }
@@ -1497,6 +1499,10 @@ export function FileTree() {
     const openNote = useEditorStore((s) => s.openNote);
     const closeTab = useEditorStore((s) => s.closeTab);
     const insertExternalTab = useEditorStore((s) => s.insertExternalTab);
+    const insertExternalTabInNewPane = useEditorStore(
+        (s) => s.insertExternalTabInNewPane,
+    );
+    const paneCount = useEditorStore((s) => s.panes.length);
     const bookmarkItems = useBookmarkStore((s) => s.items);
     const fileTreeScale = useSettingsStore((s) => s.fileTreeScale);
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
@@ -2869,8 +2875,9 @@ export function FileTree() {
 
     const openTreeNote = useCallback(
         async (note: NoteDto) => {
-            const { tabs: currentTabs } = useEditorStore.getState();
-            const existing = currentTabs.find(
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find(
                 (tab): tab is NoteTab =>
                     isNoteTab(tab) && tab.noteId === note.id,
             );
@@ -2891,8 +2898,9 @@ export function FileTree() {
     const handleOpenNoteInNewTab = useCallback(
         async (note: NoteDto) => {
             try {
-                const { tabs: currentTabs } = useEditorStore.getState();
-                const existing = currentTabs.find(
+                const existing = selectEditorWorkspaceTabs(
+                    useEditorStore.getState(),
+                ).find(
                     (tab): tab is NoteTab =>
                         isNoteTab(tab) && tab.noteId === note.id,
                 );
@@ -2915,6 +2923,36 @@ export function FileTree() {
             }
         },
         [insertExternalTab, readNoteContent],
+    );
+
+    const handleAddNoteToNewPane = useCallback(
+        async (note: NoteDto) => {
+            try {
+                const existing = selectEditorWorkspaceTabs(
+                    useEditorStore.getState(),
+                ).find(
+                    (tab): tab is NoteTab =>
+                        isNoteTab(tab) && tab.noteId === note.id,
+                );
+                const content =
+                    existing?.content ??
+                    (await readNoteContent(note.id)).content;
+
+                insertExternalTabInNewPane({
+                    id: crypto.randomUUID(),
+                    noteId: note.id,
+                    title: note.title,
+                    content,
+                });
+            } catch (error) {
+                logError(
+                    "file-tree",
+                    "Failed to add tree note to new pane",
+                    error,
+                );
+            }
+        },
+        [insertExternalTabInNewPane, readNoteContent],
     );
 
     const handleNoteClick = async (
@@ -3056,8 +3094,9 @@ export function FileTree() {
 
     const persistCopiedNote = useCallback(
         async (note: NoteDto, targetPath: string) => {
-            const { tabs: currentTabs } = useEditorStore.getState();
-            const existing = currentTabs.find(
+            const existing = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            ).find(
                 (tab): tab is NoteTab =>
                     isNoteTab(tab) && tab.noteId === note.id,
             );
@@ -3274,7 +3313,9 @@ export function FileTree() {
         async (notesToDelete: NoteDto[]) => {
             const noteIds = new Set(notesToDelete.map((note) => note.id));
 
-            const { tabs: currentTabs } = useEditorStore.getState();
+            const currentTabs = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            );
             currentTabs.forEach((tab) => {
                 if (isNoteTab(tab) && noteIds.has(tab.noteId)) {
                     closeTab(tab.id, { reason: "delete" });
@@ -3309,7 +3350,9 @@ export function FileTree() {
             );
             if (!approved) return;
 
-            const { tabs: currentTabs } = useEditorStore.getState();
+            const currentTabs = selectEditorWorkspaceTabs(
+                useEditorStore.getState(),
+            );
             const prefix = relativePath + "/";
             const sourceAbsolutePath = vaultPath
                 ? `${vaultPath}/${relativePath}`
@@ -3407,8 +3450,9 @@ export function FileTree() {
             }
 
             try {
-                const { tabs: currentTabs } = useEditorStore.getState();
-                const existing = currentTabs.find(
+                const existing = selectEditorWorkspaceTabs(
+                    useEditorStore.getState(),
+                ).find(
                     (tab): tab is NoteTab =>
                         isNoteTab(tab) && tab.noteId === note.id,
                 );
@@ -3620,6 +3664,11 @@ export function FileTree() {
                     {
                         label: "Open in New Tab",
                         action: () => void handleOpenNoteInNewTab(note),
+                    },
+                    {
+                        label: "Add to New Pane",
+                        action: () => void handleAddNoteToNewPane(note),
+                        disabled: paneCount >= 3,
                     },
                     { type: "separator" },
                     {
@@ -3886,6 +3935,7 @@ export function FileTree() {
         handleEntryRenameStart,
         handleFolderRenameStart,
         handleAddFileToChat,
+        handleAddNoteToNewPane,
         handleAddPdfToChat,
         handleMoveEntryToTrash,
         handlePdfClick,
@@ -3896,6 +3946,7 @@ export function FileTree() {
         handleRevealNoteInFinder,
         openMoveMenu,
         openTreeNote,
+        paneCount,
         startCreating,
         treeClipboard,
         bookmarkItems,


### PR DESCRIPTION
## Summary

This branch lands the multi-pane editor workspace for desktop and hardens the surrounding chat, review, drag/drop, pane layout, and persistence flows needed to make it mergeable.

At a high level it:

- introduces a pane-aware editor workspace model and split-tree layout engine
- adds multi-pane rendering, pane tab bars, split resizing, and cross-pane tab movement
- makes chat sessions bidirectional between the sidebar and workspace panes
- reopens and scopes AI review tabs correctly in pane-aware contexts
- hardens context menus, pane rendering, drop behavior, and nested split handling
- fixes map tab rename/delete lifecycle so those updates apply across the full workspace rather than only the focused pane

## Why

The previous editor model assumed a single active tab strip. That became the limiting abstraction for split panes, workspace-scoped chat tabs, review routing, and reliable tab lifecycle management across panes.

This PR replaces that assumption with pane-aware state and tree-backed layout persistence so the multi-pane workspace behaves as a first-class editor surface instead of a thin UI overlay.

## Impact

For users:

- multiple editor panes can be opened, resized, and reorganized reliably
- tabs can move between panes and between the AI sidebar and workspace
- review tabs stay attached to the correct session/pane behavior
- pane controls, tab interactions, and drop previews are more consistent

For developers:

- workspace state is modeled explicitly in the editor store
- layout persistence is tree-backed instead of linear
- more of the review/chat/editor lifecycle is tested under pane-aware conditions

## Root Cause Notes

One concrete bug fixed during the final audit was that map rename/delete behavior still mutated the legacy focused-pane mirror (`state.tabs`) instead of the full pane workspace. In multi-pane mode, that could leave stale map tabs alive in non-focused panes. The fix moved that lifecycle into pane-aware editor store actions and added regression coverage.

## Validation

- `npm run lint`
- `npm run build`
- `npm run test:split-grid-baseline`
- `npx vitest run src/app/store/editorStore.test.ts src/features/maps/MapsPanel.test.tsx`

## Commit History

- `62d1d6a` refactor: introduce pane-aware editor workspace model
- `99811e8` feat: implement multi-pane workspace
- `f8e934c` fix: stabilize multipane workspace state
- `3a295be` feat: add advanced multipane tab interactions
- `46a3d8d` feat: bidirectional chat tabs between sidebar and editor workspace
- `6f7a007` Add split-tree workspace engine for phase 1
- `316916c` feat(desktop): add tree-backed workspace layout model and persistence
- `7624a8b` fix(desktop): preserve vertical pane drop direction
- `5329bd1` feat(ai): reopen review tabs on mount for tracked sessions
- `9bb9112` Remove ACP button from unified bar
- `fdb033f` Fix empty pane collapse and split pane stretching
- `bd5c975` Refine workspace bar interactions and toolbar heights
- `d6cf97e` Fix split workspace width with media viewers
- `850467b` Refine pane tabs and split resizer visuals
- `d4757fc` Polish multi-pane chat and workspace flows
- `1a923ab` Add provider-aware new agent menu to tab bars
- `81c01fa` Harden workspace agent creation flow
- `c5a3b67` Harden context menu timing and pane rendering
- `e2109de` Fix nested down splits in editor workspace
- `69bddd7` Add wheel scrolling to split view tab strips
- `4f641fe` Remove multi-pane workspace chrome label
- `580cdc3` Unify split view tabs and pane controls
- `272d1aa` Rename unify all tabs pane action
- `453aedb` Fix multipane map tab lifecycle
