### PR TITLE
Update codex-acp vendor to 0.14.0

### DIFF
--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -197,49 +197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "age"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d86e4272c093c88caf7864a2d09af52a5159180848ca4832a3cdbd7d014d5"
-dependencies = [
- "age-core",
- "base64 0.21.7",
- "bech32",
- "chacha20poly1305",
- "cookie-factory",
- "hmac 0.12.1",
- "i18n-embed",
- "i18n-embed-fl",
- "lazy_static",
- "nom 7.1.3",
- "pin-project",
- "rand 0.8.6",
- "rust-embed",
- "scrypt",
- "sha2 0.10.9",
- "subtle",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "age-core"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2bf6a89c984ca9d850913ece2da39e1d200563b0a94b002b253beee4c5acf99"
-dependencies = [
- "base64 0.21.7",
- "chacha20poly1305",
- "cookie-factory",
- "hkdf",
- "io_tee",
- "nom 7.1.3",
- "rand 0.8.6",
- "secrecy",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "agent-client-protocol"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,8 +208,8 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "jsonrpcmsg",
- "rmcp 1.5.0",
- "rustc-hash 2.1.2",
+ "rmcp 1.6.0",
+ "rustc-hash",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -396,7 +353,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -407,7 +364,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1099,12 +1056,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -1124,21 +1075,6 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
-
-[[package]]
-name = "basic-toml"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
 
 [[package]]
 name = "beef"
@@ -1161,7 +1097,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "shlex",
  "syn 2.0.117",
 ]
@@ -1331,9 +1267,9 @@ dependencies = [
 
 [[package]]
 name = "bytestring"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "113b4343b5f6617e7ad401ced8de3cc8b012e73a594347c307b90db3e9271289"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
 ]
@@ -1411,9 +1347,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1447,30 +1383,6 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
 
 [[package]]
 name = "chardetng"
@@ -1607,11 +1519,10 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-acp"
-version = "0.12.0"
+version = "0.14.0"
 dependencies = [
  "agent-client-protocol",
  "anyhow",
- "async-trait",
  "clap",
  "codex-apply-patch",
  "codex-arg0",
@@ -1645,15 +1556,16 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "codex-protocol",
  "crypto_box",
  "ed25519-dalek",
+ "jsonwebtoken",
  "rand 0.9.4",
  "reqwest",
  "serde",
@@ -1663,12 +1575,13 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
  "codex-plugin",
  "codex-protocol",
  "os_info",
@@ -1681,12 +1594,12 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-channel",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "codex-client",
@@ -1710,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "clap",
@@ -1734,8 +1647,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1749,8 +1662,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1767,8 +1680,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1777,8 +1690,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1790,9 +1703,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-builtin-mcps"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+dependencies = [
+ "anyhow",
+ "codex-config",
+ "codex-memories-mcp",
+ "codex-utils-absolute-path",
+]
+
+[[package]]
 name = "codex-client"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1817,8 +1741,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1834,29 +1758,35 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 
 [[package]]
 name = "codex-config"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64",
  "codex-app-server-protocol",
  "codex-execpolicy",
  "codex-features",
+ "codex-file-system",
+ "codex-git-utils",
  "codex-model-provider-info",
  "codex-network-proxy",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-path",
+ "core-foundation 0.9.4",
  "dns-lookup",
+ "dunce",
  "futures",
  "gethostname",
  "libc",
  "multimap",
+ "prost",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -1866,15 +1796,18 @@ dependencies = [
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "toml_edit 0.24.1+spec-1.1.0",
+ "tonic",
+ "tonic-prost",
  "tracing",
  "wildmatch",
  "winapi-util",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-connectors"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
@@ -1884,14 +1817,14 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "arc-swap",
  "async-channel",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bm25",
  "chrono",
  "clap",
@@ -1913,6 +1846,7 @@ dependencies = [
  "codex-hooks",
  "codex-login",
  "codex-mcp",
+ "codex-memories-read",
  "codex-model-provider",
  "codex-model-provider-info",
  "codex-models-manager",
@@ -1925,7 +1859,6 @@ dependencies = [
  "codex-rollout",
  "codex-rollout-trace",
  "codex-sandboxing",
- "codex-secrets",
  "codex-shell-command",
  "codex-shell-escalation",
  "codex-state",
@@ -1945,7 +1878,6 @@ dependencies = [
  "codex-utils-string",
  "codex-utils-template",
  "codex-windows-sandbox",
- "core-foundation 0.9.4",
  "csv",
  "dirs",
  "dunce",
@@ -1981,42 +1913,47 @@ dependencies = [
  "uuid",
  "which 8.0.2",
  "whoami",
- "windows-sys 0.52.0",
- "zip",
 ]
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
+ "anyhow",
  "chrono",
+ "codex-analytics",
  "codex-app-server-protocol",
  "codex-config",
  "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
  "codex-login",
+ "codex-model-provider",
+ "codex-otel",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-plugins",
  "dirs",
+ "flate2",
  "reqwest",
  "serde",
  "serde_json",
+ "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
+ "zip",
 ]
 
 [[package]]
 name = "codex-core-skills"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -2024,6 +1961,7 @@ dependencies = [
  "codex-config",
  "codex-exec-server",
  "codex-login",
+ "codex-model-provider",
  "codex-otel",
  "codex-protocol",
  "codex-skills",
@@ -2044,16 +1982,16 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "arc-swap",
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "codex-app-server-protocol",
  "codex-client",
- "codex-config",
+ "codex-file-system",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
@@ -2062,6 +2000,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tokio-tungstenite",
@@ -2072,8 +2011,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "clap",
@@ -2088,8 +2027,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2098,8 +2037,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2111,8 +2050,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -2124,8 +2063,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "clap",
@@ -2138,13 +2077,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-file-system"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+dependencies = [
+ "async-trait",
+ "codex-protocol",
+ "codex-utils-absolute-path",
+ "serde",
+]
+
+[[package]]
 name = "codex-git-utils"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "chrono",
- "codex-exec-server",
+ "codex-file-system",
  "codex-protocol",
  "codex-utils-absolute-path",
  "futures",
@@ -2163,26 +2113,30 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "chrono",
  "codex-config",
+ "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
  "futures",
  "regex",
  "schemars 0.8.22",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "keyring",
  "tracing",
@@ -2190,31 +2144,31 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
- "cc",
  "clap",
+ "codex-process-hardening",
  "codex-protocol",
  "codex-sandboxing",
  "codex-utils-absolute-path",
  "globset",
  "landlock",
  "libc",
- "pkg-config",
  "seccompiler",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "url",
 ]
 
 [[package]]
 name = "codex-login"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "codex-agent-identity",
  "codex-app-server-protocol",
@@ -2244,15 +2198,18 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "async-channel",
+ "codex-api",
  "codex-async-utils",
+ "codex-builtin-mcps",
  "codex-config",
  "codex-exec-server",
  "codex-login",
+ "codex-model-provider",
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
@@ -2273,17 +2230,15 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "codex-arg0",
  "codex-config",
  "codex-core",
  "codex-exec-server",
- "codex-features",
  "codex-login",
- "codex-models-manager",
  "codex-protocol",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
@@ -2298,24 +2253,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-memories-mcp"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+dependencies = [
+ "anyhow",
+ "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
+ "rmcp 0.15.0",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
+name = "codex-memories-read"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+dependencies = [
+ "codex-protocol",
+ "codex-shell-command",
+ "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
+ "codex-utils-template",
+ "tokio",
+]
+
+[[package]]
 name = "codex-model-provider"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
+ "codex-agent-identity",
  "codex-api",
  "codex-aws-auth",
  "codex-client",
+ "codex-feedback",
  "codex-login",
  "codex-model-provider-info",
+ "codex-models-manager",
+ "codex-otel",
  "codex-protocol",
+ "codex-response-debug-context",
  "http 1.4.0",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2327,24 +2318,18 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
+ "async-trait",
  "chrono",
- "codex-api",
  "codex-app-server-protocol",
  "codex-collaboration-mode-templates",
- "codex-config",
- "codex-feedback",
  "codex-login",
- "codex-model-provider",
- "codex-model-provider-info",
  "codex-otel",
  "codex-protocol",
- "codex-response-debug-context",
  "codex-utils-output-truncation",
  "codex-utils-template",
- "http 1.4.0",
  "serde",
  "serde_json",
  "tokio",
@@ -2353,8 +2338,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2383,8 +2368,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2415,18 +2400,27 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
+ "codex-config",
  "codex-utils-absolute-path",
  "codex-utils-plugins",
  "thiserror 2.0.18",
 ]
 
 [[package]]
+name = "codex-process-hardening"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "codex-protocol"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2458,14 +2452,15 @@ dependencies = [
  "tracing",
  "ts-rs",
  "uuid",
+ "wildmatch",
 ]
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "codex-api",
  "http 1.4.0",
  "serde_json",
@@ -2473,12 +2468,13 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "axum",
  "bytes",
+ "codex-api",
  "codex-client",
  "codex-config",
  "codex-exec-server",
@@ -2506,8 +2502,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2530,10 +2526,11 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
+ "codex-code-mode",
  "codex-protocol",
  "serde",
  "serde_json",
@@ -2543,8 +2540,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -2559,30 +2556,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-secrets"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
-dependencies = [
- "age",
- "anyhow",
- "base64 0.22.1",
- "codex-git-utils",
- "codex-keyring-store",
- "rand 0.9.4",
- "regex",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "tracing",
-]
-
-[[package]]
 name = "codex-shell-command"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "codex-protocol",
  "codex-utils-absolute-path",
  "once_cell",
@@ -2598,8 +2576,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2618,8 +2596,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -2628,8 +2606,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2650,16 +2628,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2671,14 +2649,16 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tonic",
  "tonic-prost",
+ "tracing",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-app-server-protocol",
  "codex-code-mode",
@@ -2694,8 +2674,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "dirs",
  "dunce",
@@ -2706,16 +2686,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "lru",
  "sha1",
@@ -2724,8 +2704,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -2735,8 +2715,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2744,10 +2724,10 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "codex-utils-cache",
  "image",
  "mime_guess",
@@ -2757,8 +2737,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -2766,8 +2746,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2775,8 +2755,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2785,8 +2765,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -2797,8 +2777,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -2813,8 +2793,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-readiness"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "async-trait",
  "thiserror 2.0.18",
@@ -2824,38 +2804,41 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "regex-lite",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "codex-utils-template"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.124.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.124.0#e9fb49366c93a1478ec71cc41ecee415a197d036"
+version = "0.129.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
+ "base64",
  "chrono",
+ "codex-otel",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-pty",
@@ -2906,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -2982,15 +2965,6 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
-]
-
-[[package]]
-name = "cookie-factory"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9885fa71e26b8ab7855e2ec7cae6e9b380edff76cd052e07c683a0319d51b3a2"
-dependencies = [
- "futures",
 ]
 
 [[package]]
@@ -3075,9 +3049,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -3345,9 +3319,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "dbus"
@@ -3537,11 +3511,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "diffy"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b545b8c50194bdd008283985ab0b31dba153cfd5b3066a92770634fbc0d7d291"
+checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
- "nu-ansi-term",
+ "hashbrown 0.17.0",
 ]
 
 [[package]]
@@ -3558,9 +3532,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -3628,7 +3602,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3868,7 +3842,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3988,15 +3962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "find-crate"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a98bbaacea1c0eb6a0876280051b892eb73594fd90cf3b20e9c817029c57d2"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,50 +4011,6 @@ dependencies = [
  "crc32fast",
  "libz-sys",
  "miniz_oxide",
-]
-
-[[package]]
-name = "fluent"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb74634707bebd0ce645a981148e8fb8c7bccd4c33c652aeffd28bf2f96d555a"
-dependencies = [
- "fluent-bundle",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-bundle"
-version = "0.15.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe0a21ee80050c678013f82edf4b705fe2f26f1f9877593d13198612503f493"
-dependencies = [
- "fluent-langneg",
- "fluent-syntax",
- "intl-memoizer",
- "intl_pluralrules",
- "rustc-hash 1.1.0",
- "self_cell 0.10.3",
- "smallvec",
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-langneg"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eebbe59450baee8282d71676f3bfed5689aeab00b27545e83e5f14b1195e8b0"
-dependencies = [
- "unic-langid",
-]
-
-[[package]]
-name = "fluent-syntax"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a530c4694a6a8d528794ee9bbd8ba0122e779629ac908d15ad5a7ae7763a33d"
-dependencies = [
- "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -4603,9 +4524,9 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc99523b8bf32561b9abf72c878fbff3854d806ed46c1198e57899f9f3c7f05"
+checksum = "b94cdae4eb4b0f4136e3d9b3aa2d2cd03cfb5bb9b636b31263aea2df86d41543"
 dependencies = [
  "bstr",
  "gix-error",
@@ -4673,9 +4594,9 @@ dependencies = [
 
 [[package]]
 name = "gix-error"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c998bf10447f0797e579567382b5e22a19c22435d2df091e25857728c6d9af8d"
+checksum = "e207b971746ab724fccdfced2e4e19e854744611904a0195d3aa8fda8a110613"
 dependencies = [
  "bstr",
 ]
@@ -5293,9 +5214,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5362,6 +5283,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -5378,7 +5302,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "headers-core",
  "http 1.4.0",
@@ -5494,7 +5418,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5592,9 +5516,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -5673,7 +5597,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -5690,72 +5614,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
-]
-
-[[package]]
-name = "i18n-config"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e06b90c8a0d252e203c94344b21e35a30f3a3a85dc7db5af8f8df9f3e0c63ef"
-dependencies = [
- "basic-toml",
- "log",
- "serde",
- "serde_derive",
- "thiserror 1.0.69",
- "unic-langid",
-]
-
-[[package]]
-name = "i18n-embed"
-version = "0.15.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "669ffc2c93f97e6ddf06ddbe999fcd6782e3342978bb85f7d3c087c7978404c4"
-dependencies = [
- "arc-swap",
- "fluent",
- "fluent-langneg",
- "fluent-syntax",
- "i18n-embed-impl",
- "intl-memoizer",
- "log",
- "parking_lot",
- "rust-embed",
- "thiserror 1.0.69",
- "unic-langid",
- "walkdir",
-]
-
-[[package]]
-name = "i18n-embed-fl"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04b2969d0b3fc6143776c535184c19722032b43e6a642d710fa3f88faec53c2d"
-dependencies = [
- "find-crate",
- "fluent",
- "fluent-syntax",
- "i18n-config",
- "i18n-embed",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.117",
- "unic-langid",
-]
-
-[[package]]
-name = "i18n-embed-impl"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2cc0e0523d1fe6fc2c6f66e5038624ea8091b3e7748b5e8e0c84b1698db6c2"
-dependencies = [
- "find-crate",
- "i18n-config",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -6112,25 +5970,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "intl-memoizer"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "310da2e345f5eb861e7a07ee182262e94975051db9e4223e909ba90f392f163f"
-dependencies = [
- "type-map",
- "unic-langid",
-]
-
-[[package]]
-name = "intl_pluralrules"
-version = "7.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078ea7b7c29a2b4df841a7f6ac8775ff6074020c6776d48491ce2268e068f972"
-dependencies = [
- "unic-langid",
-]
-
-[[package]]
 name = "inventory"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6148,12 +5987,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "io_tee"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b3f7cef34251886990511df1c61443aa928499d598a9473929ab5a90a527304"
 
 [[package]]
 name = "ipconfig"
@@ -6192,7 +6025,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6252,7 +6085,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6342,9 +6175,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -6360,6 +6193,21 @@ checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
 dependencies = [
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -6407,11 +6255,11 @@ dependencies = [
 
 [[package]]
 name = "kqueue-sys"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.1",
  "libc",
 ]
 
@@ -6527,7 +6375,7 @@ dependencies = [
  "bitflags 2.11.1",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.7.5",
 ]
 
 [[package]]
@@ -7007,7 +6855,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7140,7 +6988,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -7355,15 +7203,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -7396,9 +7243,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -7472,7 +7319,7 @@ version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -7607,7 +7454,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "serde_core",
 ]
 
@@ -7656,18 +7503,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7856,28 +7703,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7949,9 +7774,9 @@ dependencies = [
 
 [[package]]
 name = "psl"
-version = "2.1.204"
+version = "2.1.207"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868e3200a2474f99d0ea576a7c76aabda7cdcc795cc27f2d93f30ab79867820d"
+checksum = "7d69acf348dc6f0ab17180913c9dcea247c404da0f915070c4175cffcd17a682"
 dependencies = [
  "psl-types",
 ]
@@ -8005,7 +7830,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "socket2 0.6.3",
  "thiserror 2.0.18",
@@ -8025,7 +7850,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.4",
  "ring",
- "rustc-hash 2.1.2",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -8141,7 +7966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453d60af031e23af2d48995e41b17023f6150044738680508b63671f8d7417dd"
 dependencies = [
  "ahash",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "chrono",
  "const_format",
@@ -8221,7 +8046,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d74fe0cd9bd4440827dc6dc0f504cf66065396532e798891dee2c1b740b2285"
 dependencies = [
  "ahash",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "const_format",
  "httpdate",
@@ -8513,9 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags 2.11.1",
 ]
@@ -8609,7 +8434,7 @@ version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "cookie",
  "cookie_store",
@@ -8692,7 +8517,7 @@ checksum = "1bef41ebc9ebed2c1b1d90203e9d1756091e8a00bbc3107676151f39868ca0ee"
 dependencies = [
  "async-trait",
  "axum",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "futures",
@@ -8722,17 +8547,17 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "chrono",
  "futures",
  "pastey",
  "pin-project-lite",
- "rmcp-macros 1.5.0",
+ "rmcp-macros 1.6.0",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -8757,9 +8582,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -8789,40 +8614,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.117",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
-dependencies = [
- "sha2 0.10.9",
- "walkdir",
-]
-
-[[package]]
 name = "rust-stemmers"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8837,12 +8628,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8891,14 +8676,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -8924,9 +8709,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -9122,32 +8907,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "seccompiler"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae55de56877481d112a559bbc12667635fdaf5e005712fd4e2b2fa50ffc884"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "secrecy"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e891af845473308773346dc847b2c23ee78fe442e0472ac50e22a18a93d3ae5a"
-dependencies = [
- "zeroize",
 ]
 
 [[package]]
@@ -9204,21 +8969,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "self_cell"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14e4d63b804dc0c7ec4a1e52bcb63f02c7ac94476755aa579edac21e01f915d"
-dependencies = [
- "self_cell 1.2.2",
-]
-
-[[package]]
-name = "self_cell"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
@@ -9461,11 +9211,11 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9480,9 +9230,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -9560,7 +9310,7 @@ checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -9643,10 +9393,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simple_asn1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -9690,7 +9452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9731,7 +9493,7 @@ version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "chrono",
  "crc",
@@ -9809,7 +9571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "byteorder",
  "bytes",
@@ -9854,7 +9616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
- "base64 0.22.1",
+ "base64",
  "bitflags 2.11.1",
  "byteorder",
  "chrono",
@@ -9916,9 +9678,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
 dependencies = [
  "bytes",
  "futures-util",
@@ -10215,6 +9977,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10224,7 +9996,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10287,7 +10059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10442,9 +10214,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
 dependencies = [
  "bytes",
  "libc",
@@ -10637,12 +10409,12 @@ checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tonic"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "bytes",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -10665,9 +10437,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
  "prost",
@@ -10695,20 +10467,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags 2.11.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -10882,15 +10654,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "type-map"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb30dbbd9036155e74adad6812e9898d03ec374946234fbcebd5dfc7b9187b90"
-dependencies = [
- "rustc-hash 2.1.2",
-]
-
-[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10904,7 +10667,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset 0.9.1",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10921,25 +10684,6 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
-
-[[package]]
-name = "unic-langid"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a28ba52c9b05311f4f6e62d5d9d46f094bd6e84cb8df7b3ef952748d752a7d05"
-dependencies = [
- "unic-langid-impl",
-]
-
-[[package]]
-name = "unic-langid-impl"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce1bf08044d4b7a94028c93786f8566047edc11110595914de93362559bc658"
-dependencies = [
- "serde",
- "tinystr",
-]
 
 [[package]]
 name = "unicase"
@@ -11032,7 +10776,7 @@ version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "der 0.8.0",
  "log",
  "native-tls",
@@ -11049,7 +10793,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "http 1.4.0",
  "httparse",
  "log",
@@ -11203,9 +10947,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -11216,9 +10960,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11226,9 +10970,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -11236,9 +10980,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -11249,9 +10993,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -11305,9 +11049,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -11447,7 +11191,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12013,18 +11757,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
- "serde",
- "zeroize",
-]
 
 [[package]]
 name = "x509-parser"

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-acp"
-version = "0.12.0"
+version = "0.14.0"
 edition = "2024"
 authors = ["Zed <hi@zed.dev>"]
 license = "Apache-2.0"
@@ -20,22 +20,21 @@ path = "src/lib.rs"
 [dependencies]
 agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
 anyhow = "1"
-async-trait = "0.1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.124.0" }
-diffy = "0.4.2"
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+diffy = { version = "0.5.0", features = ["std"] }
 # Pin gix-actor to 0.40.0 because 0.40.1 bumped winnow to 1.0 in what is
 # technically a patch release, which makes it incompatible with gix-object
 # 0.58.0 (reached transitively via gix 0.81.0 -> codex-git-utils). Both crates

--- a/vendor/codex-acp/npm/package.json
+++ b/vendor/codex-acp/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zed-industries/codex-acp",
-  "version": "0.12.0",
+  "version": "0.14.0",
   "type": "module",
   "description": "An ACP-compatible coding agent powered by Codex",
   "license": "Apache-2.0",
@@ -28,11 +28,11 @@
     "bin"
   ],
   "optionalDependencies": {
-    "@zed-industries/codex-acp-darwin-arm64": "0.12.0",
-    "@zed-industries/codex-acp-darwin-x64": "0.12.0",
-    "@zed-industries/codex-acp-linux-arm64": "0.12.0",
-    "@zed-industries/codex-acp-linux-x64": "0.12.0",
-    "@zed-industries/codex-acp-win32-arm64": "0.12.0",
-    "@zed-industries/codex-acp-win32-x64": "0.12.0"
+    "@zed-industries/codex-acp-darwin-arm64": "0.14.0",
+    "@zed-industries/codex-acp-darwin-x64": "0.14.0",
+    "@zed-industries/codex-acp-linux-arm64": "0.14.0",
+    "@zed-industries/codex-acp-linux-x64": "0.14.0",
+    "@zed-industries/codex-acp-win32-arm64": "0.14.0",
+    "@zed-industries/codex-acp-win32-x64": "0.14.0"
   }
 }

--- a/vendor/codex-acp/npm/publish/create-platform-packages.sh
+++ b/vendor/codex-acp/npm/publish/create-platform-packages.sh
@@ -61,6 +61,16 @@ for target in "${!platforms[@]}"; do
     tar xzf "$archive_path" -C "${pkg_dir}/bin/" "codex-acp${ext}"
   fi
 
+  if [[ "$os" == "linux" ]]; then
+    if tar tzf "$archive_path" | grep -qx "codex-resources/bwrap"; then
+      tar xzf "$archive_path" -C "${pkg_dir}" "codex-resources/bwrap"
+      chmod +x "${pkg_dir}/codex-resources/bwrap"
+    else
+      echo "Missing bundled bwrap in Linux archive: $archive_path" >&2
+      exit 1
+    fi
+  fi
+
   # Make binary executable (important for Unix-like systems)
   chmod +x "${pkg_dir}/bin/codex-acp${ext}" 2>/dev/null || echo "Failed to make binary executable"
 

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -14,15 +14,15 @@ use acp::{Agent, Client, ConnectTo, ConnectionTo, Error};
 use agent_client_protocol as acp;
 use codex_config::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
-    NewThread, RolloutRecorder, SortDirection, ThreadConfigSnapshot, ThreadManager, ThreadSortKey,
-    config::Config, find_thread_path_by_id_str, parse_cursor,
+    NewThread, RolloutRecorder, SortDirection, StateDbHandle, ThreadConfigSnapshot, ThreadManager,
+    ThreadSortKey, config::Config, find_thread_path_by_id_str, init_state_db, parse_cursor,
+    resolve_installation_id, thread_store_from_config,
 };
 use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
 use codex_login::{
     CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR,
     auth::{AuthManager, CodexAuth, read_codex_api_key_from_env, read_openai_api_key_from_env},
 };
-use codex_models_manager::collaboration_mode_presets::CollaborationModesConfig;
 use codex_protocol::{
     ThreadId,
     protocol::{InitialHistory, SessionConfiguredEvent, SessionSource},
@@ -54,6 +54,8 @@ pub struct CodexAgent {
     config: Config,
     /// Thread manager for handling sessions
     thread_manager: Arc<ThreadManager>,
+    /// SQLite-backed Codex state index, when initialization succeeds
+    state_db: Option<StateDbHandle>,
     /// Active sessions mapped by `SessionId`
     sessions: Arc<Mutex<HashMap<SessionId, Arc<Thread>>>>,
     /// Session working directories for filesystem sandboxing
@@ -67,34 +69,46 @@ const SESSION_TITLE_MAX_GRAPHEMES: usize = 120;
 
 impl CodexAgent {
     /// Create a new `CodexAgent` with the given configuration
-    pub fn new(config: Config, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::Result<Self> {
+    pub async fn new(
+        config: Config,
+        codex_linux_sandbox_exe: Option<PathBuf>,
+    ) -> std::io::Result<Self> {
         let auth_manager = AuthManager::shared(
             config.codex_home.to_path_buf(),
             false,
             config.cli_auth_credentials_store_mode,
             Some(config.chatgpt_base_url.clone()),
-        );
+        )
+        .await;
 
         let client_capabilities: Arc<Mutex<ClientCapabilities>> = Arc::default();
         let session_roots: Arc<Mutex<HashMap<SessionId, PathBuf>>> = Arc::default();
+        let state_db = init_state_db(&config).await;
+        let environment_manager = Arc::new(
+            EnvironmentManager::new(EnvironmentManagerArgs::new(ExecServerRuntimePaths::new(
+                std::env::current_exe()?,
+                codex_linux_sandbox_exe,
+            )?))
+            .await,
+        );
+        let thread_store = thread_store_from_config(&config, state_db.clone());
+        let installation_id = resolve_installation_id(&config.codex_home).await?;
         let thread_manager = Arc::new(ThreadManager::new(
             &config,
             auth_manager.clone(),
             SessionSource::Unknown,
-            CollaborationModesConfig {
-                // False for now
-                default_mode_request_user_input: false,
-            },
-            Arc::new(EnvironmentManager::new(EnvironmentManagerArgs::from_env(
-                ExecServerRuntimePaths::new(std::env::current_exe()?, codex_linux_sandbox_exe)?,
-            ))),
+            environment_manager,
             None,
+            thread_store,
+            state_db.clone(),
+            installation_id,
         ));
         Ok(Self {
             auth_manager,
             client_capabilities,
             config,
             thread_manager,
+            state_db,
             sessions: Arc::default(),
             session_roots,
             subagent_watcher_started: AtomicBool::new(false),
@@ -302,7 +316,11 @@ impl CodexAgent {
     }
 
     async fn check_auth(&self) -> Result<(), Error> {
-        if self.config.model_provider_id == "openai" && self.auth_manager.auth().await.is_none() {
+        if self.config.model_provider_id == "openai"
+            && self.auth_manager.auth().await.is_none()
+            // Check if anything changed on disk since the last reload
+            && !self.auth_manager.reload().await
+        {
             return Err(Error::auth_required());
         }
         Ok(())
@@ -317,7 +335,7 @@ impl CodexAgent {
         let sessions = self.sessions.clone();
         let session_roots = self.session_roots.clone();
         let auth_manager = self.auth_manager.clone();
-        let models_manager = self.thread_manager.get_models_manager();
+        let models_manager = Arc::new(self.thread_manager.get_models_manager());
         let client_capabilities = self.client_capabilities.clone();
         let base_config = self.config.clone();
 
@@ -474,7 +492,7 @@ impl CodexAgent {
         config.model = Some(session_configured.model.clone());
         config.model_provider_id = session_configured.model_provider_id.clone();
         config.model_reasoning_effort = session_configured.reasoning_effort;
-        config.service_tier = session_configured.service_tier;
+        config.service_tier = session_configured.service_tier.clone();
         config
             .permissions
             .approval_policy
@@ -482,8 +500,7 @@ impl CodexAgent {
             .map_err(Error::into_internal_error)?;
         config
             .permissions
-            .sandbox_policy
-            .set(session_configured.sandbox_policy.clone())
+            .set_permission_profile(session_configured.permission_profile.clone())
             .map_err(Error::into_internal_error)?;
         Ok(())
     }
@@ -496,7 +513,7 @@ impl CodexAgent {
         config.model = Some(snapshot.model.clone());
         config.model_provider_id = snapshot.model_provider_id.clone();
         config.model_reasoning_effort = snapshot.reasoning_effort;
-        config.service_tier = snapshot.service_tier;
+        config.service_tier = snapshot.service_tier.clone();
         config
             .permissions
             .approval_policy
@@ -504,8 +521,7 @@ impl CodexAgent {
             .map_err(Error::into_internal_error)?;
         config
             .permissions
-            .sandbox_policy
-            .set(snapshot.sandbox_policy.clone())
+            .set_permission_profile(snapshot.permission_profile.clone())
             .map_err(Error::into_internal_error)?;
         Ok(())
     }
@@ -654,8 +670,6 @@ impl CodexAgent {
                     .block_until_done()
                     .await
                     .map_err(Error::into_internal_error)?;
-
-                self.auth_manager.reload();
             }
             CodexAuthMethod::CodexApiKey => {
                 let api_key = read_codex_api_key_from_env().ok_or_else(|| {
@@ -681,7 +695,7 @@ impl CodexAgent {
             }
         }
 
-        self.auth_manager.reload();
+        self.auth_manager.reload().await;
 
         Ok(AuthenticateResponse::new())
     }
@@ -689,6 +703,7 @@ impl CodexAgent {
     async fn logout(&self, _request: LogoutRequest) -> Result<LogoutResponse, Error> {
         self.auth_manager
             .logout()
+            .await
             .map_err(Error::into_internal_error)?;
         Ok(LogoutResponse::new())
     }
@@ -729,7 +744,7 @@ impl CodexAgent {
             session_id.clone(),
             thread,
             self.auth_manager.clone(),
-            self.thread_manager.get_models_manager(),
+            Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
             config.clone(),
             cx,
@@ -765,11 +780,14 @@ impl CodexAgent {
             ..
         } = request;
 
-        let rollout_path =
-            find_thread_path_by_id_str(&self.config.codex_home, session_id.0.as_ref())
-                .await
-                .map_err(|e| Error::internal_error().data(e.to_string()))?
-                .ok_or_else(|| Error::resource_not_found(None))?;
+        let rollout_path = find_thread_path_by_id_str(
+            &self.config.codex_home,
+            session_id.0.as_ref(),
+            self.state_db.as_deref(),
+        )
+        .await
+        .map_err(|e| Error::internal_error().data(e.to_string()))?
+        .ok_or_else(|| Error::resource_not_found(None))?;
 
         let history = RolloutRecorder::get_rollout_history(&rollout_path)
             .await
@@ -802,7 +820,7 @@ impl CodexAgent {
             session_id.clone(),
             thread,
             self.auth_manager.clone(),
-            self.thread_manager.get_models_manager(),
+            Arc::new(self.thread_manager.get_models_manager()),
             self.client_capabilities.clone(),
             config.clone(),
             cx,
@@ -834,6 +852,7 @@ impl CodexAgent {
         let cursor_obj = cursor.as_deref().and_then(parse_cursor);
 
         let page = RolloutRecorder::list_threads(
+            self.state_db.clone(),
             &self.config,
             SESSION_LIST_PAGE_SIZE,
             cursor_obj.as_ref(),

--- a/vendor/codex-acp/src/lib.rs
+++ b/vendor/codex-acp/src/lib.rs
@@ -61,10 +61,7 @@ pub async fn run_main(
         config.enforce_residency.value(),
     );
 
-    let agent = Arc::new(codex_agent::CodexAgent::new(
-        config,
-        codex_linux_sandbox_exe,
-    )?);
+    let agent = Arc::new(codex_agent::CodexAgent::new(config, codex_linux_sandbox_exe).await?);
 
     let stdin = tokio::io::stdin().compat();
     let stdout = tokio::io::stdout().compat_write();

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -598,21 +598,19 @@ fn agent_status_label(status: &AgentStatus) -> String {
 mod tests {
     use super::*;
     use codex_protocol::{
-        config_types::{ApprovalsReviewer, ServiceTier},
-        models::PermissionProfile,
-        openai_models::ReasoningEffort,
-        protocol::{AskForApproval, SandboxPolicy},
+        config_types::ApprovalsReviewer, models::PermissionProfile, openai_models::ReasoningEffort,
+        protocol::AskForApproval,
     };
 
     fn thread_snapshot(parent_thread_id: ThreadId) -> ThreadConfigSnapshot {
         ThreadConfigSnapshot {
             model: "gpt-5.5".to_string(),
             model_provider_id: "openai".to_string(),
-            service_tier: Some(ServiceTier::Fast),
+            service_tier: Some("fast".to_string()),
             approval_policy: AskForApproval::OnFailure,
             approvals_reviewer: ApprovalsReviewer::default(),
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
             permission_profile: PermissionProfile::default(),
+            active_permission_profile: None,
             cwd: std::env::current_dir()
                 .expect("current dir should be available")
                 .try_into()
@@ -627,6 +625,7 @@ mod tests {
                 agent_nickname: Some("Galileo".to_string()),
                 agent_role: Some("explorer".to_string()),
             }),
+            thread_source: None,
         }
     }
 
@@ -705,6 +704,7 @@ mod tests {
                 prompt: "inspect the renderer".to_string(),
                 model: "gpt-5.5".to_string(),
                 reasoning_effort: ReasoningEffort::Medium,
+                started_at_ms: 0,
             },
         ))
         .expect("spawn begin should project");
@@ -740,6 +740,7 @@ mod tests {
                 model: "gpt-5.5".to_string(),
                 reasoning_effort: ReasoningEffort::Medium,
                 status: AgentStatus::Running,
+                completed_at_ms: 0,
             },
         ))
         .expect("spawn end should project");
@@ -773,6 +774,7 @@ mod tests {
                     status: AgentStatus::Completed(Some("done".to_string())),
                 }],
                 statuses: HashMap::new(),
+                completed_at_ms: 0,
             },
         ))
         .expect("waiting end should project");

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -31,22 +31,22 @@ use codex_core::{
     review_prompts::user_facing_hint,
 };
 use codex_features::Feature;
-use codex_login::AuthManager;
+use codex_login::auth::AuthManager;
 use codex_models_manager::manager::{ModelsManager, RefreshStrategy};
 use codex_protocol::protocol::{
     AgentMessageContentDeltaEvent, AgentMessageEvent, AgentReasoningEvent,
     AgentReasoningRawContentEvent, AgentReasoningSectionBreakEvent, ApplyPatchApprovalRequestEvent,
-    AskForApproval, ElicitationAction, ErrorEvent, Event, EventMsg, ExecApprovalRequestEvent,
+    ElicitationAction, ErrorEvent, Event, EventMsg, ExecApprovalRequestEvent,
     ExecCommandBeginEvent, ExecCommandEndEvent, ExecCommandOutputDeltaEvent, ExecCommandStatus,
     ExitedReviewModeEvent, FileChange, GuardianAssessmentEvent, GuardianAssessmentStatus,
     ImageGenerationBeginEvent, ImageGenerationEndEvent, ItemCompletedEvent, ItemStartedEvent,
     McpInvocation, McpStartupCompleteEvent, McpStartupUpdateEvent, McpToolCallBeginEvent,
     McpToolCallEndEvent, ModelRerouteEvent, Op, PatchApplyBeginEvent, PatchApplyEndEvent,
     PatchApplyStatus, PlanDeltaEvent, ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent,
-    ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget, SandboxPolicy,
-    StreamErrorEvent, TerminalInteractionEvent, TokenCountEvent, TurnAbortedEvent,
-    TurnCompleteEvent, TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent,
-    WebSearchBeginEvent, WebSearchEndEvent,
+    ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget, StreamErrorEvent,
+    TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent, TokenCountEvent,
+    TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
+    ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
 };
 use codex_protocol::{
     approvals::{ElicitationRequest, ElicitationRequestEvent},
@@ -55,9 +55,15 @@ use codex_protocol::{
     error::CodexErr,
     items::TurnItem,
     mcp::CallToolResult,
-    models::{FileSystemPermissions, PermissionProfile, ResponseItem, WebSearchAction},
+    models::{
+        ActivePermissionProfile, AdditionalPermissionProfile, PermissionProfile, ResponseItem,
+        WebSearchAction,
+    },
     openai_models::{ModelPreset, ReasoningEffort},
     parse_command::ParsedCommand,
+    permissions::{
+        FileSystemAccessMode, FileSystemPath, FileSystemSandboxEntry, FileSystemSpecialPath,
+    },
     plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs},
     protocol::{
         DynamicToolCallResponseEvent, NetworkApprovalContext, NetworkPolicyRuleAction, RolloutItem,
@@ -128,51 +134,96 @@ const CODEX_ACP_TURN_STARTED_EVENT_TYPE: &str = "turn_started";
 const CODEX_ACP_TURN_COMPLETE_EVENT_TYPE: &str = "turn_complete";
 const CODEX_ACP_TURN_ABORTED_EVENT_TYPE: &str = "turn_aborted";
 const CODEX_ACP_SHUTDOWN_COMPLETE_EVENT_TYPE: &str = "shutdown_complete";
+const CODEX_READ_ONLY_PROFILE_ID: &str = ":read-only";
+const CODEX_WORKSPACE_PROFILE_ID: &str = ":workspace";
+const CODEX_DANGER_NO_SANDBOX_PROFILE_ID: &str = ":danger-no-sandbox";
 
-fn approval_preset_matches_config(
-    preset: &ApprovalPreset,
-    approval_policy: &AskForApproval,
-    sandbox_policy: &SandboxPolicy,
-) -> bool {
-    if &preset.approval != approval_policy {
-        return false;
+fn session_mode_id_for_active_profile(profile_id: &str) -> Option<&'static str> {
+    match profile_id {
+        CODEX_READ_ONLY_PROFILE_ID => Some("read-only"),
+        CODEX_WORKSPACE_PROFILE_ID => Some("auto"),
+        CODEX_DANGER_NO_SANDBOX_PROFILE_ID => Some("full-access"),
+        _ => None,
     }
+}
 
-    match (&preset.sandbox, sandbox_policy) {
-        (
-            SandboxPolicy::ReadOnly {
-                access: preset_access,
-                network_access: preset_network_access,
-            },
-            SandboxPolicy::ReadOnly {
-                access,
-                network_access,
-            },
-        ) => preset_access == access && preset_network_access == network_access,
-        (
-            SandboxPolicy::WorkspaceWrite {
-                read_only_access: preset_read_only_access,
-                network_access: preset_network_access,
-                exclude_tmpdir_env_var: preset_exclude_tmpdir_env_var,
-                exclude_slash_tmp: preset_exclude_slash_tmp,
-                ..
-            },
-            SandboxPolicy::WorkspaceWrite {
-                read_only_access,
-                network_access,
-                exclude_tmpdir_env_var,
-                exclude_slash_tmp,
-                ..
-            },
-        ) => {
-            preset_read_only_access == read_only_access
-                && preset_network_access == network_access
-                && preset_exclude_tmpdir_env_var == exclude_tmpdir_env_var
-                && preset_exclude_slash_tmp == exclude_slash_tmp
+fn active_profile_id_for_session_mode(mode_id: &str) -> Option<&'static str> {
+    match mode_id {
+        "read-only" => Some(CODEX_READ_ONLY_PROFILE_ID),
+        "auto" => Some(CODEX_WORKSPACE_PROFILE_ID),
+        "full-access" => Some(CODEX_DANGER_NO_SANDBOX_PROFILE_ID),
+        _ => None,
+    }
+}
+
+fn approval_matches_current_config(preset: &ApprovalPreset, config: &Config) -> bool {
+    std::mem::discriminant(&preset.approval)
+        == std::mem::discriminant(config.permissions.approval_policy.get())
+}
+
+fn mode_id_if_approval_matches(mode_id: &'static str, config: &Config) -> Option<SessionModeId> {
+    APPROVAL_PRESETS
+        .iter()
+        .find(|preset| preset.id == mode_id && approval_matches_current_config(preset, config))
+        .map(|preset| SessionModeId::new(preset.id))
+}
+
+fn untrusted_read_only_mode_id(config: &Config) -> Option<SessionModeId> {
+    config
+        .active_project
+        .is_untrusted()
+        .then(|| SessionModeId::new("read-only"))
+}
+
+fn semantic_session_mode_id_for_permission_profile(config: &Config) -> Option<&'static str> {
+    let permission_profile = config.permissions.permission_profile.get();
+
+    match permission_profile {
+        PermissionProfile::Managed { .. } => {
+            let workspace_preset = APPROVAL_PRESETS.iter().find(|preset| preset.id == "auto")?;
+            if permission_profile.network_sandbox_policy()
+                != workspace_preset.permission_profile.network_sandbox_policy()
+            {
+                return None;
+            }
+
+            let file_system = permission_profile.file_system_sandbox_policy();
+            let cwd = config.cwd.as_path();
+            if file_system.has_full_disk_read_access()
+                && !file_system.has_full_disk_write_access()
+                && file_system.can_write_path_with_cwd(cwd, cwd)
+            {
+                Some("auto")
+            } else {
+                None
+            }
         }
-        (SandboxPolicy::DangerFullAccess, SandboxPolicy::DangerFullAccess) => true,
-        _ => &preset.sandbox == sandbox_policy,
+        PermissionProfile::Disabled => Some("full-access"),
+        PermissionProfile::External { .. } => None,
     }
+}
+
+fn current_session_mode_id(config: &Config) -> Option<SessionModeId> {
+    if let Some(active_profile) = config.permissions.active_permission_profile().as_ref() {
+        return session_mode_id_for_active_profile(&active_profile.id)
+            .and_then(|mode_id| mode_id_if_approval_matches(mode_id, config))
+            .or_else(|| untrusted_read_only_mode_id(config));
+    }
+
+    if let Some(preset) = APPROVAL_PRESETS.iter().find(|preset| {
+        approval_matches_current_config(preset, config)
+            && &preset.permission_profile == config.permissions.permission_profile.get()
+    }) {
+        return Some(SessionModeId::new(preset.id));
+    }
+
+    semantic_session_mode_id_for_permission_profile(config)
+        .and_then(|mode_id| mode_id_if_approval_matches(mode_id, config))
+        .or_else(|| untrusted_read_only_mode_id(config))
+}
+
+fn mode_trusts_project(mode_id: &str) -> bool {
+    matches!(mode_id, "auto" | "full-access")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -191,49 +242,61 @@ struct NeverWriteDiffHunkLine {
 }
 
 /// Trait for abstracting over the `CodexThread` to make testing easier.
-#[async_trait::async_trait]
 pub trait CodexThreadImpl: Send + Sync {
-    async fn submit(&self, op: Op) -> Result<String, CodexErr>;
-    async fn next_event(&self) -> Result<Event, CodexErr>;
+    fn submit(&self, op: Op)
+    -> Pin<Box<dyn Future<Output = Result<String, CodexErr>> + Send + '_>>;
+    fn next_event(&self) -> Pin<Box<dyn Future<Output = Result<Event, CodexErr>> + Send + '_>>;
 }
 
-#[async_trait::async_trait]
 impl CodexThreadImpl for CodexThread {
-    async fn submit(&self, op: Op) -> Result<String, CodexErr> {
-        self.submit(op).await
+    fn submit(
+        &self,
+        op: Op,
+    ) -> Pin<Box<dyn Future<Output = Result<String, CodexErr>> + Send + '_>> {
+        Box::pin(self.submit(op))
     }
 
-    async fn next_event(&self) -> Result<Event, CodexErr> {
-        self.next_event().await
+    fn next_event(&self) -> Pin<Box<dyn Future<Output = Result<Event, CodexErr>> + Send + '_>> {
+        Box::pin(self.next_event())
     }
 }
 
-#[async_trait::async_trait]
 pub trait ModelsManagerImpl: Send + Sync {
-    async fn get_model(&self, model_id: &Option<String>) -> String;
-    async fn list_models(&self) -> Vec<ModelPreset>;
+    fn get_model(
+        &self,
+        model_id: &Option<String>,
+    ) -> Pin<Box<dyn Future<Output = String> + Send + '_>>;
+    fn list_models(&self) -> Pin<Box<dyn Future<Output = Vec<ModelPreset>> + Send + '_>>;
 }
 
-#[async_trait::async_trait]
-impl ModelsManagerImpl for ModelsManager {
-    async fn get_model(&self, model_id: &Option<String>) -> String {
-        self.get_default_model(model_id, RefreshStrategy::OnlineIfUncached)
-            .await
+impl ModelsManagerImpl for Arc<dyn ModelsManager> {
+    fn get_model(
+        &self,
+        model_id: &Option<String>,
+    ) -> Pin<Box<dyn Future<Output = String> + Send + '_>> {
+        let model_id = model_id.clone();
+        Box::pin(async move {
+            self.get_default_model(&model_id, RefreshStrategy::OnlineIfUncached)
+                .await
+        })
     }
 
-    async fn list_models(&self) -> Vec<ModelPreset> {
-        self.list_models(RefreshStrategy::OnlineIfUncached).await
+    fn list_models(&self) -> Pin<Box<dyn Future<Output = Vec<ModelPreset>> + Send + '_>> {
+        Box::pin(async move {
+            ModelsManager::list_models(self.as_ref(), RefreshStrategy::OnlineIfUncached).await
+        })
     }
 }
 
 pub trait Auth {
-    fn logout(&self) -> Result<bool, Error>;
+    fn logout(&self) -> impl Future<Output = Result<bool, Error>> + Send;
 }
 
 impl Auth for Arc<AuthManager> {
-    fn logout(&self) -> Result<bool, Error> {
+    async fn logout(&self) -> Result<bool, Error> {
         self.as_ref()
             .logout()
+            .await
             .map_err(|e| Error::internal_error().data(e.to_string()))
     }
 }
@@ -517,7 +580,7 @@ enum PendingPermissionRequest {
     },
     RequestPermissions {
         call_id: String,
-        permissions: PermissionProfile,
+        permissions: RequestPermissionProfile,
     },
     McpElicitation {
         server_name: String,
@@ -858,6 +921,9 @@ fn codex_turn_lifecycle_meta(event_type: &str, turn_id: Option<&str>) -> Meta {
 }
 
 fn image_generation_tool_call_id(call_id: &str) -> String {
+    if call_id.starts_with(NEVERWRITE_IMAGE_EVENT_ID_PREFIX) {
+        return call_id.to_string();
+    }
     format!("{NEVERWRITE_IMAGE_EVENT_ID_PREFIX}{call_id}")
 }
 
@@ -868,6 +934,81 @@ fn image_generation_tool_status(status: &str) -> ToolCallStatus {
         "in_progress" | "running" => ToolCallStatus::InProgress,
         _ => ToolCallStatus::Completed,
     }
+}
+
+fn image_generation_completion_parts(
+    status: String,
+    revised_prompt: Option<String>,
+    result: String,
+    saved_path: Option<String>,
+) -> (String, ToolCallStatus, Option<String>, serde_json::Value) {
+    let tool_status = image_generation_tool_status(&status);
+    let is_failure = tool_status == ToolCallStatus::Failed;
+    let title = if is_failure {
+        "Image generation failed"
+    } else {
+        "Generated image"
+    }
+    .to_string();
+    let detail = saved_path.clone().or_else(|| Some(result.clone()));
+    let mut raw_input = json!({
+        "status": status,
+        "result": result.clone(),
+    });
+    if let Some(object) = raw_input.as_object_mut() {
+        if let Some(saved_path) = saved_path {
+            object.insert("path".to_string(), json!(saved_path));
+        }
+        if let Some(revised_prompt) = revised_prompt {
+            object.insert("revised_prompt".to_string(), json!(revised_prompt));
+        }
+        if is_failure {
+            object.insert("error".to_string(), json!(result));
+        }
+    }
+
+    (title, tool_status, detail, raw_input)
+}
+
+fn completed_image_generation_tool_call(
+    call_id: String,
+    status: String,
+    revised_prompt: Option<String>,
+    result: String,
+    saved_path: Option<String>,
+) -> ToolCall {
+    let (title, tool_status, detail, raw_input) =
+        image_generation_completion_parts(status, revised_prompt, result, saved_path);
+    let mut tool_call = ToolCall::new(image_generation_tool_call_id(&call_id), title)
+        .kind(ToolKind::Other)
+        .status(tool_status)
+        .raw_input(raw_input)
+        .meta(neverwrite_image_generation_meta());
+    if let Some(detail) = detail {
+        tool_call = tool_call.content(vec![ToolCallContent::Content(Content::new(detail))]);
+    }
+    tool_call
+}
+
+fn completed_image_generation_tool_update(
+    call_id: String,
+    status: String,
+    revised_prompt: Option<String>,
+    result: String,
+    saved_path: Option<String>,
+) -> ToolCallUpdate {
+    let (title, tool_status, detail, raw_input) =
+        image_generation_completion_parts(status, revised_prompt, result, saved_path);
+    let mut fields = ToolCallUpdateFields::new()
+        .title(title)
+        .status(tool_status)
+        .raw_input(raw_input);
+    if let Some(detail) = detail {
+        fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
+    }
+
+    ToolCallUpdate::new(image_generation_tool_call_id(&call_id), fields)
+        .meta(neverwrite_image_generation_meta())
 }
 
 fn neverwrite_user_input_meta() -> Meta {
@@ -890,6 +1031,22 @@ fn neverwrite_plan_meta(title: Option<&str>, detail: Option<&str>) -> Option<Met
     (!meta.is_empty()).then_some(meta)
 }
 
+fn format_thread_goal_update(event: &ThreadGoalUpdatedEvent) -> String {
+    let status = match event.goal.status {
+        ThreadGoalStatus::Active => "active",
+        ThreadGoalStatus::Paused => "paused",
+        ThreadGoalStatus::BudgetLimited => "budget limited",
+        ThreadGoalStatus::Complete => "complete",
+    };
+
+    let objective = event.goal.objective.trim();
+    if objective.contains('\n') {
+        format!("Goal updated ({status}):\n{objective}")
+    } else {
+        format!("Goal updated ({status}): {objective}")
+    }
+}
+
 fn turn_item_id(item: &TurnItem) -> &str {
     match item {
         TurnItem::UserMessage(item) => &item.id,
@@ -898,7 +1055,10 @@ fn turn_item_id(item: &TurnItem) -> &str {
         TurnItem::Plan(item) => &item.id,
         TurnItem::Reasoning(item) => &item.id,
         TurnItem::WebSearch(item) => &item.id,
+        TurnItem::ImageView(item) => &item.id,
         TurnItem::ImageGeneration(item) => &item.id,
+        TurnItem::FileChange(item) => &item.id,
+        TurnItem::McpToolCall(item) => &item.id,
         TurnItem::ContextCompaction(item) => &item.id,
     }
 }
@@ -917,6 +1077,7 @@ fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
                 .or_else(|| item.raw_content.first().cloned()),
         ),
         TurnItem::WebSearch(item) => ("Web search", Some(item.query.clone())),
+        TurnItem::ImageView(item) => ("Viewing image", Some(item.path.display().to_string())),
         TurnItem::ImageGeneration(item) => (
             "Generating image",
             item.saved_path
@@ -924,6 +1085,8 @@ fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
                 .map(|path| path.display().to_string())
                 .or_else(|| Some(item.result.clone())),
         ),
+        TurnItem::FileChange(..) => ("Editing files", None),
+        TurnItem::McpToolCall(item) => ("Calling MCP tool", Some(item.tool.clone())),
         TurnItem::ContextCompaction(..) => ("Compacting context", None),
     }
 }
@@ -940,36 +1103,83 @@ fn format_permission_rule(permissions: &RequestPermissionProfile) -> Option<Stri
         parts.push("network".to_string());
     }
 
-    if let Some((read, write)) = permissions
-        .file_system
-        .as_ref()
-        .and_then(FileSystemPermissions::legacy_read_write_roots)
-    {
-        if let Some(read) = read.as_ref().filter(|paths| !paths.is_empty()) {
-            parts.push(format!(
-                "read {}",
-                read.iter()
-                    .map(|path| format!("`{}`", path.display()))
-                    .join(", ")
-            ));
+    if let Some(file_system) = permissions.file_system.as_ref() {
+        let reads = format_file_system_entries(
+            file_system
+                .entries
+                .iter()
+                .filter(|entry| entry.access == FileSystemAccessMode::Read),
+        );
+        if !reads.is_empty() {
+            parts.push(format!("read {reads}"));
         }
-        if let Some(write) = write.as_ref().filter(|paths| !paths.is_empty()) {
-            parts.push(format!(
-                "write {}",
-                write
-                    .iter()
-                    .map(|path| format!("`{}`", path.display()))
-                    .join(", ")
-            ));
+
+        let writes = format_file_system_entries(
+            file_system
+                .entries
+                .iter()
+                .filter(|entry| entry.access == FileSystemAccessMode::Write),
+        );
+        if !writes.is_empty() {
+            parts.push(format!("write {writes}"));
         }
-    } else if permissions.file_system.is_some() {
-        parts.push("filesystem".to_string());
+
+        let denies = format_file_system_entries(
+            file_system
+                .entries
+                .iter()
+                .filter(|entry| entry.access == FileSystemAccessMode::None),
+        );
+        if !denies.is_empty() {
+            parts.push(format!("deny {denies}"));
+        }
     }
 
     if parts.is_empty() {
         None
     } else {
         Some(format!("Permission rule: {}", parts.join("; ")))
+    }
+}
+
+fn format_file_system_entries<'a>(
+    entries: impl Iterator<Item = &'a FileSystemSandboxEntry>,
+) -> String {
+    entries
+        .map(format_file_system_entry)
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn format_file_system_entry(entry: &FileSystemSandboxEntry) -> String {
+    match &entry.path {
+        FileSystemPath::Path { path } => path.display().to_string(),
+        FileSystemPath::GlobPattern { pattern } => format!("glob `{pattern}`"),
+        FileSystemPath::Special { value } => format_file_system_special(value),
+    }
+}
+
+fn format_file_system_special(value: &FileSystemSpecialPath) -> String {
+    match value {
+        FileSystemSpecialPath::Root => "/".to_string(),
+        FileSystemSpecialPath::Minimal => ":minimal".to_string(),
+        FileSystemSpecialPath::ProjectRoots { subpath } => {
+            format_file_system_subpath(":project_roots", subpath.as_deref())
+        }
+        FileSystemSpecialPath::Tmpdir => "$TMPDIR".to_string(),
+        FileSystemSpecialPath::SlashTmp => "/tmp".to_string(),
+        FileSystemSpecialPath::Unknown { path, subpath } => {
+            format_file_system_subpath(path, subpath.as_deref())
+        }
+    }
+}
+
+fn format_file_system_subpath(base: &str, subpath: Option<&Path>) -> String {
+    match subpath {
+        Some(subpath) if !subpath.as_os_str().is_empty() => {
+            format!("{base}/{}", subpath.display())
+        }
+        _ => base.to_string(),
     }
 }
 
@@ -1382,12 +1592,12 @@ impl PromptState {
                         ..
                     }) => match option_id.0.as_ref() {
                         "approved-for-session" => RequestPermissionsResponse {
-                            permissions: permissions.into(),
+                            permissions: permissions.clone(),
                             scope: PermissionGrantScope::Session,
                             strict_auto_review: false,
                         },
                         "approved" => RequestPermissionsResponse {
-                            permissions: permissions.into(),
+                            permissions,
                             scope: PermissionGrantScope::Turn,
                             strict_auto_review: false,
                         },
@@ -1524,43 +1734,14 @@ impl PromptState {
             saved_path,
         } = event;
         let saved_path = saved_path.map(|path| path.display().to_string());
-        let tool_status = image_generation_tool_status(&status);
-        let is_failure = tool_status == ToolCallStatus::Failed;
-        let title = if is_failure {
-            "Image generation failed"
-        } else {
-            "Generated image"
-        };
-        let detail = saved_path.clone().or_else(|| Some(result.clone()));
-        let mut raw_input = json!({
-            "status": status,
-            "result": result.clone(),
-        });
-        if let Some(object) = raw_input.as_object_mut() {
-            if let Some(saved_path) = saved_path {
-                object.insert("path".to_string(), json!(saved_path));
-            }
-            if let Some(revised_prompt) = revised_prompt {
-                object.insert("revised_prompt".to_string(), json!(revised_prompt));
-            }
-            if is_failure {
-                object.insert("error".to_string(), json!(result));
-            }
-        }
-
-        let mut fields = ToolCallUpdateFields::new()
-            .title(title.to_string())
-            .status(tool_status)
-            .raw_input(raw_input);
-        if let Some(detail) = detail {
-            fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
-        }
-
         client
-            .send_tool_call_update(
-                ToolCallUpdate::new(image_generation_tool_call_id(&call_id), fields)
-                    .meta(neverwrite_image_generation_meta()),
-            )
+            .send_tool_call_update(completed_image_generation_tool_update(
+                call_id,
+                status,
+                revised_prompt,
+                result,
+                saved_path,
+            ))
             .await;
     }
 
@@ -1650,7 +1831,12 @@ impl PromptState {
                             .await;
                     }
             }
-            EventMsg::ItemStarted(ItemStartedEvent { thread_id, turn_id, item }) => {
+            EventMsg::ItemStarted(ItemStartedEvent {
+                thread_id,
+                turn_id,
+                item,
+                ..
+            }) => {
                 info!("Item started with thread_id: {thread_id}, turn_id: {turn_id}, item: {item:?}");
                 match item {
                     TurnItem::ImageGeneration(image_item) => {
@@ -1746,15 +1932,9 @@ impl PromptState {
                     client.send_agent_thought(text).await;
                 }
             }
-            EventMsg::ThreadNameUpdated(event) => {
-                info!("Thread name updated: {:?}", event.thread_name);
-                if let Some(title) = event.thread_name {
-                    client
-                        .send_notification(SessionUpdate::SessionInfoUpdate(
-                            SessionInfoUpdate::new().title(title),
-                        ))
-                        .await;
-                }
+            EventMsg::ThreadGoalUpdated(event) => {
+                info!("Thread goal updated: {:?}", event.goal);
+                client.send_agent_text(format_thread_goal_update(&event)).await;
             }
             EventMsg::PlanUpdate(UpdatePlanArgs { explanation, plan }) => {
                 // Send this to the client via session/update notification
@@ -1927,6 +2107,7 @@ impl PromptState {
                 thread_id,
                 turn_id,
                 item,
+                ..
             }) => {
                 info!("Item completed: thread_id={}, turn_id={}, item={:?}", thread_id, turn_id, item);
                 if let TurnItem::Plan(plan_item) = &item {
@@ -1989,23 +2170,6 @@ impl PromptState {
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx.send(Ok(StopReason::EndTurn)).ok();
                 }
-            }
-            EventMsg::UndoStarted(event) => {
-                client
-                    .send_agent_text(
-                        event
-                            .message
-                            .unwrap_or_else(|| "Undo in progress...".to_string()),
-                    )
-                    .await;
-            }
-            EventMsg::UndoCompleted(event) => {
-                let fallback = if event.success {
-                    "Undo completed.".to_string()
-                } else {
-                    "Undo failed.".to_string()
-                };
-                client.send_agent_text(event.message.unwrap_or(fallback)).await;
             }
             EventMsg::StreamError(StreamErrorEvent {
                 message,
@@ -2218,29 +2382,19 @@ impl PromptState {
             | EventMsg::ThreadRolledBack(..)
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
-            // Revisit when we can emit status updates
-            | EventMsg::BackgroundEvent(..)
             | EventMsg::SkillsUpdateAvailable
-            // Old events
-            | EventMsg::AgentMessageDelta(..)
-            | EventMsg::AgentReasoningDelta(..)
-            | EventMsg::AgentReasoningRawContentDelta(..)
             | EventMsg::RawResponseItem(..)
             | EventMsg::SessionConfigured(..)
             | EventMsg::RealtimeConversationStarted(..)
             | EventMsg::RealtimeConversationSdp(..)
             | EventMsg::RealtimeConversationRealtime(..)
             | EventMsg::RealtimeConversationClosed(..)
-            | EventMsg::RealtimeConversationListVoicesResponse(..)
             | EventMsg::ModelVerification(..)
             | EventMsg::GuardianWarning(..)
             | EventMsg::HookStarted(..)
             | EventMsg::HookCompleted(..)
             | EventMsg::PatchApplyUpdated(..) => {}
-            e @ (EventMsg::McpListToolsResponse(..)
-            | EventMsg::ListSkillsResponse(..)
-            // Used for returning a single history entry
-            | EventMsg::GetHistoryEntryResponse(..)
+            e @ (EventMsg::RealtimeConversationListVoicesResponse(..)
             | EventMsg::DeprecationNotice(..)) => {
                 warn!("Unexpected event: {:?}", e);
             }
@@ -2832,6 +2986,7 @@ impl PromptState {
             cwd,
             parsed_cmd,
             process_id: _,
+            ..
         } = event;
         // Create a new tool call for the command execution
         let tool_call_id = ToolCallId::new(call_id.clone());
@@ -2900,8 +3055,8 @@ impl PromptState {
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
             let data_str = String::from_utf8_lossy(&chunk).to_string();
 
-            let update = if client.supports_terminal_output(active_command) {
-                ToolCallUpdate::new(
+            if client.supports_terminal_output(active_command) {
+                let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
                     ToolCallUpdateFields::new(),
                 )
@@ -2911,27 +3066,28 @@ impl PromptState {
                         "terminal_id": call_id,
                         "data": data_str
                     }),
-                )]))
-            } else {
-                active_command.output.push_str(&data_str);
-                let content = match active_command.file_extension.as_deref() {
-                    Some("md") => active_command.output.clone(),
-                    Some(ext) => format!(
-                        "```{ext}\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                    None => format!(
-                        "```sh\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                };
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().content(vec![content.into()]),
-                )
-            };
+                )]));
 
-            client.send_tool_call_update(update).await;
+                client.send_tool_call_update(update).await;
+            } else {
+                // Accumulate silently. Re-emitting the full buffer per chunk is O(N²)
+                // and can exhaust memory for commands with long output.
+                active_command.output.push_str(&data_str);
+            }
+        }
+    }
+
+    fn command_output_content(active_command: &ActiveCommand) -> String {
+        match active_command.file_extension.as_deref() {
+            Some("md") => active_command.output.clone(),
+            Some(ext) => format!(
+                "```{ext}\n{}\n```\n",
+                active_command.output.trim_end_matches('\n')
+            ),
+            None => format!(
+                "```sh\n{}\n```\n",
+                active_command.output.trim_end_matches('\n')
+            ),
         }
     }
 
@@ -2953,6 +3109,7 @@ impl PromptState {
             formatted_output: _,
             process_id: _,
             status,
+            ..
         } = event;
         if let Some(active_command) = self.active_commands.remove(&call_id) {
             let is_success = exit_code == 0;
@@ -2970,32 +3127,22 @@ impl PromptState {
                 vec![]
             };
 
-            // When diffs are found, reconstruct the full content array (existing
-            // output + diffs) because setting content replaces the existing items.
-            // When there are no diffs, leave content as None to preserve existing.
-            let content: Option<Vec<ToolCallContent>> = if !exec_diffs.is_empty() {
-                let mut items: Vec<ToolCallContent> = Vec::new();
-                if client.supports_terminal_output(&active_command) {
-                    items.push(ToolCallContent::Terminal(Terminal::new(call_id.clone())));
-                } else if !active_command.output.is_empty() {
-                    let text = match active_command.file_extension.as_deref() {
-                        Some("md") => active_command.output.clone(),
-                        Some(ext) => format!(
-                            "```{ext}\n{}\n```\n",
-                            active_command.output.trim_end_matches('\n')
-                        ),
-                        None => format!(
-                            "```sh\n{}\n```\n",
-                            active_command.output.trim_end_matches('\n')
-                        ),
-                    };
-                    items.push(text.into());
-                }
-                items.extend(exec_diffs);
-                Some(items)
-            } else {
-                None
-            };
+            let should_emit_accumulated_output = !client.supports_terminal_output(&active_command)
+                && !active_command.output.is_empty();
+
+            let content: Option<Vec<ToolCallContent>> =
+                if !exec_diffs.is_empty() || should_emit_accumulated_output {
+                    let mut items: Vec<ToolCallContent> = Vec::new();
+                    if client.supports_terminal_output(&active_command) {
+                        items.push(ToolCallContent::Terminal(Terminal::new(call_id.clone())));
+                    } else if !active_command.output.is_empty() {
+                        items.push(Self::command_output_content(&active_command).into());
+                    }
+                    items.extend(exec_diffs);
+                    Some(items)
+                } else {
+                    None
+                };
 
             let fields = ToolCallUpdateFields::new()
                 .status(status)
@@ -3035,8 +3182,8 @@ impl PromptState {
         let stdin = format!("\n{stdin}\n");
         // Stream output bytes to the display-only terminal via ToolCallUpdate meta.
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
-            let update = if client.supports_terminal_output(active_command) {
-                ToolCallUpdate::new(
+            if client.supports_terminal_output(active_command) {
+                let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
                     ToolCallUpdateFields::new(),
                 )
@@ -3046,27 +3193,13 @@ impl PromptState {
                         "terminal_id": call_id,
                         "data": stdin
                     }),
-                )]))
-            } else {
-                active_command.output.push_str(&stdin);
-                let content = match active_command.file_extension.as_deref() {
-                    Some("md") => active_command.output.clone(),
-                    Some(ext) => format!(
-                        "```{ext}\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                    None => format!(
-                        "```sh\n{}\n```\n",
-                        active_command.output.trim_end_matches('\n')
-                    ),
-                };
-                ToolCallUpdate::new(
-                    active_command.tool_call_id.clone(),
-                    ToolCallUpdateFields::new().content(vec![content.into()]),
-                )
-            };
+                )]));
 
-            client.send_tool_call_update(update).await;
+                client.send_tool_call_update(update).await;
+            } else {
+                // Mirror exec output fallback: accumulate and emit once on command end.
+                active_command.output.push_str(&stdin);
+            }
         }
     }
 
@@ -3139,7 +3272,7 @@ struct ExecPermissionOption {
 fn build_exec_permission_options(
     available_decisions: &[ReviewDecision],
     network_approval_context: Option<&NetworkApprovalContext>,
-    additional_permissions: Option<&PermissionProfile>,
+    additional_permissions: Option<&AdditionalPermissionProfile>,
 ) -> Vec<ExecPermissionOption> {
     available_decisions
         .iter()
@@ -3789,7 +3922,6 @@ impl<A: Auth> ThreadActor<A> {
                 "compact",
                 "summarize conversation to prevent hitting the context limit",
             ),
-            AvailableCommand::new("undo", "undo Codex’s most recent turn"),
             AvailableCommand::new("logout", "logout of Codex"),
         ];
 
@@ -3815,31 +3947,7 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     fn modes(&self) -> Option<SessionModeState> {
-        let current_mode_id = APPROVAL_PRESETS
-            .iter()
-            .find(|preset| {
-                approval_preset_matches_config(
-                    preset,
-                    self.config.permissions.approval_policy.get(),
-                    self.config.permissions.sandbox_policy.get(),
-                )
-            })
-            .or_else(|| {
-                // When the project is untrusted, the above code won't match
-                // since AskForApproval::UnlessTrusted is not part of the
-                // default presets. However, in this case we still want to show
-                // the mode selector, which allows the user to choose a
-                // different mode (which will set the project to be trusted)
-                // See https://github.com/zed-industries/zed/issues/48132
-                if self.config.active_project.is_untrusted() {
-                    APPROVAL_PRESETS
-                        .iter()
-                        .find(|preset| preset.id == "read-only")
-                } else {
-                    None
-                }
-            })
-            .map(|preset| SessionModeId::new(preset.id))?;
+        let current_mode_id = current_session_mode_id(&self.config)?;
 
         Some(SessionModeState::new(
             current_mode_id,
@@ -3884,7 +3992,10 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     fn current_service_tier(&self) -> Option<ServiceTier> {
-        self.config.service_tier
+        self.config
+            .service_tier
+            .as_deref()
+            .and_then(|value| serde_json::from_value(value.into()).ok())
     }
 
     fn fast_mode_available(&self) -> bool {
@@ -4189,14 +4300,14 @@ impl<A: Auth> ThreadActor<A> {
                 model: None,
                 effort: None,
                 summary: None,
-                service_tier: Some(service_tier),
+                service_tier: Some(service_tier.map(|tier| tier.to_string())),
                 collaboration_mode: None,
                 personality: None,
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
-        self.config.service_tier = service_tier;
+        self.config.service_tier = service_tier.map(|tier| tier.to_string());
 
         Ok(())
     }
@@ -4263,7 +4374,6 @@ impl<A: Auth> ThreadActor<A> {
         if let Some((name, rest)) = extract_slash_command(&items) {
             match name {
                 "compact" => op = Op::Compact,
-                "undo" => op = Op::Undo,
                 "init" => {
                     op = Op::UserInput {
                         environments: None,
@@ -4381,7 +4491,7 @@ impl<A: Auth> ThreadActor<A> {
                     }
                 }
                 "logout" => {
-                    self.auth.logout()?;
+                    self.auth.logout().await?;
                     return Err(Error::auth_required());
                 }
                 _ => {
@@ -4452,8 +4562,8 @@ impl<A: Auth> ThreadActor<A> {
                 cwd: None,
                 approval_policy: Some(preset.approval),
                 approvals_reviewer: None,
-                sandbox_policy: Some(preset.sandbox.clone()),
-                permission_profile: None,
+                sandbox_policy: None,
+                permission_profile: Some(preset.permission_profile.clone()),
                 windows_sandbox_level: None,
                 model: None,
                 effort: None,
@@ -4472,22 +4582,18 @@ impl<A: Auth> ThreadActor<A> {
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         self.config
             .permissions
-            .sandbox_policy
-            .set(preset.sandbox.clone())
+            .set_permission_profile_with_active_profile(
+                preset.permission_profile.clone(),
+                active_profile_id_for_session_mode(preset.id).map(ActivePermissionProfile::new),
+            )
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
-        match preset.sandbox {
-            // Treat this user action as a trusted dir
-            SandboxPolicy::DangerFullAccess
-            | SandboxPolicy::WorkspaceWrite { .. }
-            | SandboxPolicy::ExternalSandbox { .. } => {
-                set_project_trust_level(
-                    &self.config.codex_home,
-                    &self.config.cwd,
-                    TrustLevel::Trusted,
-                )?;
-            }
-            SandboxPolicy::ReadOnly { .. } => {}
+        if mode_trusts_project(preset.id) {
+            set_project_trust_level(
+                &self.config.codex_home,
+                &self.config.cwd,
+                TrustLevel::Trusted,
+            )?;
         }
 
         Ok(())
@@ -4602,6 +4708,23 @@ impl<A: Auth> ThreadActor<A> {
             }
             EventMsg::AgentReasoningRawContent(AgentReasoningRawContentEvent { text }) => {
                 self.client.send_agent_thought(text.clone()).await;
+            }
+            EventMsg::ImageGenerationEnd(ImageGenerationEndEvent {
+                call_id,
+                status,
+                revised_prompt,
+                result,
+                saved_path,
+            }) => {
+                self.client
+                    .send_tool_call(completed_image_generation_tool_call(
+                        call_id.clone(),
+                        status.clone(),
+                        revised_prompt.clone(),
+                        result.clone(),
+                        saved_path.as_ref().map(|path| path.display().to_string()),
+                    ))
+                    .await;
             }
             // Skip other event types during replay - they either:
             // - Are transient (deltas, turn lifecycle)
@@ -4929,6 +5052,22 @@ impl<A: Auth> ThreadActor<A> {
                             .kind(ToolKind::Search)
                             .status(ToolCallStatus::Completed),
                     )
+                    .await;
+            }
+            ResponseItem::ImageGenerationCall {
+                id,
+                status,
+                revised_prompt,
+                result,
+            } => {
+                self.client
+                    .send_tool_call(completed_image_generation_tool_call(
+                        id.clone(),
+                        status.clone(),
+                        revised_prompt.clone(),
+                        result.clone(),
+                        None,
+                    ))
                     .await;
             }
             // Skip GhostSnapshot, Compaction, Other, LocalShellCall without call_id
@@ -5678,7 +5817,7 @@ mod tests {
     use agent_client_protocol::schema::TextContent;
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
     use codex_features::Feature;
-    use codex_protocol::config_types::{ModeKind, ServiceTier};
+    use codex_protocol::config_types::ModeKind;
     use tokio::sync::{Mutex, mpsc::UnboundedSender};
 
     use super::*;
@@ -5762,52 +5901,6 @@ mod tests {
         );
         let ops = thread.ops.lock().unwrap();
         assert_eq!(ops.as_slice(), &[Op::Compact]);
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_undo() -> anyhow::Result<()> {
-        let (session_id, client, thread, message_tx, local_set) = setup(vec![]).await?;
-        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
-
-        message_tx.send(ThreadMessage::Prompt {
-            request: PromptRequest::new(session_id.clone(), vec!["/undo".into()]),
-            response_tx: prompt_response_tx,
-        })?;
-
-        tokio::try_join!(
-            async {
-                let stop_reason = prompt_response_rx.await??.await??;
-                assert_eq!(stop_reason, StopReason::EndTurn);
-                drop(message_tx);
-                anyhow::Ok(())
-            },
-            async {
-                drop(local_set.await);
-                anyhow::Ok(())
-            }
-        )?;
-
-        let notifications = client.notifications.lock().unwrap();
-        let undo_messages = notifications
-            .iter()
-            .filter_map(|notification| match &notification.update {
-                SessionUpdate::AgentMessageChunk(ContentChunk {
-                    content: ContentBlock::Text(TextContent { text, .. }),
-                    ..
-                }) => Some(text.as_str()),
-                _ => None,
-            })
-            .collect::<Vec<_>>();
-        assert_eq!(
-            undo_messages,
-            vec!["Undo in progress...", "Undo completed."],
-            "notifications don't match {notifications:?}"
-        );
-
-        let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::Undo]);
 
         Ok(())
     }
@@ -5918,9 +6011,9 @@ mod tests {
         assert!(matches!(
             &ops[0],
             Op::OverrideTurnContext {
-                service_tier: Some(Some(ServiceTier::Fast)),
+                service_tier: Some(Some(tier)),
                 ..
-            }
+            } if tier == "fast"
         ));
 
         Ok(())
@@ -5966,9 +6059,9 @@ mod tests {
         assert!(matches!(
             &ops[0],
             Op::OverrideTurnContext {
-                service_tier: Some(Some(ServiceTier::Fast)),
+                service_tier: Some(Some(tier)),
                 ..
-            }
+            } if tier == "fast"
         ));
 
         Ok(())
@@ -6042,9 +6135,9 @@ mod tests {
         assert!(matches!(
             &ops[0],
             Op::OverrideTurnContext {
-                service_tier: Some(Some(ServiceTier::Fast)),
+                service_tier: Some(Some(tier)),
                 ..
-            }
+            } if tier == "fast"
         ));
         assert!(matches!(
             &ops[1],
@@ -6516,6 +6609,7 @@ mod tests {
                         id: "plan-1".into(),
                         text: "# Final plan\nSummary paragraph\n- [x] Inspect current state\n- Implement live plan updates\n".into(),
                     }),
+                    completed_at_ms: 0,
                 }),
             )
             .await;
@@ -6668,6 +6762,7 @@ mod tests {
                         prompt: "inspect the renderer".to_string(),
                         model: "gpt-5.5".to_string(),
                         reasoning_effort: ReasoningEffort::Medium,
+                        started_at_ms: 0,
                     },
                 ),
             )
@@ -6685,6 +6780,7 @@ mod tests {
                     model: "gpt-5.5".to_string(),
                     reasoning_effort: ReasoningEffort::Medium,
                     status: codex_protocol::protocol::AgentStatus::Running,
+                    completed_at_ms: 0,
                 }),
             )
             .await;
@@ -6799,6 +6895,7 @@ mod tests {
                         prompt: "inspect the renderer".to_string(),
                         model: "gpt-5.5".to_string(),
                         reasoning_effort: ReasoningEffort::Medium,
+                        started_at_ms: 0,
                     },
                 ),
             })
@@ -6830,6 +6927,394 @@ mod tests {
                     .and_then(|value| value.as_str())
                     == Some("subagent_breadcrumb")
         ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn image_generation_events_preserve_neverwrite_contract() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+
+        state
+            .send_image_generation_started(
+                &session_client,
+                ImageGenerationBeginEvent {
+                    call_id: "img-1".to_string(),
+                },
+            )
+            .await;
+        state
+            .send_image_generation_completed(
+                &session_client,
+                ImageGenerationEndEvent {
+                    call_id: "img-1".to_string(),
+                    status: "completed".to_string(),
+                    revised_prompt: Some("A clearer prompt".to_string()),
+                    result: "base64-image-data".to_string(),
+                    saved_path: Some(
+                        std::env::current_dir()
+                            .expect("current dir should be available")
+                            .join("image.png")
+                            .try_into()
+                            .expect("image path should be absolute"),
+                    ),
+                },
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let start = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(tool_call) => Some(tool_call),
+                _ => None,
+            })
+            .expect("image generation should create a tool call");
+        assert_eq!(start.tool_call_id.0.as_ref(), "neverwrite:image:img-1");
+        assert_eq!(
+            start
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get(NEVERWRITE_STATUS_EVENT_TYPE_KEY))
+                .and_then(|value| value.as_str()),
+            Some(NEVERWRITE_IMAGE_GENERATION_EVENT_TYPE)
+        );
+
+        let update = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .expect("image generation should complete with a tool update");
+        let raw_input = update
+            .fields
+            .raw_input
+            .as_ref()
+            .expect("image generation completion should carry raw_input");
+        assert_eq!(
+            raw_input.get("status").and_then(|value| value.as_str()),
+            Some("completed")
+        );
+        assert_eq!(
+            raw_input.get("result").and_then(|value| value.as_str()),
+            Some("base64-image-data")
+        );
+        assert_eq!(
+            raw_input
+                .get("revised_prompt")
+                .and_then(|value| value.as_str()),
+            Some("A clearer prompt")
+        );
+        assert!(
+            raw_input
+                .get("path")
+                .and_then(|value| value.as_str())
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn image_generation_replay_response_item_preserves_neverwrite_contract()
+    -> anyhow::Result<()> {
+        let (actor, client, _conversation) = setup_actor(|_| {}).await?;
+
+        actor
+            .replay_response_item(&ResponseItem::ImageGenerationCall {
+                id: "img-replay-1".to_string(),
+                status: "completed".to_string(),
+                revised_prompt: Some("A replayed prompt".to_string()),
+                result: "replayed-base64".to_string(),
+            })
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let tool_call = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(tool_call) => Some(tool_call),
+                _ => None,
+            })
+            .expect("image replay should emit a complete tool call");
+        assert_eq!(
+            tool_call.tool_call_id.0.as_ref(),
+            "neverwrite:image:img-replay-1"
+        );
+        assert_eq!(tool_call.status, ToolCallStatus::Completed);
+        assert_eq!(
+            tool_call
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get(NEVERWRITE_STATUS_EVENT_TYPE_KEY))
+                .and_then(|value| value.as_str()),
+            Some(NEVERWRITE_IMAGE_GENERATION_EVENT_TYPE)
+        );
+        let raw_input = tool_call
+            .raw_input
+            .as_ref()
+            .expect("image replay should carry raw_input");
+        assert_eq!(
+            raw_input.get("status").and_then(|value| value.as_str()),
+            Some("completed")
+        );
+        assert_eq!(
+            raw_input.get("result").and_then(|value| value.as_str()),
+            Some("replayed-base64")
+        );
+        assert_eq!(
+            raw_input
+                .get("revised_prompt")
+                .and_then(|value| value.as_str()),
+            Some("A replayed prompt")
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn image_generation_end_replay_emits_completion_tool_call() -> anyhow::Result<()> {
+        let (actor, client, _conversation) = setup_actor(|_| {}).await?;
+        let saved_path = std::env::current_dir()
+            .expect("current dir should be available")
+            .join("replayed-image.png")
+            .try_into()
+            .expect("image path should be absolute");
+
+        actor
+            .replay_event_msg(&EventMsg::ImageGenerationEnd(ImageGenerationEndEvent {
+                call_id: "img-event-replay".to_string(),
+                status: "failed".to_string(),
+                revised_prompt: None,
+                result: "image generation failed".to_string(),
+                saved_path: Some(saved_path),
+            }))
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let tool_call = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(tool_call) => Some(tool_call),
+                _ => None,
+            })
+            .expect("image end replay should emit a complete tool call");
+        assert_eq!(
+            tool_call.tool_call_id.0.as_ref(),
+            "neverwrite:image:img-event-replay"
+        );
+        assert_eq!(tool_call.status, ToolCallStatus::Failed);
+        let raw_input = tool_call
+            .raw_input
+            .as_ref()
+            .expect("image replay failure should carry raw_input");
+        assert_eq!(
+            raw_input.get("error").and_then(|value| value.as_str()),
+            Some("image generation failed")
+        );
+        assert!(
+            raw_input
+                .get("path")
+                .and_then(|value| value.as_str())
+                .is_some()
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn active_permission_profiles_map_to_neverwrite_session_modes() -> anyhow::Result<()> {
+        let mut config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+
+        for (mode_id, active_profile_id) in [
+            ("read-only", CODEX_READ_ONLY_PROFILE_ID),
+            ("auto", CODEX_WORKSPACE_PROFILE_ID),
+            ("full-access", CODEX_DANGER_NO_SANDBOX_PROFILE_ID),
+        ] {
+            let preset = APPROVAL_PRESETS
+                .iter()
+                .find(|preset| preset.id == mode_id)
+                .expect("mode preset should exist");
+            config
+                .permissions
+                .approval_policy
+                .set(preset.approval)
+                .expect("approval policy should update");
+            config
+                .permissions
+                .set_permission_profile_with_active_profile(
+                    preset.permission_profile.clone(),
+                    Some(ActivePermissionProfile::new(active_profile_id)),
+                )
+                .expect("permission profile should update");
+
+            assert_eq!(
+                current_session_mode_id(&config).map(|id| id.0.to_string()),
+                Some(mode_id.to_string())
+            );
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn handle_set_mode_stores_matching_active_permission_profile() -> anyhow::Result<()> {
+        let (mut actor, _client, conversation) = setup_actor(|_| {}).await?;
+
+        actor
+            .handle_set_mode(SessionModeId::new("read-only"))
+            .await
+            .expect("read-only mode should be accepted");
+
+        assert_eq!(
+            actor
+                .config
+                .permissions
+                .active_permission_profile()
+                .as_ref()
+                .map(|profile| profile.id.as_str()),
+            Some(CODEX_READ_ONLY_PROFILE_ID)
+        );
+        assert!(matches!(
+            conversation.ops.lock().unwrap().last(),
+            Some(Op::OverrideTurnContext {
+                permission_profile: Some(_),
+                ..
+            })
+        ));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn terminal_interaction_fallback_accumulates_until_exec_end() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+        let cwd = std::env::current_dir().expect("current dir should be available");
+
+        state
+            .exec_command_begin(
+                &session_client,
+                ExecCommandBeginEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    started_at_ms: 0,
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo".to_string()],
+                    cwd: cwd
+                        .clone()
+                        .try_into()
+                        .expect("current dir should be absolute"),
+                    parsed_cmd: vec![ParsedCommand::Unknown {
+                        cmd: "sh".to_string(),
+                    }],
+                    source: Default::default(),
+                    interaction_input: None,
+                },
+            )
+            .await;
+        state
+            .exec_command_output_delta(
+                &session_client,
+                ExecCommandOutputDeltaEvent {
+                    call_id: "exec-1".to_string(),
+                    stream: codex_protocol::protocol::ExecOutputStream::Stdout,
+                    chunk: b"first chunk".to_vec(),
+                },
+            )
+            .await;
+        state
+            .terminal_interaction(
+                &session_client,
+                TerminalInteractionEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: "pid-1".to_string(),
+                    stdin: "typed input".to_string(),
+                },
+            )
+            .await;
+
+        assert_eq!(
+            client.notifications.lock().unwrap().len(),
+            1,
+            "fallback should not emit a full-buffer update per chunk"
+        );
+
+        state
+            .exec_command_end(
+                &session_client,
+                ExecCommandEndEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    completed_at_ms: 0,
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo".to_string()],
+                    cwd: cwd.try_into().expect("current dir should be absolute"),
+                    parsed_cmd: vec![],
+                    source: Default::default(),
+                    interaction_input: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    aggregated_output: String::new(),
+                    exit_code: 0,
+                    duration: std::time::Duration::from_millis(1),
+                    formatted_output: String::new(),
+                    status: ExecCommandStatus::Completed,
+                },
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let final_update = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .expect("command end should emit one final update");
+        let text = final_update
+            .fields
+            .content
+            .as_ref()
+            .and_then(|content| content.first())
+            .and_then(|content| match content {
+                ToolCallContent::Content(Content {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) => Some(text.as_str()),
+                _ => None,
+            })
+            .expect("final update should include accumulated text");
+        assert!(text.contains("first chunk"));
+        assert!(text.contains("typed input"));
 
         Ok(())
     }
@@ -6888,24 +7373,59 @@ mod tests {
         Ok((session_id, client, conversation, message_tx, handle))
     }
 
+    async fn setup_actor(
+        configure: impl FnOnce(&mut Config),
+    ) -> anyhow::Result<(ThreadActor<StubAuth>, Arc<StubClient>, Arc<StubCodexThread>)> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client =
+            SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let mut config = config;
+        configure(&mut config);
+        let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation.clone(),
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
+        Ok((actor, client, conversation))
+    }
+
     struct StubAuth;
 
     impl Auth for StubAuth {
-        fn logout(&self) -> Result<bool, Error> {
+        async fn logout(&self) -> Result<bool, Error> {
             Ok(true)
         }
     }
 
     struct StubModelsManager;
 
-    #[async_trait::async_trait]
     impl ModelsManagerImpl for StubModelsManager {
-        async fn get_model(&self, _model_id: &Option<String>) -> String {
-            all_model_presets()[0].to_owned().id
+        fn get_model(
+            &self,
+            _model_id: &Option<String>,
+        ) -> Pin<Box<dyn Future<Output = String> + Send + '_>> {
+            Box::pin(async { all_model_presets()[0].to_owned().id })
         }
 
-        async fn list_models(&self) -> Vec<ModelPreset> {
-            all_model_presets().to_owned()
+        fn list_models(&self) -> Pin<Box<dyn Future<Output = Vec<ModelPreset>> + Send + '_>> {
+            Box::pin(async { all_model_presets().to_owned() })
         }
     }
 
@@ -6928,122 +7448,165 @@ mod tests {
         }
     }
 
-    #[async_trait::async_trait]
     impl CodexThreadImpl for StubCodexThread {
-        async fn submit(&self, op: Op) -> Result<String, CodexErr> {
-            let id = self
-                .current_id
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        fn submit(
+            &self,
+            op: Op,
+        ) -> Pin<Box<dyn Future<Output = Result<String, CodexErr>> + Send + '_>> {
+            Box::pin(async move {
+                let id = self
+                    .current_id
+                    .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-            self.ops.lock().unwrap().push(op.clone());
+                self.ops.lock().unwrap().push(op.clone());
 
-            match op {
-                Op::UserInput { items, .. } => {
-                    let prompt = items
-                        .into_iter()
-                        .map(|i| match i {
-                            UserInput::Text { text, .. } => text,
-                            _ => unimplemented!(),
-                        })
-                        .join("\n");
+                match op {
+                    Op::UserInput { items, .. } => {
+                        let prompt = items
+                            .into_iter()
+                            .map(|i| match i {
+                                UserInput::Text { text, .. } => text,
+                                _ => unimplemented!(),
+                            })
+                            .join("\n");
 
-                    if prompt == "parallel-exec" {
-                        // Emit interleaved exec events: Begin A, Begin B, End A, End B
-                        let turn_id = id.to_string();
-                        let cwd = std::env::current_dir().unwrap();
-                        let send = |msg| {
+                        if prompt == "parallel-exec" {
+                            // Emit interleaved exec events: Begin A, Begin B, End A, End B
+                            let turn_id = id.to_string();
+                            let cwd = std::env::current_dir().unwrap();
+                            let send = |msg| {
+                                self.op_tx
+                                    .send(Event {
+                                        id: id.to_string(),
+                                        msg,
+                                    })
+                                    .unwrap();
+                            };
+                            send(EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
+                                call_id: "call-a".into(),
+                                process_id: None,
+                                turn_id: turn_id.clone(),
+                                command: vec!["echo".into(), "a".into()],
+                                cwd: cwd.clone().try_into().unwrap(),
+                                parsed_cmd: vec![ParsedCommand::Unknown {
+                                    cmd: "echo a".into(),
+                                }],
+                                source: Default::default(),
+                                interaction_input: None,
+                                started_at_ms: 0,
+                            }));
+                            send(EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
+                                call_id: "call-b".into(),
+                                process_id: None,
+                                turn_id: turn_id.clone(),
+                                command: vec!["echo".into(), "b".into()],
+                                cwd: cwd.clone().try_into().unwrap(),
+                                parsed_cmd: vec![ParsedCommand::Unknown {
+                                    cmd: "echo b".into(),
+                                }],
+                                source: Default::default(),
+                                interaction_input: None,
+                                started_at_ms: 0,
+                            }));
+                            send(EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+                                call_id: "call-a".into(),
+                                process_id: None,
+                                turn_id: turn_id.clone(),
+                                command: vec!["echo".into(), "a".into()],
+                                cwd: cwd.clone().try_into().unwrap(),
+                                parsed_cmd: vec![],
+                                source: Default::default(),
+                                interaction_input: None,
+                                stdout: "a\n".into(),
+                                stderr: String::new(),
+                                aggregated_output: "a\n".into(),
+                                exit_code: 0,
+                                duration: std::time::Duration::from_millis(10),
+                                formatted_output: "a\n".into(),
+                                status: ExecCommandStatus::Completed,
+                                completed_at_ms: 0,
+                            }));
+                            send(EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+                                call_id: "call-b".into(),
+                                process_id: None,
+                                turn_id: turn_id.clone(),
+                                command: vec!["echo".into(), "b".into()],
+                                cwd: cwd.clone().try_into().unwrap(),
+                                parsed_cmd: vec![],
+                                source: Default::default(),
+                                interaction_input: None,
+                                stdout: "b\n".into(),
+                                stderr: String::new(),
+                                aggregated_output: "b\n".into(),
+                                exit_code: 0,
+                                duration: std::time::Duration::from_millis(10),
+                                formatted_output: "b\n".into(),
+                                status: ExecCommandStatus::Completed,
+                                completed_at_ms: 0,
+                            }));
+                            send(EventMsg::TurnComplete(TurnCompleteEvent {
+                                last_agent_message: None,
+                                turn_id,
+                                completed_at: None,
+                                duration_ms: None,
+                                time_to_first_token_ms: None,
+                            }));
+                        } else {
                             self.op_tx
                                 .send(Event {
                                     id: id.to_string(),
-                                    msg,
+                                    msg: EventMsg::AgentMessageContentDelta(
+                                        AgentMessageContentDeltaEvent {
+                                            thread_id: id.to_string(),
+                                            turn_id: id.to_string(),
+                                            item_id: id.to_string(),
+                                            delta: prompt.clone(),
+                                        },
+                                    ),
                                 })
                                 .unwrap();
-                        };
-                        send(EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
-                            call_id: "call-a".into(),
-                            process_id: None,
-                            turn_id: turn_id.clone(),
-                            command: vec!["echo".into(), "a".into()],
-                            cwd: cwd.clone().try_into().unwrap(),
-                            parsed_cmd: vec![ParsedCommand::Unknown {
-                                cmd: "echo a".into(),
-                            }],
-                            source: Default::default(),
-                            interaction_input: None,
-                        }));
-                        send(EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
-                            call_id: "call-b".into(),
-                            process_id: None,
-                            turn_id: turn_id.clone(),
-                            command: vec!["echo".into(), "b".into()],
-                            cwd: cwd.clone().try_into().unwrap(),
-                            parsed_cmd: vec![ParsedCommand::Unknown {
-                                cmd: "echo b".into(),
-                            }],
-                            source: Default::default(),
-                            interaction_input: None,
-                        }));
-                        send(EventMsg::ExecCommandEnd(ExecCommandEndEvent {
-                            call_id: "call-a".into(),
-                            process_id: None,
-                            turn_id: turn_id.clone(),
-                            command: vec!["echo".into(), "a".into()],
-                            cwd: cwd.clone().try_into().unwrap(),
-                            parsed_cmd: vec![],
-                            source: Default::default(),
-                            interaction_input: None,
-                            stdout: "a\n".into(),
-                            stderr: String::new(),
-                            aggregated_output: "a\n".into(),
-                            exit_code: 0,
-                            duration: std::time::Duration::from_millis(10),
-                            formatted_output: "a\n".into(),
-                            status: ExecCommandStatus::Completed,
-                        }));
-                        send(EventMsg::ExecCommandEnd(ExecCommandEndEvent {
-                            call_id: "call-b".into(),
-                            process_id: None,
-                            turn_id: turn_id.clone(),
-                            command: vec!["echo".into(), "b".into()],
-                            cwd: cwd.clone().try_into().unwrap(),
-                            parsed_cmd: vec![],
-                            source: Default::default(),
-                            interaction_input: None,
-                            stdout: "b\n".into(),
-                            stderr: String::new(),
-                            aggregated_output: "b\n".into(),
-                            exit_code: 0,
-                            duration: std::time::Duration::from_millis(10),
-                            formatted_output: "b\n".into(),
-                            status: ExecCommandStatus::Completed,
-                        }));
-                        send(EventMsg::TurnComplete(TurnCompleteEvent {
-                            last_agent_message: None,
-                            turn_id,
-                            completed_at: None,
-                            duration_ms: None,
-                            time_to_first_token_ms: None,
-                        }));
-                    } else {
+                            // Send non-delta event (should be deduplicated, but handled by deduplication)
+                            self.op_tx
+                                .send(Event {
+                                    id: id.to_string(),
+                                    msg: EventMsg::AgentMessage(AgentMessageEvent {
+                                        message: prompt,
+                                        phase: None,
+                                        memory_citation: None,
+                                    }),
+                                })
+                                .unwrap();
+                            self.op_tx
+                                .send(Event {
+                                    id: id.to_string(),
+                                    msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                                        last_agent_message: None,
+                                        turn_id: id.to_string(),
+                                        completed_at: None,
+                                        duration_ms: None,
+                                        time_to_first_token_ms: None,
+                                    }),
+                                })
+                                .unwrap();
+                        }
+                    }
+                    Op::Compact => {
                         self.op_tx
                             .send(Event {
                                 id: id.to_string(),
-                                msg: EventMsg::AgentMessageContentDelta(
-                                    AgentMessageContentDeltaEvent {
-                                        thread_id: id.to_string(),
-                                        turn_id: id.to_string(),
-                                        item_id: id.to_string(),
-                                        delta: prompt.clone(),
-                                    },
-                                ),
+                                msg: EventMsg::TurnStarted(TurnStartedEvent {
+                                    model_context_window: None,
+                                    collaboration_mode_kind: ModeKind::default(),
+                                    turn_id: id.to_string(),
+                                    started_at: None,
+                                }),
                             })
                             .unwrap();
-                        // Send non-delta event (should be deduplicated, but handled by deduplication)
                         self.op_tx
                             .send(Event {
                                 id: id.to_string(),
                                 msg: EventMsg::AgentMessage(AgentMessageEvent {
-                                    message: prompt,
+                                    message: "Compact task completed".to_string(),
                                     phase: None,
                                     memory_citation: None,
                                 }),
@@ -7062,126 +7625,58 @@ mod tests {
                             })
                             .unwrap();
                     }
-                }
-                Op::Compact => {
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::TurnStarted(TurnStartedEvent {
-                                model_context_window: None,
-                                collaboration_mode_kind: ModeKind::default(),
-                                turn_id: id.to_string(),
-                                started_at: None,
-                            }),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::AgentMessage(AgentMessageEvent {
-                                message: "Compact task completed".to_string(),
-                                phase: None,
-                                memory_citation: None,
-                            }),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                                last_agent_message: None,
-                                turn_id: id.to_string(),
-                                completed_at: None,
-                                duration_ms: None,
-                                time_to_first_token_ms: None,
-                            }),
-                        })
-                        .unwrap();
-                }
-                Op::Undo => {
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::UndoStarted(
-                                codex_protocol::protocol::UndoStartedEvent {
-                                    message: Some("Undo in progress...".to_string()),
-                                },
-                            ),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::UndoCompleted(
-                                codex_protocol::protocol::UndoCompletedEvent {
-                                    success: true,
-                                    message: Some("Undo completed.".to_string()),
-                                },
-                            ),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                                last_agent_message: None,
-                                turn_id: id.to_string(),
-                                completed_at: None,
-                                duration_ms: None,
-                                time_to_first_token_ms: None,
-                            }),
-                        })
-                        .unwrap();
-                }
-                Op::Review { review_request } => {
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::EnteredReviewMode(review_request.clone()),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::ExitedReviewMode(ExitedReviewModeEvent {
-                                review_output: Some(ReviewOutputEvent {
-                                    findings: vec![],
-                                    overall_correctness: String::new(),
-                                    overall_explanation: review_request
-                                        .user_facing_hint
-                                        .clone()
-                                        .unwrap_or_default(),
-                                    overall_confidence_score: 1.,
+                    Op::Review { review_request } => {
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::EnteredReviewMode(review_request.clone()),
+                            })
+                            .unwrap();
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::ExitedReviewMode(ExitedReviewModeEvent {
+                                    review_output: Some(ReviewOutputEvent {
+                                        findings: vec![],
+                                        overall_correctness: String::new(),
+                                        overall_explanation: review_request
+                                            .user_facing_hint
+                                            .clone()
+                                            .unwrap_or_default(),
+                                        overall_confidence_score: 1.,
+                                    }),
                                 }),
-                            }),
-                        })
-                        .unwrap();
-                    self.op_tx
-                        .send(Event {
-                            id: id.to_string(),
-                            msg: EventMsg::TurnComplete(TurnCompleteEvent {
-                                last_agent_message: None,
-                                turn_id: id.to_string(),
-                                completed_at: None,
-                                duration_ms: None,
-                                time_to_first_token_ms: None,
-                            }),
-                        })
-                        .unwrap();
+                            })
+                            .unwrap();
+                        self.op_tx
+                            .send(Event {
+                                id: id.to_string(),
+                                msg: EventMsg::TurnComplete(TurnCompleteEvent {
+                                    last_agent_message: None,
+                                    turn_id: id.to_string(),
+                                    completed_at: None,
+                                    duration_ms: None,
+                                    time_to_first_token_ms: None,
+                                }),
+                            })
+                            .unwrap();
+                    }
+                    Op::OverrideTurnContext { .. } => {}
+                    _ => {
+                        unimplemented!()
+                    }
                 }
-                Op::OverrideTurnContext { .. } => {}
-                _ => {
-                    unimplemented!()
-                }
-            }
-            Ok(id.to_string())
+                Ok(id.to_string())
+            })
         }
 
-        async fn next_event(&self) -> Result<Event, CodexErr> {
-            let Some(event) = self.op_rx.lock().await.recv().await else {
-                return Err(CodexErr::InternalAgentDied);
-            };
-            Ok(event)
+        fn next_event(&self) -> Pin<Box<dyn Future<Output = Result<Event, CodexErr>> + Send + '_>> {
+            Box::pin(async move {
+                let Some(event) = self.op_rx.lock().await.recv().await else {
+                    return Err(CodexErr::InternalAgentDied);
+                };
+                Ok(event)
+            })
         }
     }
 


### PR DESCRIPTION
## Summary

Updates the vendored `codex-acp` runtime from `0.12.0` to upstream `0.14.0` (`156cb0d`) and moves the OpenAI Codex Rust dependencies from `rust-v0.124.0` to `rust-v0.129.0`.

This keeps the NeverWrite-specific ACP integration layered on top of upstream instead of replacing the vendor blindly.

## What changed

- Updated `vendor/codex-acp` Cargo/npm versions and lockfile to `0.14.0`.
- Migrated Codex ACP initialization to the newer async auth/session APIs, including `state_db`, `thread_store`, and `installation_id` wiring.
- Preserved NeverWrite subagent support: watcher, session creation metadata, breadcrumbs, and selective child idle behavior.
- Preserved NeverWrite diff metadata for review/control-of-changes flows, including enriched hunks and previous-path metadata.
- Kept the NeverWrite image-generation contract via metadata/raw input for both live events and replay/load-history paths.
- Adopted upstream’s O(N²) terminal-output fix so non-terminal-streaming fallbacks accumulate silently and emit once at command end.
- Extended the same no-reemit behavior to `TerminalInteractionEvent` fallback handling.
- Preserved the permission mode mapping for `read-only`, `auto/workspace`, and `full-access` active profiles.
- Kept Linux `codex-resources/bwrap` packaging behavior in the npm publish script.

## Why

Upstream `0.14.0` brings Codex `0.128/0.129`, auth reload fixes, image-generation tool calls, and the large-output memory fix. NeverWrite’s vendor is not a pure upstream snapshot, so this PR ports those upstream changes while preserving the product contract used by the agent changes panel, inline review, subagents, accept/reject flow, and generated-image rendering.

## Validation

- `git diff --check -- vendor/codex-acp`
- `/Users/jfg/.cargo/bin/cargo fmt --manifest-path vendor/codex-acp/Cargo.toml`
- `/Users/jfg/.cargo/bin/cargo check --manifest-path vendor/codex-acp/Cargo.toml`
- `/Users/jfg/.cargo/bin/cargo test --manifest-path vendor/codex-acp/Cargo.toml`
- `/Users/jfg/.cargo/bin/cargo test --manifest-path vendor/codex-acp/Cargo.toml image_generation`
- `/Users/jfg/.cargo/bin/cargo test --manifest-path vendor/codex-acp/Cargo.toml permission_profiles`
- `/Users/jfg/.cargo/bin/cargo test --manifest-path vendor/codex-acp/Cargo.toml handle_set_mode_stores_matching_active_permission_profile`
- `/Users/jfg/.cargo/bin/cargo test -p neverwrite-native-backend ai::tests`
- `/Users/jfg/.cargo/bin/cargo test -p neverwrite-ai tool_diffs`

## Not run

- Frontend/Vitest review tests.
- Electron sidecar staging/package smoke.
- Manual app smoke for Codex editing, subagents, generated images, and accept/reject review flows.
