### PR TITLE
Support single-arch mac layouts in DMG postprocess

### DIFF
--- a/apps/desktop/scripts/postprocess-macos-dmg.mjs
+++ b/apps/desktop/scripts/postprocess-macos-dmg.mjs
@@ -84,6 +84,8 @@ function findPackagedApp(distDir) {
     const candidates = [
         path.join(distDir, "mac-universal", "NeverWrite.app"),
         path.join(distDir, "mac", "NeverWrite.app"),
+        path.join(distDir, "mac-arm64", "NeverWrite.app"),
+        path.join(distDir, "mac-x64", "NeverWrite.app"),
     ];
 
     for (const candidate of candidates) {


### PR DESCRIPTION
## Summary

`apps/desktop/scripts/postprocess-macos-dmg.mjs`'s `findPackagedApp` only looks for `mac-universal/NeverWrite.app` and `mac/NeverWrite.app`. When `build-electron-release.mjs` is invoked with `--arch arm64` (or `--arch x64`), electron-builder writes the bundle under `mac-arm64/` or `mac-x64/` instead, and the postprocess step fails with:

```
Error: Could not find packaged NeverWrite.app in <distDir>
```

That makes a local single-arch macOS release impossible without bypassing the hardened DMG rebuild and codesign-verify step. Adding the two missing candidates keeps the universal layout working unchanged and unblocks single-arch builds.

## Test plan

- [ ] `node apps/desktop/scripts/build-electron-release.mjs --platform mac --arch arm64 --unsigned` runs through postprocess without error
- [ ] `--arch universal` build still finds `mac-universal/NeverWrite.app` (candidate retained)