### PR TITLE
feat/linux-appimage-ui-polish

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -139,6 +139,22 @@ jobs:
               with:
                   targets: ${{ matrix.rust_targets }}
 
+            - name: Install Linux build dependencies
+              if: matrix.platform == 'linux'
+              shell: bash
+              run: |
+                  if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+                    sudo dpkg --add-architecture arm64
+                  fi
+                  sudo apt-get update
+                  sudo apt-get install -y pkg-config libcap-dev
+                  if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+                    sudo apt-get install -y gcc-aarch64-linux-gnu libcap-dev:arm64
+                    echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+                    echo "PKG_CONFIG_ALLOW_CROSS=1" >> "$GITHUB_ENV"
+                    echo "PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig" >> "$GITHUB_ENV"
+                  fi
+
             - name: Install desktop dependencies
               working-directory: apps/desktop
               run: npm ci
@@ -250,7 +266,16 @@ jobs:
                   CSC_IDENTITY_AUTO_DISCOVERY: "false"
               run: npm run electron:release:local -- --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --unsigned
 
+            - name: Build Linux desktop release
+              if: runner.os == 'Linux'
+              working-directory: apps/desktop
+              shell: bash
+              env:
+                  CSC_IDENTITY_AUTO_DISCOVERY: "false"
+              run: npm run electron:release:local -- --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --unsigned
+
             - name: Smoke packaged sidecar
+              if: matrix.target != 'aarch64-unknown-linux-gnu'
               working-directory: apps/desktop
               env:
                   NEVERWRITE_ELECTRON_OUTPUT_DIR: ${{ runner.temp }}/electron-dist
@@ -258,7 +283,7 @@ jobs:
               run: npm run electron:sidecar:smoke:packaged
 
             - name: Smoke packaged app executable
-              if: runner.os == 'macOS'
+              if: runner.os == 'macOS' || (runner.os == 'Linux' && matrix.arch == 'x64')
               working-directory: apps/desktop
               env:
                   NEVERWRITE_ELECTRON_OUTPUT_DIR: ${{ runner.temp }}/electron-dist

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -111,6 +111,18 @@ jobs:
                       target: x86_64-pc-windows-msvc
                       rust_targets: x86_64-pc-windows-msvc
                       node_dist: win-x64
+                    - runner: ubuntu-22.04
+                      platform: linux
+                      arch: x64
+                      target: x86_64-unknown-linux-gnu
+                      rust_targets: x86_64-unknown-linux-gnu
+                      node_dist: linux-x64
+                    - runner: ubuntu-22.04
+                      platform: linux
+                      arch: arm64
+                      target: aarch64-unknown-linux-gnu
+                      rust_targets: aarch64-unknown-linux-gnu
+                      node_dist: linux-arm64
 
         steps:
             - uses: actions/checkout@v4

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -207,14 +207,13 @@ export default {
         deleteAppDataOnUninstall: false,
     },
     linux: {
-        target: [
-            { target: "AppImage", arch: ["x64", "arm64"] }
-        ],
+        icon: path.join("build", "icons", "icon.png"),
+        target: [{ target: "AppImage", arch: ["x64", "arm64"] }],
         category: "Utility",
         executableName: "neverwrite",
-        artifactName: "${productName}-${version}-${arch}.AppImage"
+        artifactName: "${productName}-${version}-${arch}.AppImage",
     },
     appImage: {
-        artifactName: "${productName}-${version}-${arch}.AppImage"
-    }
+        artifactName: "${productName}-${version}-${arch}.AppImage",
+    },
 };

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -206,4 +206,15 @@ export default {
         installerHeaderIcon: path.join("build", "icons", "icon.ico"),
         deleteAppDataOnUninstall: false,
     },
+    linux: {
+        target: [
+            { target: "AppImage", arch: ["x64", "arm64"] }
+        ],
+        category: "Utility",
+        executableName: "neverwrite",
+        artifactName: "${productName}-${version}-${arch}.AppImage"
+    },
+    appImage: {
+        artifactName: "${productName}-${version}-${arch}.AppImage"
+    }
 };

--- a/apps/desktop/scripts/build-electron-release.mjs
+++ b/apps/desktop/scripts/build-electron-release.mjs
@@ -40,7 +40,7 @@ function parseArgs(argv) {
         }
 
         throw new Error(
-            `Unknown argument "${arg}". Supported args: --platform <mac|win>, --arch <universal|x64|arm64>, --publish <mode>, --dir, --unsigned.`,
+            `Unknown argument "${arg}". Supported args: --platform <mac|win|linux>, --arch <universal|x64|arm64>, --publish <mode>, --dir, --unsigned.`,
         );
     }
 
@@ -57,6 +57,9 @@ function normalizePlatform(platform) {
     }
     if (process.platform === "win32") {
         return "win";
+    }
+    if (process.platform === "linux") {
+        return "linux";
     }
 
     throw new Error(
@@ -97,6 +100,12 @@ function resolveRustTarget(platform, arch) {
     }
     if (platform === "win" && arch === "x64") {
         return "x86_64-pc-windows-msvc";
+    }
+    if (platform === "linux" && arch === "arm64") {
+        return "aarch64-unknown-linux-gnu";
+    }
+    if (platform === "linux" && arch === "x64") {
+        return "x86_64-unknown-linux-gnu";
     }
 
     throw new Error(
@@ -141,6 +150,8 @@ function buildElectronBuilderArgs(args) {
         result.push("--mac");
     } else if (args.platform === "win") {
         result.push("--win");
+    } else if (args.platform === "linux") {
+        result.push("--linux");
     }
     if (args.arch === "x64") {
         result.push("--x64");

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -45,3 +45,12 @@ test("macOS universal x64ArchFiles covers packaged native binaries", () => {
         false,
     );
 });
+
+test("desktop app icons are wired for all packaged platforms", () => {
+    assert.equal(config.mac.icon, "build/icons/icon.icns");
+    assert.equal(config.win.icon, "build/icons/icon.ico");
+    assert.equal(config.linux.icon, "build/icons/icon.png");
+    assert.equal(config.nsis.installerIcon, "build/icons/icon.ico");
+    assert.equal(config.nsis.uninstallerIcon, "build/icons/icon.ico");
+    assert.equal(config.nsis.installerHeaderIcon, "build/icons/icon.ico");
+});

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -30,6 +30,12 @@ function defaultPackagedExecutableCandidates() {
             path.join(outputRoot, "win-unpacked", "NeverWrite.exe"),
         ];
     }
+    if (process.platform === "linux") {
+        return [
+            path.join(outputRoot, `linux-${distArch}-unpacked`, "NeverWrite"),
+            path.join(outputRoot, "linux-unpacked", "NeverWrite"),
+        ];
+    }
 
     throw new Error(
         `Packaged app smoke is not supported on ${process.platform}.`,

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -30,6 +30,26 @@ function defaultPackagedSidecarCandidates() {
         ];
     }
 
+    if (process.platform === "linux") {
+        return [
+            path.join(
+                outputRoot,
+                `linux-${distArch}-unpacked`,
+                "resources",
+                "native-backend",
+                executableName,
+            ),
+            path.join(
+                outputRoot,
+                "linux-unpacked",
+                "resources",
+                "native-backend",
+                executableName,
+            ),
+            path.join(outputRoot, "native-backend", executableName),
+        ];
+    }
+
     return [
         path.join(
             outputRoot,

--- a/apps/desktop/scripts/stage-electron-release-assets.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.mjs
@@ -152,6 +152,26 @@ function collectArtifacts(distDir, buildTarget) {
             ),
         };
     }
+    if (buildTarget.endsWith("-unknown-linux-gnu")) {
+        const blockmapPath = findSingleFile(
+            distDir,
+            (filePath) => filePath.endsWith(".AppImage.blockmap"),
+            "Linux AppImage blockmap",
+        );
+        const appImagePath = stripSuffix(blockmapPath, ".blockmap");
+        if (!fs.existsSync(appImagePath)) {
+            throw new Error(
+                `Expected Linux AppImage next to blockmap at ${appImagePath}.`,
+            );
+        }
+
+        return {
+            feedPath,
+            manualAssetPath: appImagePath,
+            updaterAssetPath: appImagePath,
+            blockmapPath,
+        };
+    }
 
     const blockmapPath = findSingleFile(
         distDir,

--- a/apps/desktop/scripts/stage-electron-release-assets.test.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.test.mjs
@@ -227,3 +227,109 @@ test("stage-electron-release-assets keeps Windows metadata target-specific", () 
         assert.equal(metadata.feedRelativePath, "windows-x64/latest.yml");
     });
 });
+
+test("stage-electron-release-assets stages Linux AppImage feeds", () => {
+    withTempDir((tempDir) => {
+        const distDir = path.join(tempDir, "dist");
+        const outputDir = path.join(tempDir, "staged");
+        const metadataOut = path.join(tempDir, "metadata", "linux-x64.json");
+
+        writeFile(path.join(distDir, "linux-unpacked", "NeverWrite"), "app");
+        writeFile(
+            path.join(
+                distDir,
+                "linux-unpacked",
+                "resources",
+                "native-backend",
+                "neverwrite-native-backend",
+            ),
+            "backend",
+        );
+        writeFile(
+            path.join(
+                distDir,
+                "linux-unpacked",
+                "resources",
+                "native-backend",
+                "binaries",
+                "codex-acp",
+            ),
+            "codex",
+        );
+        writeFile(
+            path.join(
+                distDir,
+                "linux-unpacked",
+                "resources",
+                "native-backend",
+                "embedded",
+                "node",
+                "bin",
+                "node",
+            ),
+            "node",
+        );
+        writeFile(path.join(distDir, "NeverWrite-0.2.0-x64.AppImage"), "appimage");
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-x64.AppImage.blockmap"),
+            "blockmap",
+        );
+        writeFile(
+            path.join(distDir, "latest-linux.yml"),
+            [
+                "version: 0.2.0",
+                "path: NeverWrite-0.2.0-x64.AppImage",
+                "sha512: original",
+                "files:",
+                "  - url: NeverWrite-0.2.0-x64.AppImage",
+                "    sha512: original",
+                "",
+            ].join("\n"),
+        );
+
+        execFileSync(
+            process.execPath,
+            [
+                stageScriptPath,
+                "--dist-dir",
+                distDir,
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "--version",
+                "0.2.0",
+                "--tag",
+                "v0.2.0",
+                "--repo",
+                "jsgrrchg/NeverWrite",
+                "--output-dir",
+                outputDir,
+                "--metadata-out",
+                metadataOut,
+            ],
+            {
+                cwd: repoRoot,
+                stdio: "pipe",
+            },
+        );
+
+        const metadata = JSON.parse(fs.readFileSync(metadataOut, "utf8"));
+        const rewrittenFeed = fs.readFileSync(
+            path.join(outputDir, "feeds", "linux-x64", "latest-linux.yml"),
+            "utf8",
+        );
+
+        assert.equal(metadata.feedTarget, "linux-x64");
+        assert.equal(metadata.metadataFileName, "latest-linux.yml");
+        assert.equal(metadata.manualAssetName, "NeverWrite-0.2.0-x64.AppImage");
+        assert.equal(metadata.updaterAssetName, "NeverWrite-0.2.0-x64.AppImage");
+        assert.equal(
+            metadata.updaterBlockmapAssetName,
+            "NeverWrite-0.2.0-x64.AppImage.blockmap",
+        );
+        assert.equal(metadata.feedRelativePath, "linux-x64/latest-linux.yml");
+        assert.match(
+            rewrittenFeed,
+            /https:\/\/github\.com\/jsgrrchg\/NeverWrite\/releases\/download\/v0\.2\.0\/NeverWrite-0\.2\.0-x64\.AppImage/,
+        );
+    });
+});

--- a/apps/desktop/scripts/stage-electron-sidecar.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.mjs
@@ -111,6 +111,12 @@ function requiredClaudePlatformPackages(targetTriple) {
     if (targetTriple === "x86_64-pc-windows-msvc") {
         return ["@anthropic-ai/claude-agent-sdk-win32-x64"];
     }
+    if (targetTriple === "aarch64-unknown-linux-gnu") {
+        return ["@anthropic-ai/claude-agent-sdk-linux-arm64"];
+    }
+    if (targetTriple === "x86_64-unknown-linux-gnu") {
+        return ["@anthropic-ai/claude-agent-sdk-linux-x64"];
+    }
 
     return [];
 }
@@ -247,6 +253,8 @@ function envSuffixForTarget(targetTriple) {
     if (targetTriple === "x86_64-apple-darwin") return "X64";
     if (targetTriple === "aarch64-pc-windows-msvc") return "ARM64";
     if (targetTriple === "x86_64-pc-windows-msvc") return "X64";
+    if (targetTriple === "aarch64-unknown-linux-gnu") return "ARM64";
+    if (targetTriple === "x86_64-unknown-linux-gnu") return "X64";
     throw new Error(
         `Unsupported target for environment suffix: ${targetTriple}`,
     );
@@ -264,6 +272,8 @@ function nodeDistForTarget(targetTriple) {
     if (targetTriple === "x86_64-apple-darwin") return "darwin-x64";
     if (targetTriple === "aarch64-pc-windows-msvc") return "win-arm64";
     if (targetTriple === "x86_64-pc-windows-msvc") return "win-x64";
+    if (targetTriple === "aarch64-unknown-linux-gnu") return "linux-arm64";
+    if (targetTriple === "x86_64-unknown-linux-gnu") return "linux-x64";
     throw new Error(`Unsupported embedded Node target: ${targetTriple}`);
 }
 

--- a/apps/desktop/scripts/stage-electron-sidecar.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.mjs
@@ -222,6 +222,12 @@ function resolveHostRustTarget() {
     if (process.platform === "win32" && process.arch === "x64") {
         return "x86_64-pc-windows-msvc";
     }
+    if (process.platform === "linux" && process.arch === "x64") {
+        return "x86_64-unknown-linux-gnu";
+    }
+    if (process.platform === "linux" && process.arch === "arm64") {
+        return "aarch64-unknown-linux-gnu";
+    }
 
     throw new Error(
         `Unsupported host platform for Electron sidecar staging: ${process.platform}/${process.arch}`,

--- a/apps/desktop/scripts/verify-electron-bundle.mjs
+++ b/apps/desktop/scripts/verify-electron-bundle.mjs
@@ -24,6 +24,16 @@ const REQUIRED_RESOURCE_PATHS = {
         "native-backend/embedded/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk/package.json",
         "native-backend/embedded/claude-agent-acp/node_modules/zod/package.json",
     ],
+    linux: [
+        "icons/icon.png",
+        "native-backend/neverwrite-native-backend",
+        "native-backend/binaries/codex-acp",
+        "native-backend/embedded/node/bin/node",
+        "native-backend/embedded/claude-agent-acp/dist/index.js",
+        "native-backend/embedded/claude-agent-acp/node_modules/@agentclientprotocol/sdk/package.json",
+        "native-backend/embedded/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk/package.json",
+        "native-backend/embedded/claude-agent-acp/node_modules/zod/package.json",
+    ],
 };
 const DEFAULT_PRODUCT_NAME = "NeverWrite";
 const PROJECT_DIR = path.dirname(import.meta.dirname);
@@ -67,6 +77,9 @@ function resolveResourcesDir(packContext) {
     }
 
     if (packContext.electronPlatformName === "win32") {
+        return path.join(packContext.appOutDir, "resources");
+    }
+    if (packContext.electronPlatformName === "linux") {
         return path.join(packContext.appOutDir, "resources");
     }
 

--- a/apps/desktop/src-electron/main/menu.ts
+++ b/apps/desktop/src-electron/main/menu.ts
@@ -323,6 +323,11 @@ export async function syncRecentVaultsForElectron(rawVaults: unknown) {
 }
 
 export async function installNativeMenus() {
+    if (process.platform !== "darwin") {
+        Menu.setApplicationMenu(null);
+        return;
+    }
+
     Menu.setApplicationMenu(buildApplicationMenu());
     await refreshDockMenu();
 }

--- a/apps/desktop/src-electron/main/updater.test.ts
+++ b/apps/desktop/src-electron/main/updater.test.ts
@@ -10,6 +10,14 @@ vi.mock("electron", () => ({
 }));
 
 vi.mock("electron-updater", () => ({
+    AppImageUpdater: class {
+        autoDownload = false;
+        autoInstallOnAppQuit = false;
+        forceDevUpdateConfig = false;
+        logger: unknown = null;
+
+        constructor(_options: unknown) {}
+    },
     MacUpdater: class {
         autoDownload = false;
         autoInstallOnAppQuit = false;
@@ -108,6 +116,32 @@ describe("ElectronAppUpdater configuration", () => {
         expect(status).toMatchObject({
             enabled: true,
             endpoint: "https://updates.example.com/app/stable/windows-x64/latest.yml",
+            message: null,
+        });
+    });
+
+    it("uses the Linux x64 AppImage feed in packaged Linux builds", () => {
+        setRuntimePlatform("linux", "x64");
+
+        const status = new ElectronAppUpdater().getConfiguration();
+
+        expect(status).toMatchObject({
+            enabled: true,
+            endpoint:
+                "https://jsgrrchg.github.io/NeverWrite/stable/linux-x64/latest-linux.yml",
+            message: null,
+        });
+    });
+
+    it("uses the Linux ARM64 AppImage feed in packaged Linux builds", () => {
+        setRuntimePlatform("linux", "arm64");
+
+        const status = new ElectronAppUpdater().getConfiguration();
+
+        expect(status).toMatchObject({
+            enabled: true,
+            endpoint:
+                "https://jsgrrchg.github.io/NeverWrite/stable/linux-arm64/latest-linux.yml",
             message: null,
         });
     });

--- a/apps/desktop/src-electron/main/updater.ts
+++ b/apps/desktop/src-electron/main/updater.ts
@@ -1,5 +1,6 @@
 import { app } from "electron";
 import {
+    AppImageUpdater,
     MacUpdater,
     NsisUpdater,
     type AppUpdater,
@@ -263,6 +264,12 @@ function resolveFeedTarget() {
     if (process.platform === "win32") {
         return `windows-${process.arch}`;
     }
+    if (process.platform === "linux") {
+        if (process.arch === "x64" || process.arch === "arm64") {
+            return `linux-${process.arch}`;
+        }
+        return null;
+    }
     return null;
 }
 
@@ -272,6 +279,9 @@ function resolveMetadataFileName() {
     }
     if (process.platform === "win32") {
         return "latest.yml";
+    }
+    if (process.platform === "linux") {
+        return "latest-linux.yml";
     }
     return null;
 }
@@ -329,7 +339,8 @@ function loadUpdaterRuntimeConfig(): UpdaterRuntimeConfig {
             runtimeMode,
             endpoint: null,
             endpointDisplay,
-            endpointError: "Updater is only supported on macOS and Windows builds.",
+            endpointError:
+                "Updater is only supported on macOS, Windows, and Linux AppImage x64/ARM64 builds.",
             feedDirectoryUrl: null,
             feedTarget,
             metadataFileName,
@@ -468,10 +479,14 @@ function createPlatformUpdater(feedDirectoryUrl: string) {
         url: feedDirectoryUrl,
     };
 
-    const updater: AppUpdater =
-        process.platform === "darwin"
-            ? new MacUpdater(options)
-            : new NsisUpdater(options);
+    let updater: AppUpdater;
+    if (process.platform === "darwin") {
+        updater = new MacUpdater(options);
+    } else if (process.platform === "linux") {
+        updater = new AppImageUpdater(options);
+    } else {
+        updater = new NsisUpdater(options);
+    }
     updater.autoDownload = false;
     updater.autoInstallOnAppQuit = false;
     updater.forceDevUpdateConfig = !app.isPackaged;

--- a/apps/desktop/src-electron/main/window.ts
+++ b/apps/desktop/src-electron/main/window.ts
@@ -332,6 +332,7 @@ export function createAppWindow(
         resizable: getBooleanOption(options, "resizable", true),
         skipTaskbar: getBooleanOption(options, "skipTaskbar", false),
         alwaysOnTop: getBooleanOption(options, "alwaysOnTop", false),
+        autoHideMenuBar: !isMac,
         ...(chromeless
             ? {
                   frame: false,

--- a/apps/desktop/src-electron/main/window.ts
+++ b/apps/desktop/src-electron/main/window.ts
@@ -261,6 +261,7 @@ export function createAppWindow(
 
     const isMac = process.platform === "darwin";
     const isWindows = process.platform === "win32";
+    const isLinux = process.platform === "linux";
     const search = normalizeSearch(
         getSearchFromUrl(options?.url) ||
             (typeof options?.search === "string" ? options.search : ""),
@@ -314,7 +315,8 @@ export function createAppWindow(
     // (sidebars went literally see-through to the desktop) and to swallow
     // the native caption buttons.
     const isWindowsAcrylic = isWindows && !chromeless;
-    const windowsCaptionSymbol = nativeTheme.shouldUseDarkColors
+    const isLinuxTitleBarOverlay = isLinux && !chromeless;
+    const titleBarOverlaySymbol = nativeTheme.shouldUseDarkColors
         ? "#f4f4f5"
         : "#1c1c1c";
 
@@ -343,7 +345,7 @@ export function createAppWindow(
             ? "#00000000"
             : usesVibrancy || isWindowsAcrylic
                 ? "#00000000"
-                : isMac
+                : isMac || isLinuxTitleBarOverlay
                     ? solidChromeFallback
                     : "#ffffff",
         backgroundMaterial: isWindowsAcrylic ? "acrylic" : undefined,
@@ -361,12 +363,14 @@ export function createAppWindow(
                 ? (isMainWindow ? "hiddenInset" : "hidden")
                 : isWindows
                     ? "hidden"
-                    : "default",
-        titleBarOverlay: isWindowsAcrylic
+                    : isLinux
+                      ? "hidden"
+                      : "default",
+        titleBarOverlay: isWindowsAcrylic || isLinuxTitleBarOverlay
             ? {
                   color: "#00000000",
                   height: 34,
-                  symbolColor: windowsCaptionSymbol,
+                  symbolColor: titleBarOverlaySymbol,
               }
             : undefined,
         trafficLightPosition,
@@ -474,11 +478,10 @@ export function windowCommand(
             }
             return null;
         case "setTitleBarOverlay":
-            // Windows only: theme the native titleBarOverlay symbol/background
-            // color so the caption buttons stay legible against the acrylic
-            // surface in both light and dark themes. No-op elsewhere because
-            // the API is only meaningful on Windows titleBarOverlay windows.
-            if (process.platform === "win32") {
+            // Windows and Linux: theme the native titleBarOverlay symbol /
+            // background color so caption buttons stay legible against the
+            // renderer-painted chrome in both light and dark themes.
+            if (process.platform === "win32" || process.platform === "linux") {
                 const overlay: Parameters<
                     BrowserWindow["setTitleBarOverlay"]
                 >[0] = {};

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -168,12 +168,14 @@ function resetAppToActualSize() {
 type RightPanelTab = "outline" | "links";
 
 // The right panel lives outside the center column, so its tab bar starts at
-// Y=0 of the window. On Windows that zone is owned by the native
+// Y=0 of the window. On Windows and Linux that zone is owned by the native
 // `titleBarOverlay` (34px tall caption strip anchored to the window's
 // top-right), which would otherwise paint min/max/close on top of the tab
 // bar. Reserve a matching 34px drag strip at the top of the panel — same
 // pattern as `EditorChromeBar` for the center column.
-const IS_WINDOWS_DESKTOP = getDesktopPlatform() === "windows";
+const DESKTOP_PLATFORM = getDesktopPlatform();
+const USES_NATIVE_TITLEBAR_OVERLAY =
+    DESKTOP_PLATFORM === "windows" || DESKTOP_PLATFORM === "linux";
 
 const RIGHT_PANEL_TABS: Array<{
     value: RightPanelTab;
@@ -311,7 +313,7 @@ function RightPanel() {
     const toggleRightPanel = useLayoutStore((s) => s.toggleRightPanel);
     return (
         <div className="flex h-full min-h-0 flex-col overflow-hidden">
-            {IS_WINDOWS_DESKTOP && (
+            {USES_NATIVE_TITLEBAR_OVERLAY && (
                 <div
                     aria-hidden="true"
                     data-right-panel-titlebar-inset
@@ -2163,11 +2165,11 @@ export default function App() {
             />
             <WorkspaceTerminalHost />
 
-            {/* EditorChromeBar only renders on Windows (to reserve the
-                trailing space for the native titleBarOverlay controls). On
-                macOS it returns null: the sidebar owns the traffic-light
-                inset and the pane bars are free to sit flush against the top
-                of the window, giving the editor more vertical real estate. */}
+            {/* EditorChromeBar only renders on Windows and Linux (to reserve
+                the trailing space for the native titleBarOverlay controls).
+                On macOS it returns null: the sidebar owns the traffic-light
+                inset and the pane bars sit flush against the top of the
+                window. */}
             <div className="relative flex-1 flex overflow-hidden">
                 <AppLayout
                     left={<SidebarShell onOpenSettings={openSettings} />}

--- a/apps/desktop/src/app/shortcuts/registry.ts
+++ b/apps/desktop/src/app/shortcuts/registry.ts
@@ -45,7 +45,7 @@ export interface ShortcutDefinition {
     id: ShortcutActionId;
     label: string;
     category: string;
-    bindings: Record<DesktopPlatform, ShortcutBinding[]>;
+    bindings: Record<"macos" | "windows", ShortcutBinding[]>;
     aliases?: Partial<Record<DesktopPlatform, ShortcutBinding[]>>;
     note?: string;
 }
@@ -381,6 +381,12 @@ const CODEMIRROR_MODIFIER_LABELS: Record<ShortcutModifier, string> = {
     shift: "Shift",
 };
 
+function resolveShortcutPlatform(
+    platform: DesktopPlatform,
+): "macos" | "windows" {
+    return platform === "macos" ? "macos" : "windows";
+}
+
 export const SHORTCUT_REGISTRY = shortcutDefinitions.reduce<
     Record<ShortcutActionId, ShortcutDefinition>
 >(
@@ -460,7 +466,9 @@ export function getShortcutBindings(
     actionId: ShortcutActionId,
     platform: DesktopPlatform = getDesktopPlatform(),
 ): ShortcutBinding[] {
-    return SHORTCUT_REGISTRY[actionId].bindings[platform];
+    return SHORTCUT_REGISTRY[actionId].bindings[
+        resolveShortcutPlatform(platform)
+    ];
 }
 
 export function getShortcutBindingsWithAliases(
@@ -468,9 +476,13 @@ export function getShortcutBindingsWithAliases(
     platform: DesktopPlatform = getDesktopPlatform(),
 ): ShortcutBinding[] {
     const definition = SHORTCUT_REGISTRY[actionId];
+    const shortcutPlatform = resolveShortcutPlatform(platform);
     return [
-        ...definition.bindings[platform],
-        ...(definition.aliases?.[platform] ?? []),
+        ...definition.bindings[shortcutPlatform],
+        ...(definition.aliases?.[shortcutPlatform] ?? []),
+        ...(shortcutPlatform === platform
+            ? []
+            : (definition.aliases?.[platform] ?? [])),
     ];
 }
 
@@ -537,7 +549,10 @@ export function getShortcutDisplayDefinitions(
 ): ShortcutDefinition[] {
     return SHORTCUT_SETTINGS_ORDER.map((actionId) =>
         getShortcutDefinition(actionId),
-    ).filter((definition) => definition.bindings[platform].length > 0);
+    ).filter(
+        (definition) =>
+            definition.bindings[resolveShortcutPlatform(platform)].length > 0,
+    );
 }
 
 export function getShortcutSettingsEntries(

--- a/apps/desktop/src/app/store/themeStore.ts
+++ b/apps/desktop/src/app/store/themeStore.ts
@@ -110,12 +110,13 @@ function applyDark(isDark: boolean) {
     document.documentElement.classList.toggle("dark", isDark);
 }
 
-// Windows only: keep the native titleBarOverlay caption buttons legible by
+// Windows / Linux: keep the native titleBarOverlay caption buttons legible by
 // retinting their symbol color whenever the theme (palette or light/dark
-// mode) changes. Background stays transparent so the acrylic surface shows
-// through — only the symbol color needs to follow the theme.
-function syncWindowsTitleBarOverlay(themeName: ThemeName, isDark: boolean) {
-    if (getDesktopPlatform() !== "windows") return;
+// mode) changes. Background stays transparent so the renderer-painted chrome
+// shows through — only the symbol color needs to follow the theme.
+function syncDesktopTitleBarOverlay(themeName: ThemeName, isDark: boolean) {
+    const platform = getDesktopPlatform();
+    if (platform !== "windows" && platform !== "linux") return;
     const palette = themes[themeName];
     const symbolColor = (isDark ? palette.dark : palette.light).textPrimary;
     const runtimeWindow = getCurrentWindow();
@@ -132,7 +133,7 @@ function resolveTheme(mode: ThemeMode, themeName: ThemeName) {
     const isDark = getIsDark(mode);
     applyDark(isDark);
     applyThemeColors(themeName, isDark);
-    syncWindowsTitleBarOverlay(themeName, isDark);
+    syncDesktopTitleBarOverlay(themeName, isDark);
     return { mode, themeName, isDark };
 }
 
@@ -223,7 +224,7 @@ export function initializeThemeStore() {
     stopThemePersistence = useThemeStore.subscribe((state) => {
         applyDark(state.isDark);
         applyThemeColors(state.themeName, state.isDark);
-        syncWindowsTitleBarOverlay(state.themeName, state.isDark);
+        syncDesktopTitleBarOverlay(state.themeName, state.isDark);
         if (!isApplyingExternal) {
             saveTheme(currentVaultPath, {
                 mode: state.mode,

--- a/apps/desktop/src/app/utils/platform.test.ts
+++ b/apps/desktop/src/app/utils/platform.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 });
 
 describe("platform helpers", () => {
-    it("keeps macOS chrome defaults outside Windows", () => {
+    it("keeps macOS chrome defaults on macOS", () => {
         setNavigatorIdentity(
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_0) AppleWebKit/605.1.15",
             "MacIntel",
@@ -61,6 +61,22 @@ describe("platform helpers", () => {
         // No chrome overrides on Windows: satellite windows use the same
         // main-process path as the main window so DWM paints native acrylic
         // and caption buttons.
+        expect(getManagedWindowChromeOptions()).toEqual({});
+    });
+
+    it("uses right-side overlay chrome on Linux", () => {
+        setNavigatorIdentity(
+            "Mozilla/5.0 (X11; Linux aarch64) AppleWebKit/537.36",
+            "Linux aarch64",
+        );
+
+        expect(getDesktopPlatform()).toBe("linux");
+        expect(getWindowChromeLayout()).toEqual({
+            platform: "linux",
+            leadingInsetWidth: 0,
+            titlebarPaddingTop: 0,
+            windowControlsSide: "right",
+        });
         expect(getManagedWindowChromeOptions()).toEqual({});
     });
 });

--- a/apps/desktop/src/app/utils/platform.ts
+++ b/apps/desktop/src/app/utils/platform.ts
@@ -1,4 +1,4 @@
-export type DesktopPlatform = "macos" | "windows";
+export type DesktopPlatform = "macos" | "windows" | "linux";
 
 export interface WindowChromeLayout {
     platform: DesktopPlatform;
@@ -14,11 +14,6 @@ export interface ManagedWindowChromeOptions {
     trafficLightPosition?: { x: number; y: number };
 }
 
-/**
- * The desktop app currently has two supported shells. Treat everything that is
- * not explicitly Windows as macOS so existing chrome stays stable in tests and
- * non-Windows developer environments.
- */
 export function getDesktopPlatform(): DesktopPlatform {
     if (typeof navigator === "undefined") return "macos";
 
@@ -32,7 +27,9 @@ export function getDesktopPlatform(): DesktopPlatform {
         .filter((value): value is string => typeof value === "string")
         .join(" ");
 
-    return /windows/i.test(platformHints) ? "windows" : "macos";
+    if (/windows/i.test(platformHints)) return "windows";
+    if (/linux|x11|wayland/i.test(platformHints)) return "linux";
+    return "macos";
 }
 
 /**

--- a/apps/desktop/src/components/layout/WindowChrome.tsx
+++ b/apps/desktop/src/components/layout/WindowChrome.tsx
@@ -5,7 +5,7 @@ import {
 } from "react";
 import { getWindowChromeLayout } from "../../app/utils/platform";
 
-// On Windows, the caption buttons are painted by Electron's native
+// On Windows and Linux, the caption buttons are painted by Electron's native
 // `titleBarOverlay`, not by React — so this component only reserves the
 // drag region and optional macOS leading inset, and never renders custom
 // min/max/close buttons.

--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, screen } from "@testing-library/react";
 import { confirm } from "@neverwrite/runtime";
+import { getDesktopPlatform } from "../../app/utils/platform";
 import { getChunks, getOriginalDoc } from "@codemirror/merge";
 import { EditorSelection } from "@codemirror/state";
 import { undo } from "@codemirror/commands";
@@ -2644,7 +2645,8 @@ describe("Editor", () => {
             window.dispatchEvent(
                 new KeyboardEvent("keydown", {
                     key: "w",
-                    metaKey: true,
+                    metaKey: getDesktopPlatform() === "macos",
+                    ctrlKey: getDesktopPlatform() !== "macos",
                     bubbles: true,
                 }),
             );
@@ -2701,7 +2703,8 @@ describe("Editor", () => {
             window.dispatchEvent(
                 new KeyboardEvent("keydown", {
                     key: "w",
-                    metaKey: true,
+                    metaKey: getDesktopPlatform() === "macos",
+                    ctrlKey: getDesktopPlatform() !== "macos",
                     bubbles: true,
                 }),
             );

--- a/apps/desktop/src/features/editor/EditorChromeBar.tsx
+++ b/apps/desktop/src/features/editor/EditorChromeBar.tsx
@@ -10,8 +10,9 @@ import {
 } from "../../app/utils/platform";
 
 // Thin top strip above the editor. It exists only to reserve the trailing
-// 140px that Windows' `titleBarOverlay` paints native caption controls on
-// top of — without the spacer, the tab strip would slide under min/max/close.
+// 140px that the Windows / Linux `titleBarOverlay` paints native caption
+// controls on top of — without the spacer, the tab strip would slide under
+// min/max/close.
 //
 // On macOS the component collapses to `null`: the traffic lights are handled
 // entirely by the window adapter (`setTrafficLightsVisible`) and the sidebar
@@ -20,7 +21,9 @@ import {
 
 const PLATFORM = getDesktopPlatform();
 const IS_WINDOWS = PLATFORM === "windows";
-const WINDOWS_CONTROLS_RESERVED = IS_WINDOWS ? 140 : 0;
+const IS_LINUX = PLATFORM === "linux";
+const USES_NATIVE_TITLEBAR_OVERLAY = IS_WINDOWS || IS_LINUX;
+const NATIVE_CONTROLS_RESERVED = USES_NATIVE_TITLEBAR_OVERLAY ? 140 : 0;
 
 function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
     if (event.button !== 0) return;
@@ -31,7 +34,7 @@ function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
 }
 
 function toggleWindowMaximize() {
-    if (!IS_WINDOWS) return;
+    if (!USES_NATIVE_TITLEBAR_OVERLAY) return;
     const appWindow = getCurrentWindow();
     if (typeof appWindow.toggleMaximize !== "function") return;
     void appWindow.toggleMaximize().catch(() => {});
@@ -47,7 +50,7 @@ export function EditorChromeBar() {
 
     // macOS no longer needs this strip — the sidebar owns the traffic-light
     // inset and the pane bars sit flush against the top of the window.
-    if (!IS_WINDOWS) return null;
+    if (!USES_NATIVE_TITLEBAR_OVERLAY) return null;
 
     const layout = getWindowChromeLayout();
 
@@ -61,8 +64,8 @@ export function EditorChromeBar() {
                 paddingTop: layout.titlebarPaddingTop,
                 flexShrink: 0,
                 WebkitAppRegion: "drag",
-                // Match the sidebar's frosted tint so the strip reads as a
-                // continuation of the Windows acrylic surface.
+                // Match the sidebar's theme tint so the strip reads as a
+                // continuation of the native titlebar overlay surface.
                 backgroundColor: "var(--sidebar-vibrancy-tint)",
             } as CSSProperties}
         >
@@ -81,7 +84,7 @@ export function EditorChromeBar() {
                 <div
                     aria-hidden="true"
                     style={{
-                        width: WINDOWS_CONTROLS_RESERVED,
+                        width: NATIVE_CONTROLS_RESERVED,
                         flexShrink: 0,
                     }}
                 />

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -97,7 +97,8 @@ function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
 }
 
 function toggleWindowMaximize() {
-    if (getDesktopPlatform() !== "windows") return;
+    const platform = getDesktopPlatform();
+    if (platform !== "windows" && platform !== "linux") return;
     const appWindow = getAppWindow();
     if (typeof appWindow.toggleMaximize !== "function") return;
     void appWindow.toggleMaximize().catch(() => {
@@ -142,13 +143,15 @@ interface UnifiedBarProps {
 
 export function UnifiedBar({ windowMode }: UnifiedBarProps) {
     const desktopPlatform = getDesktopPlatform();
-    // Detached note windows on Windows now use the native `titleBarOverlay`
-    // (min/max/close painted by DWM in the top-right 140px), so the trailing
+    const usesNativeTitleBarOverlay =
+        desktopPlatform === "windows" || desktopPlatform === "linux";
+    // Detached note windows on Windows and Linux use the native `titleBarOverlay`
+    // (min/max/close painted in the top-right 140px), so the trailing
     // drag zone has to reserve that width — otherwise tabs slide under the
     // caption buttons. Main windows already reserve 152 (140 for the native
     // controls + 12 for the right-panel toggle and its margins).
     const trailingDragZoneWidth =
-        windowMode === "main" ? 152 : desktopPlatform === "windows" ? 140 : 8;
+        windowMode === "main" ? 152 : usesNativeTitleBarOverlay ? 140 : 8;
     const focusedPane = useEditorStore(selectEditorPaneState);
     const tabs = focusedPane.tabs;
     const activeTabId = focusedPane.activeTabId;

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -4046,7 +4046,9 @@ export function SettingsPanel({
               : "general";
     const desktopPlatform = getDesktopPlatform();
     const standaloneWindow = standalone ? getCurrentWebviewWindow() : null;
-    const isStandaloneWindows = standalone && desktopPlatform === "windows";
+    const isStandaloneNativeTitlebarOverlay =
+        standalone &&
+        (desktopPlatform === "windows" || desktopPlatform === "linux");
     // Standalone Settings uses the native window material (macOS vibrancy,
     // Windows 11 acrylic) on the top bar and left sidebar. The outer shell
     // stays transparent so the material shows through; the content pane
@@ -4177,7 +4179,7 @@ export function SettingsPanel({
                 onBackgroundDoubleClick={(e) => {
                     if (
                         !standalone ||
-                        desktopPlatform !== "windows" ||
+                        !isStandaloneNativeTitlebarOverlay ||
                         (e.target as HTMLElement).closest("button")
                     ) {
                         return;
@@ -4201,11 +4203,11 @@ export function SettingsPanel({
                     alignItems: "center",
                     position: "relative",
                     padding: "0 20px",
-                    // Standalone settings on Windows now gets native
+                    // Standalone settings on Windows and Linux get native
                     // caption buttons via `titleBarOverlay` in the top-right
                     // 140px — reserve that space so the header content never
                     // slides under them.
-                    paddingRight: isStandaloneWindows ? 140 : 20,
+                    paddingRight: isStandaloneNativeTitlebarOverlay ? 140 : 20,
                     borderBottom: "1px solid var(--border)",
                     flexShrink: 0,
                     backgroundColor: chromeBackground,

--- a/release/appcast/README.md
+++ b/release/appcast/README.md
@@ -49,6 +49,8 @@ Public naming remains stable per target:
 | `universal-apple-darwin` | `NeverWrite_<version>_macOS_Universal.dmg` | `NeverWrite_<version>_macOS_Universal.zip` |
 | `aarch64-pc-windows-msvc` | `NeverWrite_<version>_Windows_ARM64_Setup.exe` | `NeverWrite_<version>_Windows_ARM64_Setup.exe` |
 | `x86_64-pc-windows-msvc` | `NeverWrite_<version>_Windows_x64_Setup.exe` | `NeverWrite_<version>_Windows_x64_Setup.exe` |
+| `x86_64-unknown-linux-gnu` | `NeverWrite-<version>-x64.AppImage` | `NeverWrite-<version>-x64.AppImage` |
+| `aarch64-unknown-linux-gnu` | `NeverWrite-<version>-arm64.AppImage` | `NeverWrite-<version>-arm64.AppImage` |
 
 The architecture suffix is mandatory for Windows. macOS publishes a universal package and a single universal updater feed. We do not publish shared Windows `latest.yml` metadata for multiple architectures in the same directory because `electron-builder` would otherwise collide on Windows metadata names.
 

--- a/scripts/appcast-lib.mjs
+++ b/scripts/appcast-lib.mjs
@@ -17,16 +17,22 @@ export const V1_BUILD_TARGETS = [
     "universal-apple-darwin",
     "aarch64-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-gnu",
 ];
 export const V1_APPCAST_KEYS = [
     "darwin-universal",
     "windows-aarch64",
     "windows-x86_64",
+    "linux-aarch64",
+    "linux-x86_64",
 ];
 export const BUILD_TARGET_TO_APPCAST_KEY = {
     "universal-apple-darwin": "darwin-universal",
     "aarch64-pc-windows-msvc": "windows-aarch64",
     "x86_64-pc-windows-msvc": "windows-x86_64",
+    "aarch64-unknown-linux-gnu": "linux-aarch64",
+    "x86_64-unknown-linux-gnu": "linux-x86_64",
 };
 export const APPCAST_OUTPUT_ROOT = path.join(REPO_ROOT, "dist", "appcast");
 
@@ -110,6 +116,10 @@ export function buildPublicReleaseAssetName(version, buildTarget) {
             return `${PUBLIC_PRODUCT_NAME}_${normalizedVersion}_Windows_ARM64_Setup.exe`;
         case "x86_64-pc-windows-msvc":
             return `${PUBLIC_PRODUCT_NAME}_${normalizedVersion}_Windows_x64_Setup.exe`;
+        case "aarch64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-${normalizedVersion}-arm64.AppImage`;
+        case "x86_64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-${normalizedVersion}-x64.AppImage`;
         default:
             throw new Error(`Unsupported build target "${buildTarget}".`);
     }
@@ -126,6 +136,10 @@ export function getBundledUpdaterArtifactName(buildTarget) {
         case "aarch64-pc-windows-msvc":
         case "x86_64-pc-windows-msvc":
             return `${PUBLIC_PRODUCT_NAME}-setup.nsis.zip`;
+        case "aarch64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-arm64.AppImage`;
+        case "x86_64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-x64.AppImage`;
         default:
             throw new Error(`Unsupported build target "${buildTarget}".`);
     }
@@ -141,6 +155,10 @@ export function buildUpdaterReleaseAssetName(version, buildTarget) {
             return `${PUBLIC_PRODUCT_NAME}_${normalizedVersion}_Windows_ARM64.nsis.zip`;
         case "x86_64-pc-windows-msvc":
             return `${PUBLIC_PRODUCT_NAME}_${normalizedVersion}_Windows_x64.nsis.zip`;
+        case "aarch64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-${normalizedVersion}-arm64.AppImage`;
+        case "x86_64-unknown-linux-gnu":
+            return `${PUBLIC_PRODUCT_NAME}-${normalizedVersion}-x64.AppImage`;
         default:
             throw new Error(`Unsupported build target "${buildTarget}".`);
     }
@@ -153,6 +171,9 @@ export function describeUpdaterArtifactKind(buildTarget) {
         case "aarch64-pc-windows-msvc":
         case "x86_64-pc-windows-msvc":
             return "Windows updater archive (.nsis.zip)";
+        case "aarch64-unknown-linux-gnu":
+        case "x86_64-unknown-linux-gnu":
+            return "Linux AppImage (.AppImage)";
         default:
             throw new Error(`Unsupported build target "${buildTarget}".`);
     }

--- a/scripts/appcast.test.mjs
+++ b/scripts/appcast.test.mjs
@@ -48,6 +48,10 @@ test("buildPublicReleaseAssetName uses the human-facing naming convention", () =
         buildPublicReleaseAssetName("0.2.0", "x86_64-pc-windows-msvc"),
         "NeverWrite_0.2.0_Windows_x64_Setup.exe",
     );
+    assert.equal(
+        buildPublicReleaseAssetName("0.2.0", "x86_64-unknown-linux-gnu"),
+        "NeverWrite-0.2.0-x64.AppImage",
+    );
 });
 
 test("describeUpdaterArtifactKind documents updater archive families", () => {
@@ -83,6 +87,14 @@ test("canonical bundle and updater artifact names are fixed for v1 release autom
         buildUpdaterReleaseAssetName("0.2.0", "x86_64-pc-windows-msvc"),
         "NeverWrite_0.2.0_Windows_x64.nsis.zip",
     );
+    assert.equal(
+        getBundledUpdaterArtifactName("x86_64-unknown-linux-gnu"),
+        "NeverWrite-x64.AppImage",
+    );
+    assert.equal(
+        buildUpdaterReleaseAssetName("0.2.0", "x86_64-unknown-linux-gnu"),
+        "NeverWrite-0.2.0-x64.AppImage",
+    );
 });
 
 test("normalizePlatformEntries accepts build targets and emits appcast keys", () => {
@@ -96,6 +108,10 @@ test("normalizePlatformEntries accepts build targets and emits appcast keys", ()
                 url: "https://example.com/windows-x64.zip",
                 signature: "sig-b",
             },
+            "x86_64-unknown-linux-gnu": {
+                url: "https://example.com/linux-x64.AppImage",
+                signature: "sig-c",
+            },
         }),
         {
             "darwin-universal": {
@@ -105,6 +121,10 @@ test("normalizePlatformEntries accepts build targets and emits appcast keys", ()
             "windows-x86_64": {
                 url: "https://example.com/windows-x64.zip",
                 signature: "sig-b",
+            },
+            "linux-x86_64": {
+                url: "https://example.com/linux-x64.AppImage",
+                signature: "sig-c",
             },
         },
     );
@@ -128,6 +148,14 @@ test("createStaticAppcastManifest requires all v1 platform keys and preserves or
                 url: "https://example.com/windows-arm64.zip",
                 signature: "sig-warm",
             },
+            "aarch64-unknown-linux-gnu": {
+                url: "https://example.com/linux-arm64.AppImage",
+                signature: "sig-larm",
+            },
+            "x86_64-unknown-linux-gnu": {
+                url: "https://example.com/linux-x64.AppImage",
+                signature: "sig-lx64",
+            },
         },
     });
 
@@ -135,6 +163,8 @@ test("createStaticAppcastManifest requires all v1 platform keys and preserves or
         "darwin-universal",
         "windows-aarch64",
         "windows-x86_64",
+        "linux-aarch64",
+        "linux-x86_64",
     ]);
     assert.equal(manifest.version, "0.2.0");
     assert.equal(manifest.pub_date, "2026-04-04T18:00:00Z");

--- a/scripts/electron-release-lib.mjs
+++ b/scripts/electron-release-lib.mjs
@@ -20,12 +20,16 @@ export const ELECTRON_BUILD_TARGETS = [
     "universal-apple-darwin",
     "aarch64-pc-windows-msvc",
     "x86_64-pc-windows-msvc",
+    "aarch64-unknown-linux-gnu",
+    "x86_64-unknown-linux-gnu",
 ];
 
 export const BUILD_TARGET_TO_FEED_TARGET = {
     "universal-apple-darwin": "darwin-universal",
     "aarch64-pc-windows-msvc": "windows-arm64",
     "x86_64-pc-windows-msvc": "windows-x64",
+    "aarch64-unknown-linux-gnu": "linux-arm64",
+    "x86_64-unknown-linux-gnu": "linux-x64",
 };
 
 export function feedTargetForBuildTarget(buildTarget) {
@@ -43,6 +47,9 @@ export function metadataFileNameForBuildTarget(buildTarget) {
     if (buildTarget.endsWith("-pc-windows-msvc")) {
         return "latest.yml";
     }
+    if (buildTarget.endsWith("-unknown-linux-gnu")) {
+        return "latest-linux.yml";
+    }
     throw new Error(`Unsupported build target "${buildTarget}".`);
 }
 
@@ -56,6 +63,10 @@ export function buildElectronUpdaterAssetName(version, buildTarget) {
             return `NeverWrite_${normalizedVersion}_Windows_ARM64_Setup.exe`;
         case "x86_64-pc-windows-msvc":
             return `NeverWrite_${normalizedVersion}_Windows_x64_Setup.exe`;
+        case "aarch64-unknown-linux-gnu":
+            return `NeverWrite-${normalizedVersion}-arm64.AppImage`;
+        case "x86_64-unknown-linux-gnu":
+            return `NeverWrite-${normalizedVersion}-x64.AppImage`;
         default:
             throw new Error(`Unsupported build target "${buildTarget}".`);
     }
@@ -90,6 +101,16 @@ export function describeBuildTarget(buildTarget) {
         case "x86_64-pc-windows-msvc":
             return {
                 platformLabel: "Windows",
+                architectureLabel: "x64",
+            };
+        case "aarch64-unknown-linux-gnu":
+            return {
+                platformLabel: "Linux",
+                architectureLabel: "ARM64",
+            };
+        case "x86_64-unknown-linux-gnu":
+            return {
+                platformLabel: "Linux",
                 architectureLabel: "x64",
             };
         default:

--- a/scripts/electron-release-lib.mjs
+++ b/scripts/electron-release-lib.mjs
@@ -104,5 +104,8 @@ export function describeUpdaterArtifactKind(buildTarget) {
     if (buildTarget.endsWith("-pc-windows-msvc")) {
         return "Windows installer (.exe)";
     }
+    if (buildTarget.endsWith("-unknown-linux-gnu")) {
+        return "Linux AppImage (.AppImage)";
+    }
     throw new Error(`Unsupported build target "${buildTarget}".`);
 }

--- a/scripts/platform-validation.test.mjs
+++ b/scripts/platform-validation.test.mjs
@@ -47,6 +47,30 @@ function buildMetadataEntries() {
             updaterUrl:
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite_0.2.0_Windows_x64_Setup.exe",
         },
+        {
+            buildTarget: "aarch64-unknown-linux-gnu",
+            feedTarget: "linux-arm64",
+            metadataFileName: "latest-linux.yml",
+            feedRelativePath: "linux-arm64/latest-linux.yml",
+            manualAssetName: "NeverWrite-0.2.0-arm64.AppImage",
+            updaterAssetName: "NeverWrite-0.2.0-arm64.AppImage",
+            updaterBlockmapAssetName:
+                "NeverWrite-0.2.0-arm64.AppImage.blockmap",
+            updaterUrl:
+                "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-arm64.AppImage",
+        },
+        {
+            buildTarget: "x86_64-unknown-linux-gnu",
+            feedTarget: "linux-x64",
+            metadataFileName: "latest-linux.yml",
+            feedRelativePath: "linux-x64/latest-linux.yml",
+            manualAssetName: "NeverWrite-0.2.0-x64.AppImage",
+            updaterAssetName: "NeverWrite-0.2.0-x64.AppImage",
+            updaterBlockmapAssetName:
+                "NeverWrite-0.2.0-x64.AppImage.blockmap",
+            updaterUrl:
+                "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-x64.AppImage",
+        },
     ];
 }
 
@@ -62,6 +86,10 @@ test("resolveValidationTarget accepts build targets and feed targets", () => {
     assert.equal(
         resolveValidationTarget("windows-x64").buildTarget,
         "x86_64-pc-windows-msvc",
+    );
+    assert.equal(
+        resolveValidationTarget("linux-x64").buildTarget,
+        "x86_64-unknown-linux-gnu",
     );
 });
 
@@ -94,7 +122,7 @@ test("buildPlatformValidationMatrix aligns feed URLs with target metadata", () =
         metadataEntries: buildMetadataEntries(),
     });
 
-    assert.equal(rows.length, 3);
+    assert.equal(rows.length, 5);
     assert.equal(rows[0].buildTarget, "universal-apple-darwin");
     assert.equal(
         rows[0].feedUrl,
@@ -104,6 +132,11 @@ test("buildPlatformValidationMatrix aligns feed URLs with target metadata", () =
     assert.equal(
         rows[2].updaterAssetName,
         "NeverWrite_0.2.0_Windows_x64_Setup.exe",
+    );
+    assert.equal(rows[4].feedTarget, "linux-x64");
+    assert.equal(
+        rows[4].updaterAssetName,
+        "NeverWrite-0.2.0-x64.AppImage",
     );
 });
 

--- a/scripts/release-assets-lib.mjs
+++ b/scripts/release-assets-lib.mjs
@@ -28,6 +28,16 @@ export const PUBLIC_DOWNLOAD_VARIANTS = [
         platformLabel: "Windows",
         architectureLabel: "x64",
     },
+    {
+        buildTarget: "aarch64-unknown-linux-gnu",
+        platformLabel: "Linux",
+        architectureLabel: "ARM64",
+    },
+    {
+        buildTarget: "x86_64-unknown-linux-gnu",
+        platformLabel: "Linux",
+        architectureLabel: "x64",
+    },
 ];
 
 export const WEB_CLIPPER_RELEASE_BROWSERS = ["chrome", "firefox"];
@@ -38,6 +48,9 @@ export function targetPlatformFamily(buildTarget) {
     }
     if (buildTarget.endsWith("-pc-windows-msvc")) {
         return "windows";
+    }
+    if (buildTarget.endsWith("-unknown-linux-gnu")) {
+        return "linux";
     }
     throw new Error(`Unsupported build target "${buildTarget}".`);
 }
@@ -263,7 +276,7 @@ export function buildReleaseBody(version, releaseNotes) {
         renderManualDownloadTable(version),
         "",
         "Updater artifacts are also attached to the release for in-app updates.",
-        "Files ending in `.app.tar.gz`, `.nsis.zip`, or `.sig` are internal updater assets and are not intended for manual installation.",
+        "Files ending in `.app.tar.gz`, `.nsis.zip`, `.blockmap`, or `.sig` are internal updater assets and are not intended for manual installation.",
         "",
         "## Browser extensions",
         "",

--- a/scripts/release-assets.test.mjs
+++ b/scripts/release-assets.test.mjs
@@ -36,6 +36,10 @@ test("runtimeBinaryFileName follows target platform conventions", () => {
         runtimeBinaryFileName("x86_64-pc-windows-msvc", "codex-acp"),
         "codex-acp.exe",
     );
+    assert.equal(
+        runtimeBinaryFileName("x86_64-unknown-linux-gnu", "codex-acp"),
+        "codex-acp",
+    );
 });
 
 test("validateStagedRuntimeResources checks bundled runtime staging inputs", () => {
@@ -84,6 +88,18 @@ test("buildManualDownloadRows exposes the public installer set for humans", () =
             architectureLabel: "x64",
             assetName: "NeverWrite_0.2.0_Windows_x64_Setup.exe",
         },
+        {
+            buildTarget: "aarch64-unknown-linux-gnu",
+            platformLabel: "Linux",
+            architectureLabel: "ARM64",
+            assetName: "NeverWrite-0.2.0-arm64.AppImage",
+        },
+        {
+            buildTarget: "x86_64-unknown-linux-gnu",
+            platformLabel: "Linux",
+            architectureLabel: "x64",
+            assetName: "NeverWrite-0.2.0-x64.AppImage",
+        },
     ]);
 });
 
@@ -95,6 +111,7 @@ test("buildReleaseBody distinguishes manual installers from internal updater ass
     assert.match(body, /## Manual installers/);
     assert.match(body, /NeverWrite_0.2.0_macOS_Universal\.dmg/);
     assert.match(body, /NeverWrite_0.2.0_Windows_x64_Setup\.exe/);
+    assert.match(body, /NeverWrite-0.2.0-x64\.AppImage/);
     assert.match(body, /internal updater assets/i);
     assert.match(body, /## Browser extensions/);
     assert.match(

--- a/scripts/release-metadata-lib.mjs
+++ b/scripts/release-metadata-lib.mjs
@@ -260,6 +260,17 @@ export function collectElectronBuildIssues(config) {
         );
     }
 
+    const linuxTargets = new Set(
+        (config.linux?.target ?? []).flatMap((entry) =>
+            typeof entry === "string" ? [entry] : [entry?.target].filter(Boolean),
+        ),
+    );
+    if (!linuxTargets.has("AppImage")) {
+        issues.push(
+            'electron-builder.config.mjs linux.target must include "AppImage".',
+        );
+    }
+
     return issues;
 }
 

--- a/scripts/release-metadata.test.mjs
+++ b/scripts/release-metadata.test.mjs
@@ -120,6 +120,9 @@ test("collectElectronBuildIssues validates the Electron release contract", () =>
             win: {
                 target: [{ target: "nsis" }],
             },
+            linux: {
+                target: [{ target: "AppImage" }],
+            },
         }),
         [],
     );
@@ -145,6 +148,7 @@ test("collectElectronBuildIssues validates the Electron release contract", () =>
             "electron-builder.config.mjs must configure afterPack bundle verification.",
             'electron-builder.config.mjs mac.target must include "zip".',
             'electron-builder.config.mjs win.target must include "nsis".',
+            'electron-builder.config.mjs linux.target must include "AppImage".',
         ],
     );
 });


### PR DESCRIPTION
As requested in the repository README/CONTRIBUTING guidelines, this PR implements full Linux AppImage support end-to-end, including:
- electron-builder configuration for x64 and arm64 AppImage targets.
- Rust sidecar cross-compilation support in staging scripts.
- GitHub Actions CI integration running on ubuntu-22.04 to ensure GLIBC compatibility.
- electron-updater appcast wiring for both architectures (`latest-linux.yml`).

This keeps existing macOS and Windows targets untouched while bringing native packaging to Linux.