### PR TITLE
[codex] Stabilize persisted history cache and graph state

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -101,6 +101,7 @@ import { YouTubeModalHost } from "./features/editor/YouTubeModalHost";
 import { useAppUpdateStore } from "./features/updates/store";
 import {
     buildWindowOperationalState,
+    WINDOW_OPERATIONAL_STATE_PUBLISH_DEBOUNCE_MS,
     writeWindowOperationalState,
 } from "./features/updates/sensitiveState";
 
@@ -1125,7 +1126,10 @@ export default function App() {
         }
 
         const label = getCurrentWindowLabel();
-        const publish = () => {
+        let publishTimer: number | null = null;
+
+        const publishNow = () => {
+            publishTimer = null;
             const editor = useEditorStore.getState();
             const chat = useChatStore.getState();
             writeWindowOperationalState(
@@ -1141,11 +1145,24 @@ export default function App() {
             );
         };
 
-        publish();
-        const unsubscribeEditor = useEditorStore.subscribe(publish);
-        const unsubscribeChat = useChatStore.subscribe(publish);
+        const schedulePublish = () => {
+            if (publishTimer !== null) {
+                window.clearTimeout(publishTimer);
+            }
+            publishTimer = window.setTimeout(
+                publishNow,
+                WINDOW_OPERATIONAL_STATE_PUBLISH_DEBOUNCE_MS,
+            );
+        };
+
+        publishNow();
+        const unsubscribeEditor = useEditorStore.subscribe(schedulePublish);
+        const unsubscribeChat = useChatStore.subscribe(schedulePublish);
 
         return () => {
+            if (publishTimer !== null) {
+                window.clearTimeout(publishTimer);
+            }
             unsubscribeEditor();
             unsubscribeChat();
             writeWindowOperationalState(label, null);

--- a/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
@@ -1,5 +1,5 @@
 import { act, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type Mock, beforeEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../../test/test-utils";
 import { AIAuthTerminalModal } from "./AIAuthTerminalModal";
 
@@ -117,10 +117,10 @@ describe("AIAuthTerminalModal", () => {
     });
 
     it("cleans up listeners that resolve after the modal unmounts", async () => {
-        const startedDeferred = createDeferred<() => void>();
-        const outputDeferred = createDeferred<() => void>();
-        const exitedDeferred = createDeferred<() => void>();
-        const errorDeferred = createDeferred<() => void>();
+        const startedDeferred = createDeferred<Mock>();
+        const outputDeferred = createDeferred<Mock>();
+        const exitedDeferred = createDeferred<Mock>();
+        const errorDeferred = createDeferred<Mock>();
 
         const startedUnlisten = vi.fn();
         const outputUnlisten = vi.fn();

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -9157,6 +9157,264 @@ describe("chatStore", () => {
         ).toBeUndefined();
     });
 
+    it("drops deleted persisted history metadata from the in-memory cache", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_list_runtimes") {
+                return runtimePayload;
+            }
+
+            if (command === "ai_get_setup_status") {
+                return readySetupStatus;
+            }
+
+            if (command === "ai_list_sessions") {
+                return [];
+            }
+
+            if (command === "ai_load_session_histories") {
+                return [
+                    {
+                        version: 1,
+                        session_id: "history-deleted",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 10,
+                        updated_at: 20,
+                        message_count: 1,
+                        title: "Deleted title",
+                        preview: "Deleted preview",
+                        messages: [],
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session") {
+                return {
+                    ...sessionPayload,
+                    session_id:
+                        (args as { sessionId?: string } | undefined)
+                            ?.sessionId ?? "replacement-session",
+                    models: [],
+                    modes: [],
+                    config_options: [],
+                };
+            }
+
+            if (command === "ai_load_session_history_page") {
+                return {
+                    session_id:
+                        (args as { sessionId?: string } | undefined)
+                            ?.sessionId ?? "history-deleted",
+                    total_messages: 0,
+                    start_index: 0,
+                    end_index: 0,
+                    messages: [],
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().initialize();
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("deleted-session", []),
+                historySessionId: "history-deleted",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+            },
+            true,
+        );
+
+        await useChatStore.getState().reconcileRestoredWorkspaceTabs([
+            {
+                id: "tab-deleted",
+                sessionId: "deleted-session",
+                historySessionId: "history-deleted",
+                runtimeId: "codex-acp",
+            },
+        ]);
+
+        expect(
+            useChatStore.getState().sessionsById["deleted-session"],
+        ).toMatchObject({
+            persistedTitle: "Deleted title",
+            models: [
+                expect.objectContaining({
+                    id: "test-model",
+                }),
+            ],
+        });
+
+        await useChatStore.getState().deleteSession("deleted-session");
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("replacement-session", []),
+                historySessionId: "history-deleted",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+            },
+            true,
+        );
+
+        await useChatStore.getState().reconcileRestoredWorkspaceTabs([
+            {
+                id: "tab-replacement",
+                sessionId: "replacement-session",
+                historySessionId: "history-deleted",
+                runtimeId: "codex-acp",
+            },
+        ]);
+
+        expect(
+            useChatStore.getState().sessionsById["replacement-session"],
+        ).toMatchObject({
+            persistedTitle: null,
+            persistedPreview: null,
+        });
+    });
+
+    it("clears persisted history metadata cache for the active vault on deleteAllSessions", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_list_runtimes") {
+                return runtimePayload;
+            }
+
+            if (command === "ai_get_setup_status") {
+                return readySetupStatus;
+            }
+
+            if (command === "ai_list_sessions") {
+                return [];
+            }
+
+            if (command === "ai_load_session_histories") {
+                return [
+                    {
+                        version: 1,
+                        session_id: "history-cleared",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 10,
+                        updated_at: 20,
+                        message_count: 1,
+                        title: "Cleared title",
+                        preview: "Cleared preview",
+                        messages: [],
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session") {
+                return {
+                    ...sessionPayload,
+                    session_id:
+                        (args as { sessionId?: string } | undefined)
+                            ?.sessionId ?? "after-clear-session",
+                    models: [],
+                    modes: [],
+                    config_options: [],
+                };
+            }
+
+            if (command === "ai_load_session_history_page") {
+                return {
+                    session_id:
+                        (args as { sessionId?: string } | undefined)
+                            ?.sessionId ?? "history-cleared",
+                    total_messages: 0,
+                    start_index: 0,
+                    end_index: 0,
+                    messages: [],
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().initialize();
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("before-clear-session", []),
+                historySessionId: "history-cleared",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+            },
+            true,
+        );
+
+        await useChatStore.getState().reconcileRestoredWorkspaceTabs([
+            {
+                id: "tab-before-clear",
+                sessionId: "before-clear-session",
+                historySessionId: "history-cleared",
+                runtimeId: "codex-acp",
+            },
+        ]);
+
+        expect(
+            useChatStore.getState().sessionsById["before-clear-session"],
+        ).toMatchObject({
+            persistedTitle: "Cleared title",
+            models: [
+                expect.objectContaining({
+                    id: "test-model",
+                }),
+            ],
+        });
+
+        await useChatStore.getState().deleteAllSessions();
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("after-clear-session", []),
+                historySessionId: "history-cleared",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+            },
+            true,
+        );
+
+        await useChatStore.getState().reconcileRestoredWorkspaceTabs([
+            {
+                id: "tab-after-clear",
+                sessionId: "after-clear-session",
+                historySessionId: "history-cleared",
+                runtimeId: "codex-acp",
+            },
+        ]);
+
+        expect(
+            useChatStore.getState().sessionsById["after-clear-session"],
+        ).toMatchObject({
+            persistedTitle: null,
+            persistedPreview: null,
+        });
+    });
+
     it("applies agent changes while the session is busy", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -141,10 +141,11 @@ import { logDebug, logError, logWarn } from "../../../app/utils/runtimeLog";
 
 const AI_PREFS_KEY = "neverwrite.ai.preferences";
 const AI_RUNTIME_CACHE_KEY = "neverwrite.ai.runtime-catalog";
+type PersistedSessionHistorySummary = Omit<PersistedSessionHistory, "messages">;
 let _persistedHistoryCacheVaultPath: string | null = null;
 let _persistedHistoryCacheBySessionId = new Map<
     string,
-    PersistedSessionHistory
+    PersistedSessionHistorySummary
 >();
 const AI_AUTO_CONTEXT_KEY_PREFIX = "neverwrite.ai.auto-context:";
 const AI_AUTO_CONTEXT_GLOBAL_SCOPE = "__global__";
@@ -363,7 +364,10 @@ function setPersistedHistoryCache(
 ) {
     _persistedHistoryCacheVaultPath = vaultPath ?? null;
     _persistedHistoryCacheBySessionId = new Map(
-        histories.map((history) => [history.session_id, history]),
+        histories.map((history) => [
+            history.session_id,
+            summarizePersistedHistory(history),
+        ]),
     );
 }
 
@@ -371,12 +375,36 @@ function upsertPersistedHistoryCache(
     vaultPath: string | null,
     history: PersistedSessionHistory,
 ) {
+    const summary = summarizePersistedHistory(history);
     if (_persistedHistoryCacheVaultPath !== (vaultPath ?? null)) {
         setPersistedHistoryCache(vaultPath, [history]);
         return;
     }
 
-    _persistedHistoryCacheBySessionId.set(history.session_id, history);
+    _persistedHistoryCacheBySessionId.set(summary.session_id, summary);
+}
+
+function deletePersistedHistoryCacheEntry(
+    vaultPath: string | null,
+    historySessionId: string | null | undefined,
+) {
+    if (!historySessionId) {
+        return;
+    }
+
+    if (_persistedHistoryCacheVaultPath !== (vaultPath ?? null)) {
+        return;
+    }
+
+    _persistedHistoryCacheBySessionId.delete(historySessionId);
+}
+
+function clearPersistedHistoryCache(vaultPath: string | null) {
+    if (_persistedHistoryCacheVaultPath !== (vaultPath ?? null)) {
+        return;
+    }
+
+    _persistedHistoryCacheBySessionId.clear();
 }
 
 function getPersistedHistoryFromCache(
@@ -392,6 +420,13 @@ function getPersistedHistoryFromCache(
     }
 
     return _persistedHistoryCacheBySessionId.get(historySessionId) ?? null;
+}
+
+function summarizePersistedHistory(
+    history: PersistedSessionHistory,
+): PersistedSessionHistorySummary {
+    const { messages: _messages, ...summary } = history;
+    return summary;
 }
 
 function hasRuntimeCatalog(snapshot: AIRuntimeCatalogSnapshot) {
@@ -3372,8 +3407,13 @@ function applyUserEditToTrackedFileInSession(
     });
 }
 
-function getPersistedHistoryMessageCount(history: PersistedSessionHistory) {
-    return history.message_count ?? history.messages.length;
+function getPersistedHistoryMessageCount(
+    history: PersistedSessionHistory | PersistedSessionHistorySummary,
+) {
+    return (
+        history.message_count ??
+        ("messages" in history ? history.messages.length : 0)
+    );
 }
 
 function getSessionPersistedMessageCount(session: AIChatSession) {
@@ -3439,7 +3479,7 @@ function ensurePersistedTranscriptWindowAnchor(session: AIChatSession) {
 
 function applyPersistedHistoryMetadata(
     session: AIChatSession,
-    history: PersistedSessionHistory,
+    history: PersistedSessionHistorySummary,
 ) {
     const persistedCatalog = getPersistedHistoryCatalogSnapshot(history);
     if (hasRuntimeCatalog(persistedCatalog)) {
@@ -8288,6 +8328,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     () => {},
                 );
             }
+            deletePersistedHistoryCacheEntry(vaultPath, historySessionId);
             useEditorStore.getState().closeReview(sessionId);
             useEditorStore.getState().closeChat(sessionId);
             useChatTabsStore.getState().removeTabsForSession(sessionId);
@@ -8376,6 +8417,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (vaultPath) {
                 await aiDeleteAllSessionHistories(vaultPath).catch(() => {});
             }
+            clearPersistedHistoryCache(vaultPath);
             // Close all review and chat tabs before clearing sessions
             const editor = useEditorStore.getState();
             for (const sessionId of Object.keys(get().sessionsById)) {

--- a/apps/desktop/src/features/graph/GraphViewController.tsx
+++ b/apps/desktop/src/features/graph/GraphViewController.tsx
@@ -25,7 +25,8 @@ import { GraphRenderer3D } from "./GraphRenderer3D";
 import { GraphRenderer2D } from "./GraphRenderer2D";
 import { GraphSettingsPanel } from "./GraphSettingsPanel";
 import {
-    buildGraphLayoutKey,
+    buildGraphLayoutCacheKey,
+    buildGraphPreparedSnapshotKey,
     saveGraphLayoutSnapshot,
     type GraphNodePosition,
 } from "./graphLayoutCache";
@@ -247,9 +248,11 @@ export function GraphViewController({
         };
     }, [graphSnapshot, hiddenLinkCount, hiddenNodeCount]);
 
-    const layoutKey = useMemo(() => {
+    const trimmedSearchFilter = searchFilter.trim();
+
+    const layoutCacheKey = useMemo(() => {
         if (!vaultPath || !graphSnapshot) return null;
-        return buildGraphLayoutKey({
+        return buildGraphLayoutCacheKey({
             vaultPath,
             graphVersion: graphSnapshot.version,
             graphMode,
@@ -259,7 +262,6 @@ export function GraphViewController({
             showTagNodes,
             showAttachmentNodes,
             showOrphans,
-            searchFilter: searchFilter.trim(),
             layoutStrategy,
         });
     }, [
@@ -269,10 +271,39 @@ export function GraphViewController({
         layoutStrategy,
         localDepth,
         graphSnapshot,
-        searchFilter,
         showAttachmentNodes,
         showOrphans,
         showTagNodes,
+        vaultPath,
+    ]);
+
+    const preparedSnapshotKey = useMemo(() => {
+        if (!layoutCacheKey || !vaultPath || !graphSnapshot) return null;
+        return buildGraphPreparedSnapshotKey({
+            vaultPath,
+            graphVersion: graphSnapshot.version,
+            graphMode,
+            rendererMode,
+            localDepth,
+            rootNoteId: graphMode === "local" ? activeNoteId : null,
+            showTagNodes,
+            showAttachmentNodes,
+            showOrphans,
+            searchFilter: trimmedSearchFilter,
+            layoutStrategy,
+        });
+    }, [
+        activeNoteId,
+        graphMode,
+        graphSnapshot,
+        layoutCacheKey,
+        layoutStrategy,
+        localDepth,
+        rendererMode,
+        showAttachmentNodes,
+        showOrphans,
+        showTagNodes,
+        trimmedSearchFilter,
         vaultPath,
     ]);
 
@@ -282,19 +313,22 @@ export function GraphViewController({
         error: preparedPipelineError,
     } = usePreparedGraphSnapshot({
         graphSnapshot,
-        layoutKey,
+        preparedSnapshotKey,
+        layoutCacheKey,
         layoutStrategy,
         isVisible,
     });
 
     const preparedSnapshot =
-        prepared && prepared.layoutKey === layoutKey ? prepared.snapshot : null;
+        prepared && prepared.preparedKey === preparedSnapshotKey
+            ? prepared.snapshot
+            : null;
     const restoredFromCache =
-        prepared && prepared.layoutKey === layoutKey
+        prepared && prepared.preparedKey === preparedSnapshotKey
             ? prepared.restoredFromCache
             : false;
     const neighborIndex =
-        prepared && prepared.layoutKey === layoutKey
+        prepared && prepared.preparedKey === preparedSnapshotKey
             ? prepared.neighborIndex
             : EMPTY_NEIGHBOR_INDEX;
 
@@ -366,10 +400,13 @@ export function GraphViewController({
 
     const persistPositions = useCallback(
         (positions: Record<string, GraphPosition>) => {
-            if (!layoutKey) return;
-            saveGraphLayoutSnapshot(layoutKey, toGraphNodePositions(positions));
+            if (!layoutCacheKey || trimmedSearchFilter.length > 0) return;
+            saveGraphLayoutSnapshot(
+                layoutCacheKey,
+                toGraphNodePositions(positions),
+            );
         },
-        [layoutKey],
+        [layoutCacheKey, trimmedSearchFilter],
     );
 
     const openNoteById = useCallback(async (noteId: string, title: string) => {
@@ -555,7 +592,9 @@ export function GraphViewController({
     );
 
     const rendererSurfaceKey =
-        preparedSnapshot && layoutKey ? `${rendererMode}:${layoutKey}` : null;
+        preparedSnapshot && preparedSnapshotKey
+            ? `${rendererMode}:${preparedSnapshotKey}`
+            : null;
     const [mountedRendererSurfaceKey, setMountedRendererSurfaceKey] = useState<
         string | null
     >(null);
@@ -662,7 +701,7 @@ export function GraphViewController({
         </button>
     );
 
-    if (!layoutKey || !shouldRenderRenderer) {
+    if (!layoutCacheKey || !shouldRenderRenderer) {
         let message = "Loading graph…";
         if (graphMode === "local" && !activeNoteId) {
             message = "Open a note to see its local graph";
@@ -736,7 +775,7 @@ export function GraphViewController({
                         glowIntensity={glowIntensity}
                         showTitles={showTitles}
                         textFadeThreshold={textFadeThreshold}
-                        layoutKey={layoutKey}
+                        layoutKey={layoutCacheKey}
                         restoredFromCache={restoredFromCache}
                         shouldRunSimulation={effectiveShouldRunSimulation}
                         cooldownTicks={effectiveCooldownTicks}
@@ -762,7 +801,7 @@ export function GraphViewController({
                         glowIntensity={glowIntensity}
                         showTitles={showTitles}
                         textFadeThreshold={textFadeThreshold}
-                        layoutKey={layoutKey}
+                        layoutKey={layoutCacheKey}
                         restoredFromCache={restoredFromCache}
                         shouldRunSimulation={effectiveShouldRunSimulation}
                         cooldownTicks={effectiveCooldownTicks}

--- a/apps/desktop/src/features/graph/graphLayoutCache.test.ts
+++ b/apps/desktop/src/features/graph/graphLayoutCache.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    safeStorageClear,
+    safeStorageGetItem,
+    safeStorageKeys,
+    safeStorageSetItem,
+} from "../../app/utils/safeStorage";
+import {
+    buildGraphLayoutCacheKey,
+    buildGraphPreparedSnapshotKey,
+    loadGraphLayoutSnapshot,
+    saveGraphLayoutSnapshot,
+} from "./graphLayoutCache";
+
+const GRAPH_LAYOUT_CACHE_PREFIX = "vault-graph-layout:v1:";
+const DAY_MS = 1000 * 60 * 60 * 24;
+const MAX_ENTRIES_PER_VAULT = 12;
+
+function buildBaseParts(overrides: Partial<{
+    vaultPath: string;
+    graphVersion: number;
+    graphMode: string;
+    rendererMode: string;
+    localDepth: number;
+    rootNoteId: string | null;
+    showTagNodes: boolean;
+    showAttachmentNodes: boolean;
+    showOrphans: boolean;
+    layoutStrategy: string;
+}> = {}) {
+    return {
+        vaultPath: "/tmp/neverwrite-test-vault",
+        graphVersion: 1,
+        graphMode: "global",
+        rendererMode: "2d",
+        localDepth: 2,
+        rootNoteId: null,
+        showTagNodes: false,
+        showAttachmentNodes: false,
+        showOrphans: true,
+        layoutStrategy: "preset",
+        ...overrides,
+    };
+}
+
+function storedSnapshot(nodeId: string, savedAt = Date.now()) {
+    return JSON.stringify({
+        positions: {
+            [nodeId]: { x: savedAt % 1000, y: savedAt % 100 },
+        },
+        savedAt,
+    });
+}
+
+describe("graphLayoutCache", () => {
+    beforeEach(() => {
+        safeStorageClear();
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date("2026-04-11T12:00:00Z"));
+    });
+
+    afterEach(() => {
+        safeStorageClear();
+        vi.useRealTimers();
+    });
+
+    it("keeps persistent layout keys stable while prepared keys track the search filter", () => {
+        const cacheKey = buildGraphLayoutCacheKey(buildBaseParts());
+        const preparedFoo = buildGraphPreparedSnapshotKey({
+            ...buildBaseParts(),
+            searchFilter: "foo",
+        });
+        const preparedBar = buildGraphPreparedSnapshotKey({
+            ...buildBaseParts(),
+            searchFilter: "bar",
+        });
+
+        expect(preparedFoo).not.toBe(preparedBar);
+        expect(cacheKey).not.toBe(preparedFoo);
+        expect(cacheKey).not.toBe(preparedBar);
+    });
+
+    it("merges positions instead of replacing the stored snapshot", () => {
+        const cacheKey = buildGraphLayoutCacheKey(buildBaseParts());
+
+        saveGraphLayoutSnapshot(cacheKey, {
+            alpha: { x: 10, y: 20 },
+        });
+        saveGraphLayoutSnapshot(cacheKey, {
+            beta: { x: 30, y: 40, z: 5 },
+        });
+
+        expect(loadGraphLayoutSnapshot(cacheKey)?.positions).toEqual({
+            alpha: { x: 10, y: 20 },
+            beta: { x: 30, y: 40, z: 5 },
+        });
+    });
+
+    it("prunes legacy filtered entries, expired entries, and the oldest overflow", () => {
+        const recentKeys: string[] = [];
+        for (let index = 0; index < MAX_ENTRIES_PER_VAULT + 1; index += 1) {
+            const cacheKey = buildGraphLayoutCacheKey(
+                buildBaseParts({ graphVersion: index + 1 }),
+            );
+            recentKeys.push(cacheKey);
+            safeStorageSetItem(
+                GRAPH_LAYOUT_CACHE_PREFIX + cacheKey,
+                storedSnapshot(`node-${index}`, Date.now() - index * 1000),
+            );
+        }
+
+        const legacyFilteredKey = buildGraphPreparedSnapshotKey({
+            ...buildBaseParts({ graphVersion: 100 }),
+            searchFilter: "tag:project",
+        });
+        safeStorageSetItem(
+            GRAPH_LAYOUT_CACHE_PREFIX + legacyFilteredKey,
+            storedSnapshot("legacy-filtered"),
+        );
+
+        const expiredKey = buildGraphLayoutCacheKey(
+            buildBaseParts({ graphVersion: 200 }),
+        );
+        safeStorageSetItem(
+            GRAPH_LAYOUT_CACHE_PREFIX + expiredKey,
+            storedSnapshot("expired", Date.now() - DAY_MS * 31),
+        );
+
+        const currentKey = buildGraphLayoutCacheKey(
+            buildBaseParts({ graphVersion: 999 }),
+        );
+        saveGraphLayoutSnapshot(currentKey, {
+            current: { x: 1, y: 2 },
+        });
+
+        const graphLayoutKeys = safeStorageKeys().filter((key) =>
+            key.startsWith(GRAPH_LAYOUT_CACHE_PREFIX),
+        );
+
+        expect(safeStorageGetItem(GRAPH_LAYOUT_CACHE_PREFIX + legacyFilteredKey)).toBeNull();
+        expect(safeStorageGetItem(GRAPH_LAYOUT_CACHE_PREFIX + expiredKey)).toBeNull();
+        expect(
+            safeStorageGetItem(
+                GRAPH_LAYOUT_CACHE_PREFIX + recentKeys[recentKeys.length - 1],
+            ),
+        ).toBeNull();
+        expect(safeStorageGetItem(GRAPH_LAYOUT_CACHE_PREFIX + currentKey)).not.toBeNull();
+        expect(graphLayoutKeys).toHaveLength(MAX_ENTRIES_PER_VAULT);
+    });
+});

--- a/apps/desktop/src/features/graph/graphLayoutCache.ts
+++ b/apps/desktop/src/features/graph/graphLayoutCache.ts
@@ -1,5 +1,7 @@
 import {
     safeStorageGetItem,
+    safeStorageKeys,
+    safeStorageRemoveItem,
     safeStorageSetItem,
 } from "../../app/utils/safeStorage";
 
@@ -15,42 +17,10 @@ export interface GraphLayoutSnapshot {
 }
 
 const GRAPH_LAYOUT_CACHE_PREFIX = "vault-graph-layout:v1:";
+const GRAPH_LAYOUT_CACHE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30;
+const GRAPH_LAYOUT_CACHE_MAX_ENTRIES_PER_VAULT = 12;
 
-export function loadGraphLayoutSnapshot(
-    layoutKey: string,
-): GraphLayoutSnapshot | null {
-    try {
-        const raw = safeStorageGetItem(GRAPH_LAYOUT_CACHE_PREFIX + layoutKey);
-        if (!raw) return null;
-        const parsed = JSON.parse(raw) as GraphLayoutSnapshot;
-        if (!parsed || typeof parsed !== "object") return null;
-        if (!parsed.positions || typeof parsed.positions !== "object") {
-            return null;
-        }
-        return parsed;
-    } catch {
-        return null;
-    }
-}
-
-export function saveGraphLayoutSnapshot(
-    layoutKey: string,
-    positions: Record<string, GraphNodePosition>,
-): void {
-    try {
-        safeStorageSetItem(
-            GRAPH_LAYOUT_CACHE_PREFIX + layoutKey,
-            JSON.stringify({
-                positions,
-                savedAt: Date.now(),
-            } satisfies GraphLayoutSnapshot),
-        );
-    } catch {
-        // Ignore storage quota and serialization failures.
-    }
-}
-
-export function buildGraphLayoutKey(parts: {
+interface GraphLayoutCacheKeyParts {
     vaultPath: string;
     graphVersion: number;
     graphMode: string;
@@ -60,8 +30,186 @@ export function buildGraphLayoutKey(parts: {
     showTagNodes: boolean;
     showAttachmentNodes: boolean;
     showOrphans: boolean;
-    searchFilter: string;
     layoutStrategy: string;
-}): string {
+}
+
+interface GraphPreparedSnapshotKeyParts extends GraphLayoutCacheKeyParts {
+    searchFilter: string;
+}
+
+interface ParsedGraphLayoutCacheKey extends GraphLayoutCacheKeyParts {
+    searchFilter?: string;
+}
+
+interface StoredGraphLayoutCacheEntry {
+    storageKey: string;
+    layoutKey: string;
+    snapshot: GraphLayoutSnapshot;
+    parts: ParsedGraphLayoutCacheKey;
+}
+
+let didPruneGraphLayoutCacheThisSession = false;
+
+function parseGraphLayoutSnapshot(
+    raw: string | null,
+): GraphLayoutSnapshot | null {
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as GraphLayoutSnapshot;
+    if (!parsed || typeof parsed !== "object") return null;
+    if (!parsed.positions || typeof parsed.positions !== "object") {
+        return null;
+    }
+    if (!Number.isFinite(parsed.savedAt)) {
+        return null;
+    }
+    return parsed;
+}
+
+function parseGraphLayoutCacheKey(
+    storageKey: string,
+): ParsedGraphLayoutCacheKey | null {
+    if (!storageKey.startsWith(GRAPH_LAYOUT_CACHE_PREFIX)) {
+        return null;
+    }
+    try {
+        const parsed = JSON.parse(
+            storageKey.slice(GRAPH_LAYOUT_CACHE_PREFIX.length),
+        ) as ParsedGraphLayoutCacheKey;
+        if (!parsed || typeof parsed !== "object") return null;
+        if (
+            typeof parsed.vaultPath !== "string" ||
+            parsed.vaultPath.length === 0
+        ) {
+            return null;
+        }
+        return parsed;
+    } catch {
+        return null;
+    }
+}
+
+function removeGraphLayoutSnapshot(storageKey: string) {
+    safeStorageRemoveItem(storageKey);
+}
+
+function collectStoredGraphLayoutEntries(): StoredGraphLayoutCacheEntry[] {
+    const entries: StoredGraphLayoutCacheEntry[] = [];
+    for (const storageKey of safeStorageKeys()) {
+        if (!storageKey.startsWith(GRAPH_LAYOUT_CACHE_PREFIX)) continue;
+
+        const parts = parseGraphLayoutCacheKey(storageKey);
+        if (!parts) {
+            removeGraphLayoutSnapshot(storageKey);
+            continue;
+        }
+
+        try {
+            const snapshot = parseGraphLayoutSnapshot(
+                safeStorageGetItem(storageKey),
+            );
+            if (!snapshot) {
+                removeGraphLayoutSnapshot(storageKey);
+                continue;
+            }
+            entries.push({
+                storageKey,
+                layoutKey: storageKey.slice(GRAPH_LAYOUT_CACHE_PREFIX.length),
+                snapshot,
+                parts,
+            });
+        } catch {
+            removeGraphLayoutSnapshot(storageKey);
+        }
+    }
+    return entries;
+}
+
+function pruneGraphLayoutCache(force = false) {
+    if (!force && didPruneGraphLayoutCacheThisSession) {
+        return;
+    }
+    didPruneGraphLayoutCacheThisSession = true;
+
+    const now = Date.now();
+    const entriesByVault = new Map<string, StoredGraphLayoutCacheEntry[]>();
+
+    for (const entry of collectStoredGraphLayoutEntries()) {
+        const searchFilter = entry.parts.searchFilter?.trim() ?? "";
+        const isExpired =
+            now - entry.snapshot.savedAt > GRAPH_LAYOUT_CACHE_MAX_AGE_MS;
+
+        if (searchFilter.length > 0 || isExpired) {
+            removeGraphLayoutSnapshot(entry.storageKey);
+            continue;
+        }
+
+        const bucket = entriesByVault.get(entry.parts.vaultPath);
+        if (bucket) {
+            bucket.push(entry);
+        } else {
+            entriesByVault.set(entry.parts.vaultPath, [entry]);
+        }
+    }
+
+    for (const entries of entriesByVault.values()) {
+        entries.sort(
+            (left, right) => right.snapshot.savedAt - left.snapshot.savedAt,
+        );
+        for (const staleEntry of entries.slice(
+            GRAPH_LAYOUT_CACHE_MAX_ENTRIES_PER_VAULT,
+        )) {
+            removeGraphLayoutSnapshot(staleEntry.storageKey);
+        }
+    }
+}
+
+export function loadGraphLayoutSnapshot(
+    layoutKey: string,
+): GraphLayoutSnapshot | null {
+    pruneGraphLayoutCache();
+    try {
+        return parseGraphLayoutSnapshot(
+            safeStorageGetItem(GRAPH_LAYOUT_CACHE_PREFIX + layoutKey),
+        );
+    } catch {
+        return null;
+    }
+}
+
+export function saveGraphLayoutSnapshot(
+    layoutKey: string,
+    positions: Record<string, GraphNodePosition>,
+): void {
+    pruneGraphLayoutCache();
+    try {
+        const storageKey = GRAPH_LAYOUT_CACHE_PREFIX + layoutKey;
+        const existing = parseGraphLayoutSnapshot(
+            safeStorageGetItem(storageKey),
+        );
+        safeStorageSetItem(
+            storageKey,
+            JSON.stringify({
+                positions: {
+                    ...(existing?.positions ?? {}),
+                    ...positions,
+                },
+                savedAt: Date.now(),
+            } satisfies GraphLayoutSnapshot),
+        );
+        pruneGraphLayoutCache(true);
+    } catch {
+        // Ignore storage quota and serialization failures.
+    }
+}
+
+export function buildGraphLayoutCacheKey(
+    parts: GraphLayoutCacheKeyParts,
+): string {
+    return JSON.stringify(parts);
+}
+
+export function buildGraphPreparedSnapshotKey(
+    parts: GraphPreparedSnapshotKeyParts,
+): string {
     return JSON.stringify(parts);
 }

--- a/apps/desktop/src/features/graph/graphPipeline.ts
+++ b/apps/desktop/src/features/graph/graphPipeline.ts
@@ -6,14 +6,10 @@ import {
 import { prepareGraphLayoutWithCachedPositions } from "./graphLayout";
 import type { GraphNodePosition } from "./graphLayoutCache";
 import type { GraphLayoutStrategy } from "./graphSettingsStore";
-import type {
-    GraphData,
-    GraphNodeDto,
-    GraphSnapshotDto,
-} from "./useGraphData";
+import type { GraphData, GraphNodeDto, GraphSnapshotDto } from "./useGraphData";
 
 export interface GraphPreparedPipeline {
-    layoutKey: string;
+    preparedKey: string;
     snapshot: GraphRenderSnapshot;
     restoredFromCache: boolean;
     neighborIndex: Record<string, string[]>;
@@ -21,7 +17,7 @@ export interface GraphPreparedPipeline {
 
 export interface GraphPipelineWorkerRequest {
     requestId: number;
-    layoutKey: string;
+    preparedKey: string;
     snapshot: GraphSnapshotDto;
     layoutStrategy: GraphLayoutStrategy;
     cachedPositions: Record<string, GraphNodePosition> | null;
@@ -79,7 +75,7 @@ export function runGraphPipeline(
     }
 
     return {
-        layoutKey: request.layoutKey,
+        preparedKey: request.preparedKey,
         snapshot: preparedLayout.snapshot,
         restoredFromCache: preparedLayout.restoredFromCache,
         neighborIndex,

--- a/apps/desktop/src/features/graph/usePreparedGraphSnapshot.ts
+++ b/apps/desktop/src/features/graph/usePreparedGraphSnapshot.ts
@@ -14,7 +14,8 @@ import type { GraphSnapshotDto } from "./useGraphData";
 
 interface UsePreparedGraphSnapshotOptions {
     graphSnapshot: GraphSnapshotDto | null;
-    layoutKey: string | null;
+    preparedSnapshotKey: string | null;
+    layoutCacheKey: string | null;
     layoutStrategy: GraphLayoutStrategy;
     isVisible: boolean;
 }
@@ -27,7 +28,8 @@ interface UsePreparedGraphSnapshotResult {
 
 export function usePreparedGraphSnapshot({
     graphSnapshot,
-    layoutKey,
+    preparedSnapshotKey,
+    layoutCacheKey,
     layoutStrategy,
     isVisible,
 }: UsePreparedGraphSnapshotOptions): UsePreparedGraphSnapshotResult {
@@ -40,23 +42,23 @@ export function usePreparedGraphSnapshot({
             {
                 startMs: number;
                 snapshot: GraphSnapshotDto;
-                layoutKey: string;
+                preparedKey: string;
                 restoredFromCache: boolean;
             }
         >
     >(new Map());
-    const [prepared, setPrepared] = useState<GraphPreparedPipeline | null>(
-        null,
-    );
+    const [prepared, setPrepared] = useState<
+        (GraphPreparedPipeline & { sourceSnapshot: GraphSnapshotDto }) | null
+    >(null);
     const [isPreparing, setIsPreparing] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
     const cachedPositions = useMemo(
         () =>
-            layoutKey
-                ? (loadGraphLayoutSnapshot(layoutKey)?.positions ?? null)
+            layoutCacheKey
+                ? (loadGraphLayoutSnapshot(layoutCacheKey)?.positions ?? null)
                 : null,
-        [layoutKey],
+        [layoutCacheKey],
     );
 
     useEffect(() => {
@@ -113,7 +115,14 @@ export function usePreparedGraphSnapshot({
 
             setError(null);
             startTransition(() => {
-                setPrepared(response.result ?? null);
+                setPrepared(
+                    response.result
+                        ? {
+                              ...response.result,
+                              sourceSnapshot: meta.snapshot,
+                          }
+                        : null,
+                );
             });
         };
 
@@ -135,9 +144,14 @@ export function usePreparedGraphSnapshot({
     }, []);
 
     useEffect(() => {
-        if (!graphSnapshot || !layoutKey) return;
+        if (!graphSnapshot || !preparedSnapshotKey) return;
         if (!isVisible) return;
-        if (prepared?.layoutKey === layoutKey) return;
+        if (
+            prepared?.preparedKey === preparedSnapshotKey &&
+            prepared.sourceSnapshot === graphSnapshot
+        ) {
+            return;
+        }
 
         const worker = workerRef.current;
         if (!worker) return;
@@ -148,7 +162,7 @@ export function usePreparedGraphSnapshot({
         requestMetaRef.current.set(requestId, {
             startMs: performance.now(),
             snapshot: graphSnapshot,
-            layoutKey,
+            preparedKey: preparedSnapshotKey,
             restoredFromCache: cachedPositions != null,
         });
 
@@ -159,7 +173,7 @@ export function usePreparedGraphSnapshot({
 
         worker.postMessage({
             requestId,
-            layoutKey,
+            preparedKey: preparedSnapshotKey,
             snapshot: graphSnapshot,
             layoutStrategy,
             cachedPositions,
@@ -168,14 +182,22 @@ export function usePreparedGraphSnapshot({
         cachedPositions,
         graphSnapshot,
         isVisible,
-        layoutKey,
+        preparedSnapshotKey,
         layoutStrategy,
         prepared,
     ]);
 
+    const currentPrepared =
+        graphSnapshot &&
+        preparedSnapshotKey &&
+        prepared?.sourceSnapshot === graphSnapshot &&
+        prepared.preparedKey === preparedSnapshotKey
+            ? prepared
+            : null;
+
     return {
-        prepared: graphSnapshot && layoutKey ? prepared : null,
-        isPreparing: graphSnapshot && layoutKey ? isPreparing : false,
-        error: graphSnapshot && layoutKey ? error : null,
+        prepared: currentPrepared,
+        isPreparing: graphSnapshot && preparedSnapshotKey ? isPreparing : false,
+        error: graphSnapshot && preparedSnapshotKey ? error : null,
     };
 }

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { listen } from "@tauri-apps/api/event";
 import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -557,12 +557,89 @@ describe("SettingsPanel", () => {
             }),
         );
 
-        expect(mockInvoke()).toHaveBeenCalledWith(
+        await waitFor(() => {
+            expect(mockInvoke()).toHaveBeenCalledWith(
+                "download_and_install_app_update",
+                {
+                    version: "0.2.0",
+                    target: "darwin-aarch64",
+                },
+            );
+        });
+    });
+
+    it("revalidates sensitive state before starting install", async () => {
+        vi.mocked(getAllWebviewWindows).mockResolvedValue([
+            { label: "main" },
+        ] as Awaited<ReturnType<typeof getAllWebviewWindows>>);
+        mockInvoke().mockImplementation(async (command) => {
+            if (command === "get_app_update_configuration") {
+                return {
+                    enabled: true,
+                    currentVersion: "0.1.0",
+                    channel: "stable",
+                    endpoint: "https://updates.example.com/stable/latest.json",
+                    message: null,
+                    update: null,
+                };
+            }
+
+            if (command === "check_for_app_update") {
+                return {
+                    enabled: true,
+                    currentVersion: "0.1.0",
+                    channel: "stable",
+                    endpoint: "https://updates.example.com/stable/latest.json",
+                    message: null,
+                    update: {
+                        currentVersion: "0.1.0",
+                        version: "0.2.0",
+                        date: "2026-04-04T12:00:00Z",
+                        body: "## Added\n\n- In-app install flow.",
+                        rawJson: {},
+                        target: "darwin-aarch64",
+                        downloadUrl:
+                            "https://github.com/example/neverwrite/releases/download/v0.2.0/NeverWrite.app.tar.gz",
+                    },
+                };
+            }
+
+            if (command === "download_and_install_app_update") {
+                return undefined;
+            }
+
+            return undefined;
+        });
+
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Updates" }));
+
+        expect(await screen.findByText("0.2.0")).toBeInTheDocument();
+
+        localStorage.setItem(
+            "neverwrite:window-operational-state:main",
+            JSON.stringify({
+                label: "main",
+                windowMode: "main",
+                windowRole: "main",
+                windowTitle: "NeverWrite",
+                dirtyTabs: ["Draft note"],
+                pendingReviewSessions: [],
+                activeAgentSessions: [],
+            }),
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Download and install" }),
+        );
+
+        expect(
+            await screen.findByText("This update may interrupt active work."),
+        ).toBeInTheDocument();
+        expect(mockInvoke()).not.toHaveBeenCalledWith(
             "download_and_install_app_update",
-            {
-                version: "0.2.0",
-                target: "darwin-aarch64",
-            },
+            expect.anything(),
         );
     });
 });

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -42,8 +42,9 @@ import { getChatPillMetrics } from "../ai/components/chatPillMetrics";
 import { AIProvidersSettings } from "./AIProvidersSettings";
 import { useAppUpdateStore } from "../updates/store";
 import {
-    collectSensitiveUpdateState,
-    listLiveWindowOperationalStates,
+    isWindowOperationalStateStorageKey,
+    readSensitiveUpdateState,
+    readSettledSensitiveUpdateState,
     type SensitiveUpdateState,
 } from "../updates/sensitiveState";
 
@@ -1875,16 +1876,17 @@ function UpdatesSettings() {
         let cancelled = false;
 
         const refreshSensitiveState = async () => {
-            const next = collectSensitiveUpdateState(
-                await listLiveWindowOperationalStates(),
-            );
+            const next = await readSensitiveUpdateState();
             if (!cancelled) {
                 setSensitiveState(next);
             }
         };
 
         void refreshSensitiveState();
-        const unsubscribeStorage = subscribeSafeStorage(() => {
+        const unsubscribeStorage = subscribeSafeStorage(({ key }) => {
+            if (key !== null && !isWindowOperationalStateStorageKey(key)) {
+                return;
+            }
             void refreshSensitiveState();
         });
         const onFocus = () => {
@@ -2015,14 +2017,19 @@ function UpdatesSettings() {
                         type="button"
                         disabled={anyBusy}
                         onClick={() => {
-                            if (
-                                sensitiveState.requiresConfirmation &&
-                                !showConfirmInstall
-                            ) {
-                                setConfirmInstall(true);
-                                return;
-                            }
-                            void installAvailableUpdate().catch(() => {});
+                            void (async () => {
+                                const nextSensitiveState =
+                                    await readSettledSensitiveUpdateState();
+                                setSensitiveState(nextSensitiveState);
+                                if (
+                                    nextSensitiveState.requiresConfirmation &&
+                                    !showConfirmInstall
+                                ) {
+                                    setConfirmInstall(true);
+                                    return;
+                                }
+                                await installAvailableUpdate().catch(() => {});
+                            })();
                         }}
                         style={{
                             borderRadius: 6,
@@ -2105,7 +2112,14 @@ function UpdatesSettings() {
                             type="button"
                             disabled={installing}
                             onClick={() => {
-                                void installAvailableUpdate().catch(() => {});
+                                void (async () => {
+                                    const nextSensitiveState =
+                                        await readSensitiveUpdateState();
+                                    setSensitiveState(nextSensitiveState);
+                                    await installAvailableUpdate().catch(
+                                        () => {},
+                                    );
+                                })();
                             }}
                             style={{
                                 borderRadius: 6,

--- a/apps/desktop/src/features/updates/sensitiveState.test.ts
+++ b/apps/desktop/src/features/updates/sensitiveState.test.ts
@@ -1,0 +1,97 @@
+import { getAllWebviewWindows } from "@tauri-apps/api/webviewWindow";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { subscribeSafeStorage } from "../../app/utils/safeStorage";
+import {
+    readSensitiveUpdateState,
+    writeWindowOperationalState,
+} from "./sensitiveState";
+
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+    getAllWebviewWindows: vi.fn(),
+}));
+
+afterEach(() => {
+    localStorage.clear();
+    vi.mocked(getAllWebviewWindows).mockReset();
+});
+
+describe("sensitiveState", () => {
+    it("does not rebroadcast identical operational state snapshots", () => {
+        const events: Array<{ key: string | null; newValue: string | null }> =
+            [];
+        const unsubscribe = subscribeSafeStorage((event) => {
+            events.push(event);
+        });
+
+        const state = {
+            label: "main",
+            windowMode: "main" as const,
+            windowRole: "main" as const,
+            windowTitle: "NeverWrite",
+            dirtyTabs: ["Draft"],
+            pendingReviewSessions: ["Review"],
+            activeAgentSessions: ["Agent · Streaming response"],
+        };
+
+        expect(writeWindowOperationalState("main", state)).toBe(true);
+        expect(writeWindowOperationalState("main", state)).toBe(false);
+
+        unsubscribe();
+
+        expect(
+            events.filter(
+                (event) =>
+                    event.key === "neverwrite:window-operational-state:main",
+            ),
+        ).toHaveLength(1);
+    });
+
+    it("reads the current sensitive update state from live windows", async () => {
+        vi.mocked(getAllWebviewWindows).mockResolvedValue([
+            { label: "main" },
+            { label: "note-1" },
+        ] as Awaited<ReturnType<typeof getAllWebviewWindows>>);
+
+        writeWindowOperationalState("main", {
+            label: "main",
+            windowMode: "main",
+            windowRole: "main",
+            windowTitle: "NeverWrite",
+            dirtyTabs: ["Draft note"],
+            pendingReviewSessions: ["Inline review"],
+            activeAgentSessions: [],
+        });
+        writeWindowOperationalState("note-1", {
+            label: "note-1",
+            windowMode: "note",
+            windowRole: "detached-note",
+            windowTitle: "Detached note",
+            dirtyTabs: [],
+            pendingReviewSessions: [],
+            activeAgentSessions: [],
+        });
+
+        await expect(readSensitiveUpdateState()).resolves.toEqual({
+            requiresConfirmation: true,
+            items: [
+                {
+                    key: "dirty-tabs",
+                    title: "Unsaved editor tabs",
+                    details: ["NeverWrite: Draft note"],
+                },
+                {
+                    key: "pending-review",
+                    title: "Pending inline review or agent changes",
+                    details: ["Inline review"],
+                },
+                {
+                    key: "separate-windows",
+                    title: "Separate operational windows are open",
+                    details: [
+                        "Detached note is open in a detached note window.",
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/apps/desktop/src/features/updates/sensitiveState.ts
+++ b/apps/desktop/src/features/updates/sensitiveState.ts
@@ -14,6 +14,8 @@ import {
 import type { AIChatSession } from "../ai/types";
 
 const WINDOW_OPERATIONAL_STATE_PREFIX = "neverwrite:window-operational-state:";
+export const WINDOW_OPERATIONAL_STATE_PUBLISH_DEBOUNCE_MS = 200;
+const WINDOW_OPERATIONAL_STATE_SETTLE_BUFFER_MS = 25;
 
 export interface WindowOperationalState {
     label: string;
@@ -38,6 +40,13 @@ export interface SensitiveUpdateState {
 
 function getOperationalStateKey(label: string) {
     return `${WINDOW_OPERATIONAL_STATE_PREFIX}${label}`;
+}
+
+export function isWindowOperationalStateStorageKey(key: string | null) {
+    return (
+        typeof key === "string" &&
+        key.startsWith(WINDOW_OPERATIONAL_STATE_PREFIX)
+    );
 }
 
 function resolveWindowRole(
@@ -136,11 +145,21 @@ export function writeWindowOperationalState(
 ) {
     const key = getOperationalStateKey(label);
     if (!state) {
+        if (safeStorageGetItem(key) === null) {
+            return false;
+        }
         safeStorageRemoveItem(key);
-        return;
+        return true;
     }
 
-    safeStorageSetItem(key, JSON.stringify(state));
+    // Avoid rewriting and rebroadcasting identical operational snapshots.
+    const serializedState = JSON.stringify(state);
+    if (safeStorageGetItem(key) === serializedState) {
+        return false;
+    }
+
+    safeStorageSetItem(key, serializedState);
+    return true;
 }
 
 export function readWindowOperationalState(label: string) {
@@ -175,6 +194,29 @@ export async function listLiveWindowOperationalStates() {
     return windows
         .map((window) => readWindowOperationalState(window.label))
         .filter((state): state is WindowOperationalState => state !== null);
+}
+
+export async function readSensitiveUpdateState() {
+    return collectSensitiveUpdateState(await listLiveWindowOperationalStates());
+}
+
+function waitForOperationalStateSettle(ms: number) {
+    return new Promise<void>((resolve) => {
+        window.setTimeout(resolve, ms);
+    });
+}
+
+export async function readSettledSensitiveUpdateState() {
+    const next = await readSensitiveUpdateState();
+    if (next.requiresConfirmation) {
+        return next;
+    }
+
+    await waitForOperationalStateSettle(
+        WINDOW_OPERATIONAL_STATE_PUBLISH_DEBOUNCE_MS +
+            WINDOW_OPERATIONAL_STATE_SETTLE_BUFFER_MS,
+    );
+    return readSensitiveUpdateState();
 }
 
 export function collectSensitiveUpdateState(


### PR DESCRIPTION
## What changed
- switched persisted history handling to a lighter cache path
- fixed graph layout cache growth and reduced operational state churn
- aligned the deferred auth terminal test with the updated behavior
- added focused regression coverage around chat store, graph layout cache, settings, and sensitive update state

## Why
These changes harden a few related state-management paths that were causing cache growth, excess churn, and a deferred type mismatch in the auth terminal flow.

## Impact
Desktop app state is more stable under repeated graph and history activity, with stronger regression coverage around the touched flows.

## Validation
- User confirmed the branch is already tested locally