### PR TITLE
fix(vault): tolerate non-UTF-8 bytes in markdown and text files

### DIFF
--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -2383,9 +2383,7 @@ impl NativeBackend {
             else {
                 return Ok(());
             };
-            let content_hash = fs::read_to_string(&path)
-                .ok()
-                .map(|content| note_content_hash(&content));
+            let content_hash = lossy_text_file_content_hash(&path);
             let revision = advance_revision(&mut state.note_revisions, &note_id, None).max(1);
             let change = build_vault_note_change_with_origin(
                 vault_path,
@@ -2410,9 +2408,7 @@ impl NativeBackend {
             .find(|entry| entry.relative_path == relative_path)
             .cloned();
         let revision = advance_revision(&mut state.file_revisions, &relative_path, None).max(1);
-        let content_hash = fs::read_to_string(&path)
-            .ok()
-            .map(|content| note_content_hash(&content));
+        let content_hash = lossy_text_file_content_hash(&path);
         let change = build_vault_note_change_with_origin(
             vault_path,
             "upsert",
@@ -2829,6 +2825,11 @@ fn note_content_hash(content: &str) -> String {
     content_hash_bytes(content.as_bytes())
 }
 
+fn lossy_text_file_content_hash(path: &Path) -> Option<String> {
+    let bytes = fs::read(path).ok()?;
+    Some(note_content_hash(String::from_utf8_lossy(&bytes).as_ref()))
+}
+
 fn content_hash_bytes(bytes: &[u8]) -> String {
     let mut hash = 0xcbf29ce484222325_u64;
     for byte in bytes {
@@ -3155,6 +3156,22 @@ mod tests {
         backend.lock().unwrap().invoke(command, args, backend)
     }
 
+    fn recv_vault_change(event_rx: &std::sync::mpsc::Receiver<RpcOutput>) -> Value {
+        match event_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .unwrap()
+        {
+            RpcOutput::Event {
+                event_name,
+                payload,
+            } => {
+                assert_eq!(event_name, "vault://note-changed");
+                payload
+            }
+            output => panic!("expected vault change event, got {output:?}"),
+        }
+    }
+
     #[test]
     fn invokes_vault_editor_commands_without_electron() {
         let (event_tx, _event_rx) = mpsc::channel::<RpcOutput>();
@@ -3328,5 +3345,73 @@ mod tests {
         .unwrap();
         assert_eq!(fs::read_to_string(&note_path).unwrap(), "# Beta\n");
         assert_eq!(change.get("origin").and_then(Value::as_str), Some("agent"));
+    }
+
+    #[test]
+    fn external_upsert_hashes_non_utf8_markdown_and_text_lossily() {
+        let (event_tx, event_rx) = mpsc::channel::<RpcOutput>();
+        let mut backend = NativeBackend::new(event_tx);
+        let vault_dir = tempfile::tempdir().unwrap();
+        let vault_path = vault_dir.path().to_string_lossy().to_string();
+        let root = normalize_vault_path(&vault_path).unwrap();
+        let root_path = PathBuf::from(&root);
+        let vault = Vault::open(PathBuf::from(&root)).unwrap();
+        let notes = vault.scan().unwrap();
+        let entries = vault.discover_vault_entries().unwrap();
+        let index = VaultIndex::build(notes);
+
+        backend.vaults.insert(
+            root.clone(),
+            VaultRuntimeState {
+                vault,
+                index,
+                entries,
+                open_state: VaultOpenStateDto {
+                    path: Some(root.clone()),
+                    stage: "ready".to_string(),
+                    message: "Vault ready".to_string(),
+                    processed: 0,
+                    total: 0,
+                    note_count: 0,
+                    snapshot_used: false,
+                    cancelled: false,
+                    started_at_ms: None,
+                    finished_at_ms: None,
+                    metrics: empty_metrics(),
+                    error: None,
+                },
+                graph_revision: 1,
+                note_revisions: HashMap::new(),
+                file_revisions: HashMap::new(),
+                write_tracker: WriteTracker::new(),
+                _watcher: None,
+            },
+        );
+
+        let note_path = root_path.join("bad.md");
+        let note_bytes = b"# Bad\nhello \xff markdown\n";
+        fs::write(&note_path, note_bytes).unwrap();
+        backend
+            .emit_external_upsert(&root, note_path, VAULT_CHANGE_ORIGIN_EXTERNAL)
+            .unwrap();
+        let note_change = recv_vault_change(&event_rx);
+        let expected_note_hash = note_content_hash(String::from_utf8_lossy(note_bytes).as_ref());
+        assert_eq!(
+            note_change.get("content_hash").and_then(Value::as_str),
+            Some(expected_note_hash.as_str())
+        );
+
+        let text_path = root_path.join("notes.txt");
+        let text_bytes = b"hello \xff text\n";
+        fs::write(&text_path, text_bytes).unwrap();
+        backend
+            .emit_external_upsert(&root, text_path, VAULT_CHANGE_ORIGIN_EXTERNAL)
+            .unwrap();
+        let text_change = recv_vault_change(&event_rx);
+        let expected_text_hash = note_content_hash(String::from_utf8_lossy(text_bytes).as_ref());
+        assert_eq!(
+            text_change.get("content_hash").and_then(Value::as_str),
+            Some(expected_text_hash.as_str())
+        );
     }
 }

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -262,7 +262,8 @@ impl Vault {
             return Err(VaultError::InvalidVaultPath(relative_path.to_string()));
         }
 
-        Ok(std::fs::read_to_string(path)?)
+        let bytes = std::fs::read(path)?;
+        Ok(String::from_utf8_lossy(&bytes).into_owned())
     }
 
     pub fn save_text_file(
@@ -522,7 +523,8 @@ impl Vault {
     }
 
     pub fn read_note_from_path(&self, path: &Path) -> Result<NoteDocument, VaultError> {
-        let content = std::fs::read_to_string(path)?;
+        let bytes = std::fs::read(path)?;
+        let content = String::from_utf8_lossy(&bytes).into_owned();
         let id = self.path_to_id(path);
         Ok(parser::parse_note(&id, path, &content))
     }

--- a/crates/vault/tests/integration.rs
+++ b/crates/vault/tests/integration.rs
@@ -93,6 +93,42 @@ fn parse_discovered_files_reports_progress() {
 }
 
 #[test]
+fn scan_tolerates_non_utf8_markdown_files() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("good.md"), "# Good\n\nValid UTF-8\n").unwrap();
+    fs::write(
+        dir.path().join("bad.md"),
+        b"# Heading\n\xff\xfe garbled bytes\n",
+    )
+    .unwrap();
+
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    let notes = vault.scan().unwrap();
+
+    assert_eq!(notes.len(), 2);
+    let bad = notes.iter().find(|note| note.id.0 == "bad").unwrap();
+    assert!(
+        bad.raw_markdown.contains('\u{FFFD}'),
+        "expected lossy decode to insert U+FFFD, got: {:?}",
+        bad.raw_markdown
+    );
+    assert!(bad.raw_markdown.contains("garbled bytes"));
+}
+
+#[test]
+fn read_text_file_tolerates_non_utf8_bytes() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("notes.txt"), b"hello \xff world\n").unwrap();
+
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    let content = vault.read_text_file("notes.txt").unwrap();
+
+    assert!(content.contains('\u{FFFD}'));
+    assert!(content.contains("hello"));
+    assert!(content.contains("world"));
+}
+
+#[test]
 fn scan_parses_frontmatter() {
     let (_dir, vault) = setup_vault();
     let notes = vault.scan().unwrap();


### PR DESCRIPTION
## Summary
- `Vault::scan()` aborts on the first `.md` file with non-UTF-8 bytes because `read_note_from_path` and `read_text_file` use `read_to_string`, which fails hard on `InvalidData`. Result: the whole vault stays unopened, and the bad notes can't be fixed from inside the app.
- Switch both reads to `std::fs::read` + `String::from_utf8_lossy`. Invalid bytes become U+FFFD; the note still indexes; the user can edit and re-save it.

Closes #55

## Test plan
- [x] `cargo test -p neverwrite-vault` — 54 passed (52 existing + 2 new: `scan_tolerates_non_utf8_markdown_files`, `read_text_file_tolerates_non_utf8_bytes`).
- [x] `cargo build --workspace` — clean.
- [x] Manual: build the desktop app, point it at a folder containing a `.md` with non-UTF-8 bytes (e.g. `printf '# hi\n\xff\xfe garbled\n' > Bad.md`), confirm the vault opens and the note renders with replacement chars in the affected span.
- [x] Regression: open a known-good UTF-8 vault and confirm content is byte-identical (lossy decode of valid UTF-8 is a no-op).