### PR TITLE
fix(dx): Fix desktop test/build regressions and dev runner stdin handling

### DIFF
--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -29,7 +29,7 @@ jobs:
     macos-universal:
         name: macOS Universal
         runs-on: macos-latest
-        timeout-minutes: 45
+        timeout-minutes: 120
 
         steps:
             - name: Checkout repository
@@ -54,9 +54,11 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
-            - name: Build target-specific Codex sidecar
+            - name: Build target-specific sidecars
               shell: bash
               run: |
+                  cargo build -p neverwrite-native-backend --quiet --release --target aarch64-apple-darwin
+                  cargo build -p neverwrite-native-backend --quiet --release --target x86_64-apple-darwin
                   cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin
                   cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin
 
@@ -77,9 +79,11 @@ jobs:
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN_X64=$DEST/node-v${NODE_VERSION}-darwin-x64/bin/node" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
 
-            - name: Export Codex sidecar environment
+            - name: Export sidecar environment
               shell: bash
               run: |
+                  echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/target/aarch64-apple-darwin/release/neverwrite-native-backend" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/target/x86_64-apple-darwin/release/neverwrite-native-backend" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
 
@@ -135,7 +139,7 @@ jobs:
     windows-x64:
         name: Windows x64
         runs-on: windows-latest
-        timeout-minutes: 45
+        timeout-minutes: 120
 
         steps:
             - name: Checkout repository
@@ -160,9 +164,11 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
-            - name: Build target-specific Codex sidecar
+            - name: Build target-specific sidecars
               shell: bash
-              run: cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-pc-windows-msvc
+              run: |
+                  cargo build -p neverwrite-native-backend --quiet --release --target x86_64-pc-windows-msvc
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-pc-windows-msvc
 
             - name: Download embedded Node runtime
               shell: bash
@@ -176,10 +182,12 @@ jobs:
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN=$DEST/${DIST}/node.exe" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
 
-            - name: Export Codex sidecar environment
+            - name: Export sidecar environment
               shell: bash
               run: |
+                  NATIVE_BACKEND_BIN="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release/neverwrite-native-backend.exe"
                   CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-pc-windows-msvc/release/codex-acp.exe"
+                  echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN=$NATIVE_BACKEND_BIN" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
 
             - name: Package unsigned Electron app

--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -54,6 +54,12 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
+            - name: Build target-specific Codex sidecar
+              shell: bash
+              run: |
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin
+
             - name: Download embedded Node runtimes
               shell: bash
               run: |
@@ -70,6 +76,12 @@ jobs:
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN_ARM64=$DEST/node-v${NODE_VERSION}-darwin-arm64/bin/node" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN_X64=$DEST/node-v${NODE_VERSION}-darwin-x64/bin/node" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
+
+            - name: Export Codex sidecar environment
+              shell: bash
+              run: |
+                  echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
 
             - name: Package unsigned Electron app
               working-directory: apps/desktop
@@ -148,6 +160,10 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
+            - name: Build target-specific Codex sidecar
+              shell: bash
+              run: cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-pc-windows-msvc
+
             - name: Download embedded Node runtime
               shell: bash
               run: |
@@ -159,6 +175,12 @@ jobs:
                   powershell -NoProfile -Command "Expand-Archive -Path (Join-Path \$env:RUNNER_TEMP 'node.zip') -DestinationPath (Join-Path \$env:RUNNER_TEMP 'node-dist') -Force"
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN=$DEST/${DIST}/node.exe" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
+
+            - name: Export Codex sidecar environment
+              shell: bash
+              run: |
+                  CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-pc-windows-msvc/release/codex-acp.exe"
+                  echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
 
             - name: Package unsigned Electron app
               working-directory: apps/desktop

--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -156,7 +156,7 @@ jobs:
                   DEST="$RUNNER_TEMP/node-dist"
                   mkdir -p "$DEST"
                   curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/${DIST}.zip" -o "$RUNNER_TEMP/node.zip"
-                  powershell -NoProfile -Command "Expand-Archive -Path '$env:RUNNER_TEMP/node.zip' -DestinationPath '$env:RUNNER_TEMP/node-dist'"
+                  powershell -NoProfile -Command "Expand-Archive -Path (Join-Path \$env:RUNNER_TEMP 'node.zip') -DestinationPath (Join-Path \$env:RUNNER_TEMP 'node-dist') -Force"
                   echo "NEVERWRITE_EMBEDDED_NODE_BIN=$DEST/${DIST}/node.exe" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
 

--- a/apps/desktop/scripts/common.mjs
+++ b/apps/desktop/scripts/common.mjs
@@ -1,0 +1,3 @@
+export const isWindows = process.platform === "win32";
+export const isMac = process.platform === "darwin";
+export const isLinux = process.platform === "linux";

--- a/apps/desktop/scripts/graceful-shutdown.mjs
+++ b/apps/desktop/scripts/graceful-shutdown.mjs
@@ -1,0 +1,62 @@
+import os from "node:os";
+
+import { isWindows } from "./common.mjs";
+
+/**
+ * Amount of time to wait after SIGTERM escalation to SIGKILL. 
+ * A child-process that is still alive after this window is force-killed regardless of its state.
+ */
+export const FORCE_KILL_TIMEOUT_MS = 1500;
+
+/**
+ * Last-resort deadline for process.exit(). 
+ * Must be strictly greater than `FORCE_KILL_TIMEOUT_MS` so the SIGKILL path has time to run first.
+ */
+export const FORCED_EXIT_TIMEOUT_MS = FORCE_KILL_TIMEOUT_MS + 500;
+
+/**
+ * Send SIGTERM to a child process and schedule a SIGKILL escalation after
+ * `FORCE_KILL_TIMEOUT_MS` if the child has not exited on its own.
+ *
+ * @param {import("node:child_process").ChildProcess | null} child
+ * @param {{ pidOnly?: boolean }} [options]
+ *   pidOnly – when true only the exact PID is signalled; when false the
+ *              entire process group is signalled (non-Windows only).
+ */
+export function terminateChild(child, { pidOnly = false } = {}) {
+    if (!child || child.exitCode !== null || child.signalCode !== null) {
+        return;
+    }
+    const pid = child.pid;
+    if (typeof pid !== "number") {
+        return;
+    }
+
+    const groupPid =
+        !isWindows && child.__neverwriteDetached === true ? -pid : pid;
+
+    try {
+        process.kill(pidOnly ? pid : groupPid, "SIGTERM");
+    } catch {}
+
+    setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+            try {
+                process.kill(pidOnly ? pid : groupPid, "SIGKILL");
+            } catch {}
+        }
+    }, FORCE_KILL_TIMEOUT_MS).unref();
+}
+
+/**
+ * Get the exit code corresponding to a given signal.
+ * @param {"SIGTERM"|"SIGINT"} signal 
+ * @returns {number}
+ */
+export function signalExitCode(signal) {
+    if (isWindows) {
+        return 1;
+    }
+    const num = os.constants.signals[signal];
+    return typeof num === "number" ? 128 + num : 1;
+}

--- a/apps/desktop/scripts/graceful-shutdown.mjs
+++ b/apps/desktop/scripts/graceful-shutdown.mjs
@@ -3,13 +3,13 @@ import os from "node:os";
 import { isWindows } from "./common.mjs";
 
 /**
- * Amount of time to wait after SIGTERM escalation to SIGKILL. 
+ * Amount of time to wait after SIGTERM escalation to SIGKILL.
  * A child-process that is still alive after this window is force-killed regardless of its state.
  */
 export const FORCE_KILL_TIMEOUT_MS = 1500;
 
 /**
- * Last-resort deadline for process.exit(). 
+ * Last-resort deadline for process.exit().
  * Must be strictly greater than `FORCE_KILL_TIMEOUT_MS` so the SIGKILL path has time to run first.
  */
 export const FORCED_EXIT_TIMEOUT_MS = FORCE_KILL_TIMEOUT_MS + 500;
@@ -50,7 +50,7 @@ export function terminateChild(child, { pidOnly = false } = {}) {
 
 /**
  * Get the exit code corresponding to a given signal.
- * @param {"SIGTERM"|"SIGINT"} signal 
+ * @param {"SIGTERM"|"SIGINT"} signal
  * @returns {number}
  */
 export function signalExitCode(signal) {

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -69,7 +69,10 @@ await runOnce(
 const vite = run(
     "npx",
     ["vite", "--config", "electron.vite.config.ts", "--host", "127.0.0.1"],
-    { env: { NEVERWRITE_ELECTRON_TARGET: "renderer" } },
+    {
+        env: { NEVERWRITE_ELECTRON_TARGET: "renderer" },
+        stdio: ["ignore", "inherit", "inherit"],
+    },
 );
 
 await waitForRenderer();
@@ -83,6 +86,7 @@ const electron = run(electronBin, ["."], {
     env: {
         ELECTRON_RENDERER_URL: rendererUrl,
     },
+    stdio: ["ignore", "inherit", "inherit"],
 });
 
 function shutdown() {

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -1,18 +1,15 @@
 import { spawn } from "node:child_process";
 import http from "node:http";
-import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-const isWindows = process.platform === "win32";
-const isMac = process.platform === "darwin";
-const isLinux = process.platform === "linux";
+import { isWindows } from "./common.mjs";
+import {
+    signalExitCode,
+    terminateChild,
+    FORCED_EXIT_TIMEOUT_MS,
+} from "./graceful-shutdown.mjs";
 
-function signalExitCode(signal) {
-    if (isWindows) return 1;
-    const num = os.constants.signals[signal];
-    return typeof num === "number" ? 128 + num : 1;
-}
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const rendererUrl = "http://127.0.0.1:5174";
@@ -20,7 +17,6 @@ const rendererUrl = "http://127.0.0.1:5174";
 let vite = null;
 let electron = null;
 let shuttingDown = false;
-let forcedExitTimer = null;
 
 function run(command, args, options = {}) {
     const child = spawn(command, args, {
@@ -34,39 +30,19 @@ function run(command, args, options = {}) {
     return child;
 }
 
-function terminateChild(child, { graceful = false } = {}) {
-    if (!child) return;
-    if (child.exitCode != null || child.signalCode != null) return;
+function shutdown(exitCode = 0) {
+    if (shuttingDown) {
+        return;
+    }
 
-    const pid = child.pid;
-    if (typeof pid !== "number") return;
-
-    const groupPid =
-        !isWindows && child.__neverwriteDetached === true ? -pid : pid;
-
-    try {
-        process.kill(graceful ? pid : groupPid, "SIGTERM");
-    } catch {}
+    shuttingDown = true;
+    process.exitCode = exitCode;
+    terminateChild(electron, { pidOnly: true });
+    terminateChild(vite, { pidOnly: false });
 
     setTimeout(() => {
-        if (child.exitCode == null && child.signalCode == null) {
-            try {
-                process.kill(groupPid, "SIGKILL");
-            } catch {}
-        }
-    }, 1500).unref();
-}
-
-function shutdown(exitCode = 0) {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    terminateChild(electron, { graceful: true });
-    terminateChild(vite, { graceful: false });
-
-    forcedExitTimer = setTimeout(() => {
         process.exit(exitCode);
-    }, 50);
-    forcedExitTimer.unref();
+    }, FORCED_EXIT_TIMEOUT_MS).unref();
 }
 
 function runOnce(command, args, env = {}) {
@@ -106,8 +82,8 @@ function waitForRenderer() {
 process.on("SIGINT", () => shutdown(signalExitCode("SIGINT")));
 process.on("SIGTERM", () => shutdown(signalExitCode("SIGTERM")));
 process.once("exit", () => {
-    terminateChild(electron, { graceful: true });
-    terminateChild(vite, { graceful: false });
+    terminateChild(electron, { pidOnly: true });
+    terminateChild(vite, { pidOnly: false });
 });
 process.on("uncaughtException", (error) => {
     console.error(error);

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -1,19 +1,72 @@
 import { spawn } from "node:child_process";
 import http from "node:http";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+const isWindows = process.platform === "win32";
+const isMac = process.platform === "darwin";
+const isLinux = process.platform === "linux";
+
+function signalExitCode(signal) {
+    if (isWindows) return 1;
+    const num = os.constants.signals[signal];
+    return typeof num === "number" ? 128 + num : 1;
+}
+
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
 const rendererUrl = "http://127.0.0.1:5174";
+
+let vite = null;
+let electron = null;
+let shuttingDown = false;
+let forcedExitTimer = null;
 
 function run(command, args, options = {}) {
     const child = spawn(command, args, {
         cwd: rootDir,
         env: { ...process.env, ...(options.env ?? {}) },
         stdio: options.stdio ?? "inherit",
-        shell: process.platform === "win32",
+        detached: !isWindows && options.detached === true,
+        shell: isWindows,
     });
+    child.__neverwriteDetached = options.detached === true;
     return child;
+}
+
+function terminateChild(child, { graceful = false } = {}) {
+    if (!child) return;
+    if (child.exitCode != null || child.signalCode != null) return;
+
+    const pid = child.pid;
+    if (typeof pid !== "number") return;
+
+    const groupPid =
+        !isWindows && child.__neverwriteDetached === true ? -pid : pid;
+
+    try {
+        process.kill(graceful ? pid : groupPid, "SIGTERM");
+    } catch {}
+
+    setTimeout(() => {
+        if (child.exitCode == null && child.signalCode == null) {
+            try {
+                process.kill(groupPid, "SIGKILL");
+            } catch {}
+        }
+    }, 1500).unref();
+}
+
+function shutdown(exitCode = 0) {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    terminateChild(electron, { graceful: true });
+    terminateChild(vite, { graceful: false });
+
+    forcedExitTimer = setTimeout(() => {
+        process.exit(exitCode);
+    }, 50);
+    forcedExitTimer.unref();
 }
 
 function runOnce(command, args, env = {}) {
@@ -47,57 +100,78 @@ function waitForRenderer() {
             });
             request.setTimeout(1000, () => request.destroy());
         }, 250);
+        timer.unref();
     });
 }
+process.on("SIGINT", () => shutdown(signalExitCode("SIGINT")));
+process.on("SIGTERM", () => shutdown(signalExitCode("SIGTERM")));
+process.once("exit", () => {
+    terminateChild(electron, { graceful: true });
+    terminateChild(vite, { graceful: false });
+});
+process.on("uncaughtException", (error) => {
+    console.error(error);
+    shutdown(1);
+});
+process.on("unhandledRejection", (error) => {
+    console.error(error);
+    shutdown(1);
+});
 
-await runOnce(
-    "cargo",
-    ["build", "-p", "neverwrite-native-backend"],
-);
+async function main() {
+    await runOnce(
+        "cargo",
+        ["build", "-p", "neverwrite-native-backend"],
+    );
 
-await runOnce(
-    "npx",
-    ["vite", "build", "--config", "electron.vite.config.ts"],
-    { NEVERWRITE_ELECTRON_TARGET: "main" },
-);
-await runOnce(
-    "npx",
-    ["vite", "build", "--config", "electron.vite.config.ts"],
-    { NEVERWRITE_ELECTRON_TARGET: "preload" },
-);
+    await runOnce(
+        "npx",
+        ["vite", "build", "--config", "electron.vite.config.ts"],
+        { NEVERWRITE_ELECTRON_TARGET: "main" },
+    );
+    await runOnce(
+        "npx",
+        ["vite", "build", "--config", "electron.vite.config.ts"],
+        { NEVERWRITE_ELECTRON_TARGET: "preload" },
+    );
 
-const vite = run(
-    "npx",
-    ["vite", "--config", "electron.vite.config.ts", "--host", "127.0.0.1"],
-    {
-        env: { NEVERWRITE_ELECTRON_TARGET: "renderer" },
-        stdio: ["ignore", "inherit", "inherit"],
-    },
-);
+    vite = run(
+        "npx",
+        ["vite", "--config", "electron.vite.config.ts", "--host", "127.0.0.1"],
+        {
+            detached: true,
+            env: { NEVERWRITE_ELECTRON_TARGET: "renderer" },
+            stdio: ["ignore", "inherit", "inherit"],
+        },
+    );
 
-await waitForRenderer();
+    vite.on("exit", (code) => {
+        if (shuttingDown) return;
+        shutdown(code ?? 1);
+    });
+    vite.on("error", () => shutdown(1));
 
-const electronBin =
-    process.platform === "win32"
+    await waitForRenderer();
+
+    const electronBin = isWindows
         ? path.join(rootDir, "node_modules", ".bin", "electron.cmd")
         : path.join(rootDir, "node_modules", ".bin", "electron");
 
-const electron = run(electronBin, ["."], {
-    env: {
-        ELECTRON_RENDERER_URL: rendererUrl,
-    },
-    stdio: ["ignore", "inherit", "inherit"],
-});
+    electron = run(electronBin, ["."], {
+        detached: true,
+        env: {
+            ELECTRON_RENDERER_URL: rendererUrl,
+        },
+        stdio: ["ignore", "inherit", "inherit"],
+    });
 
-function shutdown() {
-    vite.kill();
-    electron.kill();
+    electron.on("error", () => shutdown(1));
+    electron.on("exit", (code) => {
+        shutdown(code ?? 0);
+    });
 }
 
-process.on("SIGINT", shutdown);
-process.on("SIGTERM", shutdown);
-
-electron.on("exit", (code) => {
-    vite.kill();
-    process.exit(code ?? 0);
+void main().catch((error) => {
+    console.error(error);
+    shutdown(1);
 });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -5,6 +5,7 @@ import { listen } from "@neverwrite/runtime";
 import { getCurrentWebview } from "@neverwrite/runtime";
 import { open } from "@neverwrite/runtime";
 import { invoke } from "@neverwrite/runtime";
+import { confirm } from "@neverwrite/runtime";
 import { resolveDeferredUnlisten } from "./app/utils/deferredUnlisten";
 import { vaultInvoke } from "./app/utils/vaultInvoke";
 import { AppLayout } from "./components/layout/AppLayout";
@@ -18,6 +19,10 @@ import { WorkspaceTerminalHost } from "./features/terminal/WorkspaceTerminalHost
 import { migrateLegacyTerminalTabsToWorkspace } from "./features/terminal/legacyTerminalMigration";
 import { UnifiedBar } from "./features/editor/UnifiedBar";
 import { REQUEST_CLOSE_ACTIVE_TAB_EVENT } from "./features/editor/Editor";
+import {
+    findActiveSessionsAffectedByClose,
+    getCloseTabsConfirmationMessage,
+} from "./features/editor/tabClosePolicy";
 import { EditorPaneContent } from "./features/editor/EditorPaneContent";
 import { MultiPaneWorkspace } from "./features/editor/MultiPaneWorkspace";
 import { EditorChromeBar } from "./features/editor/EditorChromeBar";
@@ -728,7 +733,24 @@ function useRegisterCommands(
                     return;
                 }
 
-                state.closeTab(activeTab.id);
+                const affected = findActiveSessionsAffectedByClose(
+                    [activeTab],
+                    useChatStore.getState().sessionsById,
+                );
+                const confirmationMessage =
+                    getCloseTabsConfirmationMessage(affected);
+                if (confirmationMessage === null) {
+                    state.closeTab(activeTab.id, { reason: "user" });
+                    return;
+                }
+
+                void (async () => {
+                    if (await confirm(confirmationMessage)) {
+                        useEditorStore
+                            .getState()
+                            .closeTab(activeTab.id, { reason: "user" });
+                    }
+                })();
             },
         });
 

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -1,6 +1,7 @@
 import { act, screen, waitFor } from "@testing-library/react";
 import {
     getCurrentWindow,
+    confirm,
     invoke,
     listen,
     type UnlistenFn,
@@ -21,7 +22,7 @@ import {
 } from "./features/ai/store/chatTabsStore";
 import { useChatStore } from "./features/ai/store/chatStore";
 import { useClipImportStore } from "./features/clip/clipImportStore";
-import { flushPromises, renderComponent } from "./test/test-utils";
+import { flushPromises, renderComponent, setEditorTabs } from "./test/test-utils";
 
 const MENU_ACTION_EVENT = "menu-action";
 const DOCK_OPEN_VAULT_EVENT = "dock-open-vault";
@@ -417,6 +418,72 @@ describe("App web clipper routing", () => {
         });
 
         expect(useCommandStore.getState().activeModal).toBe("command-palette");
+    });
+
+    it("confirms before the global close-tab command closes an active agent tab", async () => {
+        vi.mocked(confirm).mockResolvedValue(false);
+        renderComponent(<App />);
+        await flushPromises();
+        await waitFor(() => {
+            expect(
+                useCommandStore.getState().commands.has("editor:close-tab"),
+            ).toBe(true);
+        });
+        setEditorTabs(
+            [
+                {
+                    id: "tab-chat",
+                    kind: "ai-chat",
+                    sessionId: "session-busy",
+                    title: "Busy chat",
+                },
+                {
+                    id: "tab-note",
+                    kind: "note",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                },
+            ],
+            "tab-chat",
+        );
+        useChatStore.setState({
+            sessionsById: {
+                "session-busy": {
+                    sessionId: "session-busy",
+                    historySessionId: "session-busy",
+                    status: "streaming",
+                    runtimeId: "codex-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                },
+            },
+            activeSessionId: "session-busy",
+        });
+        expect(
+            useCommandStore
+                .getState()
+                .commands.get("editor:close-tab")
+                ?.when?.(),
+        ).toBe(true);
+
+        act(() => {
+            useCommandStore.getState().execute("editor:close-tab");
+        });
+        await flushPromises();
+
+        expect(confirm).toHaveBeenCalledWith(
+            "The AI agent is still running. Are you sure you want to close this tab?",
+        );
+        expect(useEditorStore.getState().tabs.map((tab) => tab.id)).toEqual([
+            "tab-chat",
+            "tab-note",
+        ]);
     });
 
     it("creates a markdown note from the native New Note command", async () => {

--- a/apps/desktop/src/app/detachedWindows.test.ts
+++ b/apps/desktop/src/app/detachedWindows.test.ts
@@ -29,7 +29,7 @@ function createChatSession(overrides: Partial<AIChatSession> = {}): AIChatSessio
             {
                 id: "msg-1",
                 role: "user",
-                kind: "message",
+                kind: "text",
                 content: "keep this",
                 timestamp: 1,
             },

--- a/apps/desktop/src/app/detachedWindows.ts
+++ b/apps/desktop/src/app/detachedWindows.ts
@@ -101,7 +101,7 @@ export interface DetachedWindowPayload {
 }
 
 export interface AttachExternalTabPayload {
-    tab: Tab;
+    tab: TabInput;
     aiSessions?: AIChatSession[];
 }
 
@@ -428,7 +428,7 @@ export async function commitDetachedTabDrop({
     await openDetachedNoteWindow(
         createDetachedWindowPayload(transferTab, vaultPath),
         {
-            title: transferTab.title,
+            title: transferTab.title ?? undefined,
             position: getDetachedWindowPosition(screenX, screenY),
         },
     );

--- a/apps/desktop/src/features/ai/agentSessionActivity.test.ts
+++ b/apps/desktop/src/features/ai/agentSessionActivity.test.ts
@@ -1,5 +1,60 @@
 import { describe, expect, it } from "vitest";
-import { resolveAgentSessionActivity } from "./agentSessionActivity";
+import {
+    isAgentSessionActive,
+    resolveAgentSessionActivity,
+} from "./agentSessionActivity";
+
+describe("isAgentSessionActive", () => {
+    it("returns true for active live sessions", () => {
+        expect(
+            isAgentSessionActive({ runtimeState: "live", status: "streaming" }),
+        ).toBe(true);
+
+        expect(
+            isAgentSessionActive({
+                runtimeState: "live",
+                status: "waiting_permission",
+            }),
+        ).toBe(true);
+
+        expect(
+            isAgentSessionActive({
+                runtimeState: "live",
+                status: "waiting_user_input",
+            }),
+        ).toBe(true);
+    });
+
+    it("returns true when runtimeState is missing", () => {
+        expect(
+            isAgentSessionActive({ runtimeState: undefined, status: "streaming" }),
+        ).toBe(true);
+    });
+
+    it("returns false for idle or error live sessions", () => {
+        expect(
+            isAgentSessionActive({ runtimeState: "live", status: "idle" }),
+        ).toBe(false);
+
+        expect(
+            isAgentSessionActive({ runtimeState: "live", status: "error" }),
+        ).toBe(false);
+    });
+
+    it("returns false when runtime is not live", () => {
+        expect(
+            isAgentSessionActive({
+                runtimeState: "persisted_only",
+                status: "streaming",
+            }),
+        ).toBe(false);
+    });
+
+    it("returns false for null or undefined session", () => {
+        expect(isAgentSessionActive(null)).toBe(false);
+        expect(isAgentSessionActive(undefined)).toBe(false);
+    });
+});
 
 describe("resolveAgentSessionActivity", () => {
     it("returns a working indicator for active live sessions", () => {

--- a/apps/desktop/src/features/ai/agentSessionActivity.ts
+++ b/apps/desktop/src/features/ai/agentSessionActivity.ts
@@ -15,6 +15,27 @@ const WORKING_ACTIVITY_INDICATOR: AgentSessionActivityIndicator = {
     tone: "working",
 };
 
+export function isAgentSessionActive(
+    session:
+        | Pick<AIChatSession, "runtimeState" | "status">
+        | null
+        | undefined,
+): boolean {
+    if (!session) {
+        return false;
+    }
+
+    if (session.runtimeState != null && session.runtimeState !== "live") {
+        return false;
+    }
+
+    return (
+        session.status === "streaming" ||
+        session.status === "waiting_permission" ||
+        session.status === "waiting_user_input"
+    );
+}
+
 export function resolveAgentSessionActivity(
     session:
         | Pick<AIChatSession, "runtimeState" | "status">

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -11,10 +11,8 @@ import {
     setVaultNotes,
 } from "../../../test/test-utils";
 import type { AIAvailableCommand, AIComposerPart } from "../types";
-import {
-    AIChatComposer,
-    getComposerPillLayoutStyle,
-} from "./AIChatComposer";
+import { AIChatComposer } from "./AIChatComposer";
+import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { getChatPillMetrics } from "./chatPillMetrics";
 
 afterEach(() => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -25,6 +25,7 @@ import {
 } from "./AIChatCommandPicker";
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
+import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";
 import type {
     AIAvailableCommand,
@@ -35,7 +36,6 @@ import type {
     AIMentionSuggestion,
 } from "../types";
 import type {
-    CSSProperties,
     MouseEvent as ReactMouseEvent,
     ReactNode,
 } from "react";
@@ -51,16 +51,6 @@ import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
 
 const MIN_COMPOSER_HEIGHT = 64;
 const MAX_COMPOSER_HEIGHT = 480;
-
-type ComposerPillLayoutStyle = Pick<
-    CSSProperties,
-    | "maxWidth"
-    | "overflow"
-    | "overflowWrap"
-    | "textOverflow"
-    | "whiteSpace"
-    | "wordBreak"
->;
 
 interface AIChatComposerProps {
     parts: AIComposerPart[];
@@ -203,31 +193,6 @@ function getFallbackSlashCommands(runtimeId?: string) {
     }
 
     return COMMON_SLASH_COMMANDS;
-}
-
-export function getComposerPillLayoutStyle(
-    metrics: ChatPillMetrics,
-    options: { compact?: boolean } = {},
-): ComposerPillLayoutStyle {
-    if (options.compact === true) {
-        return {
-            maxWidth: `${metrics.maxWidth}px`,
-            overflow: "hidden",
-            overflowWrap: "normal",
-            textOverflow: "ellipsis",
-            whiteSpace: "nowrap",
-            wordBreak: "normal",
-        };
-    }
-
-    return {
-        maxWidth: "100%",
-        overflow: "visible",
-        overflowWrap: "anywhere",
-        textOverflow: "clip",
-        whiteSpace: "normal",
-        wordBreak: "break-word",
-    };
 }
 
 function applyComposerPillStyles(

--- a/apps/desktop/src/features/ai/components/chatPillLayout.ts
+++ b/apps/desktop/src/features/ai/components/chatPillLayout.ts
@@ -1,0 +1,37 @@
+import type { CSSProperties } from "react";
+import type { ChatPillMetrics } from "./chatPillMetrics";
+
+type ComposerPillLayoutStyle = Pick<
+    CSSProperties,
+    | "maxWidth"
+    | "overflow"
+    | "overflowWrap"
+    | "textOverflow"
+    | "whiteSpace"
+    | "wordBreak"
+>;
+
+export function getComposerPillLayoutStyle(
+    metrics: ChatPillMetrics,
+    options: { compact?: boolean } = {},
+): ComposerPillLayoutStyle {
+    if (options.compact === true) {
+        return {
+            maxWidth: `${metrics.maxWidth}px`,
+            overflow: "hidden",
+            overflowWrap: "normal",
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+            wordBreak: "normal",
+        };
+    }
+
+    return {
+        maxWidth: "100%",
+        overflow: "visible",
+        overflowWrap: "anywhere",
+        textOverflow: "clip",
+        whiteSpace: "normal",
+        wordBreak: "break-word",
+    };
+}

--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -99,6 +99,9 @@ function seedTrackedDiff(
 describe("Editor", () => {
     it("renders app-owned spellcheck decorations for misspelled words", async () => {
         vi.useFakeTimers();
+        useSettingsStore
+            .getState()
+            .setSetting("editorSpellcheck", true);
         mockInvoke().mockImplementation(async (command) => {
             if (command === "spellcheck_check_text") {
                 return {
@@ -133,6 +136,9 @@ describe("Editor", () => {
 
     it("does not underline words that are valid only in the secondary language", async () => {
         vi.useFakeTimers();
+        useSettingsStore
+            .getState()
+            .setSetting("editorSpellcheck", true);
         mockInvoke().mockImplementation(async (command) => {
             if (command === "spellcheck_check_text") {
                 return {

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -41,7 +41,6 @@ import {
     selectEditorWorkspaceTabs,
     useEditorStore,
     isNoteTab,
-    isChatTab,
     selectFocusedPaneId,
     selectEditorPaneState,
     type Tab,
@@ -155,6 +154,10 @@ import {
 } from "./WikilinkSuggester";
 import { isSearchTab } from "../search/searchTab";
 import { useChatStore } from "../ai/store/chatStore";
+import {
+    findActiveSessionsAffectedByClose,
+    getCloseTabsConfirmationMessage,
+} from "./tabClosePolicy";
 import { aiRegisterFileBaseline } from "../ai/api";
 import {
     changeAuthorAnnotation,
@@ -789,26 +792,21 @@ export function Editor({
         if (!tab) return;
 
         if (!isNoteTab(tab)) {
-            if (isChatTab(tab)) {
-                const session = useChatStore.getState().sessionsById[tab.sessionId];
+            const affected = findActiveSessionsAffectedByClose(
+                [tab],
+                useChatStore.getState().sessionsById,
+            );
+            void (async () => {
+                const confirmationMessage =
+                    getCloseTabsConfirmationMessage(affected);
                 if (
-                    session &&
-                    (session.status === "streaming" ||
-                        session.status === "waiting_permission" ||
-                        session.status === "waiting_user_input")
+                    confirmationMessage !== null &&
+                    !(await confirm(confirmationMessage))
                 ) {
-                    void (async () => {
-                        const confirmed = await confirm(
-                            "The AI agent is still running. Are you sure you want to close this tab?",
-                        );
-                        if (confirmed) {
-                            closeTab(activeTabId, { reason: "user" });
-                        }
-                    })();
                     return;
                 }
-            }
-            closeTab(activeTabId, { reason: "user" });
+                closeTab(activeTabId, { reason: "user" });
+            })();
             return;
         }
 

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -29,7 +29,7 @@ import {
 } from "@codemirror/search";
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { indentUnit } from "@codemirror/language";
-import { getCurrentWebview } from "@neverwrite/runtime";
+import { getCurrentWebview, confirm } from "@neverwrite/runtime";
 import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -41,6 +41,7 @@ import {
     selectEditorWorkspaceTabs,
     useEditorStore,
     isNoteTab,
+    isChatTab,
     selectFocusedPaneId,
     selectEditorPaneState,
     type Tab,
@@ -788,6 +789,25 @@ export function Editor({
         if (!tab) return;
 
         if (!isNoteTab(tab)) {
+            if (isChatTab(tab)) {
+                const session = useChatStore.getState().sessionsById[tab.sessionId];
+                if (
+                    session &&
+                    (session.status === "streaming" ||
+                        session.status === "waiting_permission" ||
+                        session.status === "waiting_user_input")
+                ) {
+                    void (async () => {
+                        const confirmed = await confirm(
+                            "The AI agent is still running. Are you sure you want to close this tab?",
+                        );
+                        if (confirmed) {
+                            closeTab(activeTabId, { reason: "user" });
+                        }
+                    })();
+                    return;
+                }
+            }
             closeTab(activeTabId, { reason: "user" });
             return;
         }

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -42,6 +42,10 @@ import { useActiveTabStripReveal } from "./tabStrip";
 import { useWorkspaceTabDrag } from "./useWorkspaceTabDrag";
 import { useDetachedTabWindowDrop } from "./useDetachedTabWindowDrop";
 import {
+    findActiveSessionsAffectedByClose,
+    getCloseTabsConfirmationMessage,
+} from "./tabClosePolicy";
+import {
     chromeControlsGroupStyle,
     getChromeIconButtonStyle,
     getChromeNavigationButtonStyle,
@@ -380,21 +384,17 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                 return;
             }
 
-            if (isChatTab(tab)) {
-                const session = useChatStore.getState().sessionsById[tab.sessionId];
-                if (
-                    session &&
-                    (session.status === "streaming" ||
-                        session.status === "waiting_permission" ||
-                        session.status === "waiting_user_input")
-                ) {
-                    const confirmed = await confirm(
-                        "The AI agent is still running. Are you sure you want to close this tab?",
-                    );
-                    if (!confirmed) {
-                        return;
-                    }
-                }
+            const affected = findActiveSessionsAffectedByClose(
+                [tab],
+                useChatStore.getState().sessionsById,
+            );
+            const confirmationMessage =
+                getCloseTabsConfirmationMessage(affected);
+            if (
+                confirmationMessage !== null &&
+                !(await confirm(confirmationMessage))
+            ) {
+                return;
             }
 
             closeTab(tab.id);

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useLayoutEffect, useRef, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { createPortal } from "react-dom";
+import { confirm } from "@neverwrite/runtime";
 import {
     type Tab,
     type TerminalTab,
@@ -371,12 +372,29 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         [renameChatSession],
     );
     const requestCloseTab = useCallback(
-        (tabId: string) => {
+        async (tabId: string) => {
             const tab = selectEditorWorkspaceTabs(
                 useEditorStore.getState(),
             ).find((candidate) => candidate.id === tabId);
             if (!tab) {
                 return;
+            }
+
+            if (isChatTab(tab)) {
+                const session = useChatStore.getState().sessionsById[tab.sessionId];
+                if (
+                    session &&
+                    (session.status === "streaming" ||
+                        session.status === "waiting_permission" ||
+                        session.status === "waiting_user_input")
+                ) {
+                    const confirmed = await confirm(
+                        "The AI agent is still running. Are you sure you want to close this tab?",
+                    );
+                    if (!confirmed) {
+                        return;
+                    }
+                }
             }
 
             closeTab(tab.id);

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -50,6 +50,10 @@ import {
 } from "../ai/dragEvents";
 import { useChatStore } from "../ai/store/chatStore";
 import {
+    findActiveSessionsAffectedByClose,
+    getCloseTabsConfirmationMessage,
+} from "./tabClosePolicy";
+import {
     buildTabFileDragDetail,
     resolveComposerDropTarget,
 } from "./tabDragAttachments";
@@ -441,6 +445,19 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                 return;
             }
 
+            const affected = findActiveSessionsAffectedByClose(
+                [targetTab],
+                useChatStore.getState().sessionsById,
+            );
+            const confirmationMessage =
+                getCloseTabsConfirmationMessage(affected);
+            if (
+                confirmationMessage !== null &&
+                !(await confirm(confirmationMessage))
+            ) {
+                return;
+            }
+
             if (windowMode === "note" && currentTabs.length === 1) {
                 const appWindow = getAppWindow();
                 await appWindow.close().catch((error) => {
@@ -460,23 +477,6 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                         new Event(REQUEST_CLOSE_ACTIVE_TAB_EVENT),
                     );
                     return;
-                }
-            }
-
-            if (isChatTab(targetTab)) {
-                const session = useChatStore.getState().sessionsById[targetTab.sessionId];
-                if (
-                    session &&
-                    (session.status === "streaming" ||
-                        session.status === "waiting_permission" ||
-                        session.status === "waiting_user_input")
-                ) {
-                    const confirmed = await confirm(
-                        "The AI agent is still running. Are you sure you want to close this tab?",
-                    );
-                    if (!confirmed) {
-                        return;
-                    }
                 }
             }
 
@@ -506,25 +506,17 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                 return false;
             }
 
-            const sessionsById = useChatStore.getState().sessionsById;
-            const hasActiveAgent = tabsToClose.some((tab) => {
-                if (!isChatTab(tab)) return false;
-                const session = sessionsById[tab.sessionId];
-                return (
-                    session &&
-                    (session.status === "streaming" ||
-                        session.status === "waiting_permission" ||
-                        session.status === "waiting_user_input")
-                );
-            });
-
-            if (hasActiveAgent) {
-                const confirmed = await confirm(
-                    "An AI agent is still running. Are you sure you want to close these tabs?",
-                );
-                if (!confirmed) {
-                    return false;
-                }
+            const affected = findActiveSessionsAffectedByClose(
+                tabsToClose,
+                useChatStore.getState().sessionsById,
+            );
+            const confirmationMessage =
+                getCloseTabsConfirmationMessage(affected);
+            if (
+                confirmationMessage !== null &&
+                !(await confirm(confirmationMessage))
+            ) {
+                return false;
             }
 
             for (const id of tabIds) {

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -463,6 +463,23 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                 }
             }
 
+            if (isChatTab(targetTab)) {
+                const session = useChatStore.getState().sessionsById[targetTab.sessionId];
+                if (
+                    session &&
+                    (session.status === "streaming" ||
+                        session.status === "waiting_permission" ||
+                        session.status === "waiting_user_input")
+                ) {
+                    const confirmed = await confirm(
+                        "The AI agent is still running. Are you sure you want to close this tab?",
+                    );
+                    if (!confirmed) {
+                        return;
+                    }
+                }
+            }
+
             closeTab(tabId, { reason: "user" });
         },
         [closeTab, windowMode],
@@ -487,6 +504,27 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
 
             if (tabsToClose.length === 0) {
                 return false;
+            }
+
+            const sessionsById = useChatStore.getState().sessionsById;
+            const hasActiveAgent = tabsToClose.some((tab) => {
+                if (!isChatTab(tab)) return false;
+                const session = sessionsById[tab.sessionId];
+                return (
+                    session &&
+                    (session.status === "streaming" ||
+                        session.status === "waiting_permission" ||
+                        session.status === "waiting_user_input")
+                );
+            });
+
+            if (hasActiveAgent) {
+                const confirmed = await confirm(
+                    "An AI agent is still running. Are you sure you want to close these tabs?",
+                );
+                if (!confirmed) {
+                    return false;
+                }
             }
 
             for (const id of tabIds) {

--- a/apps/desktop/src/features/editor/tabClosePolicy.test.ts
+++ b/apps/desktop/src/features/editor/tabClosePolicy.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    findActiveSessionsAffectedByClose,
+    getCloseTabsConfirmationMessage,
+} from "./tabClosePolicy";
+import type { Tab } from "../../app/store/editorStore";
+import type { AIChatSession } from "../ai/types";
+
+function makeChatTab(sessionId: string): Tab {
+    return {
+        id: `tab-${sessionId}`,
+        kind: "ai-chat",
+        sessionId,
+        title: "Chat",
+    } satisfies Tab;
+}
+
+function makeNoteTab(id = "note-1"): Tab {
+    return {
+        id,
+        kind: "note",
+        noteId: id,
+        title: "Note",
+        content: "",
+        history: [],
+        historyIndex: 0,
+    } satisfies Tab;
+}
+
+function makeSession(
+    sessionId: string,
+    overrides: Partial<AIChatSession> = {},
+): AIChatSession {
+    return {
+        sessionId,
+        title: null,
+        runtimeState: "live",
+        status: "idle",
+        messages: [],
+        attachments: [],
+        actionLog: [],
+        historySessionId: undefined,
+        activeWorkCycleId: null,
+        visibleWorkCycleId: null,
+        ...overrides,
+    } as AIChatSession;
+}
+
+describe("findActiveSessionsAffectedByClose", () => {
+    it("returns empty array when no chat tabs are in the list", () => {
+        const sessions: Record<string, AIChatSession> = {
+            s1: makeSession("s1", { status: "streaming" }),
+        };
+        expect(
+            findActiveSessionsAffectedByClose([makeNoteTab()], sessions),
+        ).toEqual([]);
+    });
+
+    it("returns empty array when chat tab session is idle", () => {
+        const tab = makeChatTab("s1");
+        const sessions = { s1: makeSession("s1", { status: "idle" }) };
+        expect(findActiveSessionsAffectedByClose([tab], sessions)).toEqual([]);
+    });
+
+    it("returns empty array when session has no entry in sessionsById", () => {
+        const tab = makeChatTab("missing");
+        expect(findActiveSessionsAffectedByClose([tab], {})).toEqual([]);
+    });
+
+    it("returns the active session for a streaming chat tab", () => {
+        const tab = makeChatTab("s1");
+        const session = makeSession("s1", { status: "streaming" });
+        const result = findActiveSessionsAffectedByClose([tab], { s1: session });
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBe(session);
+    });
+
+    it("returns active sessions for waiting_permission and waiting_user_input", () => {
+        const tab1 = makeChatTab("s1");
+        const tab2 = makeChatTab("s2");
+        const s1 = makeSession("s1", { status: "waiting_permission" });
+        const s2 = makeSession("s2", { status: "waiting_user_input" });
+        const result = findActiveSessionsAffectedByClose([tab1, tab2], {
+            s1,
+            s2,
+        });
+        expect(result).toHaveLength(2);
+    });
+
+    it("excludes sessions whose runtime is not live", () => {
+        const tab = makeChatTab("s1");
+        const session = makeSession("s1", {
+            status: "streaming",
+            runtimeState: "persisted_only",
+        });
+        expect(
+            findActiveSessionsAffectedByClose([tab], { s1: session }),
+        ).toEqual([]);
+    });
+
+    it("returns only active sessions when list contains mixed tabs", () => {
+        const chatTab = makeChatTab("s1");
+        const noteTab = makeNoteTab();
+        const idleChat = makeChatTab("s2");
+        const activeSession = makeSession("s1", { status: "streaming" });
+        const idleSession = makeSession("s2", { status: "idle" });
+        const result = findActiveSessionsAffectedByClose(
+            [chatTab, noteTab, idleChat],
+            { s1: activeSession, s2: idleSession },
+        );
+        expect(result).toHaveLength(1);
+        expect(result[0]).toBe(activeSession);
+    });
+});
+
+describe("getCloseTabsConfirmationMessage", () => {
+    beforeEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("returns null when there are no affected sessions", () => {
+        expect(getCloseTabsConfirmationMessage([])).toBeNull();
+    });
+
+    it("returns a singular message for a single affected session", () => {
+        const session = makeSession("s1", { status: "streaming" });
+        expect(getCloseTabsConfirmationMessage([session])).toBe(
+            "The AI agent is still running. Are you sure you want to close this tab?",
+        );
+    });
+
+    it("returns a plural message for multiple affected sessions", () => {
+        const sessions = [
+            makeSession("s1", { status: "streaming" }),
+            makeSession("s2", { status: "waiting_permission" }),
+        ];
+        expect(getCloseTabsConfirmationMessage(sessions)).toBe(
+            "Active AI agents are still running. Are you sure you want to close these tabs?",
+        );
+    });
+});

--- a/apps/desktop/src/features/editor/tabClosePolicy.ts
+++ b/apps/desktop/src/features/editor/tabClosePolicy.ts
@@ -1,0 +1,37 @@
+import { isChatTab, type Tab } from "../../app/store/editorStore";
+import { isAgentSessionActive } from "../ai/agentSessionActivity";
+import type { AIChatSession } from "../ai/types";
+
+const SINGLE_TAB_CLOSE_MESSAGE =
+    "The AI agent is still running. Are you sure you want to close this tab?";
+const MULTI_TAB_CLOSE_MESSAGE =
+    "Active AI agents are still running. Are you sure you want to close these tabs?";
+
+
+export function findActiveSessionsAffectedByClose(
+    tabs: readonly Tab[],
+    sessionsById: Record<string, AIChatSession>,
+): AIChatSession[] {
+    const active: AIChatSession[] = [];
+    for (const tab of tabs) {
+        if (!isChatTab(tab)) continue;
+        const session = sessionsById[tab.sessionId];
+        if (isAgentSessionActive(session)) {
+            active.push(session);
+        }
+    }
+    return active;
+}
+
+
+export function getCloseTabsConfirmationMessage(
+    affectedSessions: AIChatSession[],
+): string | null {
+    if (affectedSessions.length === 0) {
+        return null;
+    }
+
+    return affectedSessions.length === 1
+        ? SINGLE_TAB_CLOSE_MESSAGE
+        : MULTI_TAB_CLOSE_MESSAGE;
+}

--- a/apps/desktop/src/features/search/SearchView.test.tsx
+++ b/apps/desktop/src/features/search/SearchView.test.tsx
@@ -81,10 +81,13 @@ describe("SearchView", () => {
             await new Promise((resolve) => setTimeout(resolve, 350));
         });
 
-        expect(invokeMock).toHaveBeenCalledWith("advanced_search", {
-            params: expect.objectContaining({
-                prefer_file_name: true,
+        expect(invokeMock).toHaveBeenCalledWith(
+            "advanced_search",
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    prefer_file_name: true,
+                }),
             }),
-        });
+        );
     });
 });

--- a/apps/desktop/src/features/updates/sensitiveState.ts
+++ b/apps/desktop/src/features/updates/sensitiveState.ts
@@ -11,6 +11,7 @@ import {
     getTrackedFileReviewState,
     getTrackedFilesForSession,
 } from "../ai/store/actionLogModel";
+import { isAgentSessionActive } from "../ai/agentSessionActivity";
 import type { AIChatSession } from "../ai/types";
 
 const WINDOW_OPERATIONAL_STATE_PREFIX = "neverwrite:window-operational-state:";
@@ -69,18 +70,6 @@ function hasPendingReview(session: AIChatSession) {
 
     return Object.values(getTrackedFilesForSession(session.actionLog)).some(
         (file) => getTrackedFileReviewState(file) === "pending",
-    );
-}
-
-function isAgentSessionActive(session: AIChatSession) {
-    if (session.runtimeState != null && session.runtimeState !== "live") {
-        return false;
-    }
-
-    return (
-        session.status === "streaming" ||
-        session.status === "waiting_permission" ||
-        session.status === "waiting_user_input"
     );
 }
 

--- a/apps/desktop/src/test/test-utils.tsx
+++ b/apps/desktop/src/test/test-utils.tsx
@@ -110,6 +110,7 @@ export function getXtermMockInstances() {
             __xtermMockInstances: Array<{
                 emitData: (data: string) => void;
                 focusCalls: number;
+                scrollToTopCalls: number;
             }>;
         }
     ).__xtermMockInstances;


### PR DESCRIPTION
- fix failing desktop tests for search, spellcheck, and agent tab close confirmation
- resolve TypeScript build errors in detached window and terminal test helpers
- prevent inherited stdin in the desktop dev runner to avoid EIO after stopping dev

---

Fixed `npm run dev` post exit read EIO error:

<img width="451" height="120" alt="Screenshot from 2026-05-05 21-44-37" src="https://github.com/user-attachments/assets/a7883517-0f3c-4c9b-9318-a331c8431090" />


Fixed lint issues:

<img width="488" height="124" alt="Screenshot from 2026-05-05 21-33-06" src="https://github.com/user-attachments/assets/ce3ee858-ecff-47a4-8347-a93913830392" />

Fixed build issues:

<img width="901" height="686" alt="Screenshot from 2026-05-05 21-31-46" src="https://github.com/user-attachments/assets/2f7acb89-ab8b-4ea8-9443-ae80ceb67287" />

Fixed tests:

<img width="1061" height="628" alt="Screenshot from 2026-05-05 21-32-01" src="https://github.com/user-attachments/assets/424a2085-a02c-43eb-9edf-c0d126701499" />

