### PR TITLE
Fix external vault tree refresh

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -89,6 +89,7 @@ import {
     canUseExcalidrawRuntime,
     readSearchParam,
 } from "./app/utils/safeBrowser";
+import { getVaultChangeSyncStrategy } from "./app/utils/vaultChangeSync";
 import { logError } from "./app/utils/runtimeLog";
 import {
     flushChatTabsPersistence,
@@ -109,14 +110,6 @@ import {
     WINDOW_OPERATIONAL_STATE_PUBLISH_DEBOUNCE_MS,
     writeWindowOperationalState,
 } from "./features/updates/sensitiveState";
-
-function shouldApplyVaultChangeToVaultStore(change: VaultNoteChange) {
-    return (
-        change.origin === "external" ||
-        change.origin === "unknown" ||
-        change.origin === "agent"
-    );
-}
 
 interface WebClipperSavedPayload {
     requestId: string;
@@ -1248,6 +1241,7 @@ export default function App() {
     const vaultPath = useVaultStore((s) => s.vaultPath);
     const applyVaultNoteChange = useVaultStore((s) => s.applyVaultNoteChange);
     const refreshEntries = useVaultStore((s) => s.refreshEntries);
+    const refreshStructure = useVaultStore((s) => s.refreshStructure);
     const hydrateWorkspace = useEditorStore((s) => s.hydrateWorkspace);
     const hydrateTabs = useEditorStore((s) => s.hydrateTabs);
     const workspaceTabs = useEditorStore(useShallow(selectEditorWorkspaceTabs));
@@ -1827,9 +1821,16 @@ export default function App() {
                 )
                     return;
 
-                if (shouldApplyVaultChangeToVaultStore(event.payload)) {
+                const syncStrategy = getVaultChangeSyncStrategy(event.payload);
+                if (
+                    syncStrategy === "apply-note-change-and-refresh-entries"
+                ) {
                     applyVaultNoteChange(event.payload);
                     void refreshEntries();
+                } else if (syncStrategy === "refresh-entries") {
+                    void refreshEntries();
+                } else if (syncStrategy === "refresh-structure") {
+                    void refreshStructure();
                 }
 
                 // Reload editor content for open tabs when file changes externally
@@ -1976,7 +1977,7 @@ export default function App() {
             fileReloadVersions.clear();
             unlisten?.();
         };
-    }, [applyVaultNoteChange, refreshEntries, windowMode]);
+    }, [applyVaultNoteChange, refreshEntries, refreshStructure, windowMode]);
 
     useEffect(() => {
         let disposed = false;

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -653,6 +653,43 @@ describe("App web clipper routing", () => {
         vi.useRealTimers();
     });
 
+    it("refreshes the full vault structure for external note-looking delete events", async () => {
+        const applyVaultNoteChange = vi.fn();
+        const refreshEntries = vi.fn(async () => {});
+        const refreshStructure = vi.fn(async () => {});
+        useVaultStore.setState({
+            applyVaultNoteChange,
+            refreshEntries,
+            refreshStructure,
+        });
+
+        renderComponent(<App />);
+        await flushPromises();
+
+        await act(async () => {
+            eventHandlers.get("vault://note-changed")?.({
+                payload: {
+                    vault_path: "/vaults/a",
+                    kind: "delete",
+                    note: null,
+                    note_id: "Archive",
+                    entry: null,
+                    relative_path: "Archive.md",
+                    origin: "external",
+                    op_id: null,
+                    revision: 1,
+                    content_hash: null,
+                    graph_revision: 1,
+                },
+            });
+            await Promise.resolve();
+        });
+
+        expect(applyVaultNoteChange).not.toHaveBeenCalled();
+        expect(refreshEntries).not.toHaveBeenCalled();
+        expect(refreshStructure).toHaveBeenCalledTimes(1);
+    });
+
     it("does not open a vault window for routed clip saves", async () => {
         renderComponent(<App />);
         await flushPromises();

--- a/apps/desktop/src/app/utils/vaultChangeSync.test.ts
+++ b/apps/desktop/src/app/utils/vaultChangeSync.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import type { NoteDto, VaultEntryDto } from "../store/vaultStore";
+import type { VaultNoteChange } from "../store/vaultStore";
+import {
+    getVaultChangeSyncStrategy,
+    type VaultChangeSyncStrategy,
+} from "./vaultChangeSync";
+
+function note(id: string): NoteDto {
+    const fileName = id.split("/").pop() ?? id;
+    return {
+        id,
+        path: `/vault/${id}.md`,
+        title: fileName,
+        modified_at: 1,
+        created_at: 1,
+    };
+}
+
+function entry(path: string, kind: VaultEntryDto["kind"]): VaultEntryDto {
+    const fileName = path.split("/").pop() ?? path;
+    const dotIndex = fileName.lastIndexOf(".");
+    return {
+        id: path,
+        path: `/vault/${path}`,
+        relative_path: path,
+        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
+        file_name: fileName,
+        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
+        kind,
+        modified_at: 1,
+        created_at: 1,
+        size: kind === "folder" ? 0 : 10,
+        mime_type: kind === "folder" ? null : "text/plain",
+    };
+}
+
+function change(overrides: Partial<VaultNoteChange>): VaultNoteChange {
+    return {
+        vault_path: "/vault",
+        kind: "upsert",
+        note: null,
+        note_id: null,
+        entry: null,
+        relative_path: null,
+        origin: "external",
+        op_id: null,
+        revision: 1,
+        content_hash: null,
+        graph_revision: 1,
+        ...overrides,
+    };
+}
+
+describe("getVaultChangeSyncStrategy", () => {
+    it.each([
+        ["upsert", { kind: "upsert", note: note("plans/alpha") }],
+        ["delete", { kind: "delete", note_id: "plans/alpha" }],
+    ] satisfies Array<[string, Partial<VaultNoteChange>]>)(
+        "keeps a light sync path for specific note %s events",
+        (_label, overrides) => {
+            expect(getVaultChangeSyncStrategy(change(overrides))).toBe(
+                "apply-note-change-and-refresh-entries",
+            );
+        },
+    );
+
+    it.each([
+        [
+            "external folder upsert",
+            { kind: "upsert", entry: entry("plans", "folder") },
+        ],
+        [
+            "external delete without note_id",
+            { kind: "delete", relative_path: "plans" },
+        ],
+        [
+            "external ambiguous upsert",
+            { kind: "upsert", relative_path: "plans" },
+        ],
+    ] satisfies Array<[string, Partial<VaultNoteChange>]>)(
+        "refreshes full structure for %s",
+        (_label, overrides) => {
+            expect(getVaultChangeSyncStrategy(change(overrides))).toBe(
+                "refresh-structure",
+            );
+        },
+    );
+
+    it("refreshes only entries for a non-folder file upsert", () => {
+        expect(
+            getVaultChangeSyncStrategy(
+                change({
+                    entry: entry("assets/spec.txt", "file"),
+                    relative_path: "assets/spec.txt",
+                }),
+            ),
+        ).toBe("refresh-entries");
+    });
+
+    it("refreshes full structure for a note entry upsert without note metadata", () => {
+        expect(
+            getVaultChangeSyncStrategy(
+                change({
+                    entry: entry("plans/alpha.md", "note"),
+                    relative_path: "plans/alpha.md",
+                }),
+            ),
+        ).toBe("refresh-structure");
+    });
+
+    it.each([
+        ["user", "ignore"],
+        ["system", "ignore"],
+        ["agent", "refresh-structure"],
+        ["unknown", "refresh-structure"],
+    ] satisfies Array<[VaultNoteChange["origin"], VaultChangeSyncStrategy]>)(
+        "returns %s origin strategy",
+        (origin, expected) => {
+            expect(
+                getVaultChangeSyncStrategy(
+                    change({
+                        origin,
+                        kind: "delete",
+                        relative_path: "plans",
+                    }),
+                ),
+            ).toBe(expected);
+        },
+    );
+});

--- a/apps/desktop/src/app/utils/vaultChangeSync.test.ts
+++ b/apps/desktop/src/app/utils/vaultChangeSync.test.ts
@@ -55,9 +55,8 @@ function change(overrides: Partial<VaultNoteChange>): VaultNoteChange {
 describe("getVaultChangeSyncStrategy", () => {
     it.each([
         ["upsert", { kind: "upsert", note: note("plans/alpha") }],
-        ["delete", { kind: "delete", note_id: "plans/alpha" }],
     ] satisfies Array<[string, Partial<VaultNoteChange>]>)(
-        "keeps a light sync path for specific note %s events",
+        "keeps a light sync path for specific note %s events with note metadata",
         (_label, overrides) => {
             expect(getVaultChangeSyncStrategy(change(overrides))).toBe(
                 "apply-note-change-and-refresh-entries",
@@ -73,6 +72,14 @@ describe("getVaultChangeSyncStrategy", () => {
         [
             "external delete without note_id",
             { kind: "delete", relative_path: "plans" },
+        ],
+        [
+            "external note-looking delete",
+            {
+                kind: "delete",
+                note_id: "Archive",
+                relative_path: "Archive.md",
+            },
         ],
         [
             "external ambiguous upsert",

--- a/apps/desktop/src/app/utils/vaultChangeSync.ts
+++ b/apps/desktop/src/app/utils/vaultChangeSync.ts
@@ -1,0 +1,47 @@
+import type { VaultChangeOrigin, VaultNoteChange } from "../store/vaultStore";
+
+export type VaultChangeSyncStrategy =
+    | "ignore"
+    | "apply-note-change-and-refresh-entries"
+    | "refresh-entries"
+    | "refresh-structure";
+
+const LIVE_FILESYSTEM_ORIGINS = new Set<VaultChangeOrigin>([
+    "agent",
+    "external",
+    "unknown",
+]);
+
+export function getVaultChangeSyncStrategy(
+    change: VaultNoteChange,
+): VaultChangeSyncStrategy {
+    if (!LIVE_FILESYSTEM_ORIGINS.has(change.origin)) {
+        return "ignore";
+    }
+
+    if (isSpecificNoteChange(change)) {
+        return "apply-note-change-and-refresh-entries";
+    }
+
+    if (isNonFolderEntryUpsert(change)) {
+        return "refresh-entries";
+    }
+
+    return "refresh-structure";
+}
+
+function isSpecificNoteChange(change: VaultNoteChange) {
+    if (change.kind === "upsert") {
+        return Boolean(change.note?.id);
+    }
+
+    return Boolean(change.note_id);
+}
+
+function isNonFolderEntryUpsert(change: VaultNoteChange) {
+    return (
+        change.kind === "upsert" &&
+        Boolean(change.entry) &&
+        (change.entry?.kind === "file" || change.entry?.kind === "pdf")
+    );
+}

--- a/apps/desktop/src/app/utils/vaultChangeSync.ts
+++ b/apps/desktop/src/app/utils/vaultChangeSync.ts
@@ -35,7 +35,10 @@ function isSpecificNoteChange(change: VaultNoteChange) {
         return Boolean(change.note?.id);
     }
 
-    return Boolean(change.note_id);
+    // Delete events can be ambiguous because the backend infers note_id from
+    // the removed path suffix; a deleted folder named "Archive.md" looks like a
+    // note delete after the filesystem entry is gone.
+    return false;
 }
 
 function isNonFolderEntryUpsert(change: VaultNoteChange) {


### PR DESCRIPTION
## Summary

Fixes intermittent stale FileTree state after external filesystem changes.

NeverWrite was handling `vault://note-changed` events by applying the individual note change and then refreshing only `entries`. That worked for simple file events, but it could leave `notes` stale when macOS/FSEvents reported a folder move/delete as a higher-level structural event instead of individual markdown note events.

This caused the tree to sometimes show mixed state: refreshed folders/files from `entries`, but stale markdown notes from `notes`.

## Changes

- Added a small `getVaultChangeSyncStrategy` helper to classify vault change events.
- Kept the lightweight path for clear note updates: apply note patch + refresh entries.
- Kept entry-only refreshes for clear non-folder file/PDF upserts.
- Use full `refreshStructure()` for structural or ambiguous external changes, so `notes` and `entries` are reloaded together.
- Added unit coverage for the sync strategy, including folder upserts, ambiguous deletes, note updates, and origin handling.

## Why

The FileTree is built from both `notes` and `entries`. Refreshing only `entries` after ambiguous external changes can leave markdown notes with old paths/IDs. A full structure refresh is the safer invariant for folder-level or unclear watcher events.

## Testing

```bash
npm --prefix apps/desktop test -- src/app/utils/vaultChangeSync.test.ts --run
npm --prefix apps/desktop test -- src/app/store/vaultStore.test.ts --run
npm --prefix apps/desktop test -- src/App.webClipper.test.tsx --run
git diff --check
```

Also ran:

```bash
npx tsc -b --pretty false
```

This still fails on existing unrelated TypeScript errors in `detachedWindows.ts`, `detachedWindows.test.ts`, and `TerminalViewport.test.tsx`.
