### PR TITLE
Show .html and .htm files in default file tree

### DIFF
--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -1793,7 +1793,8 @@ export function FileTree() {
                 if (entry.kind === "note") return false;
                 if (entry.kind === "folder") return true;
                 if (fileTreeContentMode === "all_files") return true;
-                return entry.kind === "pdf";
+                if (entry.kind === "pdf") return true;
+                return entry.extension === "html" || entry.extension === "htm";
             }),
         [entries, fileTreeContentMode],
     );


### PR DESCRIPTION
## Summary

In the default `notes_only` mode the sidebar surfaced only `.md` notes and `.pdf` files. `.html` and `.htm` files come back from the vault classifier as text-like, openable entries (kind `"file"`, mime `text/html`), but they were filtered out unless the user enabled the global "all files" toggle in settings.

The patch extends the default filter to also surface `.html`/`.htm` by extension. The `"all_files"` toggle is unchanged.

The matching is on `entry.extension`, which the Rust side at `crates/vault/src/vault.rs:744` already lowercases, so casing is handled.

Click-through works without further wiring: the vault classifier maps `html`/`htm` to `text/html`, which `is_text_like_mime_type` accepts, so the entry already comes back with `open_in_app: true` and the existing text/code viewer renders the source.

## Test plan

- [ ] Default sidebar mode shows `.html` and `.htm` files alongside notes and PDFs
- [ ] "All files" toggle still surfaces every other file kind as before
- [ ] `apps/desktop` `vitest run src/features/vault/FileTree.test.tsx` (47 tests) passes