### PR TITLE
Handle missing Linux release feeds

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -702,10 +702,16 @@ jobs:
                     const metadata = JSON.parse(
                       fs.readFileSync(path.join(metadataDir, fileName), "utf8"),
                     );
+                    const feedRelativePaths = [
+                      metadata.feedRelativePath,
+                      ...(metadata.feedAliasRelativePaths ?? []),
+                    ];
                     const source = path.join(feedsDir, metadata.feedRelativePath);
-                    const destination = path.join(pagesDir, channel, metadata.feedRelativePath);
-                    fs.mkdirSync(path.dirname(destination), { recursive: true });
-                    fs.copyFileSync(source, destination);
+                    for (const relativePath of feedRelativePaths) {
+                      const destination = path.join(pagesDir, channel, relativePath);
+                      fs.mkdirSync(path.dirname(destination), { recursive: true });
+                      fs.copyFileSync(source, destination);
+                    }
                   }
                   EOF
 

--- a/apps/desktop/scripts/stage-electron-release-assets.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.mjs
@@ -116,6 +116,16 @@ function findSingleFile(rootDir, matcher, description) {
     return matches[0];
 }
 
+function findOptionalSingleFile(rootDir, matcher, description) {
+    const matches = listFilesRecursively(rootDir).filter(matcher);
+    if (matches.length > 1) {
+        throw new Error(
+            `Expected at most one ${description} in ${rootDir}, found ${matches.length}.`,
+        );
+    }
+    return matches[0] ?? null;
+}
+
 function stripSuffix(value, suffix) {
     if (!value.endsWith(suffix)) {
         throw new Error(`Expected "${value}" to end with "${suffix}".`);
@@ -135,15 +145,16 @@ function electronBuilderLinuxArch(buildTarget) {
 
 function collectArtifacts(distDir, buildTarget) {
     const metadataFileName = metadataFileNameForBuildTarget(buildTarget);
-    const feedPath = findSingleFile(
-        distDir,
-        (filePath) => path.basename(filePath) === metadataFileName,
-        `${metadataFileName} feed`,
-    );
+    const findFeedPath = () =>
+        findSingleFile(
+            distDir,
+            (filePath) => path.basename(filePath) === metadataFileName,
+            `${metadataFileName} feed`,
+        );
 
     if (buildTarget.endsWith("-apple-darwin")) {
         return {
-            feedPath,
+            feedPath: findFeedPath(),
             manualAssetPath: findSingleFile(
                 distDir,
                 (filePath) => filePath.endsWith(".dmg"),
@@ -173,6 +184,11 @@ function collectArtifacts(distDir, buildTarget) {
         const blockmapPath = fs.existsSync(`${appImagePath}.blockmap`)
             ? `${appImagePath}.blockmap`
             : null;
+        const feedPath = findOptionalSingleFile(
+            distDir,
+            (filePath) => path.basename(filePath) === metadataFileName,
+            `${metadataFileName} feed`,
+        );
 
         return {
             feedPath,
@@ -195,7 +211,7 @@ function collectArtifacts(distDir, buildTarget) {
     }
 
     return {
-        feedPath,
+        feedPath: findFeedPath(),
         manualAssetPath: installerPath,
         updaterAssetPath: installerPath,
         blockmapPath,
@@ -223,6 +239,27 @@ function sha512Base64(filePath) {
         .createHash("sha512")
         .update(fs.readFileSync(filePath))
         .digest("base64");
+}
+
+function yamlString(value) {
+    return JSON.stringify(value);
+}
+
+function writeSyntheticFeed(destinationFeedPath, version, updaterUrl, metadata) {
+    fs.writeFileSync(
+        destinationFeedPath,
+        [
+            `version: ${yamlString(version)}`,
+            `path: ${yamlString(updaterUrl)}`,
+            `sha512: ${yamlString(metadata.sha512)}`,
+            "files:",
+            `  - url: ${yamlString(updaterUrl)}`,
+            `    sha512: ${yamlString(metadata.sha512)}`,
+            `    size: ${metadata.size}`,
+            "",
+        ].join("\n"),
+        "utf8",
+    );
 }
 
 function rewriteFeed({
@@ -256,7 +293,6 @@ function rewriteFeed({
         feedTarget,
         metadataFileName,
     );
-    const document = parseDocument(fs.readFileSync(sourceFeedPath, "utf8"));
     const publishedAssetUrls = {
         manualAssetUrl,
         updaterUrl,
@@ -279,6 +315,24 @@ function rewriteFeed({
         }),
     };
 
+    fs.mkdirSync(path.dirname(destinationFeedPath), { recursive: true });
+    if (!sourceFeedPath) {
+        writeSyntheticFeed(
+            destinationFeedPath,
+            version,
+            updaterUrl,
+            publishedAssetMetadata.updaterUrl,
+        );
+
+        return {
+            feedTarget,
+            metadataFileName,
+            destinationFeedPath,
+            updaterUrl,
+        };
+    }
+
+    const document = parseDocument(fs.readFileSync(sourceFeedPath, "utf8"));
     document.set("path", updaterUrl);
     document.set("sha512", publishedAssetMetadata.updaterUrl.sha512);
     const files = document.get("files");
@@ -326,7 +380,6 @@ function rewriteFeed({
         }
     }
 
-    fs.mkdirSync(path.dirname(destinationFeedPath), { recursive: true });
     fs.writeFileSync(destinationFeedPath, document.toString(), "utf8");
 
     return {

--- a/apps/desktop/scripts/stage-electron-release-assets.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.mjs
@@ -143,6 +143,13 @@ function electronBuilderLinuxArch(buildTarget) {
     throw new Error(`Unsupported Linux build target "${buildTarget}".`);
 }
 
+function feedAliasFileNamesForBuildTarget(buildTarget) {
+    if (buildTarget === "aarch64-unknown-linux-gnu") {
+        return ["latest-linux-arm64.yml"];
+    }
+    return [];
+}
+
 function collectArtifacts(distDir, buildTarget) {
     const metadataFileName = metadataFileNameForBuildTarget(buildTarget);
     const findFeedPath = () =>
@@ -184,11 +191,14 @@ function collectArtifacts(distDir, buildTarget) {
         const blockmapPath = fs.existsSync(`${appImagePath}.blockmap`)
             ? `${appImagePath}.blockmap`
             : null;
-        const feedPath = findOptionalSingleFile(
-            distDir,
-            (filePath) => path.basename(filePath) === metadataFileName,
-            `${metadataFileName} feed`,
-        );
+        const feedPath =
+            buildTarget === "aarch64-unknown-linux-gnu"
+                ? findOptionalSingleFile(
+                      distDir,
+                      (filePath) => path.basename(filePath) === metadataFileName,
+                      `${metadataFileName} feed`,
+                  )
+                : findFeedPath();
 
         return {
             feedPath,
@@ -250,6 +260,7 @@ function writeSyntheticFeed(destinationFeedPath, version, updaterUrl, metadata) 
         destinationFeedPath,
         [
             `version: ${yamlString(version)}`,
+            `releaseDate: ${yamlString(new Date().toISOString())}`,
             `path: ${yamlString(updaterUrl)}`,
             `sha512: ${yamlString(metadata.sha512)}`,
             "files:",
@@ -260,6 +271,16 @@ function writeSyntheticFeed(destinationFeedPath, version, updaterUrl, metadata) 
         ].join("\n"),
         "utf8",
     );
+}
+
+function copyFeedAliases(destinationFeedPath, outputDir, feedTarget, buildTarget) {
+    const aliasRelativePaths = [];
+    for (const aliasFileName of feedAliasFileNamesForBuildTarget(buildTarget)) {
+        const aliasPath = path.join(outputDir, "feeds", feedTarget, aliasFileName);
+        fs.copyFileSync(destinationFeedPath, aliasPath);
+        aliasRelativePaths.push(toPosixRelativePath(feedTarget, aliasFileName));
+    }
+    return aliasRelativePaths;
 }
 
 function rewriteFeed({
@@ -323,12 +344,19 @@ function rewriteFeed({
             updaterUrl,
             publishedAssetMetadata.updaterUrl,
         );
+        const feedAliasRelativePaths = copyFeedAliases(
+            destinationFeedPath,
+            outputDir,
+            feedTarget,
+            buildTarget,
+        );
 
         return {
             feedTarget,
             metadataFileName,
             destinationFeedPath,
             updaterUrl,
+            feedAliasRelativePaths,
         };
     }
 
@@ -381,12 +409,19 @@ function rewriteFeed({
     }
 
     fs.writeFileSync(destinationFeedPath, document.toString(), "utf8");
+    const feedAliasRelativePaths = copyFeedAliases(
+        destinationFeedPath,
+        outputDir,
+        feedTarget,
+        buildTarget,
+    );
 
     return {
         feedTarget,
         metadataFileName,
         destinationFeedPath,
         updaterUrl,
+        feedAliasRelativePaths,
     };
 }
 
@@ -462,6 +497,7 @@ function main() {
             feed.feedTarget,
             feed.metadataFileName,
         ),
+        feedAliasRelativePaths: feed.feedAliasRelativePaths,
         manualAssetName,
         manualAssetSizeBytes: fileSizeInBytes(
             path.join(args.outputDir, manualAssetName),

--- a/apps/desktop/scripts/stage-electron-release-assets.test.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.test.mjs
@@ -336,3 +336,68 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
         );
     });
 });
+
+test("stage-electron-release-assets synthesizes missing Linux AppImage feeds", () => {
+    withTempDir((tempDir) => {
+        const distDir = path.join(tempDir, "dist");
+        const outputDir = path.join(tempDir, "staged");
+        const metadataOut = path.join(tempDir, "metadata", "linux-arm64.json");
+        const appImageContents = "arm64 appimage";
+        const appImageSha512 = sha512Base64(appImageContents);
+
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-arm64.AppImage"),
+            appImageContents,
+        );
+
+        execFileSync(
+            process.execPath,
+            [
+                stageScriptPath,
+                "--dist-dir",
+                distDir,
+                "--target",
+                "aarch64-unknown-linux-gnu",
+                "--version",
+                "0.2.0",
+                "--tag",
+                "v0.2.0",
+                "--repo",
+                "jsgrrchg/NeverWrite",
+                "--output-dir",
+                outputDir,
+                "--metadata-out",
+                metadataOut,
+            ],
+            {
+                cwd: repoRoot,
+                stdio: "pipe",
+            },
+        );
+
+        const metadata = JSON.parse(fs.readFileSync(metadataOut, "utf8"));
+        const rewrittenFeed = fs.readFileSync(
+            path.join(outputDir, "feeds", "linux-arm64", "latest-linux.yml"),
+            "utf8",
+        );
+
+        assert.equal(metadata.feedTarget, "linux-arm64");
+        assert.equal(metadata.metadataFileName, "latest-linux.yml");
+        assert.equal(metadata.manualAssetName, "NeverWrite-0.2.0-arm64.AppImage");
+        assert.equal(metadata.updaterAssetName, "NeverWrite-0.2.0-arm64.AppImage");
+        assert.equal(metadata.updaterBlockmapAssetName, null);
+        assert.equal(metadata.updaterBlockmapSizeBytes, 0);
+        assert.equal(metadata.feedRelativePath, "linux-arm64/latest-linux.yml");
+        assert.match(rewrittenFeed, /version: "0\.2\.0"/);
+        assert.match(
+            rewrittenFeed,
+            /path: "https:\/\/github\.com\/jsgrrchg\/NeverWrite\/releases\/download\/v0\.2\.0\/NeverWrite-0\.2\.0-arm64\.AppImage"/,
+        );
+        assert.match(rewrittenFeed, /sha512: "/);
+        assert.equal(
+            rewrittenFeed.includes(`sha512: "${appImageSha512}"`),
+            true,
+        );
+        assert.match(rewrittenFeed, /size: 14/);
+    });
+});

--- a/apps/desktop/scripts/stage-electron-release-assets.test.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.test.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { execFileSync } from "node:child_process";
+import { parseDocument } from "yaml";
 
 const repoRoot = path.resolve(import.meta.dirname, "..", "..", "..");
 const stageScriptPath = path.join(
@@ -324,6 +325,7 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
         assert.equal(metadata.updaterBlockmapAssetName, null);
         assert.equal(metadata.updaterBlockmapSizeBytes, 0);
         assert.equal(metadata.feedRelativePath, "linux-x64/latest-linux.yml");
+        assert.deepEqual(metadata.feedAliasRelativePaths, []);
         assert.equal(
             fs.existsSync(
                 path.join(outputDir, "NeverWrite-0.2.0-x64.AppImage.blockmap"),
@@ -388,16 +390,73 @@ test("stage-electron-release-assets synthesizes missing Linux AppImage feeds", (
         assert.equal(metadata.updaterBlockmapAssetName, null);
         assert.equal(metadata.updaterBlockmapSizeBytes, 0);
         assert.equal(metadata.feedRelativePath, "linux-arm64/latest-linux.yml");
-        assert.match(rewrittenFeed, /version: "0\.2\.0"/);
-        assert.match(
-            rewrittenFeed,
-            /path: "https:\/\/github\.com\/jsgrrchg\/NeverWrite\/releases\/download\/v0\.2\.0\/NeverWrite-0\.2\.0-arm64\.AppImage"/,
+        assert.deepEqual(metadata.feedAliasRelativePaths, [
+            "linux-arm64/latest-linux-arm64.yml",
+        ]);
+
+        const aliasFeed = fs.readFileSync(
+            path.join(outputDir, "feeds", "linux-arm64", "latest-linux-arm64.yml"),
+            "utf8",
         );
-        assert.match(rewrittenFeed, /sha512: "/);
+        assert.equal(aliasFeed, rewrittenFeed);
+
+        const feedDocument = parseDocument(rewrittenFeed);
+        const updaterUrl =
+            "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-arm64.AppImage";
+        assert.equal(feedDocument.get("version"), "0.2.0");
         assert.equal(
-            rewrittenFeed.includes(`sha512: "${appImageSha512}"`),
-            true,
+            Number.isNaN(Date.parse(feedDocument.get("releaseDate"))),
+            false,
         );
-        assert.match(rewrittenFeed, /size: 14/);
+        assert.equal(feedDocument.get("path"), updaterUrl);
+        assert.equal(feedDocument.get("sha512"), appImageSha512);
+
+        const files = feedDocument.get("files", true);
+        assert.equal(files.items.length, 1);
+        assert.equal(files.items[0].get("url"), updaterUrl);
+        assert.equal(files.items[0].get("sha512"), appImageSha512);
+        assert.equal(files.items[0].get("size"), 14);
+    });
+});
+
+test("stage-electron-release-assets requires generated Linux x64 feeds", () => {
+    withTempDir((tempDir) => {
+        const distDir = path.join(tempDir, "dist");
+        const outputDir = path.join(tempDir, "staged");
+        const metadataOut = path.join(tempDir, "metadata", "linux-x64.json");
+
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-x86_64.AppImage"),
+            "x64 appimage",
+        );
+
+        assert.throws(
+            () =>
+                execFileSync(
+                    process.execPath,
+                    [
+                        stageScriptPath,
+                        "--dist-dir",
+                        distDir,
+                        "--target",
+                        "x86_64-unknown-linux-gnu",
+                        "--version",
+                        "0.2.0",
+                        "--tag",
+                        "v0.2.0",
+                        "--repo",
+                        "jsgrrchg/NeverWrite",
+                        "--output-dir",
+                        outputDir,
+                        "--metadata-out",
+                        metadataOut,
+                    ],
+                    {
+                        cwd: repoRoot,
+                        stdio: "pipe",
+                    },
+                ),
+            /Expected exactly one latest-linux\.yml feed/,
+        );
     });
 });

--- a/apps/desktop/src-electron/main/updater.test.ts
+++ b/apps/desktop/src-electron/main/updater.test.ts
@@ -141,7 +141,7 @@ describe("ElectronAppUpdater configuration", () => {
         expect(status).toMatchObject({
             enabled: true,
             endpoint:
-                "https://jsgrrchg.github.io/NeverWrite/stable/linux-arm64/latest-linux.yml",
+                "https://jsgrrchg.github.io/NeverWrite/stable/linux-arm64/latest-linux-arm64.yml",
             message: null,
         });
     });

--- a/apps/desktop/src-electron/main/updater.ts
+++ b/apps/desktop/src-electron/main/updater.ts
@@ -281,6 +281,9 @@ function resolveMetadataFileName() {
         return "latest.yml";
     }
     if (process.platform === "linux") {
+        if (process.arch === "arm64") {
+            return "latest-linux-arm64.yml";
+        }
         return "latest-linux.yml";
     }
     return null;


### PR DESCRIPTION
## Summary
- allow Linux AppImage release staging to continue when electron-builder does not emit latest-linux.yml
- synthesize a minimal Linux updater feed from the staged AppImage metadata
- cover the linux-arm64 missing-feed case with a focused stage-assets test

## Root cause
The linux-arm64 release build produced the AppImage successfully, but electron-builder did not emit latest-linux.yml for that target. The staging script treated that feed as mandatory for all Linux builds, so the release failed after packaging.

## Validation
- node --test apps/desktop/scripts/stage-electron-release-assets.test.mjs scripts/platform-validation.test.mjs scripts/release-assets.test.mjs scripts/appcast.test.mjs
