### PR TITLE
Fix slash tokens rendered as pills

### DIFF
--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -243,6 +243,43 @@ describe("MarkdownContent", () => {
         ).toBeInTheDocument();
     });
 
+    it("keeps slash tokens in prose as plain text unless they resolve to vault references", () => {
+        renderComponent(
+            <MarkdownContent
+                content={[
+                    "Läuft euer S/4 in der Public Cloud?",
+                    "Viele Schaltanlagenbauer /EVU-Partner gehen in unsere Richtung.",
+                    "TCP/IP ist der Standard.",
+                    "Zielquartal ist 2024/Q1.",
+                    "Kontakt über /LinkedIn.",
+                ].join("\n")}
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(
+            screen.queryByRole("button", { name: "/4" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "/EVU-Partner" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "/IP" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "/Q1" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "/LinkedIn" }),
+        ).not.toBeInTheDocument();
+
+        expect(document.body).toHaveTextContent("S/4");
+        expect(document.body).toHaveTextContent("/EVU-Partner");
+        expect(document.body).toHaveTextContent("TCP/IP");
+        expect(document.body).toHaveTextContent("2024/Q1");
+        expect(document.body).toHaveTextContent("/LinkedIn");
+    });
+
     it("does not crash on markdown links with malformed URI encoding", () => {
         renderComponent(
             <MarkdownContent

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -339,7 +339,7 @@ function renderInlineMarkdown(
     const parts: Array<string | ReactElement> = [];
     // Process: wikilinks, inline code, bold, italic, links, and absolute vault file paths.
     const inlineRegex =
-        /(\[\[[^\]]+\]\])|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))|((?:\/)[\w\u00C0-\u024F~.()/-]+(?::\d+|#L\d+)?)/g;
+        /(\[\[[^\]]+\]\])|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))|((?<![\w\u00C0-\u024F])(?:\/)[\w\u00C0-\u024F~.()/-]+(?::\d+|#L\d+)?)/g;
     let lastIndex = 0;
     let match: RegExpExecArray | null;
     let keyIndex = 0;
@@ -684,32 +684,31 @@ function renderInlineMarkdown(
                 );
             } else {
                 const parsedReference = parseVaultReference(filePath);
-                const fileName =
-                    parsedReference?.path
-                        .split("/")
-                        .pop()
-                        ?.replace(/\.md$/, "") ?? filePath;
-                parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="accent"
-                        onClick={() =>
-                            void openChatNoteByReference(
-                                parsedReference?.path ?? filePath,
-                            )
-                        }
-                        onContextMenu={(event) =>
-                            onNoteContextMenu(
-                                event,
-                                parsedReference?.path ?? filePath,
-                            )
-                        }
-                        title={filePath}
-                    />,
-                );
+                if (parsedReference) {
+                    const fileName =
+                        parsedReference.path
+                            .split("/")
+                            .pop()
+                            ?.replace(/\.md$/, "") ?? filePath;
+                    parts.push(
+                        <ChatInlinePill
+                            key={key}
+                            label={fileName}
+                            metrics={pillMetrics}
+                            interactive
+                            variant="accent"
+                            onClick={() =>
+                                void openChatNoteByReference(parsedReference.path)
+                            }
+                            onContextMenu={(event) =>
+                                onNoteContextMenu(event, parsedReference.path)
+                            }
+                            title={filePath}
+                        />,
+                    );
+                } else {
+                    parts.push(full);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

Fixes slash-prefixed prose tokens being rendered as inline chat pills when they are not real vault references.

## Root cause

The inline markdown path regex matched slash tokens even when the slash was embedded in normal words like `S/4`, `TCP/IP`, or `2024/Q1`. The path fallback then rendered unresolved slash-prefixed tokens such as `/EVU-Partner` as `ChatInlinePill` instances anyway.

## Changes

- Require slash-path matches to start outside a word token.
- Render unresolved slash tokens as plain text instead of pills.
- Add a regression test covering `S/4`, `/EVU-Partner`, `TCP/IP`, `2024/Q1`, and `/LinkedIn`.

Closes #31

## Validation

- `npm --prefix apps/desktop test -- MarkdownContent.test.tsx`
- `npx tsc -p tsconfig.app.json --noEmit` from `apps/desktop`