### PR TITLE
feat: add file tree chat context actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.2.4] - Unreleased
+
+### Added
+
+- Added file-tree context menu actions to add notes, folders, PDFs, and sidebar files directly to the current chat composer as context pills.
+- Added "Add to New Chat" and "Add Selected to New Chat" actions from the file tree, opening a fresh agent chat with the currently selected/last active provider before attaching the chosen context.
+- Added multi-selection-aware chat context actions for selected notes and sidebar files in the file tree.
+
+### Changed
+
+- Changed file-tree path copy actions to consistently use "Copy Full Path" and copy absolute paths for notes, folders, PDFs, and sidebar files.
+
+### Fixed
+
 ## [0.2.3] - 2026-05-05
 
 ### Added

--- a/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
@@ -1,16 +1,27 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { waitFor } from "@testing-library/react";
 import { AIChatDetachedWindowHost } from "./AIChatDetachedWindowHost";
 import { AIChatWorkspaceHost } from "./AIChatWorkspaceHost";
 import { renderComponent, flushPromises } from "../../test/test-utils";
 import { resetChatStore, useChatStore } from "./store/chatStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { useEditorStore } from "../../app/store/editorStore";
+import {
+    FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+    FILE_TREE_NOTE_DRAG_EVENT,
+} from "./dragEvents";
 
 const eventBridgeMock = vi.hoisted(() => vi.fn());
+const chatPaneMovementMock = vi.hoisted(() => ({
+    createNewChatInWorkspace: vi.fn(),
+    ensureWorkspaceChatSession: vi.fn(),
+}));
 
 vi.mock("./useAiChatEventBridge", () => ({
     useAiChatEventBridge: eventBridgeMock,
 }));
+
+vi.mock("./chatPaneMovement", () => chatPaneMovementMock);
 
 function createDeferred<T>() {
     let resolve!: (value: T) => void;
@@ -32,6 +43,10 @@ describe("AIChatDetachedWindowHost", () => {
         });
         useEditorStore.getState().hydrateTabs([], null);
         eventBridgeMock.mockClear();
+        chatPaneMovementMock.createNewChatInWorkspace.mockReset();
+        chatPaneMovementMock.ensureWorkspaceChatSession
+            .mockReset()
+            .mockResolvedValue(null);
     });
 
     it("initializes detached chat support without auto-creating a default session and loads the active chat", async () => {
@@ -142,6 +157,52 @@ describe("AIChatDetachedWindowHost", () => {
         renderComponent(<AIChatWorkspaceHost listenWithoutChatTabs />);
 
         expect(eventBridgeMock).toHaveBeenCalledWith(true);
+    });
+
+    it("creates a new workspace chat before replaying add-to-new-chat attachments", async () => {
+        const replayedEvents: CustomEvent[] = [];
+        const handleReplay = (event: Event) => {
+            replayedEvents.push(event as CustomEvent);
+        };
+        const detail = {
+            phase: "attach" as const,
+            x: 0,
+            y: 0,
+            notes: [
+                {
+                    id: "docs/alpha",
+                    title: "Alpha",
+                    path: "/vault/docs/alpha.md",
+                },
+            ],
+        };
+        chatPaneMovementMock.createNewChatInWorkspace.mockResolvedValue(
+            "session-new",
+        );
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
+        try {
+            renderComponent(<AIChatWorkspaceHost listenWithoutChatTabs />);
+
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT, {
+                    detail,
+                }),
+            );
+
+            await flushPromises();
+            expect(
+                chatPaneMovementMock.createNewChatInWorkspace,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                chatPaneMovementMock.createNewChatInWorkspace,
+            ).toHaveBeenCalledWith();
+
+            await waitFor(() => expect(replayedEvents).toHaveLength(1));
+            expect(replayedEvents[0].detail).toEqual(detail);
+        } finally {
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
+        }
     });
 
     it("initializes detached chat support before any chat tab mounts", async () => {

--- a/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
@@ -164,6 +164,14 @@ describe("AIChatDetachedWindowHost", () => {
         const handleReplay = (event: Event) => {
             replayedEvents.push(event as CustomEvent);
         };
+        const composerShell = document.createElement("div");
+        composerShell.dataset.aiComposerDropZone = "true";
+        const composer = document.createElement("div");
+        composer.setAttribute("role", "textbox");
+        composer.setAttribute("contenteditable", "true");
+        composer.textContent = "Existing context";
+        composerShell.appendChild(composer);
+        document.body.appendChild(composerShell);
         const detail = {
             phase: "attach" as const,
             x: 0,
@@ -200,7 +208,9 @@ describe("AIChatDetachedWindowHost", () => {
 
             await waitFor(() => expect(replayedEvents).toHaveLength(1));
             expect(replayedEvents[0].detail).toEqual(detail);
+            await waitFor(() => expect(document.activeElement).toBe(composer));
         } finally {
+            composerShell.remove();
             window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
         }
     });

--- a/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
@@ -166,6 +166,7 @@ describe("AIChatDetachedWindowHost", () => {
         };
         const composerShell = document.createElement("div");
         composerShell.dataset.aiComposerDropZone = "true";
+        composerShell.dataset.aiComposerSessionId = "session-new";
         const composer = document.createElement("div");
         composer.setAttribute("role", "textbox");
         composer.setAttribute("contenteditable", "true");
@@ -207,7 +208,10 @@ describe("AIChatDetachedWindowHost", () => {
             ).toHaveBeenCalledWith();
 
             await waitFor(() => expect(replayedEvents).toHaveLength(1));
-            expect(replayedEvents[0].detail).toEqual(detail);
+            expect(replayedEvents[0].detail).toEqual({
+                ...detail,
+                targetSessionId: "session-new",
+            });
             await waitFor(() => expect(document.activeElement).toBe(composer));
         } finally {
             composerShell.remove();

--- a/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
+++ b/apps/desktop/src/features/ai/AIChatDetachedWindowHost.test.tsx
@@ -15,6 +15,7 @@ const eventBridgeMock = vi.hoisted(() => vi.fn());
 const chatPaneMovementMock = vi.hoisted(() => ({
     createNewChatInWorkspace: vi.fn(),
     ensureWorkspaceChatSession: vi.fn(),
+    openChatSessionInWorkspace: vi.fn(),
 }));
 
 vi.mock("./useAiChatEventBridge", () => ({
@@ -47,6 +48,7 @@ describe("AIChatDetachedWindowHost", () => {
         chatPaneMovementMock.ensureWorkspaceChatSession
             .mockReset()
             .mockResolvedValue(null);
+        chatPaneMovementMock.openChatSessionInWorkspace.mockReset();
     });
 
     it("initializes detached chat support without auto-creating a default session and loads the active chat", async () => {
@@ -214,6 +216,64 @@ describe("AIChatDetachedWindowHost", () => {
             });
             await waitFor(() => expect(document.activeElement).toBe(composer));
         } finally {
+            composerShell.remove();
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
+        }
+    });
+
+    it("replays targeted attaches when only another chat composer is visible", async () => {
+        const replayedEvents: CustomEvent[] = [];
+        const handleReplay = (event: Event) => {
+            replayedEvents.push(event as CustomEvent);
+        };
+        const composerShell = document.createElement("div");
+        composerShell.dataset.aiComposerDropZone = "true";
+        composerShell.dataset.aiComposerSessionId = "session-visible";
+        document.body.appendChild(composerShell);
+        let targetComposerShell: HTMLDivElement | null = null;
+        const detail = {
+            phase: "attach" as const,
+            x: 0,
+            y: 0,
+            targetSessionId: "session-hidden",
+            notes: [
+                {
+                    id: "docs/alpha",
+                    title: "Alpha",
+                    path: "/vault/docs/alpha.md",
+                },
+            ],
+        };
+        chatPaneMovementMock.openChatSessionInWorkspace.mockReturnValue(
+            "session-hidden",
+        );
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
+        try {
+            renderComponent(<AIChatWorkspaceHost listenWithoutChatTabs />);
+
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail,
+                }),
+            );
+            targetComposerShell = document.createElement("div");
+            targetComposerShell.dataset.aiComposerDropZone = "true";
+            targetComposerShell.dataset.aiComposerSessionId = "session-hidden";
+            document.body.appendChild(targetComposerShell);
+
+            await flushPromises();
+            expect(
+                chatPaneMovementMock.openChatSessionInWorkspace,
+            ).toHaveBeenCalledWith("session-hidden");
+            expect(
+                chatPaneMovementMock.ensureWorkspaceChatSession,
+            ).not.toHaveBeenCalled();
+
+            await waitFor(() => expect(replayedEvents).toHaveLength(2));
+            expect(replayedEvents[1].detail).toEqual(detail);
+        } finally {
+            targetComposerShell?.remove();
             composerShell.remove();
             window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleReplay);
         }

--- a/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
+++ b/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
@@ -8,11 +8,15 @@ import {
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
+    FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
     FILE_TREE_NOTE_DRAG_EVENT,
     emitFileTreeNoteDrag,
     type FileTreeNoteDragDetail,
 } from "./dragEvents";
-import { ensureWorkspaceChatSession } from "./chatPaneMovement";
+import {
+    createNewChatInWorkspace,
+    ensureWorkspaceChatSession,
+} from "./chatPaneMovement";
 import { useChatStore } from "./store/chatStore";
 import { useAiChatEventBridge } from "./useAiChatEventBridge";
 
@@ -25,6 +29,16 @@ function hasVisibleAiComposerDropZone() {
 function getActiveEditorChatSessionId() {
     const activeTab = selectFocusedEditorTab(useEditorStore.getState());
     return activeTab && isChatTab(activeTab) ? activeTab.sessionId : null;
+}
+
+function replayAttachAfterComposerMount(detail: FileTreeNoteDragDetail) {
+    // Let the newly opened chat tab mount its composer before we replay the
+    // attach event into the real in-workspace target.
+    window.requestAnimationFrame(() => {
+        window.requestAnimationFrame(() => {
+            emitFileTreeNoteDrag(detail);
+        });
+    });
 }
 
 interface AIChatWorkspaceHostProps {
@@ -190,14 +204,18 @@ export function AIChatWorkspaceHost({
 
             void ensureWorkspaceChatSession().then((sessionId) => {
                 if (!sessionId) return;
+                replayAttachAfterComposerMount(detail);
+            });
+        };
 
-                // Let the newly opened chat tab mount its composer before we
-                // replay the attach event into the real in-workspace target.
-                window.requestAnimationFrame(() => {
-                    window.requestAnimationFrame(() => {
-                        emitFileTreeNoteDrag(detail);
-                    });
-                });
+        const handleAttachToNewChat = (event: Event) => {
+            const detail = (event as CustomEvent<FileTreeNoteDragDetail>)
+                .detail;
+            if (detail.phase !== "attach") return;
+
+            void createNewChatInWorkspace().then((sessionId) => {
+                if (!sessionId) return;
+                replayAttachAfterComposerMount(detail);
             });
         };
 
@@ -205,11 +223,20 @@ export function AIChatWorkspaceHost({
             FILE_TREE_NOTE_DRAG_EVENT,
             handleAttachWithoutVisibleComposer,
         );
-        return () =>
+        window.addEventListener(
+            FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+            handleAttachToNewChat,
+        );
+        return () => {
             window.removeEventListener(
                 FILE_TREE_NOTE_DRAG_EVENT,
                 handleAttachWithoutVisibleComposer,
             );
+            window.removeEventListener(
+                FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+                handleAttachToNewChat,
+            );
+        };
     }, []);
 
     return null;

--- a/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
+++ b/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
@@ -41,6 +41,27 @@ function replayAttachAfterComposerMount(detail: FileTreeNoteDragDetail) {
     });
 }
 
+function focusVisibleComposerAtEnd() {
+    window.requestAnimationFrame(() => {
+        window.setTimeout(() => {
+            const composer = document.querySelector<HTMLElement>(
+                '[data-ai-composer-drop-zone="true"] [role="textbox"][contenteditable="true"]',
+            );
+            if (!composer) return;
+
+            composer.focus();
+            const selection = window.getSelection();
+            if (!selection) return;
+
+            const range = document.createRange();
+            range.selectNodeContents(composer);
+            range.collapse(false);
+            selection.removeAllRanges();
+            selection.addRange(range);
+        }, 0);
+    });
+}
+
 interface AIChatWorkspaceHostProps {
     startupReady?: boolean;
     listenWithoutChatTabs?: boolean;
@@ -216,6 +237,7 @@ export function AIChatWorkspaceHost({
             void createNewChatInWorkspace().then((sessionId) => {
                 if (!sessionId) return;
                 replayAttachAfterComposerMount(detail);
+                focusVisibleComposerAtEnd();
             });
         };
 

--- a/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
+++ b/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
@@ -31,21 +31,24 @@ function getActiveEditorChatSessionId() {
     return activeTab && isChatTab(activeTab) ? activeTab.sessionId : null;
 }
 
-function replayAttachAfterComposerMount(detail: FileTreeNoteDragDetail) {
+function replayAttachAfterComposerMount(
+    detail: FileTreeNoteDragDetail,
+    targetSessionId: string,
+) {
     // Let the newly opened chat tab mount its composer before we replay the
     // attach event into the real in-workspace target.
     window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
-            emitFileTreeNoteDrag(detail);
+            emitFileTreeNoteDrag({ ...detail, targetSessionId });
         });
     });
 }
 
-function focusVisibleComposerAtEnd() {
+function focusComposerAtEnd(sessionId: string) {
     window.requestAnimationFrame(() => {
         window.setTimeout(() => {
             const composer = document.querySelector<HTMLElement>(
-                '[data-ai-composer-drop-zone="true"] [role="textbox"][contenteditable="true"]',
+                `[data-ai-composer-drop-zone="true"][data-ai-composer-session-id="${CSS.escape(sessionId)}"] [role="textbox"][contenteditable="true"]`,
             );
             if (!composer) return;
 
@@ -225,7 +228,7 @@ export function AIChatWorkspaceHost({
 
             void ensureWorkspaceChatSession().then((sessionId) => {
                 if (!sessionId) return;
-                replayAttachAfterComposerMount(detail);
+                replayAttachAfterComposerMount(detail, sessionId);
             });
         };
 
@@ -236,8 +239,8 @@ export function AIChatWorkspaceHost({
 
             void createNewChatInWorkspace().then((sessionId) => {
                 if (!sessionId) return;
-                replayAttachAfterComposerMount(detail);
-                focusVisibleComposerAtEnd();
+                replayAttachAfterComposerMount(detail, sessionId);
+                focusComposerAtEnd(sessionId);
             });
         };
 

--- a/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
+++ b/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
@@ -16,14 +16,16 @@ import {
 import {
     createNewChatInWorkspace,
     ensureWorkspaceChatSession,
+    openChatSessionInWorkspace,
 } from "./chatPaneMovement";
 import { useChatStore } from "./store/chatStore";
 import { useAiChatEventBridge } from "./useAiChatEventBridge";
 
-function hasVisibleAiComposerDropZone() {
-    return (
-        document.querySelector('[data-ai-composer-drop-zone="true"]') !== null
-    );
+function hasVisibleAiComposerDropZone(targetSessionId?: string) {
+    const selector = targetSessionId
+        ? `[data-ai-composer-drop-zone="true"][data-ai-composer-session-id="${CSS.escape(targetSessionId)}"]`
+        : '[data-ai-composer-drop-zone="true"]';
+    return document.querySelector(selector) !== null;
 }
 
 function getActiveEditorChatSessionId() {
@@ -213,7 +215,7 @@ export function AIChatWorkspaceHost({
                 .detail;
             const replayKey = detail as object;
             if (detail.phase !== "attach") return;
-            if (hasVisibleAiComposerDropZone()) {
+            if (hasVisibleAiComposerDropZone(detail.targetSessionId)) {
                 attachReplayCountsRef.current.delete(replayKey);
                 return;
             }
@@ -226,7 +228,13 @@ export function AIChatWorkspaceHost({
             }
             attachReplayCountsRef.current.set(replayKey, replayCount + 1);
 
-            void ensureWorkspaceChatSession().then((sessionId) => {
+            const ensureTargetSession = detail.targetSessionId
+                ? Promise.resolve(
+                      openChatSessionInWorkspace(detail.targetSessionId),
+                  )
+                : ensureWorkspaceChatSession();
+
+            void ensureTargetSession.then((sessionId) => {
                 if (!sessionId) return;
                 replayAttachAfterComposerMount(detail, sessionId);
             });

--- a/apps/desktop/src/features/ai/chatPaneMovement.test.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./chatPaneMovement";
 import { resetChatStore, useChatStore } from "./store/chatStore";
 import { resetChatTabsStore } from "./store/chatTabsStore";
-import type { AIChatSession } from "./types";
+import type { AIChatSession, AIRuntimeSetupStatus } from "./types";
 
 const invokeMock = vi.mocked(invoke);
 
@@ -56,6 +56,43 @@ const runtimeDescriptor = {
     ],
 };
 
+const claudeRuntimeDescriptor = {
+    runtime: {
+        id: "claude-acp",
+        name: "Claude ACP",
+        description: "Claude runtime",
+        capabilities: ["create_session"],
+    },
+    models: [
+        {
+            id: "claude-model",
+            runtimeId: "claude-acp",
+            name: "Claude Model",
+            description: "Model for tests",
+        },
+    ],
+    modes: [
+        {
+            id: "default",
+            runtimeId: "claude-acp",
+            name: "Default",
+            description: "Default mode",
+            disabled: false,
+        },
+    ],
+    configOptions: [
+        {
+            id: "model",
+            runtimeId: "claude-acp",
+            category: "model" as const,
+            label: "Model",
+            type: "select" as const,
+            value: "claude-model",
+            options: [{ value: "claude-model", label: "Claude Model" }],
+        },
+    ],
+};
+
 const setupStatusPayload = {
     runtime_id: "codex-acp",
     binary_ready: true,
@@ -66,6 +103,17 @@ const setupStatusPayload = {
     auth_methods: [],
     onboarding_required: false,
     message: null,
+};
+
+const readySetupStatusState: AIRuntimeSetupStatus = {
+    runtimeId: "codex-acp",
+    binaryReady: true,
+    binaryPath: "/Applications/NeverWrite/codex-acp",
+    binarySource: "bundled",
+    authReady: true,
+    authMethod: "openai-api-key",
+    authMethods: [],
+    onboardingRequired: false,
 };
 
 const createdSessionPayload = {
@@ -212,6 +260,58 @@ describe("createNewChatInWorkspace", () => {
             throw new Error("Expected the focused tab to remain a chat tab");
         }
         expect(focusedResolvedTab.sessionId).toBe("codex-session-1");
+    });
+
+    it("uses the first configured runtime when the selected runtime still needs onboarding", async () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [runtimeDescriptor, claudeRuntimeDescriptor],
+            selectedRuntimeId: "codex-acp",
+            setupStatusByRuntimeId: {
+                "codex-acp": {
+                    ...readySetupStatusState,
+                    authReady: false,
+                    onboardingRequired: true,
+                },
+                "claude-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "claude-acp",
+                    authMethod: "claude-login",
+                },
+            },
+        }));
+
+        invokeMock.mockImplementation((command) => {
+            if (command === "ai_get_setup_status") {
+                return Promise.resolve({
+                    ...setupStatusPayload,
+                    runtime_id: "claude-acp",
+                    auth_method: "claude-login",
+                });
+            }
+            if (command === "ai_create_session") {
+                return Promise.resolve({
+                    ...createdSessionPayload,
+                    session_id: "claude-session-1",
+                    runtime_id: "claude-acp",
+                });
+            }
+            return Promise.reject(new Error(`Unexpected invoke: ${command}`));
+        });
+
+        const pendingSessionId = await createNewChatInWorkspace();
+        expect(pendingSessionId).toMatch(/^pending:/);
+
+        const pendingSession =
+            useChatStore.getState().sessionsById[pendingSessionId!];
+        expect(pendingSession?.runtimeId).toBe("claude-acp");
+        expect(pendingSession?.modelId).toBe("claude-model");
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().sessionsById["claude-session-1"],
+            ).toBeDefined();
+        });
     });
 });
 

--- a/apps/desktop/src/features/ai/chatPaneMovement.test.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.test.ts
@@ -156,13 +156,14 @@ const createdSessionPayload = {
 function createStoredSession(
     sessionId: string,
     title: string,
+    runtimeId = "codex-acp",
 ): AIChatSession {
     return {
         sessionId,
         historySessionId: sessionId,
         status: "idle",
-        runtimeId: "codex-acp",
-        modelId: "test-model",
+        runtimeId,
+        modelId: runtimeId === "claude-acp" ? "claude-model" : "test-model",
         modeId: "default",
         models: [],
         modes: [],
@@ -310,6 +311,97 @@ describe("createNewChatInWorkspace", () => {
         await waitFor(() => {
             expect(
                 useChatStore.getState().sessionsById["claude-session-1"],
+            ).toBeDefined();
+        });
+    });
+
+    it("inherits the focused workspace chat runtime before the selected runtime", async () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [runtimeDescriptor, claudeRuntimeDescriptor],
+            selectedRuntimeId: "codex-acp",
+            setupStatusByRuntimeId: {
+                "codex-acp": readySetupStatusState,
+                "claude-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "claude-acp",
+                    authMethod: "claude-login",
+                },
+            },
+        }));
+        const claudeSession = createStoredSession(
+            "claude-session-existing",
+            "Claude chat",
+            "claude-acp",
+        );
+        seedChatSessions(claudeSession);
+        useEditorStore.getState().openChat(claudeSession.sessionId, {
+            title: "Claude chat",
+            paneId: "primary",
+        });
+
+        invokeMock.mockImplementation((command, args) => {
+            if (command === "ai_get_setup_status") {
+                expect(
+                    (args as { runtimeId?: string } | undefined)?.runtimeId,
+                ).toBe("claude-acp");
+                return Promise.resolve({
+                    ...setupStatusPayload,
+                    runtime_id: "claude-acp",
+                    auth_method: "claude-login",
+                });
+            }
+            if (command === "ai_create_session") {
+                expect(
+                    (
+                        args as
+                            | { input?: { runtime_id?: string } }
+                            | undefined
+                    )?.input?.runtime_id,
+                ).toBe("claude-acp");
+                return Promise.resolve({
+                    ...createdSessionPayload,
+                    session_id: "claude-session-2",
+                    runtime_id: "claude-acp",
+                    model_id: "claude-model",
+                    models: [
+                        {
+                            id: "claude-model",
+                            runtime_id: "claude-acp",
+                            name: "Claude Model",
+                            description: "Model for tests",
+                        },
+                    ],
+                    config_options: [
+                        {
+                            id: "model",
+                            runtime_id: "claude-acp",
+                            category: "model",
+                            label: "Model",
+                            type: "select",
+                            value: "claude-model",
+                            options: [
+                                {
+                                    value: "claude-model",
+                                    label: "Claude Model",
+                                },
+                            ],
+                        },
+                    ],
+                });
+            }
+            return Promise.reject(new Error(`Unexpected invoke: ${command}`));
+        });
+
+        const pendingSessionId = await createNewChatInWorkspace();
+        expect(pendingSessionId).toMatch(/^pending:/);
+        expect(
+            useChatStore.getState().sessionsById[pendingSessionId!]?.runtimeId,
+        ).toBe("claude-acp");
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().sessionsById["claude-session-2"],
             ).toBeDefined();
         });
     });

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -8,7 +8,11 @@ import { getSessionTitle } from "./sessionPresentation";
 import { useChatStore } from "./store/chatStore";
 import { useChatTabsStore } from "./store/chatTabsStore";
 import { getPreferredWorkspaceChatSessionIdForSession } from "./chatWorkspaceSelectors";
-import type { AIChatSession, AIRuntimeDescriptor } from "./types";
+import type {
+    AIChatSession,
+    AIRuntimeDescriptor,
+    AIRuntimeSetupStatus,
+} from "./types";
 
 interface OpenChatInWorkspaceOptions {
     paneId?: string;
@@ -30,18 +34,43 @@ function getConfigDefaultValue(
         ?.value;
 }
 
+function isRuntimeSetupReady(setupStatus?: AIRuntimeSetupStatus | null) {
+    return setupStatus?.authReady === true && !setupStatus.onboardingRequired;
+}
+
 function resolvePendingRuntime(runtimeId?: string) {
     const state = useChatStore.getState();
+    const getRuntime = (candidateRuntimeId?: string | null) =>
+        candidateRuntimeId
+            ? (state.runtimes.find(
+                  (descriptor) =>
+                      descriptor.runtime.id === candidateRuntimeId,
+              ) ?? null)
+            : null;
+    const firstReadyRuntime = state.runtimes.find((descriptor) =>
+        isRuntimeSetupReady(
+            state.setupStatusByRuntimeId[descriptor.runtime.id],
+        ),
+    );
+    const selectedRuntime = getRuntime(state.selectedRuntimeId);
+    const readySelectedRuntimeId =
+        selectedRuntime &&
+        isRuntimeSetupReady(
+            state.setupStatusByRuntimeId[selectedRuntime.runtime.id],
+        )
+            ? selectedRuntime.runtime.id
+            : null;
     const resolvedRuntimeId =
-        runtimeId ?? state.selectedRuntimeId ?? state.runtimes[0]?.runtime.id;
+        runtimeId ??
+        readySelectedRuntimeId ??
+        firstReadyRuntime?.runtime.id ??
+        state.selectedRuntimeId ??
+        state.runtimes[0]?.runtime.id;
     if (!resolvedRuntimeId) {
         return null;
     }
 
-    const runtime =
-        state.runtimes.find(
-            (descriptor) => descriptor.runtime.id === resolvedRuntimeId,
-        ) ?? null;
+    const runtime = getRuntime(resolvedRuntimeId);
     if (!runtime) {
         return null;
     }

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -1,5 +1,6 @@
 import {
     isChatTab,
+    selectFocusedEditorTab,
     useEditorStore,
 } from "../../app/store/editorStore";
 import { createChatTab } from "../../app/store/editorTabs";
@@ -79,6 +80,35 @@ function resolvePendingRuntime(runtimeId?: string) {
         runtime,
         runtimeId: resolvedRuntimeId,
     };
+}
+
+function getSessionRuntimeId(sessionId?: string | null) {
+    if (!sessionId) {
+        return null;
+    }
+    return useChatStore.getState().sessionsById[sessionId]?.runtimeId ?? null;
+}
+
+function resolveWorkspaceNewChatRuntimeId(runtimeId?: string) {
+    if (runtimeId) {
+        return runtimeId;
+    }
+
+    const focusedTab = selectFocusedEditorTab(useEditorStore.getState());
+    const focusedChatRuntimeId =
+        focusedTab && isChatTab(focusedTab)
+            ? getSessionRuntimeId(focusedTab.sessionId)
+            : null;
+    if (focusedChatRuntimeId) {
+        return focusedChatRuntimeId;
+    }
+
+    const chatState = useChatStore.getState();
+    return (
+        getSessionRuntimeId(chatState.lastFocusedSessionId) ??
+        getSessionRuntimeId(chatState.activeSessionId) ??
+        undefined
+    );
 }
 
 function createPendingWorkspaceSession(
@@ -248,11 +278,12 @@ export async function createNewChatInWorkspace(
     runtimeId?: string,
     options?: OpenChatInWorkspaceOptions,
 ) {
-    const pendingSession = createPendingWorkspaceSession(runtimeId);
+    const resolvedRuntimeId = resolveWorkspaceNewChatRuntimeId(runtimeId);
+    const pendingSession = createPendingWorkspaceSession(resolvedRuntimeId);
     if (!pendingSession) {
         const createdSessionId = await useChatStore
             .getState()
-            .newSession(runtimeId);
+            .newSession(resolvedRuntimeId);
         if (!createdSessionId) {
             return null;
         }

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -40,6 +40,8 @@ function renderComposer({
     availableCommands = [],
     isStopping = false,
     hasPendingSubmitAfterStop = false,
+    onMentionAttach = vi.fn(),
+    onFolderAttach = vi.fn(),
     onSubmit = () => {},
     onStop = () => {},
 }: {
@@ -53,6 +55,12 @@ function renderComposer({
     availableCommands?: AIAvailableCommand[];
     isStopping?: boolean;
     hasPendingSubmitAfterStop?: boolean;
+    onMentionAttach?: (note: {
+        id: string;
+        title: string;
+        path: string;
+    }) => void;
+    onFolderAttach?: (folderPath: string, name: string) => void;
     onSubmit?: () => void;
     onStop?: () => void;
 } = {}) {
@@ -79,8 +87,8 @@ function renderComposer({
             isStopping={isStopping}
             hasPendingSubmitAfterStop={hasPendingSubmitAfterStop}
             onChange={onChange}
-            onMentionAttach={vi.fn()}
-            onFolderAttach={vi.fn()}
+            onMentionAttach={onMentionAttach}
+            onFolderAttach={onFolderAttach}
             onSubmit={onSubmit}
             onStop={onStop}
         />,
@@ -89,7 +97,7 @@ function renderComposer({
     const composer = screen.getByRole("textbox", {
         name: "Message NeverWrite",
     });
-    return { composer, onChange, onSubmit, onStop };
+    return { composer, onChange, onFolderAttach, onMentionAttach, onSubmit, onStop };
 }
 
 function setCaret(node: Node, offset: number) {
@@ -217,6 +225,66 @@ describe("AIChatComposer mention picker", () => {
 
         await waitFor(() => expect(secondOnChange).toHaveBeenCalledTimes(1));
         expect(firstOnChange).not.toHaveBeenCalled();
+    });
+
+    it("applies mixed file-tree folders, files, and notes in one attach", async () => {
+        const onFolderAttach = vi.fn();
+        const onMentionAttach = vi.fn();
+        const { onChange } = renderComposer({
+            onFolderAttach,
+            onMentionAttach,
+        });
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "attach",
+                        x: 0,
+                        y: 0,
+                        notes: [
+                            {
+                                id: "notes/alpha.md",
+                                title: "Alpha",
+                                path: "/vault/notes/alpha.md",
+                            },
+                        ],
+                        folders: [
+                            { path: "docs", name: "docs" },
+                            { path: "research", name: "research" },
+                        ],
+                        files: [
+                            {
+                                filePath: "/vault/docs/config.toml",
+                                fileName: "config.toml",
+                                mimeType: "application/toml",
+                            },
+                        ],
+                    },
+                }),
+            );
+        });
+
+        await waitFor(() => expect(onChange).toHaveBeenCalledTimes(1));
+        const parts = onChange.mock.calls[0]?.[0] as AIComposerPart[];
+        expect(
+            parts
+                .filter((part) => part.type !== "text")
+                .map((part) => part.type),
+        ).toEqual([
+            "folder_mention",
+            "folder_mention",
+            "file_attachment",
+            "mention",
+        ]);
+        expect(onFolderAttach).toHaveBeenCalledTimes(2);
+        expect(onFolderAttach).toHaveBeenNthCalledWith(1, "docs", "docs");
+        expect(onFolderAttach).toHaveBeenNthCalledWith(
+            2,
+            "research",
+            "research",
+        );
+        expect(onMentionAttach).toHaveBeenCalledTimes(1);
     });
 
     it("opens the @ picker when the caret is inside a text node", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -10,6 +10,7 @@ import {
     setVaultEntries,
     setVaultNotes,
 } from "../../../test/test-utils";
+import { FILE_TREE_NOTE_DRAG_EVENT } from "../dragEvents";
 import type { AIAvailableCommand, AIComposerPart } from "../types";
 import { AIChatComposer } from "./AIChatComposer";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
@@ -29,6 +30,7 @@ afterEach(() => {
 });
 
 function renderComposer({
+    sessionId = "session-1",
     parts = [],
     status = "idle" as const,
     runtimeId,
@@ -41,6 +43,7 @@ function renderComposer({
     onSubmit = () => {},
     onStop = () => {},
 }: {
+    sessionId?: string;
     parts?: AIComposerPart[];
     status?: "idle" | "streaming";
     runtimeId?: string;
@@ -57,6 +60,7 @@ function renderComposer({
 
     renderComponent(
         <AIChatComposer
+            sessionId={sessionId}
             parts={parts}
             notes={[
                 {
@@ -133,6 +137,86 @@ describe("AIChatComposer mention picker", () => {
         });
 
         expect(screen.getByText("Loading agent")).toBeInTheDocument();
+    });
+
+    it("ignores targeted file-tree attaches for other chat sessions", async () => {
+        const { onChange } = renderComposer({ sessionId: "session-target" });
+
+        window.dispatchEvent(
+            new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                detail: {
+                    phase: "attach",
+                    x: 0,
+                    y: 0,
+                    targetSessionId: "session-other",
+                    notes: [
+                        {
+                            id: "notes/alpha.md",
+                            title: "Alpha",
+                            path: "/vault/notes/alpha.md",
+                        },
+                    ],
+                },
+            }),
+        );
+
+        await new Promise((resolve) => window.setTimeout(resolve, 0));
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("only applies targeted file-tree attaches to the matching chat session", async () => {
+        const firstOnChange = vi.fn();
+        const secondOnChange = vi.fn();
+
+        renderComponent(
+            <>
+                <AIChatComposer
+                    sessionId="session-a"
+                    parts={[]}
+                    notes={[]}
+                    status="idle"
+                    runtimeName="Assistant"
+                    onChange={firstOnChange}
+                    onMentionAttach={vi.fn()}
+                    onFolderAttach={vi.fn()}
+                    onSubmit={vi.fn()}
+                    onStop={vi.fn()}
+                />
+                <AIChatComposer
+                    sessionId="session-b"
+                    parts={[]}
+                    notes={[]}
+                    status="idle"
+                    runtimeName="Assistant"
+                    onChange={secondOnChange}
+                    onMentionAttach={vi.fn()}
+                    onFolderAttach={vi.fn()}
+                    onSubmit={vi.fn()}
+                    onStop={vi.fn()}
+                />
+            </>,
+        );
+
+        window.dispatchEvent(
+            new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                detail: {
+                    phase: "attach",
+                    x: 0,
+                    y: 0,
+                    targetSessionId: "session-b",
+                    notes: [
+                        {
+                            id: "notes/alpha.md",
+                            title: "Alpha",
+                            path: "/vault/notes/alpha.md",
+                        },
+                    ],
+                },
+            }),
+        );
+
+        await waitFor(() => expect(secondOnChange).toHaveBeenCalledTimes(1));
+        expect(firstOnChange).not.toHaveBeenCalled();
     });
 
     it("opens the @ picker when the caret is inside a text node", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -1362,26 +1362,25 @@ export function AIChatComposer({
                     return;
                 }
 
+                let current = partsRef.current;
+                let didAttach = false;
+                const folders =
+                    detail.folders ??
+                    (detail.folder ? [detail.folder] : []);
+
                 // Folder drop
-                if (detail.folder) {
-                    onChangeRef.current(
-                        appendFolderMentionPart(
-                            partsRef.current,
-                            detail.folder.path,
-                            detail.folder.name,
-                        ),
+                for (const folder of folders) {
+                    current = appendFolderMentionPart(
+                        current,
+                        folder.path,
+                        folder.name,
                     );
-                    onFolderAttachRef.current(
-                        detail.folder.path,
-                        detail.folder.name,
-                    );
-                    focusComposerAtEnd();
-                    return;
+                    onFolderAttachRef.current(folder.path, folder.name);
+                    didAttach = true;
                 }
 
                 // File drop (PDFs, etc.) — inline pills
                 if (detail.files && detail.files.length > 0) {
-                    let current = partsRef.current;
                     for (const file of detail.files) {
                         current = appendFileAttachmentPart(current, {
                             filePath: file.filePath,
@@ -1389,26 +1388,27 @@ export function AIChatComposer({
                             label: file.fileName,
                         });
                     }
-                    onChangeRef.current(current);
-                    focusComposerAtEnd();
-                    return;
+                    didAttach = true;
                 }
 
                 // Notes drop
-                if (detail.notes.length === 0) return;
-                onChangeRef.current(
-                    appendMentionParts(
-                        partsRef.current,
+                if (detail.notes.length > 0) {
+                    current = appendMentionParts(
+                        current,
                         detail.notes.map((note) => ({
                             noteId: note.id,
                             label: note.title,
                             path: note.path,
                         })),
-                    ),
-                );
-                detail.notes.forEach((note) =>
-                    onMentionAttachRef.current(note),
-                );
+                    );
+                    detail.notes.forEach((note) =>
+                        onMentionAttachRef.current(note),
+                    );
+                    didAttach = true;
+                }
+
+                if (!didAttach) return;
+                onChangeRef.current(current);
                 focusComposerAtEnd();
             }
         };

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -53,6 +53,7 @@ const MIN_COMPOSER_HEIGHT = 64;
 const MAX_COMPOSER_HEIGHT = 480;
 
 interface AIChatComposerProps {
+    sessionId?: string;
     parts: AIComposerPart[];
     notes: AIChatNoteSummary[];
     files?: AIChatFileSummary[];
@@ -946,6 +947,7 @@ function getMentionSuggestions(
 }
 
 export function AIChatComposer({
+    sessionId,
     parts,
     notes,
     files,
@@ -1352,6 +1354,13 @@ export function AIChatComposer({
             if (detail.phase === "end" || detail.phase === "attach") {
                 setExternalDragActive(false);
                 if (detail.phase === "end" && !isOver) return;
+                if (
+                    detail.phase === "attach" &&
+                    detail.targetSessionId &&
+                    detail.targetSessionId !== sessionId
+                ) {
+                    return;
+                }
 
                 // Folder drop
                 if (detail.folder) {
@@ -1407,7 +1416,7 @@ export function AIChatComposer({
         window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleDrag);
         return () =>
             window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleDrag);
-    }, [focusComposerAtEnd]);
+    }, [focusComposerAtEnd, sessionId]);
 
     // Native Finder/Explorer file drop
     useEffect(() => {
@@ -1564,6 +1573,7 @@ export function AIChatComposer({
         <div
             ref={shellRef}
             data-ai-composer-drop-zone="true"
+            data-ai-composer-session-id={sessionId}
             className={
                 expanded
                     ? "flex h-full min-h-0 flex-1 flex-col"

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -24,6 +24,7 @@ import {
     type AIChatSlashCommand,
 } from "./AIChatCommandPicker";
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
+import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -26,7 +26,6 @@ import {
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
-import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";
 import type {
     AIAvailableCommand,

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -511,6 +511,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 />
                 <AIChatComposer
                     key={sessionId}
+                    sessionId={sessionId}
                     parts={composerParts}
                     notes={noteOptions}
                     files={fileOptions}

--- a/apps/desktop/src/features/ai/dragEvents.ts
+++ b/apps/desktop/src/features/ai/dragEvents.ts
@@ -1,6 +1,8 @@
 import type { AIChatNoteSummary } from "./types";
 
 export const FILE_TREE_NOTE_DRAG_EVENT = "neverwrite:file-tree-note-drag";
+export const FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT =
+    "neverwrite:file-tree-attach-to-new-chat";
 
 // "attach" skips the position check — used by context menu "Add to Chat"
 export type FileTreeNoteDragPhase =
@@ -34,5 +36,16 @@ export function emitFileTreeNoteDrag(detail: FileTreeNoteDragDetail) {
         new CustomEvent<FileTreeNoteDragDetail>(FILE_TREE_NOTE_DRAG_EVENT, {
             detail,
         }),
+    );
+}
+
+export function emitFileTreeAttachToNewChat(detail: FileTreeNoteDragDetail) {
+    window.dispatchEvent(
+        new CustomEvent<FileTreeNoteDragDetail>(
+            FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+            {
+                detail,
+            },
+        ),
     );
 }

--- a/apps/desktop/src/features/ai/dragEvents.ts
+++ b/apps/desktop/src/features/ai/dragEvents.ts
@@ -22,6 +22,7 @@ export interface FileTreeNoteDragDetail {
     phase: FileTreeNoteDragPhase;
     x: number;
     y: number;
+    targetSessionId?: string;
     notes: AIChatNoteSummary[];
     files?: FileTreeDraggedFile[];
     folder?: { path: string; name: string };

--- a/apps/desktop/src/features/ai/dragEvents.ts
+++ b/apps/desktop/src/features/ai/dragEvents.ts
@@ -18,6 +18,11 @@ export interface FileTreeDraggedFile {
     mimeType: string;
 }
 
+export interface FileTreeDraggedFolder {
+    path: string;
+    name: string;
+}
+
 export interface FileTreeNoteDragDetail {
     phase: FileTreeNoteDragPhase;
     x: number;
@@ -25,7 +30,8 @@ export interface FileTreeNoteDragDetail {
     targetSessionId?: string;
     notes: AIChatNoteSummary[];
     files?: FileTreeDraggedFile[];
-    folder?: { path: string; name: string };
+    folder?: FileTreeDraggedFolder;
+    folders?: FileTreeDraggedFolder[];
     origin?: {
         kind: "workspace-tab";
         tabId: string;

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -789,6 +789,77 @@ describe("chatStore", () => {
         );
     });
 
+    it("selects the first configured runtime on fresh boot", async () => {
+        const claudeRuntimePayload = {
+            runtime: {
+                ...runtimePayload[0].runtime,
+                id: "claude-acp",
+                name: "Claude ACP",
+                description: "Claude runtime embedded as an ACP sidecar.",
+            },
+            models: [],
+            modes: [],
+            config_options: [],
+        };
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_list_runtimes") {
+                return [runtimePayload[0], claudeRuntimePayload];
+            }
+
+            if (command === "ai_get_setup_status") {
+                const runtimeId =
+                    typeof args === "object" &&
+                    args !== null &&
+                    "runtimeId" in args
+                        ? (args.runtimeId as string)
+                        : null;
+
+                if (runtimeId === "claude-acp") {
+                    return {
+                        ...readySetupStatus,
+                        runtime_id: "claude-acp",
+                        auth_method: "claude-login",
+                    };
+                }
+
+                return {
+                    ...readySetupStatus,
+                    auth_ready: false,
+                    onboarding_required: true,
+                    message: "Connect Codex to continue.",
+                };
+            }
+
+            if (command === "ai_create_session") {
+                const runtimeId =
+                    typeof args === "object" &&
+                    args !== null &&
+                    "input" in args
+                        ? (args.input as { runtime_id?: string }).runtime_id
+                        : null;
+
+                expect(runtimeId).toBe("claude-acp");
+                return {
+                    ...sessionPayload,
+                    session_id: "claude-session-1",
+                    runtime_id: "claude-acp",
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().initialize();
+
+        const state = useChatStore.getState();
+        expect(state.selectedRuntimeId).toBe("claude-acp");
+        expect(state.activeSessionId).toBe("claude-session-1");
+        expect(state.sessionsById["claude-session-1"]?.runtimeId).toBe(
+            "claude-acp",
+        );
+    });
+
     it("reports session inventory load failures without pretending restoration succeeded", async () => {
         invokeMock.mockImplementation(async (command, args) => {
             if (command === "ai_list_sessions") {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -4785,8 +4785,23 @@ function mergeSession(
     );
 }
 
-function getDefaultRuntimeId(runtimes: AIRuntimeDescriptor[]) {
-    return runtimes[0]?.runtime.id ?? null;
+function isRuntimeSetupReady(setupStatus?: AIRuntimeSetupStatus | null) {
+    return setupStatus?.authReady === true && !setupStatus.onboardingRequired;
+}
+
+function getDefaultRuntimeId(
+    runtimes: AIRuntimeDescriptor[],
+    setupStatusByRuntimeId?: Record<string, AIRuntimeSetupStatus>,
+) {
+    const readyRuntime = setupStatusByRuntimeId
+        ? runtimes.find((runtime) =>
+              isRuntimeSetupReady(
+                  setupStatusByRuntimeId[runtime.runtime.id],
+              ),
+          )
+        : null;
+
+    return readyRuntime?.runtime.id ?? runtimes[0]?.runtime.id ?? null;
 }
 
 function runtimeSupportsCapability(
@@ -4840,13 +4855,17 @@ function getSessionRuntimeId(
 function getEffectiveRuntimeId(
     state: Pick<
         ChatStore,
-        "activeSessionId" | "sessionsById" | "selectedRuntimeId" | "runtimes"
+        | "activeSessionId"
+        | "sessionsById"
+        | "selectedRuntimeId"
+        | "runtimes"
+        | "setupStatusByRuntimeId"
     >,
 ) {
     return (
         getSessionRuntimeId(state) ??
         state.selectedRuntimeId ??
-        getDefaultRuntimeId(state.runtimes)
+        getDefaultRuntimeId(state.runtimes, state.setupStatusByRuntimeId)
     );
 }
 
@@ -6098,7 +6117,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const setupStatusByRuntimeId =
                     buildSetupStatusMap(setupStatuses);
                 const defaultRuntimeId =
-                    get().selectedRuntimeId ?? getDefaultRuntimeId(runtimes);
+                    get().selectedRuntimeId ??
+                    getDefaultRuntimeId(runtimes, setupStatusByRuntimeId);
 
                 set({
                     runtimes,
@@ -6222,7 +6242,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                                       ?.runtimeId
                                 : null) ??
                             state.selectedRuntimeId ??
-                            getDefaultRuntimeId(hydratedRuntimes);
+                            getDefaultRuntimeId(
+                                hydratedRuntimes,
+                                state.setupStatusByRuntimeId,
+                            );
 
                         return {
                             runtimes: hydratedRuntimes,
@@ -6286,7 +6309,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
             } catch (error) {
                 const runtimeId =
                     get().selectedRuntimeId ??
-                    getDefaultRuntimeId(get().runtimes);
+                    getDefaultRuntimeId(
+                        get().runtimes,
+                        get().setupStatusByRuntimeId,
+                    );
                 if (runtimeId) {
                     set((state) => ({
                         runtimeConnectionByRuntimeId: setRuntimeConnectionState(
@@ -9604,7 +9630,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const nextRuntimeId =
                 runtimeId ??
                 get().selectedRuntimeId ??
-                getDefaultRuntimeId(runtimes);
+                getDefaultRuntimeId(runtimes, get().setupStatusByRuntimeId);
             if (!nextRuntimeId) return null;
 
             const markPendingSessionError = (message: string) => {
@@ -9926,7 +9952,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 sessionOrder: [],
                 activeSessionId: null,
                 lastFocusedSessionId: null,
-                selectedRuntimeId: getDefaultRuntimeId(get().runtimes),
+                selectedRuntimeId: getDefaultRuntimeId(
+                    get().runtimes,
+                    get().setupStatusByRuntimeId,
+                ),
                 composerPartsBySessionId: {},
                 queuedMessagesBySessionId: {},
                 queuedMessageEditBySessionId: {},

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -13,6 +13,10 @@ import {
     isFileTab,
     isNoteTab,
 } from "../../app/store/editorStore";
+import {
+    FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+    FILE_TREE_NOTE_DRAG_EVENT,
+} from "../ai/dragEvents";
 import { useBookmarkStore } from "../../app/store/bookmarkStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
@@ -2086,6 +2090,281 @@ describe("FileTree", () => {
         expect(
             await screen.findByRole("button", { name: "Add to Chat" }),
         ).toBeInTheDocument();
+    });
+
+    it("adds folders, notes, and sidebar files to chat from the context menu", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleAttach = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                ...buildFileEntry("docs/reference.pdf", "application/pdf"),
+                kind: "pdf" as const,
+            },
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "docs");
+
+            fireEvent.contextMenu(getFolderRow("docs"));
+            await user.click(
+                await screen.findByRole("button", { name: "Add to Chat" }),
+            );
+            await waitFor(() => expect(events).toHaveLength(1));
+            expect(events[0].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                folder: { path: "docs", name: "docs" },
+            });
+
+            fireEvent.contextMenu(getNoteRow("Alpha"));
+            await user.click(
+                await screen.findByRole("button", { name: "Add to Chat" }),
+            );
+            await waitFor(() => expect(events).toHaveLength(2));
+            expect(events[1].detail).toMatchObject({
+                phase: "attach",
+                notes: [
+                    {
+                        id: "docs/alpha",
+                        title: "Alpha",
+                        path: "/vault/docs/alpha.md",
+                    },
+                ],
+            });
+
+            fireEvent.contextMenu(getFileRow("config"));
+            await user.click(
+                await screen.findByRole("button", { name: "Add to Chat" }),
+            );
+            await waitFor(() => expect(events).toHaveLength(3));
+            expect(events[2].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                files: [
+                    {
+                        filePath: "/vault/docs/config.toml",
+                        fileName: "config.toml",
+                        mimeType: "application/toml",
+                    },
+                ],
+            });
+
+            fireEvent.contextMenu(getFileRow("reference"));
+            await user.click(
+                await screen.findByRole("button", { name: "Add to Chat" }),
+            );
+            await waitFor(() => expect(events).toHaveLength(4));
+            expect(events[3].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                files: [
+                    {
+                        filePath: "/vault/docs/reference.pdf",
+                        fileName: "reference.pdf",
+                        mimeType: "application/pdf",
+                    },
+                ],
+            });
+        } finally {
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        }
+    });
+
+    it("adds folders, notes, and sidebar files to a new chat from the context menu", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleAttachToNewChat = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                ...buildFileEntry("docs/reference.pdf", "application/pdf"),
+                kind: "pdf" as const,
+            },
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        window.addEventListener(
+            FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+            handleAttachToNewChat,
+        );
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "docs");
+
+            fireEvent.contextMenu(getFolderRow("docs"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add to New Chat",
+                }),
+            );
+            await waitFor(() => expect(events).toHaveLength(1));
+            expect(events[0].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                folder: { path: "docs", name: "docs" },
+            });
+
+            fireEvent.contextMenu(getNoteRow("Alpha"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add to New Chat",
+                }),
+            );
+            await waitFor(() => expect(events).toHaveLength(2));
+            expect(events[1].detail).toMatchObject({
+                phase: "attach",
+                notes: [
+                    {
+                        id: "docs/alpha",
+                        title: "Alpha",
+                        path: "/vault/docs/alpha.md",
+                    },
+                ],
+            });
+
+            fireEvent.contextMenu(getFileRow("config"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add to New Chat",
+                }),
+            );
+            await waitFor(() => expect(events).toHaveLength(3));
+            expect(events[2].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                files: [
+                    {
+                        filePath: "/vault/docs/config.toml",
+                        fileName: "config.toml",
+                        mimeType: "application/toml",
+                    },
+                ],
+            });
+
+            fireEvent.contextMenu(getFileRow("reference"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add to New Chat",
+                }),
+            );
+            await waitFor(() => expect(events).toHaveLength(4));
+            expect(events[3].detail).toMatchObject({
+                phase: "attach",
+                notes: [],
+                files: [
+                    {
+                        filePath: "/vault/docs/reference.pdf",
+                        fileName: "reference.pdf",
+                        mimeType: "application/pdf",
+                    },
+                ],
+            });
+        } finally {
+            window.removeEventListener(
+                FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+                handleAttachToNewChat,
+            );
+        }
+    });
+
+    it("copies full paths for folders, notes, and sidebar files", async () => {
+        const user = userEvent.setup();
+        const writeText = vi
+            .spyOn(navigator.clipboard, "writeText")
+            .mockResolvedValue(undefined);
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                ...buildFileEntry("docs/reference.pdf", "application/pdf"),
+                kind: "pdf" as const,
+            },
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+
+        fireEvent.contextMenu(getFolderRow("docs"));
+        await user.click(
+            await screen.findByRole("button", { name: "Copy Full Path" }),
+        );
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith("/vault/docs");
+        });
+
+        fireEvent.contextMenu(getNoteRow("Alpha"));
+        await user.click(
+            await screen.findByRole("button", { name: "Copy Full Path" }),
+        );
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith("/vault/docs/alpha.md");
+        });
+
+        fireEvent.contextMenu(getFileRow("config"));
+        await user.click(
+            await screen.findByRole("button", { name: "Copy Full Path" }),
+        );
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith("/vault/docs/config.toml");
+        });
+
+        fireEvent.contextMenu(getFileRow("reference"));
+        await user.click(
+            await screen.findByRole("button", { name: "Copy Full Path" }),
+        );
+        await waitFor(() => {
+            expect(writeText).toHaveBeenCalledWith(
+                "/vault/docs/reference.pdf",
+            );
+        });
     });
 
     it("moves generic files to another folder via drag and drop", async () => {

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -1933,6 +1933,38 @@ describe("FileTree", () => {
         expect(getFileRow("Config")).toHaveAttribute("data-selected", "true");
     });
 
+    it("allows folders to participate in mixed cmd-click selections", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+
+        fireEvent.click(getFolderRow("docs"), { metaKey: true });
+        fireEvent.click(getNoteRow("Alpha"), { metaKey: true });
+        fireEvent.click(getFileRow("config"), { metaKey: true });
+
+        expect(getFolderRow("docs")).toHaveAttribute("data-selected", "true");
+        expect(getNoteRow("Alpha")).toHaveAttribute("data-selected", "true");
+        expect(getFileRow("config")).toHaveAttribute("data-selected", "true");
+    });
+
     it("keeps mixed selections with cmd-option click", async () => {
         const user = userEvent.setup();
 
@@ -2048,6 +2080,53 @@ describe("FileTree", () => {
         expect(getFileRow("Config")).toHaveAttribute("data-selected", "true");
         expect(getNoteRow("Guide")).toHaveAttribute("data-selected", "true");
         expect(getFileRow("Reference")).toHaveAttribute(
+            "data-selected",
+            "true",
+        );
+    });
+
+    it("includes folders in contiguous mixed row selections", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "docs/guide",
+                path: "/vault/docs/guide.md",
+                title: "Guide",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                ...buildFileEntry("docs/reference.pdf", "application/pdf"),
+                kind: "pdf" as const,
+            },
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+
+        fireEvent.click(getFolderRow("docs"), { metaKey: true });
+        fireEvent.click(getFileRow("reference"), { shiftKey: true });
+
+        expect(getFolderRow("docs")).toHaveAttribute("data-selected", "true");
+        expect(getNoteRow("Alpha")).toHaveAttribute("data-selected", "true");
+        expect(getFileRow("config")).toHaveAttribute("data-selected", "true");
+        expect(getNoteRow("Guide")).toHaveAttribute("data-selected", "true");
+        expect(getFileRow("reference")).toHaveAttribute(
             "data-selected",
             "true",
         );
@@ -2190,6 +2269,141 @@ describe("FileTree", () => {
         }
     });
 
+    it("adds mixed folder, note, and file selections to chat from any selected row", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleAttach = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                ...buildFileEntry("docs/reference.pdf", "application/pdf"),
+                kind: "pdf" as const,
+            },
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "docs");
+
+            fireEvent.click(getFolderRow("docs"), { metaKey: true });
+            fireEvent.click(getNoteRow("Alpha"), { metaKey: true });
+            fireEvent.click(getFileRow("config"), { metaKey: true });
+            fireEvent.click(getFileRow("reference"), { metaKey: true });
+
+            fireEvent.contextMenu(getNoteRow("Alpha"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add Selected to Chat",
+                }),
+            );
+
+            await waitFor(() => expect(events).toHaveLength(1));
+            expect(events[0].detail).toMatchObject({
+                phase: "attach",
+                folders: [{ path: "docs", name: "docs" }],
+                notes: [
+                    {
+                        id: "docs/alpha",
+                        title: "Alpha",
+                        path: "/vault/docs/alpha.md",
+                    },
+                ],
+                files: [
+                    {
+                        filePath: "/vault/docs/config.toml",
+                        fileName: "config.toml",
+                        mimeType: "application/toml",
+                    },
+                    {
+                        filePath: "/vault/docs/reference.pdf",
+                        fileName: "reference.pdf",
+                        mimeType: "application/pdf",
+                    },
+                ],
+            });
+        } finally {
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        }
+    });
+
+    it("targets add-to-chat actions at the active workspace chat", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleAttach = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "Alpha",
+                path: "/vault/Alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        try {
+            renderComponent(<FileTree />);
+
+            await screen.findByText("Alpha");
+            setEditorTabs(
+                [
+                    {
+                        id: "chat-a",
+                        kind: "ai-chat",
+                        sessionId: "session-a",
+                        title: "Chat A",
+                    },
+                    {
+                        id: "chat-b",
+                        kind: "ai-chat",
+                        sessionId: "session-b",
+                        title: "Chat B",
+                    },
+                ],
+                "chat-b",
+            );
+            fireEvent.contextMenu(getNoteRow("Alpha"));
+            await user.click(
+                await screen.findByRole("button", { name: "Add to Chat" }),
+            );
+
+            await waitFor(() => expect(events).toHaveLength(1));
+            expect(events[0].detail).toMatchObject({
+                phase: "attach",
+                targetSessionId: "session-b",
+                notes: [
+                    {
+                        id: "Alpha",
+                        title: "Alpha",
+                        path: "/vault/Alpha.md",
+                    },
+                ],
+            });
+        } finally {
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleAttach);
+        }
+    });
+
     it("adds folders, notes, and sidebar files to a new chat from the context menu", async () => {
         const user = userEvent.setup();
         const events: CustomEvent[] = [];
@@ -2299,6 +2513,154 @@ describe("FileTree", () => {
                 FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
                 handleAttachToNewChat,
             );
+        }
+    });
+
+    it("adds mixed folder, note, and file selections to a new chat from any selected row", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleAttachToNewChat = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        window.addEventListener(
+            FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+            handleAttachToNewChat,
+        );
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "docs");
+
+            fireEvent.click(getFolderRow("docs"), { metaKey: true });
+            fireEvent.click(getNoteRow("Alpha"), { metaKey: true });
+            fireEvent.click(getFileRow("config"), { metaKey: true });
+
+            fireEvent.contextMenu(getFileRow("config"));
+            await user.click(
+                await screen.findByRole("button", {
+                    name: "Add Selected to New Chat",
+                }),
+            );
+
+            await waitFor(() => expect(events).toHaveLength(1));
+            expect(events[0].detail).toMatchObject({
+                phase: "attach",
+                folders: [{ path: "docs", name: "docs" }],
+                notes: [
+                    {
+                        id: "docs/alpha",
+                        title: "Alpha",
+                        path: "/vault/docs/alpha.md",
+                    },
+                ],
+                files: [
+                    {
+                        filePath: "/vault/docs/config.toml",
+                        fileName: "config.toml",
+                        mimeType: "application/toml",
+                    },
+                ],
+            });
+        } finally {
+            window.removeEventListener(
+                FILE_TREE_ATTACH_TO_NEW_CHAT_EVENT,
+                handleAttachToNewChat,
+            );
+        }
+    });
+
+    it("drags mixed folder, note, and file selections with the full chat context contract", async () => {
+        const user = userEvent.setup();
+        const events: CustomEvent[] = [];
+        const handleDrag = (event: Event) => {
+            events.push(event as CustomEvent);
+        };
+
+        setVaultNotes([
+            {
+                id: "docs/alpha",
+                path: "/vault/docs/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeContentMode", "all_files");
+
+        const elementsFromPoint = vi.fn(() => []);
+        Object.defineProperty(document, "elementsFromPoint", {
+            configurable: true,
+            value: elementsFromPoint,
+        });
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleDrag);
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "docs");
+
+            fireEvent.click(getFolderRow("docs"), { metaKey: true });
+            fireEvent.click(getNoteRow("Alpha"), { metaKey: true });
+            fireEvent.click(getFileRow("config"), { metaKey: true });
+
+            fireEvent.mouseDown(getFolderRow("docs"), {
+                button: 0,
+                clientX: 10,
+                clientY: 10,
+            });
+            fireEvent.mouseMove(window, { clientX: 30, clientY: 30 });
+            fireEvent.mouseUp(window, { clientX: 30, clientY: 30 });
+
+            await waitFor(() => expect(events).toHaveLength(4));
+            expect(events.map((event) => event.detail.phase)).toEqual([
+                "start",
+                "move",
+                "end",
+                "cancel",
+            ]);
+            expect(events.at(-2)?.detail).toMatchObject({
+                phase: "end",
+                folders: [{ path: "docs", name: "docs" }],
+                notes: [
+                    {
+                        id: "docs/alpha",
+                        title: "Alpha",
+                        path: "/vault/docs/alpha.md",
+                    },
+                ],
+                files: [
+                    {
+                        filePath: "/vault/docs/config.toml",
+                        fileName: "config.toml",
+                        mimeType: "application/toml",
+                    },
+                ],
+            });
+            expect(elementsFromPoint).toHaveBeenCalled();
+        } finally {
+            window.removeEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleDrag);
         }
     });
 

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -708,6 +708,10 @@ describe("FileTree", () => {
         expect(useEditorStore.getState().tabs.map((tab) => tab.id)).toEqual([
             "keep-tab",
         ]);
+        expect(getFolderRow("assets")).toHaveAttribute(
+            "data-selected",
+            "false",
+        );
     });
 
     it("renames a folder from the context menu using the inline input", async () => {
@@ -785,6 +789,10 @@ describe("FileTree", () => {
             });
         });
         await screen.findByText("roadmap");
+        expect(getFolderRow("roadmap")).toHaveAttribute(
+            "data-selected",
+            "true",
+        );
         expect(useEditorStore.getState().tabs).toEqual([
             expect.objectContaining({
                 id: "tab-alpha",

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -56,7 +56,11 @@ import {
 } from "../../components/context-menu/ContextMenu";
 import { FileTypeIcon } from "../../components/icons/FileTypeIcon";
 import { FolderTypeIcon } from "../../components/icons/FolderTypeIcon";
-import { emitFileTreeNoteDrag } from "../ai/dragEvents";
+import {
+    emitFileTreeAttachToNewChat,
+    emitFileTreeNoteDrag,
+    type FileTreeNoteDragDetail,
+} from "../ai/dragEvents";
 import { SidebarFilterInput } from "../../components/layout/SidebarFilterInput";
 import { useBookmarkStore } from "../../app/store/bookmarkStore";
 import { perfMeasure, perfNow } from "../../app/utils/perfInstrumentation";
@@ -435,6 +439,43 @@ function shouldConvertRenamedNoteToFile(name: string) {
         return false;
     }
     return !isMarkdownLeafName(leafName);
+}
+
+function isAbsolutePath(path: string) {
+    const normalized = path.replace(/\\/g, "/");
+    return (
+        normalized.startsWith("/") ||
+        normalized.startsWith("//") ||
+        /^[A-Za-z]:\//.test(normalized)
+    );
+}
+
+function getAbsoluteVaultPath(vaultPath: string | null, path: string) {
+    if (!path || isAbsolutePath(path)) return path;
+    if (!vaultPath) return path;
+    return `${vaultPath.replace(/\/+$/, "")}/${path.replace(/^\/+/, "")}`;
+}
+
+function getDraggedVaultFile(entry: VaultEntryDto) {
+    return {
+        filePath: entry.path,
+        fileName: entry.file_name,
+        mimeType:
+            entry.kind === "pdf"
+                ? "application/pdf"
+                : (entry.mime_type ?? "application/octet-stream"),
+    };
+}
+
+function emitFileTreeAttachment(
+    detail: FileTreeNoteDragDetail,
+    target: "current-chat" | "new-chat",
+) {
+    if (target === "new-chat") {
+        emitFileTreeAttachToNewChat(detail);
+        return;
+    }
+    emitFileTreeNoteDrag(detail);
 }
 
 // --- Icons ---
@@ -2962,37 +3003,78 @@ export function FileTree() {
         setSelectedEntryPaths(new Set());
     }, []);
 
-    const handleAddPdfToChat = useCallback((entry: VaultEntryDto) => {
-        emitFileTreeNoteDrag({
-            phase: "attach",
-            x: 0,
-            y: 0,
-            notes: [],
-            files: [
-                {
-                    filePath: entry.path,
-                    fileName: entry.file_name,
-                    mimeType: "application/pdf",
-                },
-            ],
-        });
+    const handleCopyFullPath = useCallback((path: string) => {
+        if (!path) return;
+        void navigator.clipboard.writeText(path);
     }, []);
 
-    const handleAddFileToChat = useCallback((entry: VaultEntryDto) => {
-        emitFileTreeNoteDrag({
-            phase: "attach",
-            x: 0,
-            y: 0,
-            notes: [],
-            files: [
+    const handleAddFolderToChat = useCallback(
+        (path: string, target: "current-chat" | "new-chat" = "current-chat") => {
+            emitFileTreeAttachment(
                 {
-                    filePath: entry.path,
-                    fileName: entry.file_name,
-                    mimeType: entry.mime_type ?? "application/octet-stream",
+                    phase: "attach",
+                    x: 0,
+                    y: 0,
+                    notes: [],
+                    folder: {
+                        path,
+                        name: getBaseName(path),
+                    },
                 },
-            ],
-        });
-    }, []);
+                target,
+            );
+        },
+        [],
+    );
+
+    const handleAddNotesToChat = useCallback(
+        (
+            notesToAdd: NoteDto[],
+            target: "current-chat" | "new-chat" = "current-chat",
+        ) => {
+            if (notesToAdd.length === 0) return;
+            emitFileTreeAttachment(
+                {
+                    phase: "attach",
+                    x: 0,
+                    y: 0,
+                    notes: notesToAdd.map((note) => ({
+                        id: note.id,
+                        title: note.title,
+                        path: note.path,
+                    })),
+                },
+                target,
+            );
+        },
+        [],
+    );
+
+    const handleAddEntriesToChat = useCallback(
+        (
+            entriesToAdd: VaultEntryDto[],
+            target: "current-chat" | "new-chat" = "current-chat",
+        ) => {
+            const files = entriesToAdd
+                .filter(
+                    (entry) => entry.kind === "pdf" || entry.kind === "file",
+                )
+                .map(getDraggedVaultFile);
+            if (files.length === 0) return;
+
+            emitFileTreeAttachment(
+                {
+                    phase: "attach",
+                    x: 0,
+                    y: 0,
+                    notes: [],
+                    files,
+                },
+                target,
+            );
+        },
+        [],
+    );
 
     const readNoteContent = useCallback(
         (noteId: string) =>
@@ -3151,6 +3233,23 @@ export function FileTree() {
             return [note];
         },
         [notes, selectedNoteIds],
+    );
+
+    const getContextTargetEntries = useCallback(
+        (entry: VaultEntryDto) => {
+            if (
+                selectedEntryPaths.size > 1 &&
+                selectedEntryPaths.has(entry.path)
+            ) {
+                return entries.filter(
+                    (item) =>
+                        selectedEntryPaths.has(item.path) &&
+                        (item.kind === "pdf" || item.kind === "file"),
+                );
+            }
+            return [entry];
+        },
+        [entries, selectedEntryPaths],
     );
 
     const applyMove = useCallback(
@@ -3700,6 +3799,7 @@ export function FileTree() {
             case "folder": {
                 const { path, expanded } = contextMenu.payload;
                 const folderName = path.split("/").pop() ?? path;
+                const absolutePath = getAbsoluteVaultPath(vaultPath, path);
                 return [
                     {
                         label: "New Note Here",
@@ -3722,6 +3822,14 @@ export function FileTree() {
                             (treeClipboard.kind === "folder" &&
                                 !canPasteFolderClipboard(treeClipboard, path)),
                     },
+                    {
+                        label: "Add to Chat",
+                        action: () => handleAddFolderToChat(path),
+                    },
+                    {
+                        label: "Add to New Chat",
+                        action: () => handleAddFolderToChat(path, "new-chat"),
+                    },
                     { type: "separator" },
                     {
                         label: expanded ? "Collapse" : "Expand",
@@ -3736,8 +3844,8 @@ export function FileTree() {
                         action: () => handleRevealFolderInFinder(path),
                     },
                     {
-                        label: "Copy Folder Path",
-                        action: () => void navigator.clipboard.writeText(path),
+                        label: "Copy Full Path",
+                        action: () => handleCopyFullPath(absolutePath),
                     },
                     { type: "separator" },
                     {
@@ -3759,6 +3867,14 @@ export function FileTree() {
                     contextTargetNotes.length > 1
                         ? "Move Selected Notes to…"
                         : "Move Note to…";
+                const addToChatLabel =
+                    contextTargetNotes.length > 1
+                        ? "Add Selected to Chat"
+                        : "Add to Chat";
+                const addToNewChatLabel =
+                    contextTargetNotes.length > 1
+                        ? "Add Selected to New Chat"
+                        : "Add to New Chat";
 
                 return [
                     {
@@ -3789,6 +3905,18 @@ export function FileTree() {
                                     getParentPath(note.id),
                                 )),
                     },
+                    {
+                        label: addToChatLabel,
+                        action: () => handleAddNotesToChat(contextTargetNotes),
+                    },
+                    {
+                        label: addToNewChatLabel,
+                        action: () =>
+                            handleAddNotesToChat(
+                                contextTargetNotes,
+                                "new-chat",
+                            ),
+                    },
                     { type: "separator" },
                     {
                         label: "Rename",
@@ -3809,9 +3937,14 @@ export function FileTree() {
                         action: () => handleRevealNoteInFinder(note),
                     },
                     {
-                        label: "Copy Note Path",
+                        label: "Copy Full Path",
                         action: () =>
-                            void navigator.clipboard.writeText(note.id),
+                            handleCopyFullPath(
+                                getAbsoluteVaultPath(
+                                    vaultPath,
+                                    note.path || note.id,
+                                ),
+                            ),
                     },
                     { type: "separator" },
                     {
@@ -3843,6 +3976,15 @@ export function FileTree() {
             }
             case "pdf": {
                 const { entry } = contextMenu.payload;
+                const contextTargetEntries = getContextTargetEntries(entry);
+                const addToChatLabel =
+                    contextTargetEntries.length > 1
+                        ? "Add Selected to Chat"
+                        : "Add to Chat";
+                const addToNewChatLabel =
+                    contextTargetEntries.length > 1
+                        ? "Add Selected to New Chat"
+                        : "Add to New Chat";
                 return [
                     {
                         label: "Open",
@@ -3862,13 +4004,25 @@ export function FileTree() {
                         action: () => void openPath(entry.path),
                     },
                     {
+                        label: addToChatLabel,
+                        action: () =>
+                            handleAddEntriesToChat(contextTargetEntries),
+                    },
+                    {
+                        label: addToNewChatLabel,
+                        action: () =>
+                            handleAddEntriesToChat(
+                                contextTargetEntries,
+                                "new-chat",
+                            ),
+                    },
+                    {
                         label: "Reveal in Finder",
                         action: () => void revealItemInDir(entry.path),
                     },
                     {
-                        label: "Copy Path",
-                        action: () =>
-                            void navigator.clipboard.writeText(entry.path),
+                        label: "Copy Full Path",
+                        action: () => handleCopyFullPath(entry.path),
                     },
                     { type: "separator" },
                     {
@@ -3898,16 +4052,20 @@ export function FileTree() {
                         action: () => void handleMoveEntryToTrash(entry),
                         danger: true,
                     },
-                    { type: "separator" },
-                    {
-                        label: "Add to Chat",
-                        action: () => handleAddPdfToChat(entry),
-                    },
                 ];
             }
             case "file": {
                 const { entry } = contextMenu.payload;
                 const canOpenInApp = canOpenVaultFileEntryInApp(entry);
+                const contextTargetEntries = getContextTargetEntries(entry);
+                const addToChatLabel =
+                    contextTargetEntries.length > 1
+                        ? "Add Selected to Chat"
+                        : "Add to Chat";
+                const addToNewChatLabel =
+                    contextTargetEntries.length > 1
+                        ? "Add Selected to New Chat"
+                        : "Add to New Chat";
                 return [
                     {
                         label: "Open",
@@ -3929,15 +4087,25 @@ export function FileTree() {
                         action: () => handleEntryRenameStart(entry),
                     },
                     {
+                        label: addToChatLabel,
+                        action: () =>
+                            handleAddEntriesToChat(contextTargetEntries),
+                    },
+                    {
+                        label: addToNewChatLabel,
+                        action: () =>
+                            handleAddEntriesToChat(
+                                contextTargetEntries,
+                                "new-chat",
+                            ),
+                    },
+                    {
                         label: "Reveal in Finder",
                         action: () => void revealItemInDir(entry.path),
                     },
                     {
-                        label: "Copy Path",
-                        action: () =>
-                            void navigator.clipboard.writeText(
-                                entry.relative_path,
-                            ),
+                        label: "Copy Full Path",
+                        action: () => handleCopyFullPath(entry.path),
                     },
                     { type: "separator" },
                     {
@@ -3966,11 +4134,6 @@ export function FileTree() {
                         label: "Move File to Trash",
                         action: () => void handleMoveEntryToTrash(entry),
                         danger: true,
-                    },
-                    { type: "separator" },
-                    {
-                        label: "Add to Chat",
-                        action: () => handleAddFileToChat(entry),
                     },
                 ];
             }
@@ -4025,16 +4188,19 @@ export function FileTree() {
         applyMove,
         contextMenu,
         expandedFolders.size,
+        getContextTargetEntries,
         getContextTargetNotes,
+        handleAddEntriesToChat,
+        handleAddFolderToChat,
+        handleAddNotesToChat,
         handleCopyFolder,
+        handleCopyFullPath,
         handleCopyNotes,
         handleDelete,
         handleDeleteFolder,
         handleDuplicateNote,
         handleEntryRenameStart,
         handleFolderRenameStart,
-        handleAddFileToChat,
-        handleAddPdfToChat,
         handleMoveEntryToTrash,
         handlePdfClick,
         handleOpenPdfInNewTab,
@@ -4047,6 +4213,7 @@ export function FileTree() {
         startCreating,
         treeClipboard,
         bookmarkItems,
+        vaultPath,
     ]);
 
     // Ref-backed stable callbacks so memo'd FlatTreeRowView stays fresh

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -2400,6 +2400,15 @@ export function FileTree() {
                     }
                     return next;
                 });
+                setSelectedFolderPaths((prev) => {
+                    const next = new Set<string>();
+                    for (const path of prev) {
+                        next.add(
+                            movePathPrefix(path, folderPath, nextFolderPath),
+                        );
+                    }
+                    return next;
+                });
                 setFocusedFolderPath(nextFolderPath);
 
                 setExpandedFolders((prev) => {
@@ -3783,6 +3792,18 @@ export function FileTree() {
                             entryPath.startsWith(`${sourceAbsolutePath}/`)
                         ) {
                             next.delete(entryPath);
+                        }
+                    });
+                    return next;
+                });
+                setSelectedFolderPaths((prev) => {
+                    const next = new Set(prev);
+                    next.forEach((path) => {
+                        if (
+                            path === relativePath ||
+                            path.startsWith(`${relativePath}/`)
+                        ) {
+                            next.delete(path);
                         }
                     });
                     return next;

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -61,6 +61,7 @@ import {
     emitFileTreeNoteDrag,
     type FileTreeNoteDragDetail,
 } from "../ai/dragEvents";
+import { getPreferredWorkspaceChatSessionId } from "../ai/chatWorkspaceSelectors";
 import { SidebarFilterInput } from "../../components/layout/SidebarFilterInput";
 import { useBookmarkStore } from "../../app/store/bookmarkStore";
 import { perfMeasure, perfNow } from "../../app/utils/perfInstrumentation";
@@ -169,9 +170,19 @@ type FlatTreeRow =
 type TreeSelectionState = {
     noteIds: Set<string>;
     entryPaths: Set<string>;
+    folderPaths: Set<string>;
+};
+
+type ChatContextTargets = {
+    notes: NoteDto[];
+    entries: VaultEntryDto[];
+    folderPaths: string[];
 };
 
 function getSelectableRowKey(row: FlatTreeRow): string | null {
+    if (row.kind === "folder") {
+        return `folder:${row.path}`;
+    }
     if (row.kind === "note") {
         return `note:${row.note.id}`;
     }
@@ -184,8 +195,13 @@ function getSelectableRowKey(row: FlatTreeRow): string | null {
 function buildSelectionFromRows(rows: FlatTreeRow[]): TreeSelectionState {
     const noteIds = new Set<string>();
     const entryPaths = new Set<string>();
+    const folderPaths = new Set<string>();
 
     for (const row of rows) {
+        if (row.kind === "folder") {
+            folderPaths.add(row.path);
+            continue;
+        }
         if (row.kind === "note") {
             noteIds.add(row.note.id);
             continue;
@@ -195,7 +211,7 @@ function buildSelectionFromRows(rows: FlatTreeRow[]): TreeSelectionState {
         }
     }
 
-    return { noteIds, entryPaths };
+    return { noteIds, entryPaths, folderPaths };
 }
 
 function buildTree(
@@ -467,6 +483,17 @@ function getDraggedVaultFile(entry: VaultEntryDto) {
     };
 }
 
+function getDraggedVaultFolder(path: string) {
+    return {
+        path,
+        name: getBaseName(path),
+    };
+}
+
+function isChatAttachableEntry(entry: VaultEntryDto) {
+    return entry.kind === "pdf" || entry.kind === "file";
+}
+
 function emitFileTreeAttachment(
     detail: FileTreeNoteDragDetail,
     target: "current-chat" | "new-chat",
@@ -475,7 +502,11 @@ function emitFileTreeAttachment(
         emitFileTreeAttachToNewChat(detail);
         return;
     }
-    emitFileTreeNoteDrag(detail);
+
+    const targetSessionId = getPreferredWorkspaceChatSessionId();
+    emitFileTreeNoteDrag(
+        targetSessionId ? { ...detail, targetSessionId } : detail,
+    );
 }
 
 // --- Icons ---
@@ -732,11 +763,15 @@ interface FlatTreeRowViewProps {
     expandedFolders: Set<string>;
     selectedNoteIds: Set<string>;
     selectedEntryPaths: Set<string>;
+    selectedFolderPaths: Set<string>;
     contextMenuFolderPath: string | null;
     draggingNoteIds: Set<string>;
     draggingFolderPath: string | null;
     dragOverPath: string | null;
-    onFolderClick: (path: string) => void;
+    onFolderClick: (
+        path: string,
+        modifiers: { cmd: boolean; shift: boolean },
+    ) => void;
     onFolderMouseDown: (path: string, e: React.MouseEvent) => void;
     onFolderContextMenu: (e: React.MouseEvent, path: string) => void;
     onNoteClick: (
@@ -785,6 +820,7 @@ const FlatTreeRowView = memo(
         expandedFolders,
         selectedNoteIds,
         selectedEntryPaths,
+        selectedFolderPaths,
         contextMenuFolderPath,
         draggingNoteIds,
         draggingFolderPath,
@@ -828,6 +864,8 @@ const FlatTreeRowView = memo(
         const noteOffset = Math.round(14 * metrics.scale);
 
         const isFolder = row.kind === "folder";
+        const isSelectedFolder =
+            row.kind === "folder" && selectedFolderPaths.has(row.path);
         const isDragOver = dragOverPath === row.path;
         const isDraggingFolder =
             row.kind === "folder" && draggingFolderPath === row.path;
@@ -928,8 +966,15 @@ const FlatTreeRowView = memo(
 
             return (
                 <button
-                    onMouseDown={(event) => onFolderMouseDown(row.path, event)}
-                    onClick={() => onFolderClick(row.path)}
+                    onMouseDown={(event) =>
+                        onFolderMouseDown(row.path, event)
+                    }
+                    onClick={(event) =>
+                        onFolderClick(row.path, {
+                            cmd: event.metaKey || event.ctrlKey,
+                            shift: event.shiftKey,
+                        })
+                    }
                     onContextMenu={(event) => {
                         event.preventDefault();
                         event.stopPropagation();
@@ -938,7 +983,9 @@ const FlatTreeRowView = memo(
                     data-folder-path={row.path}
                     data-drag-over={isDragOver ? "true" : "false"}
                     data-selected={
-                        contextMenuFolderPath === row.path ? "true" : "false"
+                        isSelectedFolder || contextMenuFolderPath === row.path
+                            ? "true"
+                            : "false"
                     }
                     className="file-tree-row flex items-center gap-1.5 text-left text-xs rounded"
                     style={{
@@ -953,7 +1000,8 @@ const FlatTreeRowView = memo(
                                   backgroundColor:
                                       "color-mix(in srgb, var(--accent) 18%, var(--bg-secondary))",
                               }
-                            : contextMenuFolderPath === row.path
+                            : isSelectedFolder ||
+                                contextMenuFolderPath === row.path
                               ? {
                                     backgroundColor:
                                         "color-mix(in srgb, var(--accent) 22%, transparent)",
@@ -1383,6 +1431,11 @@ const FlatTreeRowView = memo(
             )
                 return false;
             if (
+                prev.selectedFolderPaths.has(path) !==
+                next.selectedFolderPaths.has(path)
+            )
+                return false;
+            if (
                 (prev.draggingFolderPath === path) !==
                 (next.draggingFolderPath === path)
             )
@@ -1513,10 +1566,72 @@ interface DragState {
         | { kind: "notes"; notes: NoteDto[] }
         | { kind: "folder"; path: string }
         | { kind: "pdf"; entry: VaultEntryDto }
-        | { kind: "file"; entry: VaultEntryDto };
+        | { kind: "file"; entry: VaultEntryDto }
+        | { kind: "selection"; targets: ChatContextTargets };
     startX: number;
     startY: number;
     active: boolean;
+}
+
+function getDraggedVaultNote(note: NoteDto) {
+    return {
+        id: note.id,
+        title: note.title,
+        path: note.path,
+    };
+}
+
+function buildFileTreeDragDetail(
+    item: DragState["item"],
+    phase: FileTreeNoteDragDetail["phase"],
+    x: number,
+    y: number,
+): FileTreeNoteDragDetail {
+    if (item.kind === "selection") {
+        const notes = item.targets.notes.map(getDraggedVaultNote);
+        const files = item.targets.entries
+            .filter(isChatAttachableEntry)
+            .map(getDraggedVaultFile);
+        const folders = item.targets.folderPaths.map(getDraggedVaultFolder);
+        return {
+            phase,
+            x,
+            y,
+            notes,
+            ...(files.length > 0 ? { files } : {}),
+            ...(folders.length === 1 ? { folder: folders[0] } : {}),
+            ...(folders.length > 0 ? { folders } : {}),
+        };
+    }
+
+    if (item.kind === "folder") {
+        const folder = getDraggedVaultFolder(item.path);
+        return {
+            phase,
+            x,
+            y,
+            notes: [],
+            folder,
+            folders: [folder],
+        };
+    }
+
+    if (item.kind === "pdf" || item.kind === "file") {
+        return {
+            phase,
+            x,
+            y,
+            notes: [],
+            files: [getDraggedVaultFile(item.entry)],
+        };
+    }
+
+    return {
+        phase,
+        x,
+        y,
+        notes: item.notes.map(getDraggedVaultNote),
+    };
 }
 
 // --- Main FileTree ---
@@ -1589,6 +1704,13 @@ export function FileTree() {
     const [selectedEntryPaths, setSelectedEntryPaths] = useState<Set<string>>(
         new Set(),
     );
+    const [selectedFolderPaths, setSelectedFolderPaths] = useState<
+        Set<string>
+    >(new Set());
+    const selectedRowCount =
+        selectedNoteIds.size +
+        selectedEntryPaths.size +
+        selectedFolderPaths.size;
     const [draggingNoteIds, setDraggingNoteIds] = useState<Set<string>>(
         new Set(),
     );
@@ -1660,6 +1782,7 @@ export function FileTree() {
         if (!activeEntryPath) return new Set<string>();
         return new Set([activeEntryPath]);
     }, [activeEntryPath, selectedEntryPaths]);
+    const visibleSelectedFolderPaths = selectedFolderPaths;
     const treeRevision =
         sortMode === "modified_desc" || sortMode === "modified_asc"
             ? `${structureRevision}:${contentRevision}`
@@ -2164,7 +2287,7 @@ export function FileTree() {
 
     // Handle REVEAL_NOTE_IN_TREE_EVENT: expand folders + defer scroll
     useEffect(() => {
-        const handleReveal = (event: Event) => {
+    const handleReveal = (event: Event) => {
             const noteId = (event as CustomEvent<{ noteId?: string }>).detail
                 ?.noteId;
             if (!noteId) return;
@@ -2176,6 +2299,8 @@ export function FileTree() {
 
             setExpandedFolders((prev) => new Set([...prev, ...folders]));
             setSelectedNoteIds(new Set([noteId]));
+            setSelectedEntryPaths(new Set());
+            setSelectedFolderPaths(new Set());
             lastClickedRowKeyRef.current = `note:${noteId}`;
             pendingRevealRef.current = noteId;
         };
@@ -2358,6 +2483,7 @@ export function FileTree() {
                 }));
 
                 setSelectedEntryPaths(new Set([updated.path]));
+                setSelectedFolderPaths(new Set());
                 setFocusedFolderPath(getParentPath(updated.relative_path));
                 await useVaultStore.getState().refreshEntries();
                 return updated;
@@ -2381,6 +2507,25 @@ export function FileTree() {
     const getDragTargetFolder = useCallback(
         (item: DragState["item"], hoveredFolder: string | null) => {
             if (hoveredFolder === null) return null;
+
+            if (item.kind === "selection") {
+                const foldersMovable = item.targets.folderPaths.every((path) =>
+                    canMoveFolderToTarget(path, hoveredFolder),
+                );
+                const entriesMovable = item.targets.entries.every(
+                    (entry) => buildEntryMovePath(entry, hoveredFolder) !== null,
+                );
+                const noteOperations = buildNoteMoveOperations(
+                    item.targets.notes,
+                    hoveredFolder,
+                );
+                const notesMovable =
+                    item.targets.notes.length === 0 ||
+                    noteOperations.length > 0;
+                return foldersMovable && entriesMovable && notesMovable
+                    ? hoveredFolder
+                    : null;
+            }
 
             if (item.kind === "folder") {
                 return canMoveFolderToTarget(item.path, hoveredFolder)
@@ -2425,51 +2570,27 @@ export function FileTree() {
                 const dy = e.clientY - s.startY;
                 if (Math.sqrt(dx * dx + dy * dy) < 5) return;
                 s.active = true;
-                if (s.item.kind === "folder") {
+                if (s.item.kind === "selection") {
+                    setDraggingNoteIds(
+                        new Set(
+                            s.item.targets.notes.map((note) => note.id),
+                        ),
+                    );
+                    setDraggingFolderPath(
+                        s.item.targets.folderPaths[0] ?? null,
+                    );
+                    const itemCount =
+                        s.item.targets.notes.length +
+                        s.item.targets.entries.length +
+                        s.item.targets.folderPaths.length;
+                    setDragLabel(`${itemCount} items`);
+                } else if (s.item.kind === "folder") {
                     setDraggingFolderPath(s.item.path);
                     setDragLabel(getBaseName(s.item.path));
-                    emitFileTreeNoteDrag({
-                        phase: "start",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        folder: {
-                            path: s.item.path,
-                            name: getBaseName(s.item.path),
-                        },
-                    });
                 } else if (s.item.kind === "pdf") {
                     setDragLabel(s.item.entry.file_name);
-                    emitFileTreeNoteDrag({
-                        phase: "start",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        files: [
-                            {
-                                filePath: s.item.entry.path,
-                                fileName: s.item.entry.file_name,
-                                mimeType: "application/pdf",
-                            },
-                        ],
-                    });
                 } else if (s.item.kind === "file") {
                     setDragLabel(s.item.entry.file_name);
-                    emitFileTreeNoteDrag({
-                        phase: "start",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        files: [
-                            {
-                                filePath: s.item.entry.path,
-                                fileName: s.item.entry.file_name,
-                                mimeType:
-                                    s.item.entry.mime_type ??
-                                    "application/octet-stream",
-                            },
-                        ],
-                    });
                 } else {
                     setDraggingNoteIds(
                         new Set(s.item.notes.map((note) => note.id)),
@@ -2479,74 +2600,27 @@ export function FileTree() {
                             ? `${s.item.notes.length} notes`
                             : (s.item.notes[0]?.title ?? null),
                     );
-                    emitFileTreeNoteDrag({
-                        phase: "start",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: s.item.notes.map((note) => ({
-                            id: note.id,
-                            title: note.title,
-                            path: note.path,
-                        })),
-                    });
                 }
+                emitFileTreeNoteDrag(
+                    buildFileTreeDragDetail(
+                        s.item,
+                        "start",
+                        e.clientX,
+                        e.clientY,
+                    ),
+                );
             }
 
             setDragPos({ x: e.clientX, y: e.clientY });
             if (s.active) {
-                if (s.item.kind === "notes") {
-                    emitFileTreeNoteDrag({
-                        phase: "move",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: s.item.notes.map((note) => ({
-                            id: note.id,
-                            title: note.title,
-                            path: note.path,
-                        })),
-                    });
-                } else if (s.item.kind === "folder") {
-                    emitFileTreeNoteDrag({
-                        phase: "move",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        folder: {
-                            path: s.item.path,
-                            name: getBaseName(s.item.path),
-                        },
-                    });
-                } else if (s.item.kind === "pdf") {
-                    emitFileTreeNoteDrag({
-                        phase: "move",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        files: [
-                            {
-                                filePath: s.item.entry.path,
-                                fileName: s.item.entry.file_name,
-                                mimeType: "application/pdf",
-                            },
-                        ],
-                    });
-                } else if (s.item.kind === "file") {
-                    emitFileTreeNoteDrag({
-                        phase: "move",
-                        x: e.clientX,
-                        y: e.clientY,
-                        notes: [],
-                        files: [
-                            {
-                                filePath: s.item.entry.path,
-                                fileName: s.item.entry.file_name,
-                                mimeType:
-                                    s.item.entry.mime_type ??
-                                    "application/octet-stream",
-                            },
-                        ],
-                    });
-                }
+                emitFileTreeNoteDrag(
+                    buildFileTreeDragDetail(
+                        s.item,
+                        "move",
+                        e.clientX,
+                        e.clientY,
+                    ),
+                );
             }
 
             const els = document.elementsFromPoint(e.clientX, e.clientY);
@@ -2566,59 +2640,9 @@ export function FileTree() {
 
             if (!s?.active) return;
 
-            if (s.item.kind === "notes") {
-                emitFileTreeNoteDrag({
-                    phase: "end",
-                    x: e.clientX,
-                    y: e.clientY,
-                    notes: s.item.notes.map((note) => ({
-                        id: note.id,
-                        title: note.title,
-                        path: note.path,
-                    })),
-                });
-            } else if (s.item.kind === "folder") {
-                emitFileTreeNoteDrag({
-                    phase: "end",
-                    x: e.clientX,
-                    y: e.clientY,
-                    notes: [],
-                    folder: {
-                        path: s.item.path,
-                        name: getBaseName(s.item.path),
-                    },
-                });
-            } else if (s.item.kind === "pdf") {
-                emitFileTreeNoteDrag({
-                    phase: "end",
-                    x: e.clientX,
-                    y: e.clientY,
-                    notes: [],
-                    files: [
-                        {
-                            filePath: s.item.entry.path,
-                            fileName: s.item.entry.file_name,
-                            mimeType: "application/pdf",
-                        },
-                    ],
-                });
-            } else if (s.item.kind === "file") {
-                emitFileTreeNoteDrag({
-                    phase: "end",
-                    x: e.clientX,
-                    y: e.clientY,
-                    notes: [],
-                    files: [
-                        {
-                            filePath: s.item.entry.path,
-                            fileName: s.item.entry.file_name,
-                            mimeType:
-                                s.item.entry.mime_type ??
-                                "application/octet-stream",
-                        },
-                    ],
-                });
-            }
+            emitFileTreeNoteDrag(
+                buildFileTreeDragDetail(s.item, "end", e.clientX, e.clientY),
+            );
 
             wasJustDraggingRef.current = true;
             requestAnimationFrame(() => {
@@ -2632,6 +2656,41 @@ export function FileTree() {
             setDragOverPath(null);
 
             if (folder === null) return;
+
+            if (s.item.kind === "selection") {
+                const selectedFolderPaths = s.item.targets.folderPaths;
+                const isInsideSelectedFolder = (path: string) =>
+                    selectedFolderPaths.some((folderPath) =>
+                        path.startsWith(`${folderPath}/`),
+                    );
+                const folderPathsToMove = selectedFolderPaths.filter(
+                    (path) =>
+                        !selectedFolderPaths.some(
+                            (candidate) =>
+                                candidate !== path &&
+                                path.startsWith(`${candidate}/`),
+                        ),
+                );
+                const notesToMove = s.item.targets.notes.filter(
+                    (note) => !isInsideSelectedFolder(note.id),
+                );
+                const entriesToMove = s.item.targets.entries.filter(
+                    (entry) => !isInsideSelectedFolder(entry.relative_path),
+                );
+
+                for (const folderPath of folderPathsToMove) {
+                    await moveFolder(folderPath, folder);
+                }
+                if (notesToMove.length > 0) {
+                    await applyMoveOperations(
+                        buildNoteMoveOperations(notesToMove, folder),
+                    );
+                }
+                for (const entry of entriesToMove) {
+                    await moveVaultEntry(entry, folder);
+                }
+                return;
+            }
 
             if (s.item.kind === "folder") {
                 await moveFolder(s.item.path, folder);
@@ -2673,14 +2732,6 @@ export function FileTree() {
         });
     };
 
-    const handleFolderClick = useCallback((path: string) => {
-        if (wasJustDraggingRef.current) return;
-        setFocusedFolderPath(path);
-        setSelectedEntryPaths(new Set());
-        setSelectedNoteIds(new Set());
-        handleToggleFolder(path);
-    }, []);
-
     const handleSortSelect = (mode: SortMode) => {
         setSortMode(mode);
         safeStorageSetItem(SORT_KEY, mode);
@@ -2690,6 +2741,7 @@ export function FileTree() {
     const applySelectionState = useCallback((selection: TreeSelectionState) => {
         setSelectedNoteIds(selection.noteIds);
         setSelectedEntryPaths(selection.entryPaths);
+        setSelectedFolderPaths(selection.folderPaths);
     }, []);
 
     const extendSelectionState = useCallback(
@@ -2703,6 +2755,13 @@ export function FileTree() {
                 const next = new Set(prev);
                 selection.entryPaths.forEach((entryPath) =>
                     next.add(entryPath),
+                );
+                return next;
+            });
+            setSelectedFolderPaths((prev) => {
+                const next = new Set(prev);
+                selection.folderPaths.forEach((folderPath) =>
+                    next.add(folderPath),
                 );
                 return next;
             });
@@ -2743,6 +2802,36 @@ export function FileTree() {
         [applySelectionState, extendSelectionState],
     );
 
+    const handleFolderClick = useCallback(
+        (path: string, modifiers: { cmd: boolean; shift: boolean }) => {
+            if (wasJustDraggingRef.current) return;
+            setFocusedFolderPath(path);
+            const rowKey = `folder:${path}`;
+
+            if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
+                return;
+            }
+
+            if (modifiers.cmd) {
+                setSelectedFolderPaths((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(path)) next.delete(path);
+                    else next.add(path);
+                    return next;
+                });
+                lastClickedRowKeyRef.current = rowKey;
+                return;
+            }
+
+            setSelectedEntryPaths(new Set());
+            setSelectedNoteIds(new Set());
+            setSelectedFolderPaths(new Set());
+            lastClickedRowKeyRef.current = rowKey;
+            handleToggleFolder(path);
+        },
+        [selectRowRange],
+    );
+
     const handleRevealToggle = () => {
         const next = !revealActive;
         if (!next) {
@@ -2761,10 +2850,44 @@ export function FileTree() {
         }
     };
 
+    const getSelectedChatContextTargets = useCallback(
+        (): ChatContextTargets => ({
+            notes: notes.filter((item) => selectedNoteIds.has(item.id)),
+            entries: entries.filter(
+                (item) =>
+                    selectedEntryPaths.has(item.path) &&
+                    isChatAttachableEntry(item),
+            ),
+            folderPaths: allFolderPaths.filter((path) =>
+                selectedFolderPaths.has(path),
+            ),
+        }),
+        [
+            allFolderPaths,
+            entries,
+            notes,
+            selectedEntryPaths,
+            selectedFolderPaths,
+            selectedNoteIds,
+        ],
+    );
+
     const handleNoteMouseDown = useCallback(
         (note: NoteDto, e: React.MouseEvent) => {
             if (e.button !== 0) return;
             e.preventDefault(); // prevent text selection during drag
+            if (selectedRowCount > 1 && selectedNoteIds.has(note.id)) {
+                dragStateRef.current = {
+                    item: {
+                        kind: "selection",
+                        targets: getSelectedChatContextTargets(),
+                    },
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    active: false,
+                };
+                return;
+            }
             const dragNotes =
                 selectedNoteIds.size > 1 && selectedNoteIds.has(note.id)
                     ? notes.filter((item) => selectedNoteIds.has(item.id))
@@ -2776,13 +2899,30 @@ export function FileTree() {
                 active: false,
             };
         },
-        [notes, selectedNoteIds],
+        [
+            getSelectedChatContextTargets,
+            notes,
+            selectedNoteIds,
+            selectedRowCount,
+        ],
     );
 
     const handleFolderMouseDown = useCallback(
         (path: string, e: React.MouseEvent) => {
             if (e.button !== 0) return;
             e.preventDefault();
+            if (selectedRowCount > 1 && selectedFolderPaths.has(path)) {
+                dragStateRef.current = {
+                    item: {
+                        kind: "selection",
+                        targets: getSelectedChatContextTargets(),
+                    },
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    active: false,
+                };
+                return;
+            }
             dragStateRef.current = {
                 item: { kind: "folder", path },
                 startX: e.clientX,
@@ -2790,7 +2930,11 @@ export function FileTree() {
                 active: false,
             };
         },
-        [],
+        [
+            getSelectedChatContextTargets,
+            selectedFolderPaths,
+            selectedRowCount,
+        ],
     );
 
     const openPdf = useEditorStore((s) => s.openPdf);
@@ -2820,6 +2964,7 @@ export function FileTree() {
             }
             setSelectedNoteIds(new Set());
             setSelectedEntryPaths(new Set([entry.path]));
+            setSelectedFolderPaths(new Set());
             lastClickedEntryPathRef.current = entry.path;
             lastClickedRowKeyRef.current = rowKey;
             openPdf(entry.id, entry.title, entry.path);
@@ -2831,6 +2976,18 @@ export function FileTree() {
         (entry: VaultEntryDto, e: React.MouseEvent) => {
             if (e.button !== 0) return;
             e.preventDefault();
+            if (selectedRowCount > 1 && selectedEntryPaths.has(entry.path)) {
+                dragStateRef.current = {
+                    item: {
+                        kind: "selection",
+                        targets: getSelectedChatContextTargets(),
+                    },
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    active: false,
+                };
+                return;
+            }
             dragStateRef.current = {
                 item: { kind: "pdf", entry },
                 startX: e.clientX,
@@ -2838,7 +2995,11 @@ export function FileTree() {
                 active: false,
             };
         },
-        [],
+        [
+            getSelectedChatContextTargets,
+            selectedEntryPaths,
+            selectedRowCount,
+        ],
     );
 
     const handlePdfContextMenu = useCallback(
@@ -2846,11 +3007,12 @@ export function FileTree() {
             e.preventDefault();
             setFocusedFolderPath(getParentPath(entry.relative_path));
             const preserveSelection =
-                selectedEntryPaths.size > 1 &&
+                selectedRowCount > 1 &&
                 selectedEntryPaths.has(entry.path);
             if (!preserveSelection) {
                 setSelectedNoteIds(new Set());
                 setSelectedEntryPaths(new Set([entry.path]));
+                setSelectedFolderPaths(new Set());
             }
             setContextMenu({
                 x: e.clientX,
@@ -2858,7 +3020,7 @@ export function FileTree() {
                 payload: { kind: "pdf", entry },
             });
         },
-        [selectedEntryPaths],
+        [selectedEntryPaths, selectedRowCount],
     );
 
     const handleOpenPdfInNewTab = useCallback(
@@ -2887,6 +3049,7 @@ export function FileTree() {
             setFocusedFolderPath(getParentPath(entry.relative_path));
             setSelectedNoteIds(new Set());
             setSelectedEntryPaths(new Set([entry.path]));
+            setSelectedFolderPaths(new Set());
             lastClickedEntryPathRef.current = entry.path;
             handleOpenPdfInNewTab(entry);
         },
@@ -2918,6 +3081,7 @@ export function FileTree() {
             }
             setSelectedNoteIds(new Set());
             setSelectedEntryPaths(new Set([entry.path]));
+            setSelectedFolderPaths(new Set());
             lastClickedEntryPathRef.current = entry.path;
             lastClickedRowKeyRef.current = rowKey;
             void openVaultFileEntry(entry);
@@ -2929,6 +3093,18 @@ export function FileTree() {
         (entry: VaultEntryDto, e: React.MouseEvent) => {
             if (e.button !== 0) return;
             e.preventDefault();
+            if (selectedRowCount > 1 && selectedEntryPaths.has(entry.path)) {
+                dragStateRef.current = {
+                    item: {
+                        kind: "selection",
+                        targets: getSelectedChatContextTargets(),
+                    },
+                    startX: e.clientX,
+                    startY: e.clientY,
+                    active: false,
+                };
+                return;
+            }
             dragStateRef.current = {
                 item: { kind: "file", entry },
                 startX: e.clientX,
@@ -2936,7 +3112,11 @@ export function FileTree() {
                 active: false,
             };
         },
-        [],
+        [
+            getSelectedChatContextTargets,
+            selectedEntryPaths,
+            selectedRowCount,
+        ],
     );
 
     const handleFileContextMenu = useCallback(
@@ -2944,11 +3124,12 @@ export function FileTree() {
             e.preventDefault();
             setFocusedFolderPath(getParentPath(entry.relative_path));
             const preserveSelection =
-                selectedEntryPaths.size > 1 &&
+                selectedRowCount > 1 &&
                 selectedEntryPaths.has(entry.path);
             if (!preserveSelection) {
                 setSelectedNoteIds(new Set());
                 setSelectedEntryPaths(new Set([entry.path]));
+                setSelectedFolderPaths(new Set());
             }
             setContextMenu({
                 x: e.clientX,
@@ -2956,7 +3137,7 @@ export function FileTree() {
                 payload: { kind: "file", entry },
             });
         },
-        [selectedEntryPaths],
+        [selectedEntryPaths, selectedRowCount],
     );
 
     const handleOpenFileInNewTab = useCallback(async (entry: VaultEntryDto) => {
@@ -2977,6 +3158,7 @@ export function FileTree() {
             setFocusedFolderPath(getParentPath(entry.relative_path));
             setSelectedNoteIds(new Set());
             setSelectedEntryPaths(new Set([entry.path]));
+            setSelectedFolderPaths(new Set());
             lastClickedEntryPathRef.current = entry.path;
             void handleOpenFileInNewTab(entry);
         },
@@ -3001,6 +3183,7 @@ export function FileTree() {
 
     const clearEntrySelection = useCallback(() => {
         setSelectedEntryPaths(new Set());
+        setSelectedFolderPaths(new Set());
     }, []);
 
     const handleCopyFullPath = useCallback((path: string) => {
@@ -3008,67 +3191,37 @@ export function FileTree() {
         void navigator.clipboard.writeText(path);
     }, []);
 
-    const handleAddFolderToChat = useCallback(
-        (path: string, target: "current-chat" | "new-chat" = "current-chat") => {
-            emitFileTreeAttachment(
-                {
-                    phase: "attach",
-                    x: 0,
-                    y: 0,
-                    notes: [],
-                    folder: {
-                        path,
-                        name: getBaseName(path),
-                    },
-                },
-                target,
-            );
-        },
-        [],
-    );
-
-    const handleAddNotesToChat = useCallback(
+    const handleAddChatTargetsToChat = useCallback(
         (
-            notesToAdd: NoteDto[],
+            targets: ChatContextTargets,
             target: "current-chat" | "new-chat" = "current-chat",
         ) => {
-            if (notesToAdd.length === 0) return;
-            emitFileTreeAttachment(
-                {
-                    phase: "attach",
-                    x: 0,
-                    y: 0,
-                    notes: notesToAdd.map((note) => ({
-                        id: note.id,
-                        title: note.title,
-                        path: note.path,
-                    })),
-                },
-                target,
-            );
-        },
-        [],
-    );
-
-    const handleAddEntriesToChat = useCallback(
-        (
-            entriesToAdd: VaultEntryDto[],
-            target: "current-chat" | "new-chat" = "current-chat",
-        ) => {
-            const files = entriesToAdd
-                .filter(
-                    (entry) => entry.kind === "pdf" || entry.kind === "file",
-                )
+            const notesToAdd = targets.notes.map((note) => ({
+                id: note.id,
+                title: note.title,
+                path: note.path,
+            }));
+            const files = targets.entries
+                .filter(isChatAttachableEntry)
                 .map(getDraggedVaultFile);
-            if (files.length === 0) return;
+            const folders = targets.folderPaths.map(getDraggedVaultFolder);
+            if (
+                notesToAdd.length === 0 &&
+                files.length === 0 &&
+                folders.length === 0
+            ) {
+                return;
+            }
 
             emitFileTreeAttachment(
                 {
                     phase: "attach",
                     x: 0,
                     y: 0,
-                    notes: [],
-                    files,
+                    notes: notesToAdd,
+                    ...(folders.length === 1 ? { folder: folders[0] } : {}),
+                    ...(folders.length > 0 ? { folders } : {}),
+                    ...(files.length > 0 ? { files } : {}),
                 },
                 target,
             );
@@ -3170,11 +3323,12 @@ export function FileTree() {
 
             event.preventDefault();
             event.stopPropagation();
+            clearEntrySelection();
             setSelectedNoteIds(new Set([note.id]));
             lastClickedRowKeyRef.current = `note:${note.id}`;
             void handleOpenNoteInNewTab(note);
         },
-        [handleOpenNoteInNewTab],
+        [clearEntrySelection, handleOpenNoteInNewTab],
     );
 
     const handleNoteContextMenu = (e: React.MouseEvent, note: NoteDto) => {
@@ -3182,7 +3336,7 @@ export function FileTree() {
         setFocusedFolderPath(getParentPath(note.id));
 
         const preserveSelection =
-            selectedNoteIds.size > 1 && selectedNoteIds.has(note.id);
+            selectedRowCount > 1 && selectedNoteIds.has(note.id);
 
         if (!preserveSelection) {
             clearEntrySelection();
@@ -3200,8 +3354,16 @@ export function FileTree() {
     const handleFolderContextMenu = (e: React.MouseEvent, path: string) => {
         e.preventDefault();
         setFocusedFolderPath(path);
-        clearEntrySelection();
-        setSelectedNoteIds(new Set());
+        const preserveSelection =
+            selectedRowCount > 1 && selectedFolderPaths.has(path);
+
+        if (!preserveSelection) {
+            clearEntrySelection();
+            setSelectedNoteIds(new Set());
+            setSelectedFolderPaths(new Set([path]));
+            lastClickedRowKeyRef.current = `folder:${path}`;
+        }
+
         setContextMenu({
             x: e.clientX,
             y: e.clientY,
@@ -3235,21 +3397,38 @@ export function FileTree() {
         [notes, selectedNoteIds],
     );
 
-    const getContextTargetEntries = useCallback(
-        (entry: VaultEntryDto) => {
-            if (
-                selectedEntryPaths.size > 1 &&
-                selectedEntryPaths.has(entry.path)
-            ) {
-                return entries.filter(
-                    (item) =>
-                        selectedEntryPaths.has(item.path) &&
-                        (item.kind === "pdf" || item.kind === "file"),
-                );
+    const getContextChatTargetsForNote = useCallback(
+        (note: NoteDto): ChatContextTargets => {
+            if (selectedRowCount > 1 && selectedNoteIds.has(note.id)) {
+                return getSelectedChatContextTargets();
             }
-            return [entry];
+            return { notes: [note], entries: [], folderPaths: [] };
         },
-        [entries, selectedEntryPaths],
+        [getSelectedChatContextTargets, selectedNoteIds, selectedRowCount],
+    );
+
+    const getContextChatTargetsForEntry = useCallback(
+        (entry: VaultEntryDto): ChatContextTargets => {
+            if (selectedRowCount > 1 && selectedEntryPaths.has(entry.path)) {
+                return getSelectedChatContextTargets();
+            }
+            return {
+                notes: [],
+                entries: isChatAttachableEntry(entry) ? [entry] : [],
+                folderPaths: [],
+            };
+        },
+        [getSelectedChatContextTargets, selectedEntryPaths, selectedRowCount],
+    );
+
+    const getContextChatTargetsForFolder = useCallback(
+        (path: string): ChatContextTargets => {
+            if (selectedRowCount > 1 && selectedFolderPaths.has(path)) {
+                return getSelectedChatContextTargets();
+            }
+            return { notes: [], entries: [], folderPaths: [path] };
+        },
+        [getSelectedChatContextTargets, selectedFolderPaths, selectedRowCount],
     );
 
     const applyMove = useCallback(
@@ -3408,6 +3587,8 @@ export function FileTree() {
         setCreatingParentPath("");
         setNewItemName("");
         setSelectedNoteIds(new Set());
+        setSelectedEntryPaths(new Set());
+        setSelectedFolderPaths(new Set());
         if (!name || !mode) return;
 
         if (mode === "folder") {
@@ -3800,6 +3981,19 @@ export function FileTree() {
                 const { path, expanded } = contextMenu.payload;
                 const folderName = path.split("/").pop() ?? path;
                 const absolutePath = getAbsoluteVaultPath(vaultPath, path);
+                const chatTargets = getContextChatTargetsForFolder(path);
+                const chatTargetCount =
+                    chatTargets.notes.length +
+                    chatTargets.entries.length +
+                    chatTargets.folderPaths.length;
+                const addToChatLabel =
+                    chatTargetCount > 1
+                        ? "Add Selected to Chat"
+                        : "Add to Chat";
+                const addToNewChatLabel =
+                    chatTargetCount > 1
+                        ? "Add Selected to New Chat"
+                        : "Add to New Chat";
                 return [
                     {
                         label: "New Note Here",
@@ -3823,12 +4017,13 @@ export function FileTree() {
                                 !canPasteFolderClipboard(treeClipboard, path)),
                     },
                     {
-                        label: "Add to Chat",
-                        action: () => handleAddFolderToChat(path),
+                        label: addToChatLabel,
+                        action: () => handleAddChatTargetsToChat(chatTargets),
                     },
                     {
-                        label: "Add to New Chat",
-                        action: () => handleAddFolderToChat(path, "new-chat"),
+                        label: addToNewChatLabel,
+                        action: () =>
+                            handleAddChatTargetsToChat(chatTargets, "new-chat"),
                     },
                     { type: "separator" },
                     {
@@ -3858,6 +4053,11 @@ export function FileTree() {
             case "note": {
                 const { note } = contextMenu.payload;
                 const contextTargetNotes = getContextTargetNotes(note);
+                const chatTargets = getContextChatTargetsForNote(note);
+                const chatTargetCount =
+                    chatTargets.notes.length +
+                    chatTargets.entries.length +
+                    chatTargets.folderPaths.length;
                 const deleteTargets = contextTargetNotes;
                 const deleteLabel =
                     deleteTargets.length > 1
@@ -3868,11 +4068,11 @@ export function FileTree() {
                         ? "Move Selected Notes to…"
                         : "Move Note to…";
                 const addToChatLabel =
-                    contextTargetNotes.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to Chat"
                         : "Add to Chat";
                 const addToNewChatLabel =
-                    contextTargetNotes.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to New Chat"
                         : "Add to New Chat";
 
@@ -3907,15 +4107,12 @@ export function FileTree() {
                     },
                     {
                         label: addToChatLabel,
-                        action: () => handleAddNotesToChat(contextTargetNotes),
+                        action: () => handleAddChatTargetsToChat(chatTargets),
                     },
                     {
                         label: addToNewChatLabel,
                         action: () =>
-                            handleAddNotesToChat(
-                                contextTargetNotes,
-                                "new-chat",
-                            ),
+                            handleAddChatTargetsToChat(chatTargets, "new-chat"),
                     },
                     { type: "separator" },
                     {
@@ -3976,13 +4173,17 @@ export function FileTree() {
             }
             case "pdf": {
                 const { entry } = contextMenu.payload;
-                const contextTargetEntries = getContextTargetEntries(entry);
+                const chatTargets = getContextChatTargetsForEntry(entry);
+                const chatTargetCount =
+                    chatTargets.notes.length +
+                    chatTargets.entries.length +
+                    chatTargets.folderPaths.length;
                 const addToChatLabel =
-                    contextTargetEntries.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to Chat"
                         : "Add to Chat";
                 const addToNewChatLabel =
-                    contextTargetEntries.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to New Chat"
                         : "Add to New Chat";
                 return [
@@ -4005,16 +4206,12 @@ export function FileTree() {
                     },
                     {
                         label: addToChatLabel,
-                        action: () =>
-                            handleAddEntriesToChat(contextTargetEntries),
+                        action: () => handleAddChatTargetsToChat(chatTargets),
                     },
                     {
                         label: addToNewChatLabel,
                         action: () =>
-                            handleAddEntriesToChat(
-                                contextTargetEntries,
-                                "new-chat",
-                            ),
+                            handleAddChatTargetsToChat(chatTargets, "new-chat"),
                     },
                     {
                         label: "Reveal in Finder",
@@ -4057,13 +4254,17 @@ export function FileTree() {
             case "file": {
                 const { entry } = contextMenu.payload;
                 const canOpenInApp = canOpenVaultFileEntryInApp(entry);
-                const contextTargetEntries = getContextTargetEntries(entry);
+                const chatTargets = getContextChatTargetsForEntry(entry);
+                const chatTargetCount =
+                    chatTargets.notes.length +
+                    chatTargets.entries.length +
+                    chatTargets.folderPaths.length;
                 const addToChatLabel =
-                    contextTargetEntries.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to Chat"
                         : "Add to Chat";
                 const addToNewChatLabel =
-                    contextTargetEntries.length > 1
+                    chatTargetCount > 1
                         ? "Add Selected to New Chat"
                         : "Add to New Chat";
                 return [
@@ -4088,16 +4289,12 @@ export function FileTree() {
                     },
                     {
                         label: addToChatLabel,
-                        action: () =>
-                            handleAddEntriesToChat(contextTargetEntries),
+                        action: () => handleAddChatTargetsToChat(chatTargets),
                     },
                     {
                         label: addToNewChatLabel,
                         action: () =>
-                            handleAddEntriesToChat(
-                                contextTargetEntries,
-                                "new-chat",
-                            ),
+                            handleAddChatTargetsToChat(chatTargets, "new-chat"),
                     },
                     {
                         label: "Reveal in Finder",
@@ -4188,11 +4385,11 @@ export function FileTree() {
         applyMove,
         contextMenu,
         expandedFolders.size,
-        getContextTargetEntries,
+        getContextChatTargetsForEntry,
+        getContextChatTargetsForFolder,
+        getContextChatTargetsForNote,
         getContextTargetNotes,
-        handleAddEntriesToChat,
-        handleAddFolderToChat,
-        handleAddNotesToChat,
+        handleAddChatTargetsToChat,
         handleCopyFolder,
         handleCopyFullPath,
         handleCopyNotes,
@@ -4238,6 +4435,22 @@ export function FileTree() {
     const stableNoteContextMenu = useCallback(
         (e: React.MouseEvent, note: NoteDto) =>
             noteContextMenuRef.current(e, note),
+        [],
+    );
+
+    const folderClickRef = useRef(handleFolderClick);
+    folderClickRef.current = handleFolderClick;
+    const stableFolderClick = useCallback(
+        (path: string, modifiers: { cmd: boolean; shift: boolean }) =>
+            folderClickRef.current(path, modifiers),
+        [],
+    );
+
+    const folderMouseDownRef = useRef(handleFolderMouseDown);
+    folderMouseDownRef.current = handleFolderMouseDown;
+    const stableFolderMouseDown = useCallback(
+        (path: string, e: React.MouseEvent) =>
+            folderMouseDownRef.current(path, e),
         [],
     );
 
@@ -4688,6 +4901,9 @@ export function FileTree() {
                                             selectedEntryPaths={
                                                 visibleSelectedEntryPaths
                                             }
+                                            selectedFolderPaths={
+                                                visibleSelectedFolderPaths
+                                            }
                                             contextMenuFolderPath={
                                                 contextMenuFolderPath
                                             }
@@ -4696,9 +4912,9 @@ export function FileTree() {
                                                 draggingFolderPath
                                             }
                                             dragOverPath={dragOverPath}
-                                            onFolderClick={handleFolderClick}
+                                            onFolderClick={stableFolderClick}
                                             onFolderMouseDown={
-                                                handleFolderMouseDown
+                                                stableFolderMouseDown
                                             }
                                             onFolderContextMenu={
                                                 stableFolderContextMenu
@@ -4815,6 +5031,9 @@ export function FileTree() {
                                             selectedEntryPaths={
                                                 visibleSelectedEntryPaths
                                             }
+                                            selectedFolderPaths={
+                                                visibleSelectedFolderPaths
+                                            }
                                             contextMenuFolderPath={
                                                 contextMenuFolderPath
                                             }
@@ -4823,9 +5042,9 @@ export function FileTree() {
                                                 draggingFolderPath
                                             }
                                             dragOverPath={dragOverPath}
-                                            onFolderClick={handleFolderClick}
+                                            onFolderClick={stableFolderClick}
                                             onFolderMouseDown={
-                                                handleFolderMouseDown
+                                                stableFolderMouseDown
                                             }
                                             onFolderContextMenu={
                                                 stableFolderContextMenu


### PR DESCRIPTION
## Summary
- Add file tree context menu actions to attach notes, folders, PDFs, and sidebar files to the current chat.
- Add “Add to New Chat” / “Add Selected to New Chat”, opening a fresh agent chat with the selected or last active provider before attaching context.
- Add consistent “Copy Full Path” actions for notes, folders, PDFs, and sidebar files.

## Tests
- `pnpm --dir apps/desktop test FileTree.test.tsx`
- `pnpm --dir apps/desktop test AIChatDetachedWindowHost.test.tsx`
- `pnpm --dir apps/desktop exec eslint src/features/ai/dragEvents.ts src/features/ai/AIChatWorkspaceHost.tsx src/features/ai/AIChatDetachedWindowHost.test.tsx src/features/vault/FileTree.tsx src/features/vault/FileTree.test.tsx`
