### PR TITLE
Fix Linux release packaging pipeline

### DIFF
--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -208,7 +208,7 @@ export default {
     },
     linux: {
         icon: path.join("build", "icons", "icon.png"),
-        target: [{ target: "AppImage", arch: ["x64", "arm64"] }],
+        target: ["AppImage"],
         category: "Utility",
         executableName: "neverwrite",
         artifactName: "${productName}-${version}-${arch}.AppImage",

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -50,6 +50,7 @@ test("desktop app icons are wired for all packaged platforms", () => {
     assert.equal(config.mac.icon, "build/icons/icon.icns");
     assert.equal(config.win.icon, "build/icons/icon.ico");
     assert.equal(config.linux.icon, "build/icons/icon.png");
+    assert.deepEqual(config.linux.target, ["AppImage"]);
     assert.equal(config.nsis.installerIcon, "build/icons/icon.ico");
     assert.equal(config.nsis.uninstallerIcon, "build/icons/icon.ico");
     assert.equal(config.nsis.installerHeaderIcon, "build/icons/icon.ico");

--- a/apps/desktop/scripts/smoke-packaged-app.mjs
+++ b/apps/desktop/scripts/smoke-packaged-app.mjs
@@ -32,6 +32,8 @@ function defaultPackagedExecutableCandidates() {
     }
     if (process.platform === "linux") {
         return [
+            path.join(outputRoot, `linux-${distArch}-unpacked`, "neverwrite"),
+            path.join(outputRoot, "linux-unpacked", "neverwrite"),
             path.join(outputRoot, `linux-${distArch}-unpacked`, "NeverWrite"),
             path.join(outputRoot, "linux-unpacked", "NeverWrite"),
         ];

--- a/apps/desktop/scripts/stage-electron-release-assets.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.mjs
@@ -123,6 +123,16 @@ function stripSuffix(value, suffix) {
     return value.slice(0, -suffix.length);
 }
 
+function electronBuilderLinuxArch(buildTarget) {
+    if (buildTarget === "aarch64-unknown-linux-gnu") {
+        return "arm64";
+    }
+    if (buildTarget === "x86_64-unknown-linux-gnu") {
+        return "x86_64";
+    }
+    throw new Error(`Unsupported Linux build target "${buildTarget}".`);
+}
+
 function collectArtifacts(distDir, buildTarget) {
     const metadataFileName = metadataFileNameForBuildTarget(buildTarget);
     const feedPath = findSingleFile(
@@ -153,17 +163,16 @@ function collectArtifacts(distDir, buildTarget) {
         };
     }
     if (buildTarget.endsWith("-unknown-linux-gnu")) {
-        const blockmapPath = findSingleFile(
+        const electronArch = electronBuilderLinuxArch(buildTarget);
+        const appImagePath = findSingleFile(
             distDir,
-            (filePath) => filePath.endsWith(".AppImage.blockmap"),
-            "Linux AppImage blockmap",
+            (filePath) =>
+                path.basename(filePath).endsWith(`-${electronArch}.AppImage`),
+            `${electronArch} Linux AppImage`,
         );
-        const appImagePath = stripSuffix(blockmapPath, ".blockmap");
-        if (!fs.existsSync(appImagePath)) {
-            throw new Error(
-                `Expected Linux AppImage next to blockmap at ${appImagePath}.`,
-            );
-        }
+        const blockmapPath = fs.existsSync(`${appImagePath}.blockmap`)
+            ? `${appImagePath}.blockmap`
+            : null;
 
         return {
             feedPath,
@@ -227,18 +236,18 @@ function rewriteFeed({
 }) {
     const manualAssetName = buildPublicReleaseAssetName(version, buildTarget);
     const updaterAssetName = buildElectronUpdaterAssetName(version, buildTarget);
-    const blockmapAssetName = buildElectronBlockmapAssetName(version, buildTarget);
+    const blockmapAssetName = artifacts.blockmapPath
+        ? buildElectronBlockmapAssetName(version, buildTarget)
+        : null;
     const manualAssetUrl = buildGitHubReleaseAssetUrl(
         repoSlug,
         tag,
         manualAssetName,
     );
     const updaterUrl = buildGitHubReleaseAssetUrl(repoSlug, tag, updaterAssetName);
-    const blockmapUrl = buildGitHubReleaseAssetUrl(
-        repoSlug,
-        tag,
-        blockmapAssetName,
-    );
+    const blockmapUrl = blockmapAssetName
+        ? buildGitHubReleaseAssetUrl(repoSlug, tag, blockmapAssetName)
+        : null;
     const metadataFileName = metadataFileNameForBuildTarget(buildTarget);
     const feedTarget = feedTargetForBuildTarget(buildTarget);
     const destinationFeedPath = path.join(
@@ -262,10 +271,12 @@ function rewriteFeed({
             size: fileSizeInBytes(artifacts.updaterAssetPath),
             sha512: sha512Base64(artifacts.updaterAssetPath),
         },
-        blockmapUrl: {
-            size: fileSizeInBytes(artifacts.blockmapPath),
-            sha512: sha512Base64(artifacts.blockmapPath),
-        },
+        ...(artifacts.blockmapPath && {
+            blockmapUrl: {
+                size: fileSizeInBytes(artifacts.blockmapPath),
+                sha512: sha512Base64(artifacts.blockmapPath),
+            },
+        }),
     };
 
     document.set("path", updaterUrl);
@@ -345,7 +356,7 @@ function resolvePublishedAssetUrl(sourceValue, publishedAssetUrls) {
     if (normalizedValue.endsWith(".dmg")) {
         return publishedAssetUrls.manualAssetUrl;
     }
-    if (normalizedValue.endsWith(".blockmap")) {
+    if (normalizedValue.endsWith(".blockmap") && publishedAssetUrls.blockmapUrl) {
         return publishedAssetUrls.blockmapUrl;
     }
 
@@ -360,10 +371,9 @@ function main() {
 
     const manualAssetName = buildPublicReleaseAssetName(args.version, args.target);
     const updaterAssetName = buildElectronUpdaterAssetName(args.version, args.target);
-    const blockmapAssetName = buildElectronBlockmapAssetName(
-        args.version,
-        args.target,
-    );
+    const blockmapAssetName = artifacts.blockmapPath
+        ? buildElectronBlockmapAssetName(args.version, args.target)
+        : null;
     const feed = rewriteFeed({
         sourceFeedPath: artifacts.feedPath,
         artifacts,
@@ -382,10 +392,12 @@ function main() {
         artifacts.updaterAssetPath,
         path.join(args.outputDir, updaterAssetName),
     );
-    copyIfNeeded(
-        artifacts.blockmapPath,
-        path.join(args.outputDir, blockmapAssetName),
-    );
+    if (artifacts.blockmapPath && blockmapAssetName) {
+        copyIfNeeded(
+            artifacts.blockmapPath,
+            path.join(args.outputDir, blockmapAssetName),
+        );
+    }
 
     const metadata = {
         tag: args.tag,
@@ -406,9 +418,10 @@ function main() {
             path.join(args.outputDir, updaterAssetName),
         ),
         updaterBlockmapAssetName: blockmapAssetName,
-        updaterBlockmapSizeBytes: fileSizeInBytes(
-            path.join(args.outputDir, blockmapAssetName),
-        ),
+        updaterBlockmapSizeBytes:
+            artifacts.blockmapPath && blockmapAssetName
+                ? fileSizeInBytes(path.join(args.outputDir, blockmapAssetName))
+                : 0,
         updaterUrl: feed.updaterUrl,
     };
 

--- a/apps/desktop/scripts/stage-electron-release-assets.test.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.test.mjs
@@ -234,7 +234,7 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
         const outputDir = path.join(tempDir, "staged");
         const metadataOut = path.join(tempDir, "metadata", "linux-x64.json");
 
-        writeFile(path.join(distDir, "linux-unpacked", "NeverWrite"), "app");
+        writeFile(path.join(distDir, "linux-unpacked", "neverwrite"), "app");
         writeFile(
             path.join(
                 distDir,
@@ -269,10 +269,9 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
             ),
             "node",
         );
-        writeFile(path.join(distDir, "NeverWrite-0.2.0-x64.AppImage"), "appimage");
         writeFile(
-            path.join(distDir, "NeverWrite-0.2.0-x64.AppImage.blockmap"),
-            "blockmap",
+            path.join(distDir, "NeverWrite-0.2.0-x86_64.AppImage"),
+            "appimage",
         );
         writeFile(
             path.join(distDir, "latest-linux.yml"),
@@ -322,11 +321,15 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
         assert.equal(metadata.metadataFileName, "latest-linux.yml");
         assert.equal(metadata.manualAssetName, "NeverWrite-0.2.0-x64.AppImage");
         assert.equal(metadata.updaterAssetName, "NeverWrite-0.2.0-x64.AppImage");
-        assert.equal(
-            metadata.updaterBlockmapAssetName,
-            "NeverWrite-0.2.0-x64.AppImage.blockmap",
-        );
+        assert.equal(metadata.updaterBlockmapAssetName, null);
+        assert.equal(metadata.updaterBlockmapSizeBytes, 0);
         assert.equal(metadata.feedRelativePath, "linux-x64/latest-linux.yml");
+        assert.equal(
+            fs.existsSync(
+                path.join(outputDir, "NeverWrite-0.2.0-x64.AppImage.blockmap"),
+            ),
+            false,
+        );
         assert.match(
             rewrittenFeed,
             /https:\/\/github\.com\/jsgrrchg\/NeverWrite\/releases\/download\/v0\.2\.0\/NeverWrite-0\.2\.0-x64\.AppImage/,

--- a/scripts/platform-validation.test.mjs
+++ b/scripts/platform-validation.test.mjs
@@ -54,8 +54,7 @@ function buildMetadataEntries() {
             feedRelativePath: "linux-arm64/latest-linux.yml",
             manualAssetName: "NeverWrite-0.2.0-arm64.AppImage",
             updaterAssetName: "NeverWrite-0.2.0-arm64.AppImage",
-            updaterBlockmapAssetName:
-                "NeverWrite-0.2.0-arm64.AppImage.blockmap",
+            updaterBlockmapAssetName: null,
             updaterUrl:
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-arm64.AppImage",
         },
@@ -66,8 +65,7 @@ function buildMetadataEntries() {
             feedRelativePath: "linux-x64/latest-linux.yml",
             manualAssetName: "NeverWrite-0.2.0-x64.AppImage",
             updaterAssetName: "NeverWrite-0.2.0-x64.AppImage",
-            updaterBlockmapAssetName:
-                "NeverWrite-0.2.0-x64.AppImage.blockmap",
+            updaterBlockmapAssetName: null,
             updaterUrl:
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-x64.AppImage",
         },


### PR DESCRIPTION
## Summary
- keep Linux AppImage packaging arch-specific per release matrix job
- smoke the lowercase Linux executable name while preserving the previous fallback
- stage Linux AppImage releases without requiring an external .AppImage.blockmap

## Validation
- node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs scripts/platform-validation.test.mjs scripts/release-metadata.test.mjs scripts/release-assets.test.mjs scripts/appcast.test.mjs
- node scripts/validate-release-metadata.mjs --tag v0.2.5