### PR TITLE
Add ARM64 OpenSSL release dependency

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -169,7 +169,7 @@ jobs:
                   sudo apt-get update
                   sudo apt-get install -y pkg-config libcap-dev
                   if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
-                    sudo apt-get install -y gcc-aarch64-linux-gnu libcap-dev:arm64
+                    sudo apt-get install -y gcc-aarch64-linux-gnu libcap-dev:arm64 libssl-dev:arm64
                     echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
                     echo "PKG_CONFIG_ALLOW_CROSS=1" >> "$GITHUB_ENV"
                     echo "PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig:/usr/share/pkgconfig" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- Install libssl-dev:arm64 for the Linux ARM64 release job
- Allows openssl-sys to find openssl.pc while cross-compiling the sidecar

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.2.5
- ruby -e 'require "psych"; Psych.load_file(".github/workflows/release-desktop.yml"); puts "workflow YAML parses"'