### PR TITLE
Secure AI provider secret persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,6 +316,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,6 +339,12 @@ name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -297,6 +447,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,6 +509,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,6 +559,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "aes",
+ "block-padding",
+ "cbc",
+ "dbus",
+ "fastrand",
+ "hkdf",
+ "num",
+ "once_cell",
+ "sha2",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,6 +628,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -484,6 +679,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,7 +718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -506,6 +728,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bb7ef65b3777a325d1eeefefab5b6d4959da54747e33bd6258e789640f307ad"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -811,10 +1054,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"
@@ -1203,6 +1470,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "linux-keyutils",
+ "log",
+ "secret-service",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zbus",
+ "zeroize",
+]
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1526,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,6 +1544,16 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.7.3",
+]
+
+[[package]]
+name = "linux-keyutils"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83270a18e9f90d0707c41e9f35efada77b64c0e6f3f1810e71c8368a864d5590"
+dependencies = [
+ "bitflags 2.11.0",
+ "libc",
 ]
 
 [[package]]
@@ -1298,7 +1602,7 @@ dependencies = [
  "md-5",
  "nom",
  "nom_locate",
- "rand",
+ "rand 0.9.2",
  "rangemap",
  "sha2",
  "stringprep",
@@ -1328,6 +1632,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1394,6 +1707,7 @@ name = "neverwrite-native-backend"
 version = "0.2.4"
 dependencies = [
  "agent-client-protocol",
+ "keyring",
  "neverwrite-ai",
  "neverwrite-diff",
  "neverwrite-index",
@@ -1449,6 +1763,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases 0.2.1",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1497,10 +1824,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1522,6 +1913,16 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "parking"
@@ -1614,10 +2015,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "pom"
@@ -1638,7 +2070,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "nix",
+ "nix 0.28.0",
  "serial2",
  "shared_library",
  "shell-words",
@@ -1687,6 +2119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1725,7 +2166,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1774,12 +2215,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1789,7 +2251,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -1990,7 +2461,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2016,7 +2487,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2044,10 +2515,10 @@ dependencies = [
  "rustls-native-certs",
  "rustls-platform-verifier-android",
  "rustls-webpki",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2143,6 +2614,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "secret-service"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4d35ad99a181be0a60ffcbe85d680d98f87bdc4d7644ade319b87076b9dbfd4"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "hkdf",
+ "num",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "zbus",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2226,6 +2729,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_with"
 version = "3.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2278,6 +2792,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2348,7 +2873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2366,6 +2891,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -2473,7 +3004,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2625,6 +3156,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap 2.13.0",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2726,6 +3287,17 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "unicode-bidi"
@@ -3007,7 +3579,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3100,6 +3672,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -3309,6 +3890,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3412,6 +4002,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3432,6 +4032,68 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-fs",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -3480,6 +4142,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zerotrie"
@@ -3519,3 +4195,40 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
+keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-async-persistent", "async-io", "crypto-rust"] }
 neverwrite-diff = { path = "../../../crates/diff" }
 neverwrite-ai = { path = "../../../crates/ai" }
 neverwrite-index = { path = "../../../crates/index" }

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -88,6 +88,7 @@ const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
 const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
+const RUNTIME_SECRET_STORE_MODE_ENV: &str = "NEVERWRITE_AI_SECRET_STORE";
 const RUNTIME_SETUP_LOAD_ERROR_MESSAGE: &str = "Secure credential storage is unavailable. Reconnect this AI provider or configure an environment variable before starting a session.";
 
 #[derive(Debug, Clone)]
@@ -306,13 +307,11 @@ impl RuntimeSecretStore for OsRuntimeSecretStore {
     }
 }
 
-#[cfg(test)]
 #[derive(Default)]
 struct InMemoryRuntimeSecretStore {
     values: Mutex<HashMap<(String, String), String>>,
 }
 
-#[cfg(test)]
 impl RuntimeSecretStore for InMemoryRuntimeSecretStore {
     fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String> {
         Ok(self
@@ -349,13 +348,30 @@ struct RuntimeSetupStore {
     secrets: Arc<dyn RuntimeSecretStore>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RuntimeSecretStoreMode {
+    OsKeyring,
+    InMemory,
+}
+
 impl RuntimeSetupStore {
     fn new(path: PathBuf) -> Self {
-        Self::with_secret_store(path, Arc::new(OsRuntimeSecretStore))
+        Self::with_secret_store(path, Self::default_secret_store())
     }
 
     fn with_secret_store(path: PathBuf, secrets: Arc<dyn RuntimeSecretStore>) -> Self {
         Self { path, secrets }
+    }
+
+    fn default_secret_store() -> Arc<dyn RuntimeSecretStore> {
+        match runtime_secret_store_mode_from_env(
+            std::env::var(RUNTIME_SECRET_STORE_MODE_ENV).ok().as_deref(),
+        ) {
+            RuntimeSecretStoreMode::OsKeyring => Arc::new(OsRuntimeSecretStore),
+            // This is intentionally opt-in for CI/smoke tests that run without a
+            // desktop keyring service. Production keeps using OS secure storage.
+            RuntimeSecretStoreMode::InMemory => Arc::new(InMemoryRuntimeSecretStore::default()),
+        }
     }
 
     fn load(&self) -> Result<HashMap<String, RuntimeSetupState>, String> {
@@ -500,6 +516,13 @@ impl RuntimeSetupStore {
             let _ = std::fs::remove_file(&temp_path);
             format!("Failed to replace AI runtime setup store: {error}")
         })
+    }
+}
+
+fn runtime_secret_store_mode_from_env(value: Option<&str>) -> RuntimeSecretStoreMode {
+    match value.map(str::trim) {
+        Some("memory") => RuntimeSecretStoreMode::InMemory,
+        _ => RuntimeSecretStoreMode::OsKeyring,
     }
 }
 
@@ -8368,6 +8391,30 @@ mod tests {
             CLAUDE_RUNTIME_ID,
             "Authentication succeeded"
         ));
+    }
+
+    #[test]
+    fn runtime_secret_store_mode_requires_explicit_memory_value() {
+        assert_eq!(
+            runtime_secret_store_mode_from_env(Some("memory")),
+            RuntimeSecretStoreMode::InMemory
+        );
+        assert_eq!(
+            runtime_secret_store_mode_from_env(Some(" memory ")),
+            RuntimeSecretStoreMode::InMemory
+        );
+        assert_eq!(
+            runtime_secret_store_mode_from_env(None),
+            RuntimeSecretStoreMode::OsKeyring
+        );
+        assert_eq!(
+            runtime_secret_store_mode_from_env(Some("")),
+            RuntimeSecretStoreMode::OsKeyring
+        );
+        assert_eq!(
+            runtime_secret_store_mode_from_env(Some("plaintext")),
+            RuntimeSecretStoreMode::OsKeyring
+        );
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -239,6 +239,194 @@ struct RuntimeSetupState {
     env: HashMap<String, String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedRuntimeSetupFile {
+    version: u32,
+    runtimes: HashMap<String, PersistedRuntimeSetupState>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PersistedRuntimeSetupState {
+    custom_binary_path: Option<String>,
+    auth_method: Option<String>,
+    env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone)]
+struct RuntimeSetupStore {
+    path: PathBuf,
+}
+
+impl RuntimeSetupStore {
+    // Plain-file persistence is isolated here so it can be replaced by keychain storage later.
+    fn new(path: PathBuf) -> Self {
+        Self { path }
+    }
+
+    fn load(&self) -> Result<HashMap<String, RuntimeSetupState>, String> {
+        let raw = match std::fs::read_to_string(&self.path) {
+            Ok(raw) => raw,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(HashMap::new()),
+            Err(error) => {
+                return Err(format!("Failed to read AI runtime setup store: {error}"));
+            }
+        };
+        let persisted: PersistedRuntimeSetupFile = serde_json::from_str(&raw)
+            .map_err(|error| format!("Failed to parse AI runtime setup store: {error}"))?;
+        if persisted.version != 1 {
+            return Ok(HashMap::new());
+        }
+
+        let mut setup = HashMap::new();
+        for (runtime_id, persisted_setup) in persisted.runtimes {
+            if validate_runtime_id(&runtime_id).is_err() {
+                continue;
+            }
+            let mut runtime_setup = RuntimeSetupState {
+                custom_binary_path: persisted_setup
+                    .custom_binary_path
+                    .and_then(normalize_optional_string),
+                auth_method: persisted_setup
+                    .auth_method
+                    .and_then(normalize_optional_string),
+                env: persisted_setup
+                    .env
+                    .into_iter()
+                    .filter_map(|(key, value)| {
+                        normalize_optional_string(value).map(|value| (key, value))
+                    })
+                    .collect(),
+                ..RuntimeSetupState::default()
+            };
+            refresh_runtime_setup_flags(&runtime_id, &mut runtime_setup);
+            if !runtime_setup
+                .auth_method
+                .as_deref()
+                .is_some_and(|method| auth_method_has_local_config(&runtime_setup, method))
+            {
+                runtime_setup.auth_method =
+                    local_auth_method_for_runtime(&runtime_id, &runtime_setup);
+            }
+            runtime_setup.auth_ready = has_local_auth_config(&runtime_setup);
+            setup.insert(runtime_id, runtime_setup);
+        }
+        Ok(setup)
+    }
+
+    fn save(&self, setup: &HashMap<String, RuntimeSetupState>) -> Result<(), String> {
+        let runtimes = setup
+            .iter()
+            .filter_map(|(runtime_id, setup)| {
+                PersistedRuntimeSetupState::from_runtime_setup(setup)
+                    .map(|persisted_setup| (runtime_id.clone(), persisted_setup))
+            })
+            .collect::<HashMap<_, _>>();
+
+        if runtimes.is_empty() {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => {
+                    return Err(format!("Failed to remove AI runtime setup store: {error}"));
+                }
+            }
+            return Ok(());
+        }
+
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)
+                .map_err(|error| format!("Failed to create AI runtime setup directory: {error}"))?;
+        }
+
+        let persisted = PersistedRuntimeSetupFile {
+            version: 1,
+            runtimes,
+        };
+        let encoded = serde_json::to_vec_pretty(&persisted)
+            .map_err(|error| format!("Failed to encode AI runtime setup store: {error}"))?;
+        let temp_path = self.path.with_extension(format!(
+            "json.tmp-{}",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or_default()
+        ));
+        write_secret_file(&temp_path, &encoded)?;
+        replace_secret_file(&temp_path, &self.path).map_err(|error| {
+            let _ = std::fs::remove_file(&temp_path);
+            format!("Failed to replace AI runtime setup store: {error}")
+        })
+    }
+}
+
+impl Default for RuntimeSetupStore {
+    fn default() -> Self {
+        Self::new(app_data_dir().join("ai").join("runtime-setup.json"))
+    }
+}
+
+impl PersistedRuntimeSetupState {
+    fn from_runtime_setup(setup: &RuntimeSetupState) -> Option<Self> {
+        let env = setup
+            .env
+            .iter()
+            .filter(|(_, value)| !value.trim().is_empty())
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<HashMap<_, _>>();
+        let custom_binary_path = setup
+            .custom_binary_path
+            .clone()
+            .and_then(normalize_optional_string);
+        let auth_method = setup
+            .auth_method
+            .clone()
+            .and_then(normalize_optional_string)
+            .filter(|method| auth_method_has_local_config(setup, method));
+
+        if custom_binary_path.is_none() && auth_method.is_none() && env.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            custom_binary_path,
+            auth_method,
+            env,
+        })
+    }
+}
+
+fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
+    let mut options = std::fs::OpenOptions::new();
+    options.create(true).truncate(true).write(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .map_err(|error| format!("Failed to open AI runtime setup store: {error}"))?;
+    file.write_all(bytes)
+        .map_err(|error| format!("Failed to write AI runtime setup store: {error}"))?;
+    file.flush()
+        .map_err(|error| format!("Failed to flush AI runtime setup store: {error}"))
+}
+
+#[cfg(windows)]
+fn replace_secret_file(temp_path: &Path, target_path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(target_path) {
+        Ok(()) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+        Err(error) => return Err(error),
+    }
+    std::fs::rename(temp_path, target_path)
+}
+
+#[cfg(not(windows))]
+fn replace_secret_file(temp_path: &Path, target_path: &Path) -> std::io::Result<()> {
+    std::fs::rename(temp_path, target_path)
+}
+
 #[derive(Debug, Clone)]
 struct ManagedAiSession {
     session: AiSession,
@@ -379,6 +567,7 @@ enum AcpConfigOptionRemoteCommand {
 pub(crate) struct NativeAi {
     inner: Arc<Mutex<NativeAiInner>>,
     event_tx: Sender<RpcOutput>,
+    setup_store: RuntimeSetupStore,
     tool_diffs: ToolDiffState,
     agent_writes: AgentWriteTracker,
     auth_terminal_sessions: Arc<Mutex<HashMap<String, AuthTerminalHandle>>>,
@@ -387,9 +576,18 @@ pub(crate) struct NativeAi {
 
 impl NativeAi {
     pub(crate) fn new(event_tx: Sender<RpcOutput>) -> Self {
+        Self::with_setup_store(event_tx, RuntimeSetupStore::default())
+    }
+
+    fn with_setup_store(event_tx: Sender<RpcOutput>, setup_store: RuntimeSetupStore) -> Self {
+        let setup = setup_store.load().unwrap_or_default();
         Self {
-            inner: Arc::new(Mutex::new(NativeAiInner::default())),
+            inner: Arc::new(Mutex::new(NativeAiInner {
+                setup,
+                ..NativeAiInner::default()
+            })),
             event_tx,
+            setup_store,
             tool_diffs: ToolDiffState::default(),
             agent_writes: AgentWriteTracker::default(),
             auth_terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
@@ -492,7 +690,11 @@ impl NativeAi {
             .clone()
             .and_then(normalize_optional_string);
         update_auth_state(setup, &runtime_id, input)?;
-        Ok(json!(setup_status_for(&runtime_id, setup.clone())?))
+        let status = setup_status_for(&runtime_id, setup.clone())?;
+        let persisted_setup = state.setup.clone();
+        drop(state);
+        self.setup_store.save(&persisted_setup)?;
+        Ok(json!(status))
     }
 
     pub(crate) fn start_auth(&self, args: &Value) -> Result<Value, String> {
@@ -579,7 +781,11 @@ impl NativeAi {
             .map_err(|error| format!("Internal AI state error: {error}"))?;
         let setup = state.setup.entry(runtime_id.clone()).or_default();
         clear_runtime_auth_state(setup);
-        Ok(json!(setup_status_for(&runtime_id, setup.clone())?))
+        let status = setup_status_for(&runtime_id, setup.clone())?;
+        let persisted_setup = state.setup.clone();
+        drop(state);
+        self.setup_store.save(&persisted_setup)?;
+        Ok(json!(status))
     }
 
     pub(crate) fn list_sessions(&self, vault_root: Option<PathBuf>) -> Result<Value, String> {
@@ -3968,6 +4174,47 @@ fn home_dir() -> Option<PathBuf> {
     }
 }
 
+fn app_data_dir() -> PathBuf {
+    if let Ok(path) = std::env::var("NEVERWRITE_APP_DATA_DIR") {
+        let trimmed = path.trim();
+        if !trimmed.is_empty() {
+            return PathBuf::from(trimmed);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Application Support")
+                .join("NeverWrite");
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata) = std::env::var_os("APPDATA") {
+            return PathBuf::from(appdata).join("NeverWrite");
+        }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
+            return PathBuf::from(xdg_data_home).join("NeverWrite");
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            return PathBuf::from(home)
+                .join(".local")
+                .join("share")
+                .join("NeverWrite");
+        }
+    }
+
+    std::env::temp_dir().join("NeverWrite")
+}
+
 fn resolve_command_candidate(raw: &str, source: AiRuntimeBinarySource) -> ResolvedAcpCommand {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -4160,6 +4407,45 @@ fn auth_method_has_local_config(setup: &RuntimeSetupState, method_id: &str) -> b
     }
 }
 
+fn local_auth_method_for_runtime(runtime_id: &str, setup: &RuntimeSetupState) -> Option<String> {
+    match runtime_id {
+        CODEX_RUNTIME_ID => setup
+            .env
+            .get("CODEX_API_KEY")
+            .is_some_and(|value| !value.is_empty())
+            .then(|| "codex-api-key".to_string())
+            .or_else(|| {
+                setup
+                    .env
+                    .get("OPENAI_API_KEY")
+                    .is_some_and(|value| !value.is_empty())
+                    .then(|| "openai-api-key".to_string())
+            }),
+        CLAUDE_RUNTIME_ID => setup
+            .has_gateway_config
+            .then(|| "gateway".to_string())
+            .or_else(|| {
+                setup
+                    .env
+                    .get("ANTHROPIC_API_KEY")
+                    .is_some_and(|value| !value.is_empty())
+                    .then(|| "anthropic-api-key".to_string())
+            })
+            .or_else(|| {
+                setup
+                    .env
+                    .get("ANTHROPIC_AUTH_TOKEN")
+                    .is_some_and(|value| !value.is_empty())
+                    .then(|| "console-login".to_string())
+            }),
+        GEMINI_RUNTIME_ID => ["GEMINI_API_KEY", "GOOGLE_API_KEY"]
+            .into_iter()
+            .any(|key| setup.env.get(key).is_some_and(|value| !value.is_empty()))
+            .then(|| "use_gemini".to_string()),
+        _ => None,
+    }
+}
+
 fn has_local_auth_config(setup: &RuntimeSetupState) -> bool {
     setup.has_gateway_config
         || [
@@ -4172,6 +4458,19 @@ fn has_local_auth_config(setup: &RuntimeSetupState) -> bool {
         ]
         .into_iter()
         .any(|key| setup.env.get(key).is_some_and(|value| !value.is_empty()))
+}
+
+fn refresh_runtime_setup_flags(runtime_id: &str, setup: &mut RuntimeSetupState) {
+    setup.has_gateway_url = setup
+        .env
+        .get("ANTHROPIC_BASE_URL")
+        .is_some_and(|value| !value.is_empty());
+    setup.has_gateway_config = runtime_id == CLAUDE_RUNTIME_ID
+        && (setup.has_gateway_url
+            || setup
+                .env
+                .get("ANTHROPIC_CUSTOM_HEADERS")
+                .is_some_and(|value| !value.is_empty()));
 }
 
 fn clear_runtime_auth_state(setup: &mut RuntimeSetupState) {
@@ -4482,22 +4781,21 @@ fn update_auth_state(
         }
     }
 
-    setup.has_gateway_url = setup
-        .env
-        .get("ANTHROPIC_BASE_URL")
-        .is_some_and(|value| !value.is_empty());
-    setup.has_gateway_config = runtime_id == CLAUDE_RUNTIME_ID
-        && (setup.has_gateway_url
-            || setup
-                .env
-                .get("ANTHROPIC_CUSTOM_HEADERS")
-                .is_some_and(|value| !value.is_empty()));
+    refresh_runtime_setup_flags(runtime_id, setup);
     if setup.has_gateway_config && gateway_config_touched {
         setup.auth_method = Some("gateway".to_string());
         touched_auth = true;
     }
     if touched_auth {
         setup.auth_ready = has_local_auth_config(setup);
+        if setup.auth_ready
+            && !setup
+                .auth_method
+                .as_deref()
+                .is_some_and(|method| auth_method_has_local_config(setup, method))
+        {
+            setup.auth_method = local_auth_method_for_runtime(runtime_id, setup);
+        }
         setup.suppress_persisted_auth = false;
         setup.message = None;
     }
@@ -5225,6 +5523,11 @@ mod tests {
     const CODEX_ACP_SUBAGENT_WAITING_END_EVENT: &str = "waiting_end";
     const PARENT_RUNTIME_SESSION_ID: &str = "parent-runtime-session-id";
     const CHILD_RUNTIME_SESSION_ID: &str = "child-runtime-session-id";
+
+    fn test_native_ai_with_setup_store(path: PathBuf) -> NativeAi {
+        let (event_tx, _event_rx) = mpsc::channel();
+        NativeAi::with_setup_store(event_tx, RuntimeSetupStore::new(path))
+    }
 
     fn subagent_session_created_meta() -> Meta {
         Meta::from_iter([
@@ -7708,6 +8011,74 @@ mod tests {
             CLAUDE_RUNTIME_ID,
             "Authentication succeeded"
         ));
+    }
+
+    #[test]
+    fn gemini_api_key_setup_persists_across_native_ai_instances() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_setup_store(store_path.clone());
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "gemini_api_key": {
+                        "action": "set",
+                        "value": "gemini-test-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        let rehydrated_native_ai = test_native_ai_with_setup_store(store_path);
+        let status = rehydrated_native_ai
+            .get_setup_status(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .unwrap();
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            status.get("auth_method").and_then(Value::as_str),
+            Some("use_gemini")
+        );
+        assert!(!status.to_string().contains("gemini-test-secret"));
+    }
+
+    #[test]
+    fn logout_removes_persisted_gemini_api_key_setup() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_setup_store(store_path.clone());
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "gemini_api_key": {
+                        "action": "set",
+                        "value": "gemini-test-secret",
+                    },
+                },
+            }))
+            .unwrap();
+        assert!(store_path.exists());
+
+        native_ai
+            .logout(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .unwrap();
+
+        assert!(!store_path.exists());
+        let setup = native_ai.inner.lock().unwrap();
+        let gemini_setup = setup
+            .setup
+            .get(GEMINI_RUNTIME_ID)
+            .expect("Gemini setup entry should remain in memory");
+        assert!(!gemini_setup.env.contains_key("GEMINI_API_KEY"));
+        assert_eq!(gemini_setup.auth_method, None);
+        assert!(!gemini_setup.auth_ready);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{
@@ -86,6 +86,9 @@ const AUTH_TERMINAL_DEFAULT_ROWS: u16 = 28;
 const AUTH_TERMINAL_MONITOR_INTERVAL: Duration = Duration::from_millis(120);
 const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
+const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
+const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
+const RUNTIME_SETUP_LOAD_ERROR_MESSAGE: &str = "Secure credential storage is unavailable. Reconnect this AI provider or configure an environment variable before starting a session.";
 
 #[derive(Debug, Clone)]
 struct TerminalExitMeta {
@@ -249,18 +252,110 @@ struct PersistedRuntimeSetupFile {
 struct PersistedRuntimeSetupState {
     custom_binary_path: Option<String>,
     auth_method: Option<String>,
+    #[serde(default)]
     env: HashMap<String, String>,
+    #[serde(default)]
+    secret_env_keys: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+trait RuntimeSecretStore: Send + Sync {
+    fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String>;
+    fn set_secret(&self, runtime_id: &str, env_key: &str, value: &str) -> Result<(), String>;
+    fn delete_secret(&self, runtime_id: &str, env_key: &str) -> Result<(), String>;
+}
+
+#[derive(Debug)]
+struct OsRuntimeSecretStore;
+
+impl OsRuntimeSecretStore {
+    fn entry(runtime_id: &str, env_key: &str) -> Result<keyring::Entry, String> {
+        keyring::Entry::new(
+            RUNTIME_SECRET_SERVICE,
+            &runtime_secret_account(runtime_id, env_key),
+        )
+        .map_err(|error| format!("Secure credential storage is unavailable: {error}"))
+    }
+}
+
+impl RuntimeSecretStore for OsRuntimeSecretStore {
+    fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String> {
+        match Self::entry(runtime_id, env_key)?.get_password() {
+            Ok(value) => Ok(normalize_optional_string(value)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(format!(
+                "Failed to read AI provider secret from secure storage: {error}"
+            )),
+        }
+    }
+
+    fn set_secret(&self, runtime_id: &str, env_key: &str, value: &str) -> Result<(), String> {
+        Self::entry(runtime_id, env_key)?
+            .set_password(value)
+            .map_err(|error| {
+                format!("Failed to save AI provider secret to secure storage: {error}")
+            })
+    }
+
+    fn delete_secret(&self, runtime_id: &str, env_key: &str) -> Result<(), String> {
+        match Self::entry(runtime_id, env_key)?.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(format!(
+                "Failed to remove AI provider secret from secure storage: {error}"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct InMemoryRuntimeSecretStore {
+    values: Mutex<HashMap<(String, String), String>>,
+}
+
+#[cfg(test)]
+impl RuntimeSecretStore for InMemoryRuntimeSecretStore {
+    fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String> {
+        Ok(self
+            .values
+            .lock()
+            .map_err(|error| format!("Test secret store lock error: {error}"))?
+            .get(&(runtime_id.to_string(), env_key.to_string()))
+            .cloned())
+    }
+
+    fn set_secret(&self, runtime_id: &str, env_key: &str, value: &str) -> Result<(), String> {
+        self.values
+            .lock()
+            .map_err(|error| format!("Test secret store lock error: {error}"))?
+            .insert(
+                (runtime_id.to_string(), env_key.to_string()),
+                value.to_string(),
+            );
+        Ok(())
+    }
+
+    fn delete_secret(&self, runtime_id: &str, env_key: &str) -> Result<(), String> {
+        self.values
+            .lock()
+            .map_err(|error| format!("Test secret store lock error: {error}"))?
+            .remove(&(runtime_id.to_string(), env_key.to_string()));
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
 struct RuntimeSetupStore {
     path: PathBuf,
+    secrets: Arc<dyn RuntimeSecretStore>,
 }
 
 impl RuntimeSetupStore {
-    // Plain-file persistence is isolated here so it can be replaced by keychain storage later.
     fn new(path: PathBuf) -> Self {
-        Self { path }
+        Self::with_secret_store(path, Arc::new(OsRuntimeSecretStore))
+    }
+
+    fn with_secret_store(path: PathBuf, secrets: Arc<dyn RuntimeSecretStore>) -> Self {
+        Self { path, secrets }
     }
 
     fn load(&self) -> Result<HashMap<String, RuntimeSetupState>, String> {
@@ -273,14 +368,59 @@ impl RuntimeSetupStore {
         };
         let persisted: PersistedRuntimeSetupFile = serde_json::from_str(&raw)
             .map_err(|error| format!("Failed to parse AI runtime setup store: {error}"))?;
-        if persisted.version != 1 {
+        if !matches!(persisted.version, 1 | RUNTIME_SETUP_STORE_VERSION) {
             return Ok(HashMap::new());
         }
 
         let mut setup = HashMap::new();
+        let mut should_rewrite_store = false;
         for (runtime_id, persisted_setup) in persisted.runtimes {
             if validate_runtime_id(&runtime_id).is_err() {
+                should_rewrite_store = true;
                 continue;
+            }
+            let mut env = HashMap::new();
+            for (key, value) in persisted_setup.env {
+                let Some(value) = normalize_optional_string(value) else {
+                    continue;
+                };
+                if is_secret_runtime_env_key(&key) {
+                    should_rewrite_store = true;
+                    if is_secret_env_key_for_runtime(&runtime_id, &key) {
+                        self.secrets.set_secret(&runtime_id, &key, &value)?;
+                        env.insert(key, value);
+                    }
+                    // Cross-runtime secrets are intentionally dropped instead of being
+                    // written to this runtime's credential namespace.
+                    continue;
+                } else {
+                    env.insert(key, value);
+                }
+            }
+            let mut secret_env_keys = persisted_setup
+                .secret_env_keys
+                .into_iter()
+                .filter(|key| {
+                    let allowed = is_secret_env_key_for_runtime(&runtime_id, key);
+                    if !allowed && is_secret_runtime_env_key(key) {
+                        should_rewrite_store = true;
+                    }
+                    allowed
+                })
+                .collect::<HashSet<_>>();
+            for key in env
+                .keys()
+                .filter(|key| is_secret_env_key_for_runtime(&runtime_id, key))
+            {
+                secret_env_keys.insert(key.clone());
+            }
+            for key in secret_env_keys {
+                if env.contains_key(&key) {
+                    continue;
+                }
+                if let Some(value) = self.secrets.get_secret(&runtime_id, &key)? {
+                    env.insert(key, value);
+                }
             }
             let mut runtime_setup = RuntimeSetupState {
                 custom_binary_path: persisted_setup
@@ -289,13 +429,7 @@ impl RuntimeSetupStore {
                 auth_method: persisted_setup
                     .auth_method
                     .and_then(normalize_optional_string),
-                env: persisted_setup
-                    .env
-                    .into_iter()
-                    .filter_map(|(key, value)| {
-                        normalize_optional_string(value).map(|value| (key, value))
-                    })
-                    .collect(),
+                env,
                 ..RuntimeSetupState::default()
             };
             refresh_runtime_setup_flags(&runtime_id, &mut runtime_setup);
@@ -307,8 +441,11 @@ impl RuntimeSetupStore {
                 runtime_setup.auth_method =
                     local_auth_method_for_runtime(&runtime_id, &runtime_setup);
             }
-            runtime_setup.auth_ready = has_local_auth_config(&runtime_setup);
+            runtime_setup.auth_ready = has_local_auth_config(&runtime_id, &runtime_setup);
             setup.insert(runtime_id, runtime_setup);
+        }
+        if should_rewrite_store {
+            self.save(&setup)?;
         }
         Ok(setup)
     }
@@ -316,11 +453,18 @@ impl RuntimeSetupStore {
     fn save(&self, setup: &HashMap<String, RuntimeSetupState>) -> Result<(), String> {
         let runtimes = setup
             .iter()
-            .filter_map(|(runtime_id, setup)| {
-                PersistedRuntimeSetupState::from_runtime_setup(setup)
-                    .map(|persisted_setup| (runtime_id.clone(), persisted_setup))
-            })
-            .collect::<HashMap<_, _>>();
+            .filter_map(
+                |(runtime_id, setup)| match PersistedRuntimeSetupState::from_runtime_setup(
+                    runtime_id,
+                    setup,
+                    self.secrets.as_ref(),
+                ) {
+                    Ok(Some(persisted_setup)) => Some(Ok((runtime_id.clone(), persisted_setup))),
+                    Ok(None) => None,
+                    Err(error) => Some(Err(error)),
+                },
+            )
+            .collect::<Result<HashMap<_, _>, _>>()?;
 
         if runtimes.is_empty() {
             match std::fs::remove_file(&self.path) {
@@ -339,7 +483,7 @@ impl RuntimeSetupStore {
         }
 
         let persisted = PersistedRuntimeSetupFile {
-            version: 1,
+            version: RUNTIME_SETUP_STORE_VERSION,
             runtimes,
         };
         let encoded = serde_json::to_vec_pretty(&persisted)
@@ -365,14 +509,43 @@ impl Default for RuntimeSetupStore {
     }
 }
 
+#[cfg(test)]
+impl RuntimeSetupStore {
+    fn in_memory_for_tests() -> Self {
+        let path = std::env::temp_dir().join(format!(
+            "neverwrite-ai-runtime-setup-test-{}.json",
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or_default()
+        ));
+        Self::with_secret_store(path, Arc::new(InMemoryRuntimeSecretStore::default()))
+    }
+}
+
 impl PersistedRuntimeSetupState {
-    fn from_runtime_setup(setup: &RuntimeSetupState) -> Option<Self> {
+    fn from_runtime_setup(
+        runtime_id: &str,
+        setup: &RuntimeSetupState,
+        secrets: &dyn RuntimeSecretStore,
+    ) -> Result<Option<Self>, String> {
+        reconcile_runtime_secrets(runtime_id, setup, secrets)?;
         let env = setup
             .env
             .iter()
+            .filter(|(key, _)| !is_secret_runtime_env_key(key))
             .filter(|(_, value)| !value.trim().is_empty())
             .map(|(key, value)| (key.clone(), value.clone()))
             .collect::<HashMap<_, _>>();
+        let mut secret_env_keys = setup
+            .env
+            .iter()
+            .filter(|(key, value)| {
+                is_secret_env_key_for_runtime(runtime_id, key) && !value.trim().is_empty()
+            })
+            .map(|(key, _)| key.clone())
+            .collect::<Vec<_>>();
+        secret_env_keys.sort();
         let custom_binary_path = setup
             .custom_binary_path
             .clone()
@@ -383,16 +556,73 @@ impl PersistedRuntimeSetupState {
             .and_then(normalize_optional_string)
             .filter(|method| auth_method_has_local_config(setup, method));
 
-        if custom_binary_path.is_none() && auth_method.is_none() && env.is_empty() {
-            return None;
+        if custom_binary_path.is_none()
+            && auth_method.is_none()
+            && env.is_empty()
+            && secret_env_keys.is_empty()
+        {
+            return Ok(None);
         }
 
-        Some(Self {
+        Ok(Some(Self {
             custom_binary_path,
             auth_method,
             env,
-        })
+            secret_env_keys,
+        }))
     }
+}
+
+fn runtime_secret_account(runtime_id: &str, env_key: &str) -> String {
+    format!("{runtime_id}:{env_key}")
+}
+
+fn is_secret_runtime_env_key(key: &str) -> bool {
+    matches!(
+        key,
+        "CODEX_API_KEY"
+            | "OPENAI_API_KEY"
+            | "ANTHROPIC_AUTH_TOKEN"
+            | "ANTHROPIC_API_KEY"
+            | "ANTHROPIC_CUSTOM_HEADERS"
+            | "GEMINI_API_KEY"
+            | "GOOGLE_API_KEY"
+    )
+}
+
+fn secret_env_keys_for_runtime(runtime_id: &str) -> &'static [&'static str] {
+    match runtime_id {
+        CODEX_RUNTIME_ID => &["CODEX_API_KEY", "OPENAI_API_KEY"],
+        CLAUDE_RUNTIME_ID => &[
+            "ANTHROPIC_AUTH_TOKEN",
+            "ANTHROPIC_API_KEY",
+            "ANTHROPIC_CUSTOM_HEADERS",
+        ],
+        GEMINI_RUNTIME_ID => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        _ => &[],
+    }
+}
+
+fn is_secret_env_key_for_runtime(runtime_id: &str, env_key: &str) -> bool {
+    secret_env_keys_for_runtime(runtime_id).contains(&env_key)
+}
+
+fn reconcile_runtime_secrets(
+    runtime_id: &str,
+    setup: &RuntimeSetupState,
+    secrets: &dyn RuntimeSecretStore,
+) -> Result<(), String> {
+    for env_key in secret_env_keys_for_runtime(runtime_id) {
+        match setup
+            .env
+            .get(*env_key)
+            .and_then(|value| normalize_optional_string(value.clone()))
+        {
+            Some(value) => secrets.set_secret(runtime_id, env_key, &value)?,
+            None => secrets.delete_secret(runtime_id, env_key)?,
+        }
+    }
+    Ok(())
 }
 
 fn write_secret_file(path: &Path, bytes: &[u8]) -> Result<(), String> {
@@ -441,6 +671,7 @@ struct NativeAiInner {
     sessions: HashMap<String, ManagedAiSession>,
     session_order: Vec<String>,
     setup: HashMap<String, RuntimeSetupState>,
+    setup_load_error: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -576,14 +807,23 @@ pub(crate) struct NativeAi {
 
 impl NativeAi {
     pub(crate) fn new(event_tx: Sender<RpcOutput>) -> Self {
+        #[cfg(test)]
+        {
+            return Self::with_setup_store(event_tx, RuntimeSetupStore::in_memory_for_tests());
+        }
+        #[cfg(not(test))]
         Self::with_setup_store(event_tx, RuntimeSetupStore::default())
     }
 
     fn with_setup_store(event_tx: Sender<RpcOutput>, setup_store: RuntimeSetupStore) -> Self {
-        let setup = setup_store.load().unwrap_or_default();
+        let (setup, setup_load_error) = match setup_store.load() {
+            Ok(setup) => (setup, None),
+            Err(error) => (HashMap::new(), Some(runtime_setup_load_error(error))),
+        };
         Self {
             inner: Arc::new(Mutex::new(NativeAiInner {
                 setup,
+                setup_load_error,
                 ..NativeAiInner::default()
             })),
             event_tx,
@@ -605,6 +845,9 @@ impl NativeAi {
             .inner
             .lock()
             .map_err(|error| format!("Internal AI state error: {error}"))?;
+        if let Some(message) = state.setup_load_error.clone() {
+            return Ok(json!(setup_load_error_status_for(&runtime_id, message)?));
+        }
         Ok(json!(setup_status_for(
             &runtime_id,
             state.setup.get(&runtime_id).cloned().unwrap_or_default(),
@@ -636,13 +879,21 @@ impl NativeAi {
             .map(|descriptor| {
                 let runtime_id = descriptor.runtime.id.clone();
                 let runtime_name = descriptor.runtime.name.clone();
-                let setup_status = self
+                let (setup_status, setup_load_error) = self
                     .inner
                     .lock()
                     .ok()
-                    .and_then(|state| state.setup.get(&runtime_id).cloned())
+                    .map(|state| {
+                        (
+                            state.setup.get(&runtime_id).cloned().unwrap_or_default(),
+                            state.setup_load_error.clone(),
+                        )
+                    })
                     .unwrap_or_default();
-                let status = setup_status_for(&runtime_id, setup_status);
+                let status = match setup_load_error {
+                    Some(message) => setup_load_error_status_for(&runtime_id, message),
+                    None => setup_status_for(&runtime_id, setup_status),
+                };
                 let (setup_status, setup_error) = match status {
                     Ok(status) => (Some(status), None),
                     Err(error) => (None, Some(error)),
@@ -679,11 +930,17 @@ impl NativeAi {
                 .ok_or_else(|| "Missing argument: input".to_string())?,
         )
         .map_err(|error| error.to_string())?;
-        let mut state = self
-            .inner
-            .lock()
-            .map_err(|error| format!("Internal AI state error: {error}"))?;
-        let setup = state.setup.entry(runtime_id.clone()).or_default();
+        let (mut pending_setup, setup_load_error) = {
+            let state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            (state.setup.clone(), state.setup_load_error.clone())
+        };
+        if setup_load_error.is_some() {
+            pending_setup = self.setup_store.load().map_err(runtime_setup_load_error)?;
+        }
+        let setup = pending_setup.entry(runtime_id.clone()).or_default();
 
         setup.custom_binary_path = input
             .custom_binary_path
@@ -691,9 +948,14 @@ impl NativeAi {
             .and_then(normalize_optional_string);
         update_auth_state(setup, &runtime_id, input)?;
         let status = setup_status_for(&runtime_id, setup.clone())?;
-        let persisted_setup = state.setup.clone();
-        drop(state);
-        self.setup_store.save(&persisted_setup)?;
+        self.setup_store.save(&pending_setup)?;
+
+        let mut state = self
+            .inner
+            .lock()
+            .map_err(|error| format!("Internal AI state error: {error}"))?;
+        state.setup = pending_setup;
+        state.setup_load_error = None;
         Ok(json!(status))
     }
 
@@ -761,30 +1023,38 @@ impl NativeAi {
         validate_runtime_id(&runtime_id)?;
         let cwd = resolve_auth_terminal_cwd(args.get("vaultPath").and_then(Value::as_str))?;
 
-        let setup = self
-            .inner
-            .lock()
-            .map_err(|error| format!("Internal AI state error: {error}"))?
-            .setup
-            .get(&runtime_id)
-            .cloned()
-            .unwrap_or_default();
+        let (setup_snapshot, setup_load_error) = {
+            let state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            (state.setup.clone(), state.setup_load_error.clone())
+        };
+        let mut pending_setup = if setup_load_error.is_some() {
+            self.setup_store.load().map_err(runtime_setup_load_error)?
+        } else {
+            setup_snapshot
+        };
+        let setup_for_logout = pending_setup.get(&runtime_id).cloned().unwrap_or_default();
 
-        if runtime_id == CODEX_RUNTIME_ID && setup.auth_method.as_deref() == Some("chatgpt") {
-            let spec = acp_process_spec(&runtime_id, &setup, cwd)?;
+        if runtime_id == CODEX_RUNTIME_ID
+            && setup_for_logout.auth_method.as_deref() == Some("chatgpt")
+        {
+            let spec = acp_process_spec(&runtime_id, &setup_for_logout, cwd)?;
             run_acp_logout(spec)?;
         }
+
+        let setup = pending_setup.entry(runtime_id.clone()).or_default();
+        clear_runtime_auth_state(setup);
+        let status = setup_status_for(&runtime_id, setup.clone())?;
+        self.setup_store.save(&pending_setup)?;
 
         let mut state = self
             .inner
             .lock()
             .map_err(|error| format!("Internal AI state error: {error}"))?;
-        let setup = state.setup.entry(runtime_id.clone()).or_default();
-        clear_runtime_auth_state(setup);
-        let status = setup_status_for(&runtime_id, setup.clone())?;
-        let persisted_setup = state.setup.clone();
-        drop(state);
-        self.setup_store.save(&persisted_setup)?;
+        state.setup = pending_setup;
+        state.setup_load_error = None;
         Ok(json!(status))
     }
 
@@ -3873,6 +4143,29 @@ fn setup_status_for(
     })
 }
 
+fn runtime_setup_load_error(error: String) -> String {
+    format!("{RUNTIME_SETUP_LOAD_ERROR_MESSAGE} Details: {error}")
+}
+
+fn setup_load_error_status_for(
+    runtime_id: &str,
+    message: String,
+) -> Result<AiRuntimeSetupStatus, String> {
+    let visible_message = message.clone();
+    let mut setup = RuntimeSetupState {
+        suppress_persisted_auth: true,
+        message: Some(message),
+        ..RuntimeSetupState::default()
+    };
+    refresh_runtime_setup_flags(runtime_id, &mut setup);
+    let mut status = setup_status_for(runtime_id, setup)?;
+    status.auth_ready = false;
+    status.auth_method = None;
+    status.onboarding_required = true;
+    status.message = Some(visible_message);
+    Ok(status)
+}
+
 fn acp_process_spec(
     runtime_id: &str,
     setup: &RuntimeSetupState,
@@ -4446,18 +4739,11 @@ fn local_auth_method_for_runtime(runtime_id: &str, setup: &RuntimeSetupState) ->
     }
 }
 
-fn has_local_auth_config(setup: &RuntimeSetupState) -> bool {
-    setup.has_gateway_config
-        || [
-            "CODEX_API_KEY",
-            "OPENAI_API_KEY",
-            "ANTHROPIC_AUTH_TOKEN",
-            "ANTHROPIC_API_KEY",
-            "GEMINI_API_KEY",
-            "GOOGLE_API_KEY",
-        ]
-        .into_iter()
-        .any(|key| setup.env.get(key).is_some_and(|value| !value.is_empty()))
+fn has_local_auth_config(runtime_id: &str, setup: &RuntimeSetupState) -> bool {
+    (runtime_id == CLAUDE_RUNTIME_ID && setup.has_gateway_config)
+        || secret_env_keys_for_runtime(runtime_id)
+            .iter()
+            .any(|key| setup.env.get(*key).is_some_and(|value| !value.is_empty()))
 }
 
 fn refresh_runtime_setup_flags(runtime_id: &str, setup: &mut RuntimeSetupState) {
@@ -4787,7 +5073,7 @@ fn update_auth_state(
         touched_auth = true;
     }
     if touched_auth {
-        setup.auth_ready = has_local_auth_config(setup);
+        setup.auth_ready = has_local_auth_config(runtime_id, setup);
         if setup.auth_ready
             && !setup
                 .auth_method
@@ -5524,9 +5810,80 @@ mod tests {
     const PARENT_RUNTIME_SESSION_ID: &str = "parent-runtime-session-id";
     const CHILD_RUNTIME_SESSION_ID: &str = "child-runtime-session-id";
 
-    fn test_native_ai_with_setup_store(path: PathBuf) -> NativeAi {
+    fn test_native_ai_with_secret_store(
+        path: PathBuf,
+        secrets: Arc<dyn RuntimeSecretStore>,
+    ) -> NativeAi {
         let (event_tx, _event_rx) = mpsc::channel();
-        NativeAi::with_setup_store(event_tx, RuntimeSetupStore::new(path))
+        NativeAi::with_setup_store(
+            event_tx,
+            RuntimeSetupStore::with_secret_store(path, secrets),
+        )
+    }
+
+    #[derive(Default)]
+    struct FailableRuntimeSecretStore {
+        values: Mutex<HashMap<(String, String), String>>,
+        fail_get: AtomicBool,
+        fail_set: AtomicBool,
+        fail_delete: AtomicBool,
+    }
+
+    impl FailableRuntimeSecretStore {
+        fn fail_set(&self, fail: bool) {
+            self.fail_set.store(fail, Ordering::Relaxed);
+        }
+
+        fn fail_delete(&self, fail: bool) {
+            self.fail_delete.store(fail, Ordering::Relaxed);
+        }
+
+        fn stored_secret(&self, runtime_id: &str, env_key: &str) -> Option<String> {
+            self.values
+                .lock()
+                .unwrap()
+                .get(&(runtime_id.to_string(), env_key.to_string()))
+                .cloned()
+        }
+    }
+
+    impl RuntimeSecretStore for FailableRuntimeSecretStore {
+        fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String> {
+            if self.fail_get.load(Ordering::Relaxed) {
+                return Err("test get_secret failure".to_string());
+            }
+            Ok(self
+                .values
+                .lock()
+                .map_err(|error| format!("Test secret store lock error: {error}"))?
+                .get(&(runtime_id.to_string(), env_key.to_string()))
+                .cloned())
+        }
+
+        fn set_secret(&self, runtime_id: &str, env_key: &str, value: &str) -> Result<(), String> {
+            if self.fail_set.load(Ordering::Relaxed) {
+                return Err("test set_secret failure".to_string());
+            }
+            self.values
+                .lock()
+                .map_err(|error| format!("Test secret store lock error: {error}"))?
+                .insert(
+                    (runtime_id.to_string(), env_key.to_string()),
+                    value.to_string(),
+                );
+            Ok(())
+        }
+
+        fn delete_secret(&self, runtime_id: &str, env_key: &str) -> Result<(), String> {
+            if self.fail_delete.load(Ordering::Relaxed) {
+                return Err("test delete_secret failure".to_string());
+            }
+            self.values
+                .lock()
+                .map_err(|error| format!("Test secret store lock error: {error}"))?
+                .remove(&(runtime_id.to_string(), env_key.to_string()));
+            Ok(())
+        }
     }
 
     fn subagent_session_created_meta() -> Meta {
@@ -8017,7 +8374,8 @@ mod tests {
     fn gemini_api_key_setup_persists_across_native_ai_instances() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
-        let native_ai = test_native_ai_with_setup_store(store_path.clone());
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
 
         native_ai
             .update_setup(&json!({
@@ -8031,7 +8389,11 @@ mod tests {
             }))
             .unwrap();
 
-        let rehydrated_native_ai = test_native_ai_with_setup_store(store_path);
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(!encoded.contains("gemini-test-secret"));
+        assert!(encoded.contains("GEMINI_API_KEY"));
+
+        let rehydrated_native_ai = test_native_ai_with_secret_store(store_path, secrets);
         let status = rehydrated_native_ai
             .get_setup_status(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
             .unwrap();
@@ -8048,10 +8410,296 @@ mod tests {
     }
 
     #[test]
+    fn update_setup_secret_store_failure_does_not_commit_memory() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        secrets.fail_set(true);
+        let native_ai = test_native_ai_with_secret_store(store_path, secrets);
+
+        let error = native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "gemini_api_key": {
+                        "action": "set",
+                        "value": "gemini-new-secret",
+                    },
+                },
+            }))
+            .expect_err("secret store failure should reject setup update");
+
+        assert!(error.contains("test set_secret failure"));
+        assert!(!error.contains("gemini-new-secret"));
+        let state = native_ai.inner.lock().unwrap();
+        let setup = state
+            .setup
+            .get(GEMINI_RUNTIME_ID)
+            .cloned()
+            .unwrap_or_default();
+        assert!(!setup.auth_ready);
+        assert!(!setup.env.contains_key("GEMINI_API_KEY"));
+    }
+
+    #[test]
+    fn legacy_plaintext_migration_failure_fails_closed_without_rewriting_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        fs::write(
+            &store_path,
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "runtimes": {
+                    GEMINI_RUNTIME_ID: {
+                        "custom_binary_path": null,
+                        "auth_method": "use_gemini",
+                        "env": {
+                            "GEMINI_API_KEY": "legacy-gemini-secret"
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let original = fs::read_to_string(&store_path).unwrap();
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        secrets.fail_set(true);
+
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets);
+        let status = native_ai
+            .get_setup_status(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .unwrap();
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            status.get("onboarding_required").and_then(Value::as_bool),
+            Some(true)
+        );
+        let message = status
+            .get("message")
+            .and_then(Value::as_str)
+            .expect("setup load failure should be visible");
+        assert!(message.contains("Secure credential storage is unavailable"));
+        assert!(!message.contains("legacy-gemini-secret"));
+        assert_eq!(fs::read_to_string(&store_path).unwrap(), original);
+
+        let update_error = native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": temp.path().join("fake-gemini")
+                },
+            }))
+            .expect_err("updates should not rewrite setup while migration is failing");
+        assert!(update_error.contains("Secure credential storage is unavailable"));
+        assert!(!update_error.contains("legacy-gemini-secret"));
+        assert_eq!(fs::read_to_string(&store_path).unwrap(), original);
+
+        let logout_error = native_ai
+            .logout(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .expect_err("logout should not rewrite setup while migration is failing");
+        assert!(logout_error.contains("Secure credential storage is unavailable"));
+        assert!(!logout_error.contains("legacy-gemini-secret"));
+        assert_eq!(fs::read_to_string(&store_path).unwrap(), original);
+    }
+
+    #[test]
+    fn persisted_runtime_setup_redacts_gemini_codex_and_claude_secrets() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets);
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "gemini_api_key": { "action": "set", "value": "gemini-secret" },
+                },
+            }))
+            .unwrap();
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": CODEX_RUNTIME_ID,
+                "input": {
+                    "openai_api_key": { "action": "set", "value": "openai-secret" },
+                },
+            }))
+            .unwrap();
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": CLAUDE_RUNTIME_ID,
+                "input": {
+                    "anthropic_api_key": { "action": "set", "value": "claude-secret" },
+                },
+            }))
+            .unwrap();
+
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(!encoded.contains("gemini-secret"));
+        assert!(!encoded.contains("openai-secret"));
+        assert!(!encoded.contains("claude-secret"));
+        assert!(encoded.contains("\"secret_env_keys\""));
+        assert!(encoded.contains("GEMINI_API_KEY"));
+        assert!(encoded.contains("OPENAI_API_KEY"));
+        assert!(encoded.contains("ANTHROPIC_API_KEY"));
+    }
+
+    #[test]
+    fn legacy_plaintext_runtime_setup_is_migrated_to_secret_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        fs::write(
+            &store_path,
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "runtimes": {
+                    GEMINI_RUNTIME_ID: {
+                        "custom_binary_path": null,
+                        "auth_method": "use_gemini",
+                        "env": {
+                            "GEMINI_API_KEY": "legacy-gemini-secret"
+                        }
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let status = native_ai
+            .get_setup_status(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .unwrap();
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            secrets
+                .get_secret(GEMINI_RUNTIME_ID, "GEMINI_API_KEY")
+                .expect("migrated secret should be readable"),
+            Some("legacy-gemini-secret".to_string())
+        );
+        let migrated = fs::read_to_string(&store_path).unwrap();
+        assert!(migrated.contains("\"version\": 2"));
+        assert!(!migrated.contains("legacy-gemini-secret"));
+    }
+
+    #[test]
+    fn cross_runtime_legacy_secret_is_not_valid_or_persisted_for_codex() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        fs::write(
+            &store_path,
+            serde_json::to_string_pretty(&json!({
+                "version": 1,
+                "runtimes": {
+                    CODEX_RUNTIME_ID: {
+                        "custom_binary_path": null,
+                        "auth_method": "codex-api-key",
+                        "env": {
+                            "GEMINI_API_KEY": "wrong-runtime-secret"
+                        },
+                        "secret_env_keys": ["GEMINI_API_KEY"]
+                    }
+                }
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let status = native_ai
+            .get_setup_status(&json!({ "runtime_id": CODEX_RUNTIME_ID }))
+            .unwrap();
+
+        assert_ne!(
+            status.get("auth_method").and_then(Value::as_str),
+            Some("codex-api-key")
+        );
+        let setup = native_ai.inner.lock().unwrap();
+        let codex_setup = setup
+            .setup
+            .get(CODEX_RUNTIME_ID)
+            .cloned()
+            .unwrap_or_default();
+        assert!(!codex_setup.auth_ready);
+        assert!(!codex_setup.env.contains_key("GEMINI_API_KEY"));
+        assert_eq!(
+            secrets.stored_secret(CODEX_RUNTIME_ID, "GEMINI_API_KEY"),
+            None
+        );
+        let persisted = fs::read_to_string(&store_path).unwrap_or_default();
+        assert!(!persisted.contains("GEMINI_API_KEY"));
+        assert!(!persisted.contains("wrong-runtime-secret"));
+    }
+
+    #[test]
     fn logout_removes_persisted_gemini_api_key_setup() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
-        let native_ai = test_native_ai_with_setup_store(store_path.clone());
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GEMINI_RUNTIME_ID,
+                "input": {
+                    "gemini_api_key": {
+                        "action": "set",
+                        "value": "gemini-test-secret",
+                    },
+                    "google_api_key": {
+                        "action": "set",
+                        "value": "google-test-secret",
+                    },
+                },
+            }))
+            .unwrap();
+        assert!(store_path.exists());
+
+        native_ai
+            .logout(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
+            .unwrap();
+
+        assert!(!store_path.exists());
+        assert_eq!(
+            secrets
+                .get_secret(GEMINI_RUNTIME_ID, "GEMINI_API_KEY")
+                .expect("secret store should remain readable"),
+            None
+        );
+        assert_eq!(
+            secrets
+                .get_secret(GEMINI_RUNTIME_ID, "GOOGLE_API_KEY")
+                .expect("secret store should remain readable"),
+            None
+        );
+        let setup = native_ai.inner.lock().unwrap();
+        let gemini_setup = setup
+            .setup
+            .get(GEMINI_RUNTIME_ID)
+            .expect("Gemini setup entry should remain in memory");
+        assert!(!gemini_setup.env.contains_key("GEMINI_API_KEY"));
+        assert!(!gemini_setup.env.contains_key("GOOGLE_API_KEY"));
+        assert_eq!(gemini_setup.auth_method, None);
+        assert!(!gemini_setup.auth_ready);
+    }
+
+    #[test]
+    fn logout_secret_store_failure_does_not_commit_memory() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path, secrets.clone());
 
         native_ai
             .update_setup(&json!({
@@ -8064,21 +8712,29 @@ mod tests {
                 },
             }))
             .unwrap();
-        assert!(store_path.exists());
 
-        native_ai
+        secrets.fail_delete(true);
+        let error = native_ai
             .logout(&json!({ "runtime_id": GEMINI_RUNTIME_ID }))
-            .unwrap();
+            .expect_err("secret store delete failure should reject logout");
 
-        assert!(!store_path.exists());
+        assert!(error.contains("test delete_secret failure"));
+        assert!(!error.contains("gemini-test-secret"));
+        assert_eq!(
+            secrets.stored_secret(GEMINI_RUNTIME_ID, "GEMINI_API_KEY"),
+            Some("gemini-test-secret".to_string())
+        );
         let setup = native_ai.inner.lock().unwrap();
         let gemini_setup = setup
             .setup
             .get(GEMINI_RUNTIME_ID)
-            .expect("Gemini setup entry should remain in memory");
-        assert!(!gemini_setup.env.contains_key("GEMINI_API_KEY"));
-        assert_eq!(gemini_setup.auth_method, None);
-        assert!(!gemini_setup.auth_ready);
+            .expect("Gemini setup should remain committed after failed logout");
+        assert!(gemini_setup.auth_ready);
+        assert_eq!(gemini_setup.auth_method.as_deref(), Some("use_gemini"));
+        assert_eq!(
+            gemini_setup.env.get("GEMINI_API_KEY").map(String::as_str),
+            Some("gemini-test-secret")
+        );
     }
 
     #[test]

--- a/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
+++ b/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
@@ -22,11 +22,12 @@ class SidecarClient {
   #eventWaiters = [];
   #stderr = "";
 
-  constructor(executablePath) {
+  constructor(executablePath, appDataDir) {
     this.#child = spawn(executablePath, [], {
       cwd: desktopRoot,
       env: {
         ...process.env,
+        NEVERWRITE_APP_DATA_DIR: appDataDir,
         // Headless Linux CI does not provide a desktop keyring service. The
         // smoke test opts into process-memory secrets while production remains
         // backed by OS secure storage.
@@ -324,12 +325,15 @@ async function main() {
   });
 
   const vaultPath = await fs.mkdtemp(path.join(os.tmpdir(), "neverwrite-ai-"));
+  const appDataDir = await fs.mkdtemp(
+    path.join(os.tmpdir(), "neverwrite-ai-app-data-"),
+  );
   const runtimeDir = await fs.mkdtemp(
     path.join(os.tmpdir(), "neverwrite-fake-acp-"),
   );
   const fakeAcpPath = await writeFakeAcpRuntime(runtimeDir);
   await writeFixtureVault(vaultPath);
-  const client = new SidecarClient(sidecarPath);
+  const client = new SidecarClient(sidecarPath, appDataDir);
 
   try {
     await client.invoke("start_open_vault", { path: vaultPath });

--- a/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
+++ b/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
@@ -25,6 +25,14 @@ class SidecarClient {
   constructor(executablePath) {
     this.#child = spawn(executablePath, [], {
       cwd: desktopRoot,
+      env: {
+        ...process.env,
+        // Headless Linux CI does not provide a desktop keyring service. The
+        // smoke test opts into process-memory secrets while production remains
+        // backed by OS secure storage.
+        NEVERWRITE_AI_SECRET_STORE:
+          process.env.NEVERWRITE_AI_SECRET_STORE?.trim() || "memory",
+      },
       stdio: ["pipe", "pipe", "pipe"],
     });
 

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -112,6 +112,17 @@ const SUPPORTED_COMMANDS = new Set([
     "web_clipper_save_note",
 ]);
 
+const NATIVE_BACKEND_SECRET_JSON_KEY_PATTERN =
+    /("(?:codex_api_key|openai_api_key|gemini_api_key|google_api_key|gateway_headers|anthropic_custom_headers|anthropic_auth_token|anthropic_api_key|api[_-]?key|authorization|token|secret|password|value)"\s*:\s*")([^"]*)(")/giu;
+const NATIVE_BACKEND_SECRET_ENV_PATTERN =
+    /\b((?:CODEX_API_KEY|OPENAI_API_KEY|ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_CUSTOM_HEADERS|GEMINI_API_KEY|GOOGLE_API_KEY)\s*=\s*)([^\s"',}]+)/gu;
+
+function redactNativeBackendSecrets(value: string) {
+    return value
+        .replace(NATIVE_BACKEND_SECRET_JSON_KEY_PATTERN, "$1[redacted]$3")
+        .replace(NATIVE_BACKEND_SECRET_ENV_PATTERN, "$1[redacted]");
+}
+
 interface SidecarMessage {
     type?: unknown;
     id?: unknown;
@@ -320,7 +331,7 @@ class NativeBackendSidecar implements NativeBackendBridge {
             .on("line", (line) => this.handleLine(line));
 
         this.child.stderr.on("data", (chunk) => {
-            const message = String(chunk).trimEnd();
+            const message = redactNativeBackendSecrets(String(chunk).trimEnd());
             writeAppLog("native-backend", "warn", message);
             console.warn(`[native-backend] ${message}`);
         });
@@ -421,7 +432,9 @@ class NativeBackendSidecar implements NativeBackendBridge {
         try {
             message = JSON.parse(line) as SidecarMessage;
         } catch {
-            console.warn(`[native-backend] Ignoring malformed message: ${line}`);
+            console.warn(
+                `[native-backend] Ignoring malformed message: ${redactNativeBackendSecrets(line)}`,
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary

Fixes AI provider API key persistence so keys entered in NeverWrite survive backend/app restarts without being stored in plaintext JSON.

## Root cause

Gemini API keys entered through the UI were previously stored only in the native backend in-memory `RuntimeSetupState.env`. They worked during the current process lifetime, but after restart `NativeAi::new` rebuilt setup from an empty default state. Account-based auth survived because the underlying CLIs persist their own credentials on disk.

## Changes

- Added secure AI runtime setup persistence in the native backend.
- Stores sensitive provider values in OS credential storage via `keyring`.
- Persists only non-secret metadata in `runtime-setup.json`, including `secret_env_keys`.
- Rehydrates runtime setup from metadata + keyring during backend startup.
- Migrates legacy plaintext runtime setup JSON into the secret store and rewrites metadata cleanly.
- Fails closed if secure storage or migration fails, without using plaintext legacy secrets or destructively rewriting them.
- Makes `ai_update_setup` and `ai_logout` transactional so memory is committed only after secure persistence succeeds.
- Validates secret keys by runtime to avoid cross-runtime auth or stale metadata.
- Redacts sensitive native backend stderr/malformed-output logging.
- Adds an explicit `NEVERWRITE_AI_SECRET_STORE=memory` mode for headless CI/smoke tests only; production still defaults to OS secure storage.
- Isolates the Electron AI runtime smoke test with a temporary `NEVERWRITE_APP_DATA_DIR` so test fake runtimes cannot contaminate a real developer/user profile.
- Adds regression and security tests for restart rehydration, migration, failure paths, logout cleanup, explicit smoke secret-store selection, and no-plaintext persistence.

## Validation

Post-rebase on `origin/main`:

- `/Users/jfg/.cargo/bin/cargo test -p neverwrite-native-backend`
- `npm --prefix apps/desktop run electron:ai-runtime:smoke`
- `npm --prefix apps/desktop test -- src/features/settings/AIProvidersSettings.test.tsx`

Final local results:

- Rust backend: `83 passed`
- Electron AI runtime smoke: passed
- Settings UI: `8 passed`

## Audit

A final read-only audit found no blocking or relevant findings. Security tradeoff accepted: if OS credential storage is unavailable or metadata is corrupt, setup fails closed and the user must reconnect or use environment variables instead of NeverWrite falling back to plaintext secret persistence. This favors protecting provider API keys over making persistence work in unsupported/headless environments.

Headless CI opts into in-memory secret storage explicitly for the smoke test because Linux runners do not provide `org.freedesktop.secrets`. The smoke test also runs against temporary app data so its fake runtime setup cannot be persisted into the real NeverWrite profile.

Refs #30

Supersedes #57, which GitHub closed when the branch was renamed.
