### PR TITLE
Add context usage indicator to AI chat composer

### DIFF
--- a/apps/desktop/src-tauri/src/ai/claude/client.rs
+++ b/apps/desktop/src-tauri/src/ai/claude/client.rs
@@ -36,10 +36,11 @@ use crate::ai::emit::{
     emit_available_commands_updated, emit_message_completed, emit_message_delta,
     emit_message_started, emit_permission_request, emit_plan_update, emit_runtime_connection,
     emit_session_error, emit_session_updated, emit_status_event, emit_thinking_completed,
-    emit_thinking_delta, emit_thinking_started, emit_tool_activity, AiAvailableCommandPayload,
-    AiAvailableCommandsPayload, AiFileDiffHunkPayload, AiFileDiffPayload,
-    AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload, AiPlanUpdatePayload,
-    AiRuntimeConnectionPayload, AiStatusEventPayload, AiToolActivityPayload,
+    emit_thinking_delta, emit_thinking_started, emit_token_usage, emit_tool_activity,
+    AiAvailableCommandPayload, AiAvailableCommandsPayload, AiFileDiffHunkPayload,
+    AiFileDiffPayload, AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload,
+    AiPlanUpdatePayload, AiRuntimeConnectionPayload, AiStatusEventPayload, AiTokenUsageCostPayload,
+    AiTokenUsagePayload, AiToolActivityPayload,
 };
 use crate::ai::env::preferred_path_value;
 use crate::branding::APP_BRAND_NAME;
@@ -975,6 +976,9 @@ impl Client for VaultAiAcpClient {
             }
             SessionUpdate::Plan(plan) => {
                 emit_plan_update(&self.app, map_plan_update(&session_id, plan));
+            }
+            SessionUpdate::UsageUpdate(update) => {
+                emit_token_usage(&self.app, map_usage_update(&session_id, update));
             }
             SessionUpdate::AvailableCommandsUpdate(update) => {
                 emit_available_commands_updated(
@@ -2409,6 +2413,21 @@ fn map_available_commands_update(
                 }
             })
             .collect(),
+    }
+}
+
+fn map_usage_update(
+    session_id: &str,
+    update: agent_client_protocol::UsageUpdate,
+) -> AiTokenUsagePayload {
+    AiTokenUsagePayload {
+        session_id: session_id.to_string(),
+        used: update.used,
+        size: update.size,
+        cost: update.cost.map(|cost| AiTokenUsageCostPayload {
+            amount: cost.amount,
+            currency: cost.currency,
+        }),
     }
 }
 

--- a/apps/desktop/src-tauri/src/ai/codex/client.rs
+++ b/apps/desktop/src-tauri/src/ai/codex/client.rs
@@ -35,11 +35,12 @@ use tokio::sync::mpsc as tokio_mpsc;
 use crate::ai::emit::{
     emit_message_completed, emit_message_delta, emit_message_started, emit_permission_request,
     emit_plan_update, emit_runtime_connection, emit_session_error, emit_status_event,
-    emit_thinking_completed, emit_thinking_delta, emit_thinking_started, emit_tool_activity,
-    emit_user_input_request, AiFileDiffHunkPayload, AiFileDiffPayload, AiPermissionOptionPayload,
-    AiPermissionRequestPayload, AiPlanEntryPayload, AiPlanUpdatePayload,
-    AiRuntimeConnectionPayload, AiStatusEventPayload, AiToolActivityPayload,
-    AiUserInputQuestionOptionPayload, AiUserInputQuestionPayload, AiUserInputRequestPayload,
+    emit_thinking_completed, emit_thinking_delta, emit_thinking_started, emit_token_usage,
+    emit_tool_activity, emit_user_input_request, AiFileDiffHunkPayload, AiFileDiffPayload,
+    AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload, AiPlanUpdatePayload,
+    AiRuntimeConnectionPayload, AiStatusEventPayload, AiTokenUsageCostPayload, AiTokenUsagePayload,
+    AiToolActivityPayload, AiUserInputQuestionOptionPayload, AiUserInputQuestionPayload,
+    AiUserInputRequestPayload,
 };
 use crate::ai::env::preferred_path_value;
 use crate::branding::APP_BRAND_NAME;
@@ -933,6 +934,9 @@ impl Client for VaultAiAcpClient {
             }
             SessionUpdate::Plan(plan) => {
                 emit_plan_update(&self.app, map_plan_update(&session_id, plan));
+            }
+            SessionUpdate::UsageUpdate(update) => {
+                emit_token_usage(&self.app, map_usage_update(&session_id, update));
             }
             _ => {}
         }
@@ -2117,6 +2121,21 @@ fn map_plan_update(session_id: &str, plan: agent_client_protocol::Plan) -> AiPla
                 },
             })
             .collect(),
+    }
+}
+
+fn map_usage_update(
+    session_id: &str,
+    update: agent_client_protocol::UsageUpdate,
+) -> AiTokenUsagePayload {
+    AiTokenUsagePayload {
+        session_id: session_id.to_string(),
+        used: update.used,
+        size: update.size,
+        cost: update.cost.map(|cost| AiTokenUsageCostPayload {
+            amount: cost.amount,
+            currency: cost.currency,
+        }),
     }
 }
 

--- a/apps/desktop/src-tauri/src/ai/emit.rs
+++ b/apps/desktop/src-tauri/src/ai/emit.rs
@@ -18,6 +18,7 @@ pub const AI_USER_INPUT_REQUEST_EVENT: &str = "ai://user-input-request";
 pub const AI_PLAN_UPDATED_EVENT: &str = "ai://plan-updated";
 pub const AI_AVAILABLE_COMMANDS_UPDATED_EVENT: &str = "ai://available-commands-updated";
 pub const AI_RUNTIME_CONNECTION_EVENT: &str = "ai://runtime-connection";
+pub const AI_TOKEN_USAGE_EVENT: &str = "ai://token-usage";
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AiSessionErrorPayload {
@@ -30,6 +31,21 @@ pub struct AiRuntimeConnectionPayload {
     pub runtime_id: String,
     pub status: String,
     pub message: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiTokenUsageCostPayload {
+    pub amount: f64,
+    pub currency: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct AiTokenUsagePayload {
+    pub session_id: String,
+    pub used: u64,
+    pub size: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cost: Option<AiTokenUsageCostPayload>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -268,4 +284,8 @@ pub fn emit_available_commands_updated(app: &AppHandle, payload: AiAvailableComm
 
 pub fn emit_runtime_connection(app: &AppHandle, payload: AiRuntimeConnectionPayload) {
     let _ = app.emit(AI_RUNTIME_CONNECTION_EVENT, payload);
+}
+
+pub fn emit_token_usage(app: &AppHandle, payload: AiTokenUsagePayload) {
+    let _ = app.emit(AI_TOKEN_USAGE_EVENT, payload);
 }

--- a/apps/desktop/src-tauri/src/ai/gemini/client.rs
+++ b/apps/desktop/src-tauri/src/ai/gemini/client.rs
@@ -36,11 +36,12 @@ use crate::ai::emit::{
     emit_available_commands_updated, emit_message_completed, emit_message_delta,
     emit_message_started, emit_permission_request, emit_plan_update, emit_runtime_connection,
     emit_session_error, emit_status_event, emit_thinking_completed, emit_thinking_delta,
-    emit_thinking_started, emit_tool_activity, AiAvailableCommandPayload,
+    emit_thinking_started, emit_token_usage, emit_tool_activity, AiAvailableCommandPayload,
     AiAvailableCommandsPayload, AiFileDiffHunkPayload, AiFileDiffPayload,
     AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload, AiPlanUpdatePayload,
-    AiRuntimeConnectionPayload, AiStatusEventPayload, AiToolActivityPayload,
-    AiUserInputQuestionOptionPayload, AiUserInputQuestionPayload, AiUserInputRequestPayload,
+    AiRuntimeConnectionPayload, AiStatusEventPayload, AiTokenUsageCostPayload, AiTokenUsagePayload,
+    AiToolActivityPayload, AiUserInputQuestionOptionPayload, AiUserInputQuestionPayload,
+    AiUserInputRequestPayload,
 };
 use crate::ai::env::preferred_path_value;
 use crate::branding::APP_BRAND_NAME;
@@ -932,6 +933,9 @@ impl Client for VaultAiAcpClient {
             }
             SessionUpdate::Plan(plan) => {
                 emit_plan_update(&self.app, map_plan_update(&session_id, plan));
+            }
+            SessionUpdate::UsageUpdate(update) => {
+                emit_token_usage(&self.app, map_usage_update(&session_id, update));
             }
             SessionUpdate::AvailableCommandsUpdate(update) => {
                 emit_available_commands_updated(
@@ -2205,6 +2209,21 @@ fn map_available_commands_update(
                 }
             })
             .collect(),
+    }
+}
+
+fn map_usage_update(
+    session_id: &str,
+    update: agent_client_protocol::UsageUpdate,
+) -> AiTokenUsagePayload {
+    AiTokenUsagePayload {
+        session_id: session_id.to_string(),
+        used: update.used,
+        size: update.size,
+        cost: update.cost.map(|cost| AiTokenUsageCostPayload {
+            amount: cost.amount,
+            currency: cost.currency,
+        }),
     }
 }
 

--- a/apps/desktop/src-tauri/src/ai/kilo/client.rs
+++ b/apps/desktop/src-tauri/src/ai/kilo/client.rs
@@ -36,10 +36,11 @@ use crate::ai::emit::{
     emit_available_commands_updated, emit_message_completed, emit_message_delta,
     emit_message_started, emit_permission_request, emit_plan_update, emit_runtime_connection,
     emit_session_error, emit_session_updated, emit_status_event, emit_thinking_completed,
-    emit_thinking_delta, emit_thinking_started, emit_tool_activity, AiAvailableCommandPayload,
-    AiAvailableCommandsPayload, AiFileDiffHunkPayload, AiFileDiffPayload,
-    AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload, AiPlanUpdatePayload,
-    AiRuntimeConnectionPayload, AiStatusEventPayload, AiToolActivityPayload,
+    emit_thinking_delta, emit_thinking_started, emit_token_usage, emit_tool_activity,
+    AiAvailableCommandPayload, AiAvailableCommandsPayload, AiFileDiffHunkPayload,
+    AiFileDiffPayload, AiPermissionOptionPayload, AiPermissionRequestPayload, AiPlanEntryPayload,
+    AiPlanUpdatePayload, AiRuntimeConnectionPayload, AiStatusEventPayload, AiTokenUsageCostPayload,
+    AiTokenUsagePayload, AiToolActivityPayload,
 };
 use crate::ai::env::preferred_path_value;
 use crate::branding::APP_BRAND_NAME;
@@ -1019,6 +1020,9 @@ impl Client for VaultAiAcpClient {
             }
             SessionUpdate::Plan(plan) => {
                 emit_plan_update(&self.app, map_plan_update(&session_id, plan));
+            }
+            SessionUpdate::UsageUpdate(update) => {
+                emit_token_usage(&self.app, map_usage_update(&session_id, update));
             }
             SessionUpdate::AvailableCommandsUpdate(update) => {
                 emit_available_commands_updated(
@@ -2524,6 +2528,21 @@ fn map_available_commands_update(
                 }
             })
             .collect(),
+    }
+}
+
+fn map_usage_update(
+    session_id: &str,
+    update: agent_client_protocol::UsageUpdate,
+) -> AiTokenUsagePayload {
+    AiTokenUsagePayload {
+        session_id: session_id.to_string(),
+        used: update.used,
+        size: update.size,
+        cost: update.cost.map(|cost| AiTokenUsageCostPayload {
+            amount: cost.amount,
+            currency: cost.currency,
+        }),
     }
 }
 

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -19,6 +19,7 @@ import type {
     AIPermissionRequestPayload,
     AIPlanUpdatePayload,
     AIStatusEventPayload,
+    AITokenUsagePayload,
     AIToolActivityPayload,
     AIUserInputRequestPayload,
     AIRuntimeDescriptor,
@@ -51,6 +52,7 @@ export const AI_PLAN_UPDATED_EVENT = "ai://plan-updated";
 export const AI_AVAILABLE_COMMANDS_UPDATED_EVENT =
     "ai://available-commands-updated";
 export const AI_RUNTIME_CONNECTION_EVENT = "ai://runtime-connection";
+export const AI_TOKEN_USAGE_EVENT = "ai://token-usage";
 export const AI_AUTH_TERMINAL_STARTED_EVENT = "ai://auth-terminal-started";
 export const AI_AUTH_TERMINAL_OUTPUT_EVENT = "ai://auth-terminal-output";
 export const AI_AUTH_TERMINAL_EXITED_EVENT = "ai://auth-terminal-exited";
@@ -831,6 +833,14 @@ export async function listenToAiRuntimeConnection(
             callback(event.payload);
         },
     );
+}
+
+export async function listenToAiTokenUsage(
+    callback: (payload: AITokenUsagePayload) => void,
+): Promise<UnlistenFn> {
+    return listen<AITokenUsagePayload>(AI_TOKEN_USAGE_EVENT, (event) => {
+        callback(event.payload);
+    });
 }
 
 export async function listenToAiAuthTerminalStarted(

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -74,6 +74,10 @@ interface AIChatComposerProps {
     expanded?: boolean;
     contextBar?: ReactNode;
     footer?: ReactNode;
+    // Accent overlay rendered along the inner bottom edge of the composer
+    // shell (e.g. the context-usage progress strip). Absolutely positioned,
+    // should not capture pointer events.
+    bottomAccent?: ReactNode;
     onChange: (parts: AIComposerPart[]) => void;
     onMentionAttach: (note: AIChatNoteSummary) => void;
     onFileMentionAttach?: (file: AIChatFileSummary) => void;
@@ -937,6 +941,7 @@ export function AIChatComposer({
     expanded = false,
     contextBar,
     footer,
+    bottomAccent,
     onChange,
     onMentionAttach,
     onFileMentionAttach,
@@ -2318,6 +2323,7 @@ export function AIChatComposer({
                         ]}
                     />
                 )}
+                {bottomAccent}
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/AIChatContextUsageBar.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatContextUsageBar.test.tsx
@@ -1,0 +1,59 @@
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { renderComponent } from "../../../test/test-utils";
+import { AIChatContextUsageBar } from "./AIChatContextUsageBar";
+
+describe("AIChatContextUsageBar", () => {
+    it("renders a progressbar with accessible usage details", () => {
+        renderComponent(
+            <AIChatContextUsageBar
+                usage={{
+                    session_id: "session-1",
+                    used: 170_000,
+                    size: 200_000,
+                    cost: {
+                        amount: 0.0421,
+                        currency: "USD",
+                    },
+                    updatedAt: Date.now(),
+                }}
+            />,
+        );
+
+        const bar = screen.getByRole("progressbar", {
+            name: /Context window 85% used/i,
+        });
+        expect(bar).toHaveAttribute("aria-valuenow", "85");
+        expect(bar).toHaveAttribute("aria-valuemin", "0");
+        expect(bar).toHaveAttribute("aria-valuemax", "100");
+        expect(bar).toHaveAttribute(
+            "title",
+            expect.stringContaining("170k / 200k tokens"),
+        );
+        expect(bar).toHaveAttribute(
+            "title",
+            expect.stringContaining("Estimated cost:"),
+        );
+    });
+
+    it("stays hidden when there is no valid usage payload", () => {
+        const { container, rerender } = renderComponent(
+            <AIChatContextUsageBar usage={null} />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+
+        rerender(
+            <AIChatContextUsageBar
+                usage={{
+                    session_id: "session-1",
+                    used: 0,
+                    size: 0,
+                    updatedAt: Date.now(),
+                }}
+            />,
+        );
+
+        expect(container).toBeEmptyDOMElement();
+    });
+});

--- a/apps/desktop/src/features/ai/components/AIChatContextUsageBar.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatContextUsageBar.tsx
@@ -1,0 +1,120 @@
+import type { AITokenUsage } from "../types";
+
+const WARNING_THRESHOLD = 0.85;
+const EXCEEDED_THRESHOLD = 1;
+const BAR_HEIGHT = 2;
+
+interface AIChatContextUsageBarProps {
+    usage?: AITokenUsage | null;
+    // Inner corner radius of the composer shell (outer radius minus its 1px
+    // border) so the bar follows the rounded bottom edge cleanly.
+    cornerRadius?: number;
+}
+
+function clamp(value: number, min: number, max: number) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function formatCompactTokenCount(value: number) {
+    if (value >= 1_000_000) {
+        return `${(value / 1_000_000).toFixed(value >= 10_000_000 ? 0 : 1).replace(/\.0$/, "")}M`;
+    }
+
+    if (value >= 1_000) {
+        return `${(value / 1_000).toFixed(value >= 100_000 ? 0 : 1).replace(/\.0$/, "")}k`;
+    }
+
+    return value.toString();
+}
+
+function formatPercent(value: number) {
+    return `${Math.round(value * 100)}%`;
+}
+
+function formatCost(amount: number, currency: string) {
+    const upperCurrency = currency.toUpperCase();
+
+    try {
+        return new Intl.NumberFormat("en-US", {
+            style: "currency",
+            currency: upperCurrency,
+            maximumFractionDigits: 4,
+        }).format(amount);
+    } catch {
+        return `${upperCurrency} ${amount.toFixed(4)}`;
+    }
+}
+
+// Tones match the palette used across the chat surface: theme accent by
+// default, `#d97706` (chatPillPalette file) on warning and `#dc2626`
+// (AIChatRuntimeBanner error) when the window is exceeded.
+function getTone(ratio: number) {
+    if (ratio >= EXCEEDED_THRESHOLD) return "#dc2626";
+    if (ratio >= WARNING_THRESHOLD) return "#d97706";
+    return "var(--accent)";
+}
+
+export function AIChatContextUsageBar({
+    usage,
+    cornerRadius = 11,
+}: AIChatContextUsageBarProps) {
+    if (!usage || usage.size <= 0) {
+        return null;
+    }
+
+    const rawRatio = usage.used / usage.size;
+    const ratio = clamp(rawRatio, 0, 1);
+    const percent = formatPercent(rawRatio);
+    const usedTokens = formatCompactTokenCount(usage.used);
+    const sizeTokens = formatCompactTokenCount(usage.size);
+    const titleLines = [
+        `Context window: ${percent} used`,
+        `${usedTokens} / ${sizeTokens} tokens`,
+    ];
+    const ariaParts = [
+        `Context window ${percent} used.`,
+        `${usedTokens} of ${sizeTokens} tokens.`,
+    ];
+
+    if (usage.cost) {
+        const formattedCost = formatCost(usage.cost.amount, usage.cost.currency);
+        titleLines.push(`Estimated cost: ${formattedCost}`);
+        ariaParts.push(`Estimated cost ${formattedCost}.`);
+    }
+
+    const tone = getTone(rawRatio);
+    const shouldGlow = rawRatio >= WARNING_THRESHOLD;
+
+    return (
+        <div
+            role="progressbar"
+            aria-label={ariaParts.join(" ")}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={Math.round(rawRatio * 100)}
+            title={titleLines.join("\n")}
+            className="pointer-events-none absolute left-0 right-0"
+            style={{
+                bottom: 0,
+                height: BAR_HEIGHT,
+                borderBottomLeftRadius: cornerRadius,
+                borderBottomRightRadius: cornerRadius,
+                overflow: "hidden",
+                zIndex: 1,
+            }}
+        >
+            <div
+                style={{
+                    width: `${ratio * 100}%`,
+                    height: "100%",
+                    backgroundColor: tone,
+                    boxShadow: shouldGlow
+                        ? `0 0 8px ${tone}, 0 0 2px ${tone}`
+                        : "none",
+                    transition:
+                        "width 220ms ease, background-color 160ms ease, box-shadow 160ms ease",
+                }}
+            />
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -31,6 +31,7 @@ import { AIChatMessageList } from "./AIChatMessageList";
 import { AIChatComposer } from "./AIChatComposer";
 import { AIChatContextBar } from "./AIChatContextBar";
 import { AIChatAgentControls } from "./AIChatAgentControls";
+import { AIChatContextUsageBar } from "./AIChatContextUsageBar";
 import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
 import { QueuedMessagesPanel } from "./QueuedMessagesPanel";
 import { AIChatRuntimeBanner } from "./AIChatRuntimeBanner";
@@ -73,6 +74,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         queuedMessages,
         queuedMessageEdit,
         interruptedTurnState,
+        tokenUsage,
     } = useChatStore(
         useShallow((state) => {
             const s = sessionId
@@ -94,6 +96,9 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     : null,
                 interruptedTurnState: sid
                     ? (state.interruptedTurnStateBySessionId[sid] ?? null)
+                    : null,
+                tokenUsage: sid
+                    ? (state.tokenUsageBySessionId[sid] ?? null)
                     : null,
             };
         }),
@@ -513,30 +518,41 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                             onClearAll={handleClearAttachments}
                         />
                     }
-                    footer={
-                        <AIChatAgentControls
-                            disabled={agentControlsDisabled}
-                            runtimeId={session?.runtimeId}
-                            modelId={session?.modelId ?? ""}
-                            modeId={session?.modeId ?? ""}
-                            effortsByModel={session?.effortsByModel ?? {}}
-                            models={agentCatalog.models}
-                            modes={agentCatalog.modes}
-                            configOptions={agentCatalog.configOptions}
-                            onModelChange={(modelId) => {
-                                void chatActions.setModel(modelId, sessionId);
-                            }}
-                            onModeChange={(modeId) => {
-                                void chatActions.setMode(modeId, sessionId);
-                            }}
-                            onConfigOptionChange={(optionId, value) => {
-                                void chatActions.setConfigOption(
-                                    optionId,
-                                    value,
-                                    sessionId,
-                                );
-                            }}
+                    bottomAccent={
+                        <AIChatContextUsageBar
+                            usage={tokenUsage}
+                            cornerRadius={composerExpanded ? 9 : 11}
                         />
+                    }
+                    footer={
+                        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                            <AIChatAgentControls
+                                disabled={agentControlsDisabled}
+                                runtimeId={session?.runtimeId}
+                                modelId={session?.modelId ?? ""}
+                                modeId={session?.modeId ?? ""}
+                                effortsByModel={session?.effortsByModel ?? {}}
+                                models={agentCatalog.models}
+                                modes={agentCatalog.modes}
+                                configOptions={agentCatalog.configOptions}
+                                onModelChange={(modelId) => {
+                                    void chatActions.setModel(
+                                        modelId,
+                                        sessionId,
+                                    );
+                                }}
+                                onModeChange={(modeId) => {
+                                    void chatActions.setMode(modeId, sessionId);
+                                }}
+                                onConfigOptionChange={(optionId, value) => {
+                                    void chatActions.setConfigOption(
+                                        optionId,
+                                        value,
+                                        sessionId,
+                                    );
+                                }}
+                            />
+                        </div>
                     }
                     onChange={(parts) => {
                         chatActions.setComposerParts(parts, sessionId);

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -8181,6 +8181,51 @@ describe("chatStore", () => {
         });
     });
 
+    it("tracks token usage outside the transcript and clears it when the model changes", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+
+        useChatStore.getState().applyTokenUsage({
+            session_id: activeSessionId,
+            used: 170_000,
+            size: 200_000,
+            cost: {
+                amount: 0.0421,
+                currency: "USD",
+            },
+        });
+
+        expect(
+            useChatStore.getState().tokenUsageBySessionId[activeSessionId],
+        ).toMatchObject({
+            session_id: activeSessionId,
+            used: 170_000,
+            size: 200_000,
+            cost: {
+                amount: 0.0421,
+                currency: "USD",
+            },
+        });
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById[activeSessionId]?.messages.filter(
+                    (message) => message.kind === "status",
+                ),
+        ).toHaveLength(0);
+
+        useChatStore.getState().upsertSession({
+            ...session,
+            modelId: "wide-model",
+        });
+
+        expect(
+            useChatStore.getState().tokenUsageBySessionId[activeSessionId],
+        ).toBeUndefined();
+    });
+
     it("upserts plan updates into a single live plan message", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -114,6 +114,8 @@ import {
     type AIPermissionRequestPayload,
     type AIPlanUpdatePayload,
     type AIStatusEventPayload,
+    type AITokenUsage,
+    type AITokenUsagePayload,
     type AIToolActivityPayload,
     type AIUserInputRequestPayload,
     type AIRuntimeConnectionPayload,
@@ -787,6 +789,19 @@ function getConfigOptionValue(
         ?.value;
 }
 
+function removeSessionMapEntry<T>(
+    map: Record<string, T>,
+    sessionId: string,
+): Record<string, T> {
+    if (!(sessionId in map)) {
+        return map;
+    }
+
+    const next = { ...map };
+    delete next[sessionId];
+    return next;
+}
+
 function supportsModelSelection(
     session: Pick<AIChatSession, "models" | "configOptions">,
     modelId: string,
@@ -977,12 +992,20 @@ async function applyAgentConfigMutation({
                         runtime.runtime.id === currentSession.runtimeId,
                 ),
             );
+            const nextSession = applyLocal(hydratedSession);
 
             return {
                 sessionsById: {
                     ...state.sessionsById,
-                    [session.sessionId]: applyLocal(hydratedSession),
+                    [session.sessionId]: nextSession,
                 },
+                tokenUsageBySessionId:
+                    currentSession.modelId !== nextSession.modelId
+                        ? removeSessionMapEntry(
+                              state.tokenUsageBySessionId,
+                              session.sessionId,
+                          )
+                        : state.tokenUsageBySessionId,
             };
         });
         persistPreference();
@@ -1081,6 +1104,7 @@ interface ChatStore {
     activeQueuedMessageBySessionId: Record<string, DeferredQueuedMessage>;
     pausedQueueBySessionId: Record<string, PausedQueueState>;
     interruptedTurnStateBySessionId: Record<string, InterruptedTurnState>;
+    tokenUsageBySessionId: Record<string, AITokenUsage>;
     initialize: (
         options?: { createDefaultSession?: boolean },
     ) => Promise<ChatInitializationResult>;
@@ -1130,6 +1154,7 @@ interface ChatStore {
     upsertSession: (session: AIChatSession, activate?: boolean) => void;
     applySessionError: (payload: AISessionErrorPayload) => void;
     applyRuntimeConnection: (payload: AIRuntimeConnectionPayload) => void;
+    applyTokenUsage: (payload: AITokenUsagePayload) => void;
     applyMessageStarted: (payload: {
         session_id: string;
         message_id: string;
@@ -5757,6 +5782,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         activeQueuedMessageBySessionId: {},
         pausedQueueBySessionId: {},
         interruptedTurnStateBySessionId: {},
+        tokenUsageBySessionId: {},
 
         syncAutoContextForVault: (vaultPath) => {
             const next = loadAutoContextPreference(vaultPath);
@@ -6402,6 +6428,13 @@ export const useChatStore = create<ChatStore>((set, get) => {
                           scopedSession,
                       ]);
                 const nextSession = mergeSession(existing, scopedSession);
+                const nextTokenUsageBySessionId =
+                    existing && existing.modelId !== nextSession.modelId
+                        ? removeSessionMapEntry(
+                              state.tokenUsageBySessionId,
+                              scopedSession.sessionId,
+                          )
+                        : state.tokenUsageBySessionId;
                 const reconciledQueueState =
                     existing &&
                     nextSession.status === "idle" &&
@@ -6446,6 +6479,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                               [scopedSession.sessionId]:
                                   createEmptyComposerParts(),
                           },
+                    tokenUsageBySessionId: nextTokenUsageBySessionId,
                     ...(reconciledQueueState ?? {}),
                 };
             });
@@ -6576,6 +6610,27 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     void persistSession(session);
                 }
             }
+        },
+
+        applyTokenUsage: ({ session_id, used, size, cost }) => {
+            set((state) => {
+                if (!state.sessionsById[session_id]) {
+                    return state;
+                }
+
+                return {
+                    tokenUsageBySessionId: {
+                        ...state.tokenUsageBySessionId,
+                        [session_id]: {
+                            session_id,
+                            used,
+                            size,
+                            cost: cost ?? null,
+                            updatedAt: Date.now(),
+                        },
+                    },
+                };
+            });
         },
 
         applySessionError: ({ session_id, message }) => {
@@ -9269,6 +9324,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 ...state.queuedMessageEditBySessionId,
             };
             delete nextQueuedMessageEditBySessionId[sessionId];
+            const nextTokenUsageBySessionId = removeSessionMapEntry(
+                state.tokenUsageBySessionId,
+                sessionId,
+            );
             const nextActiveQueuedMessageBySessionId =
                 cleanupDeferredQueuedMessagesBySessionId(
                     state.activeQueuedMessageBySessionId,
@@ -9312,6 +9371,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     [],
                 ),
                 queuedMessageEditBySessionId: nextQueuedMessageEditBySessionId,
+                tokenUsageBySessionId: nextTokenUsageBySessionId,
                 activeQueuedMessageBySessionId:
                     nextActiveQueuedMessageBySessionId,
                 pausedQueueBySessionId: nextPausedQueueBySessionId,
@@ -9368,6 +9428,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 activeQueuedMessageBySessionId: {},
                 pausedQueueBySessionId: {},
                 interruptedTurnStateBySessionId: {},
+                tokenUsageBySessionId: {},
             });
             await get().newSession();
         },
@@ -9937,6 +9998,7 @@ export function resetChatStore() {
         activeQueuedMessageBySessionId: {},
         pausedQueueBySessionId: {},
         interruptedTurnStateBySessionId: {},
+        tokenUsageBySessionId: {},
     });
 }
 

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -24,6 +24,22 @@ export interface AIRuntimeConnectionPayload extends AIRuntimeConnectionState {
     runtime_id: string;
 }
 
+export interface AITokenUsageCost {
+    amount: number;
+    currency: string;
+}
+
+export interface AITokenUsagePayload {
+    session_id: string;
+    used: number;
+    size: number;
+    cost?: AITokenUsageCost | null;
+}
+
+export interface AITokenUsage extends AITokenUsagePayload {
+    updatedAt: number;
+}
+
 export type AISecretPatch =
     | { action: "unchanged" }
     | { action: "clear" }

--- a/apps/desktop/src/features/ai/useAiChatEventBridge.ts
+++ b/apps/desktop/src/features/ai/useAiChatEventBridge.ts
@@ -14,6 +14,7 @@ import {
     listenToAiThinkingCompleted,
     listenToAiThinkingDelta,
     listenToAiThinkingStarted,
+    listenToAiTokenUsage,
     listenToAiToolActivity,
     listenToAiUserInputRequest,
 } from "./api";
@@ -88,6 +89,9 @@ export function useAiChatEventBridge(enabled = true) {
                 }),
                 listenToAiRuntimeConnection((payload) => {
                     if (!disposed) chatActions.applyRuntimeConnection(payload);
+                }),
+                listenToAiTokenUsage((payload) => {
+                    if (!disposed) chatActions.applyTokenUsage(payload);
                 }),
             ]);
 


### PR DESCRIPTION
## Summary
- surface ACP context usage as a thin progress strip pinned to the bottom edge of the AI composer
- forward context usage updates from Claude, Codex, Gemini, and Kilo through the backend bridge into chat store state
- add focused coverage for the new composer bar and the usage plumbing

## Validation
- `npm test -- AIChatContextUsageBar.test.tsx chatStore.test.ts`
- `AIChatContextUsageBar.test.tsx` passes
- `chatStore.test.ts` still has 8 pre-existing failures on both this branch and `origin/main`
