### PR TITLE
Fix agent drags from collapsed sidebar

### DIFF
--- a/apps/desktop/src/components/layout/AppLayout.test.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.test.tsx
@@ -16,6 +16,10 @@ import {
     FILE_TREE_NOTE_DRAG_EVENT,
     type FileTreeNoteDragDetail,
 } from "../../features/ai/dragEvents";
+import {
+    AGENT_SIDEBAR_DRAG_EVENT,
+    type AgentSidebarDragDetail,
+} from "../../features/ai/agentSidebarDragEvents";
 
 class MockResizeObserver {
     static instances: MockResizeObserver[] = [];
@@ -366,6 +370,69 @@ describe("AppLayout", () => {
                 ),
             );
             vi.advanceTimersByTime(360);
+        });
+
+        expect(
+            screen.queryByTestId("sidebar-peek-overlay"),
+        ).not.toBeInTheDocument();
+    });
+
+    it("keeps the collapsed sidebar peek overlay mounted during agent drags", () => {
+        vi.useFakeTimers();
+        useLayoutStore.setState({ sidebarCollapsed: true });
+
+        render(
+            <AppLayout
+                left={<div>Left</div>}
+                center={<div>Center</div>}
+                right={<div>Right</div>}
+            />,
+        );
+
+        fireEvent.mouseEnter(screen.getByTestId("sidebar-peek-hotspot"));
+        const overlay = screen.getByTestId("sidebar-peek-overlay");
+        expect(overlay).toContainElement(screen.getByText("Left"));
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent<AgentSidebarDragDetail>(
+                    AGENT_SIDEBAR_DRAG_EVENT,
+                    {
+                        detail: {
+                            phase: "start",
+                            x: 40,
+                            y: 40,
+                            sessionId: "session-1",
+                            title: "Dragged agent",
+                        },
+                    },
+                ),
+            );
+        });
+
+        fireEvent.mouseLeave(overlay);
+        act(() => {
+            vi.advanceTimersByTime(400);
+        });
+
+        expect(screen.getByTestId("sidebar-peek-overlay")).toBeInTheDocument();
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent<AgentSidebarDragDetail>(
+                    AGENT_SIDEBAR_DRAG_EVENT,
+                    {
+                        detail: {
+                            phase: "end",
+                            x: 600,
+                            y: 400,
+                            sessionId: "session-1",
+                            title: "Dragged agent",
+                        },
+                    },
+                ),
+            );
+            vi.advanceTimersByTime(400);
         });
 
         expect(

--- a/apps/desktop/src/components/layout/AppLayout.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.tsx
@@ -19,6 +19,10 @@ import {
     FILE_TREE_NOTE_DRAG_EVENT,
     type FileTreeNoteDragDetail,
 } from "../../features/ai/dragEvents";
+import {
+    AGENT_SIDEBAR_DRAG_EVENT,
+    type AgentSidebarDragDetail,
+} from "../../features/ai/agentSidebarDragEvents";
 
 // Both macOS (native "sidebar" vibrancy) and Windows 11 (native acrylic
 // backgroundMaterial) paint a translucent window material beneath the
@@ -358,9 +362,11 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     ]);
 
     useEffect(() => {
-        const handleFileTreeDrag = (event: Event) => {
-            const detail = (event as CustomEvent<FileTreeNoteDragDetail>)
-                .detail;
+        const handleSidebarOriginDrag = (
+            detail:
+                | FileTreeNoteDragDetail
+                | AgentSidebarDragDetail,
+        ) => {
             if (!detail) return;
             if (Number.isFinite(detail.x) && Number.isFinite(detail.y)) {
                 sidebarPointerRef.current = {
@@ -376,7 +382,9 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
                     detail.phase === "start" &&
                     sidebarCollapsed &&
                     sidebarOverlayVisible &&
-                    detail.origin?.kind !== "workspace-tab" &&
+                    ("origin" in detail
+                        ? detail.origin?.kind !== "workspace-tab"
+                        : true) &&
                     detail.x >= overlayLeft &&
                     detail.x <= overlayLeft + sidebarWidth;
 
@@ -407,12 +415,32 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
             }
         };
 
+        const handleFileTreeDrag = (event: Event) => {
+            handleSidebarOriginDrag(
+                (event as CustomEvent<FileTreeNoteDragDetail>).detail,
+            );
+        };
+
+        const handleAgentSidebarDrag = (event: Event) => {
+            handleSidebarOriginDrag(
+                (event as CustomEvent<AgentSidebarDragDetail>).detail,
+            );
+        };
+
         window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleFileTreeDrag);
+        window.addEventListener(
+            AGENT_SIDEBAR_DRAG_EVENT,
+            handleAgentSidebarDrag,
+        );
         return () => {
             sidebarDragActiveRef.current = false;
             window.removeEventListener(
                 FILE_TREE_NOTE_DRAG_EVENT,
                 handleFileTreeDrag,
+            );
+            window.removeEventListener(
+                AGENT_SIDEBAR_DRAG_EVENT,
+                handleAgentSidebarDrag,
             );
         };
     }, [

--- a/apps/desktop/src/features/pdf/PdfTabView.tsx
+++ b/apps/desktop/src/features/pdf/PdfTabView.tsx
@@ -709,10 +709,17 @@ function PdfViewer({ tab }: { tab: PdfTab }) {
 
         let frame = 0;
         const scheduleSync = () => {
-            persistScrollPosition({
-                top: scrollContainer.scrollTop,
-                left: scrollContainer.scrollLeft,
-            });
+            // A real scroll event should win over a pending restore. This keeps
+            // user-driven continuous scroll from being dropped in the frame
+            // between mounting the surface and completing scroll restoration.
+            persistScrollPosition(
+                {
+                    top: scrollContainer.scrollTop,
+                    left: scrollContainer.scrollLeft,
+                },
+                false,
+                true,
+            );
             window.cancelAnimationFrame(frame);
             frame = window.requestAnimationFrame(() =>
                 syncScrollStateFromContainer(scrollContainer),


### PR DESCRIPTION
## Summary

Fixes #51.

This keeps the collapsed sidebar peek overlay mounted while an agent/sidebar drag is active, matching the existing behavior for FileTree drags. Without this, dragging an agent out of a hidden sidebar could allow the overlay to dismiss mid-drag, interrupting the pointer lifecycle before the multi-pane drop handler received a clean end event.

This also fixes a PDF continuous-scroll persistence race exposed by the full test suite: a real scroll event now wins over pending scroll restoration, so user-driven scroll positions are not dropped before the next animation frame.

## Impact

Agent sessions dragged from the hidden sidebar can now be dropped into multi-pane targets reliably, including pane center, tab strip, and split-edge targets. PDF continuous scrolling also persists immediately and deterministically.

## Validation

- `npm test -- --run src/features/pdf/PdfTabView.test.tsx src/components/layout/AppLayout.test.tsx`
- `npx tsc -p tsconfig.app.json --noEmit`
- `npm test`