### PR TITLE
Prepare 0.2.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,32 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.2.5] - 2026-05-11
+
+### Added
+
+- Added Linux AppImage releases for x64 and ARM64, including Linux update feed support and AppImage updater integration. Thanks to @seifzellaban.
+- Added Kilo API key setup in AI provider settings, with `KILO_API_KEY` detection, secure local persistence, logout cleanup, and setup-state validation alongside the existing Kilo CLI login flow.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to upstream `0.33.1`, keeping the vendored Claude agent adapter aligned with current upstream behavior.
+- Updated the embedded Codex agent runtime to `0.14.0`, keeping subagents, permissions, history replay, and change-review metadata compatible with NeverWrite.
+- Polished Linux-specific desktop packaging behavior, window chrome, updater handling, and cross-platform shortcut behavior as part of the AppImage release path.
+
+### Fixed
+
+- Fixed chat Markdown rendering so slash-prefixed text is no longer converted into a clickable vault pill unless it resolves to a valid vault reference.
+- Fixed dragging agent chats from the collapsed sidebar so the sidebar overlay stays active while the drag starts.
+- Fixed provider quota, rate-limit, and usage-limit failures so the chat shows a clear provider-limit message instead of treating the error like a setup or authentication failure.
+- Fixed oversized saved AI session transcripts by compacting new saves and repairing previously inflated saved chats on load.
+- Fixed vault scans, text-file reads, and watcher/upsert hashing for Markdown and text files that contain invalid UTF-8 bytes by decoding them lossily instead of failing the vault operation. Thanks to @kwojtaszek.
+
+### Security
+
+- Secured persisted AI provider secrets for Codex/OpenAI, Claude/Anthropic, Gemini/Google, and newly added Kilo API keys through OS credential storage instead of storing secret values in runtime setup JSON.
+- Added migration for legacy plaintext AI provider setup data, transactional setup/logout persistence, fail-closed behavior when secure storage is unavailable, and broader redaction for native backend secret logs.
+
 ## [0.2.4] - 2026-05-08
 
 ### Added
@@ -47,7 +73,6 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ### Changed
 
-- Updated the embedded Claude ACP runtime to upstream `0.33.1`, keeping the vendored Claude agent adapter aligned with the latest available upstream release.
 - Changed file-tree path copy actions to consistently use "Copy Full Path" and copy absolute paths for notes, folders, PDFs, and sidebar files.
 
 ### Fixed

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.2.4"
+version = "0.2.5"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.2.4",
+    "version": "0.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.2.4",
+            "version": "0.2.5",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "module",
     "main": "out/electron/main/index.js",
     "engines": {

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.2.4",
+    "version": "0.2.5",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Prepare the 0.2.5 release metadata.
- Align desktop, native backend, desktop lockfile, and web clipper versions at 0.2.5.
- Add the 0.2.5 changelog entry from the post-0.2.4 release commits.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.2.5`
- `node --test scripts/release-metadata.test.mjs apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs scripts/appcast.test.mjs scripts/platform-validation.test.mjs scripts/release-assets.test.mjs`
