### PR TITLE
Sync Cargo.lock with 0.2.5 version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.2.4"
+version = "0.2.5"
 dependencies = [
  "agent-client-protocol",
  "keyring",


### PR DESCRIPTION
## Summary

`Cargo.lock` pinned `neverwrite-native-backend` at `0.2.4` while the workspace manifest is at `0.2.5`. The `Prepare 0.2.5 release` commit bumped the crate manifest but missed regenerating the lockfile, so the first cargo invocation on a fresh checkout always rewrites this single line. Sending the update so the lockfile reflects the released version cleanly.

## Test plan

- [ ] `cargo build` in a fresh clone produces no Cargo.lock diff
- [ ] `cargo test` passes