### PR TITLE
fix(ai): clarify provider quota errors

### DIFF
--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1741,6 +1741,70 @@ describe("chatStore", () => {
         });
     });
 
+    it("shows provider quota errors as provider limits", () => {
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: { ...runtimePayload[0].runtime },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                "codex-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "codex-acp",
+                },
+            },
+            sessionsById: {
+                "codex-session-1": {
+                    sessionId: "codex-session-1",
+                    historySessionId: "codex-session-1",
+                    runtimeId: "codex-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    status: "streaming",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                    runtimeState: "live",
+                },
+            },
+            selectedRuntimeId: "codex-acp",
+        });
+
+        useChatStore.getState().applySessionError({
+            session_id: "codex-session-1",
+            message: "Internal error: Limitation until 12 May 2026.",
+        });
+
+        const expected =
+            "Provider quota reached. Check your plan or wait until it resets.";
+        expect(
+            useChatStore.getState().runtimeConnectionByRuntimeId["codex-acp"],
+        ).toMatchObject({
+            status: "error",
+            message: expected,
+        });
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById["codex-session-1"]?.messages.at(-1),
+        ).toMatchObject({
+            kind: "error",
+            content: expected,
+        });
+        expect(
+            useChatStore.getState().setupStatusByRuntimeId["codex-acp"],
+        ).toMatchObject({
+            authReady: true,
+            onboardingRequired: false,
+        });
+    });
+
     it("hydrates existing backend sessions before creating a new one", async () => {
         invokeMock.mockImplementation(async (command) => {
             if (command === "ai_list_runtimes") {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1462,6 +1462,22 @@ function isContextTooLargeErrorMessage(message: string) {
     );
 }
 
+function isProviderQuotaErrorMessage(message: string) {
+    const normalized = message.trim().toLowerCase();
+    return (
+        normalized.includes("insufficient_quota") ||
+        normalized.includes("quota") ||
+        normalized.includes("rate_limit") ||
+        normalized.includes("rate limit") ||
+        normalized.includes("resource_exhausted") ||
+        normalized.includes("usage limit") ||
+        normalized.includes("limitation until") ||
+        normalized.includes("limit resets") ||
+        normalized.includes("billing hard limit") ||
+        normalized.includes("payment required")
+    );
+}
+
 function isRuntimeSessionDisconnectedErrorMessage(message: string) {
     const normalized = message.trim().toLowerCase();
     return normalized.includes("runtime session is not connected");
@@ -1474,6 +1490,10 @@ function normalizeAiErrorMessage(message: string) {
 
     if (isContextTooLargeErrorMessage(message)) {
         return "This chat context grew too large to continue. Start a new chat and resend your last message.";
+    }
+
+    if (isProviderQuotaErrorMessage(message)) {
+        return "Provider quota reached. Check your plan or wait until it resets.";
     }
 
     if (isAuthenticationErrorMessage(message)) {
@@ -7249,7 +7269,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
             });
         },
 
-        applySessionError: ({ session_id, message }) => {
+        applySessionError: ({ session_id, message: rawMessage }) => {
+            const message = normalizeAiErrorMessage(rawMessage);
             if (session_id) clearStaleStreamingCheck(session_id);
             set((state) => {
                 const sessionRuntimeId = session_id


### PR DESCRIPTION
## Summary

Clarifies provider quota failures before they reach the chat UI so subscription or usage limits no longer look like internal NeverWrite errors.

## Root cause

Async provider failures were emitted as raw session errors and `applySessionError` appended them directly to the chat transcript. Existing normalization covered auth and context-size errors, but not provider quota/limit wording.

## Changes

- Detect provider quota and usage-limit phrases in the centralized AI error normalization path.
- Normalize matching errors to: `Provider quota reached. Check your plan or wait until it resets.`
- Normalize errors inside `applySessionError` so async provider events use the same user-facing copy.
- Add store coverage for the issue case: `Internal error: Limitation until 12 May 2026.`

Fixes #49.

## Validation

- `npm run test -- src/features/ai/store/chatStore.test.ts`
