### PR TITLE
Add in-app HTML viewer with sandboxed JS execution

### DIFF
--- a/apps/desktop/config/desktop-security.json
+++ b/apps/desktop/config/desktop-security.json
@@ -1,3 +1,3 @@
 {
-    "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost asset: neverwrite-file: http://neverwrite-file.localhost https://neverwrite-file.localhost https://www.youtube.com; worker-src 'self' blob:; img-src 'self' asset: data: neverwrite-file: http://neverwrite-file.localhost https://neverwrite-file.localhost https: http:; style-src 'self' 'unsafe-inline'; frame-src https://www.youtube.com https://www.youtube-nocookie.com"
+    "csp": "default-src 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self' ipc: http://ipc.localhost asset: neverwrite-file: http://neverwrite-file.localhost https://neverwrite-file.localhost https://www.youtube.com; worker-src 'self' blob:; img-src 'self' asset: data: neverwrite-file: http://neverwrite-file.localhost https://neverwrite-file.localhost https: http:; style-src 'self' 'unsafe-inline'; frame-src https://www.youtube.com https://www.youtube-nocookie.com neverwrite-file:"
 }

--- a/apps/desktop/src-electron/main/ipc.ts
+++ b/apps/desktop/src-electron/main/ipc.ts
@@ -318,8 +318,8 @@ export function registerPreviewProtocolHandler() {
     return async (request: Request) => {
         try {
             const url = new URL(request.url);
-            const [, scope, encodedVaultPath, encodedRelativePath] =
-                url.pathname.split("/");
+            const segments = url.pathname.split("/");
+            const [, scope, encodedVaultPath, encodedRelativePath] = segments;
             if (scope === "vault" && encodedVaultPath && encodedRelativePath) {
                 const vaultPath = decodeBase64UrlSegment(encodedVaultPath);
                 const relativePath =
@@ -335,6 +335,34 @@ export function registerPreviewProtocolHandler() {
                         "cache-control": "no-store",
                     },
                 });
+            }
+
+            if (scope === "assets" && encodedVaultPath && segments.length > 3) {
+                const vaultPath = decodeBase64UrlSegment(encodedVaultPath);
+                const relativePath = segments
+                    .slice(3)
+                    .map((segment) => decodeURIComponent(segment))
+                    .join("/");
+                const filePath = resolvePreviewFilePath(
+                    vaultPath,
+                    relativePath,
+                );
+                const data = await fs.readFile(filePath);
+                const mimeType = previewMimeType(filePath);
+                const headers: Record<string, string> = {
+                    "content-type": mimeType,
+                    "cache-control": "no-store",
+                };
+                if (mimeType === "text/html") {
+                    headers["content-security-policy"] =
+                        "default-src 'self' 'unsafe-inline' 'unsafe-eval' neverwrite-file: data: blob:; " +
+                        "connect-src 'self' neverwrite-file:; " +
+                        "img-src 'self' neverwrite-file: data: blob:; " +
+                        "media-src 'self' neverwrite-file: data: blob:; " +
+                        "frame-src 'self' neverwrite-file:; " +
+                        "form-action 'none'";
+                }
+                return new Response(new Uint8Array(data), { headers });
             }
 
             if (scope === "codex-image" && encodedVaultPath) {

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -2,7 +2,7 @@ import { toVaultRelativePath } from "../utils/vaultPaths";
 import { useVaultStore } from "./vaultStore";
 
 export type PdfViewMode = "single" | "continuous";
-export type FileViewerMode = "text" | "image" | "csv";
+export type FileViewerMode = "text" | "image" | "csv" | "html";
 
 const IMAGE_FILE_EXTENSIONS = new Set([
     "png",
@@ -998,7 +998,12 @@ export function ensureFileTabDefaults(tab: FileTabInput): FileTab {
 }
 
 export function isFileViewerMode(value: unknown): value is FileViewerMode {
-    return value === "text" || value === "image" || value === "csv";
+    return (
+        value === "text" ||
+        value === "image" ||
+        value === "csv" ||
+        value === "html"
+    );
 }
 
 export function inferFileViewer(
@@ -1012,6 +1017,9 @@ export function inferFileViewer(
     if (IMAGE_FILE_EXTENSIONS.has(extension)) {
         return "image";
     }
+    if (extension === "html" || extension === "htm") {
+        return "html";
+    }
     return "text";
 }
 
@@ -1024,7 +1032,7 @@ export function normalizeFileViewer(
 }
 
 export function fileViewerNeedsTextContent(viewer: FileViewerMode) {
-    return viewer !== "image";
+    return viewer !== "image" && viewer !== "html";
 }
 
 export function ensureNoteTabHistory(tab: NoteTabInput): NoteTab {

--- a/apps/desktop/src/app/utils/desktopCsp.test.ts
+++ b/apps/desktop/src/app/utils/desktopCsp.test.ts
@@ -30,7 +30,7 @@ describe("desktop CSP allowlist", () => {
         expect(csp).toContain("worker-src 'self' blob:");
         expect(csp).toContain("style-src 'self' 'unsafe-inline'");
         expect(csp).toContain(
-            "frame-src https://www.youtube.com https://www.youtube-nocookie.com",
+            "frame-src https://www.youtube.com https://www.youtube-nocookie.com neverwrite-file:",
         );
     });
 });

--- a/apps/desktop/src/app/utils/filePreviewUrl.ts
+++ b/apps/desktop/src/app/utils/filePreviewUrl.ts
@@ -50,6 +50,21 @@ export function buildVaultPreviewUrlFromAbsolutePath(
     return previewUrl ? `${previewUrl}${suffix}` : null;
 }
 
+export function buildVaultAssetUrl(
+    vaultPath: string | null,
+    relativePath: string,
+) {
+    if (!vaultPath) {
+        return null;
+    }
+
+    const encodedPath = relativePath
+        .split("/")
+        .map((segment) => encodeURIComponent(segment))
+        .join("/");
+    return `${FILE_PREVIEW_SCHEME}/assets/${encodeBase64Url(vaultPath)}/${encodedPath}`;
+}
+
 export function buildCodexGeneratedImagePreviewUrl(absolutePath: string) {
     const { pathname, suffix } = splitPathSuffix(absolutePath);
     if (!pathname.trim()) {

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -344,6 +344,21 @@ async function buildVaultEntryTab(
         };
     }
 
+    if (getVaultEntryViewerKind(entry) === "html") {
+        return {
+            id: crypto.randomUUID(),
+            kind: "file",
+            relativePath: entry.relative_path,
+            title: entry.file_name,
+            path: entry.path,
+            mimeType: entry.mime_type,
+            viewer: "html",
+            content: "",
+            sizeBytes: entry.size,
+            contentTruncated: false,
+        };
+    }
+
     if (!canOpenVaultFileEntryInApp(entry)) {
         return null;
     }

--- a/apps/desktop/src/features/editor/FileTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.tsx
@@ -23,6 +23,7 @@ import { buildVaultPreviewUrlFromAbsolutePath } from "../../app/utils/filePrevie
 import { formatZoomPercentage } from "../../app/utils/zoom";
 import { FileTextTabView } from "./FileTextTabView";
 import { CsvFileTabView } from "./CsvFileTabView";
+import { HtmlTabView } from "./HtmlTabView";
 
 const IMG_MIN_ZOOM = 0.1;
 const IMG_MAX_ZOOM = 10;
@@ -60,6 +61,10 @@ export function FileTabView({ paneId }: FileTabViewProps) {
 
     if (tab.viewer === "csv") {
         return <CsvFileTabView key={tab.id} paneId={paneId} />;
+    }
+
+    if (tab.viewer === "html") {
+        return <HtmlTabView key={tab.id} tab={tab} />;
     }
 
     if (fileViewerNeedsTextContent(tab.viewer)) {

--- a/apps/desktop/src/features/editor/HtmlTabView.tsx
+++ b/apps/desktop/src/features/editor/HtmlTabView.tsx
@@ -1,0 +1,98 @@
+import { useMemo } from "react";
+import { openPath, revealItemInDir } from "@neverwrite/runtime";
+import { useVaultStore } from "../../app/store/vaultStore";
+import { toVaultRelativePath } from "../../app/utils/vaultPaths";
+import { buildVaultAssetUrl } from "../../app/utils/filePreviewUrl";
+import type { FileTab } from "../../app/store/editorStore";
+
+export function HtmlTabView({ tab }: { tab: FileTab }) {
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+
+    const previewUrl = useMemo(() => {
+        const relative = toVaultRelativePath(tab.path, vaultPath);
+        if (!relative) return null;
+        return buildVaultAssetUrl(vaultPath, relative);
+    }, [tab.path, vaultPath]);
+
+    return (
+        <div className="h-full min-w-0 flex flex-col overflow-hidden">
+            <div
+                className="flex min-w-0 items-center justify-between gap-2 px-3 shrink-0 overflow-x-auto"
+                style={{
+                    height: 39,
+                    borderBottom: "1px solid var(--border)",
+                    backgroundColor: "var(--bg-secondary)",
+                }}
+            >
+                <div
+                    className="min-w-0 truncate text-[11px]"
+                    title={tab.relativePath}
+                >
+                    <span
+                        className="font-medium"
+                        style={{ color: "var(--text-primary)" }}
+                    >
+                        {tab.title}
+                    </span>
+                    <span
+                        className="ml-1.5"
+                        style={{ color: "var(--text-secondary)" }}
+                    >
+                        {tab.relativePath}
+                    </span>
+                </div>
+                <div className="flex items-center gap-1 shrink-0">
+                    <button
+                        type="button"
+                        onClick={() => void openPath(tab.path)}
+                        className="inline-flex items-center rounded px-1.5 text-[10px]"
+                        style={headerButtonStyle}
+                    >
+                        Open Externally
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void revealItemInDir(tab.path)}
+                        className="inline-flex items-center rounded px-1.5 text-[10px]"
+                        style={headerButtonStyle}
+                    >
+                        Reveal in Finder
+                    </button>
+                </div>
+            </div>
+
+            <div className="min-w-0 flex-1 overflow-hidden">
+                {previewUrl ? (
+                    <iframe
+                        key={previewUrl}
+                        title={tab.title}
+                        src={previewUrl}
+                        sandbox="allow-scripts allow-same-origin allow-forms allow-modals"
+                        referrerPolicy="no-referrer"
+                        style={{
+                            width: "100%",
+                            height: "100%",
+                            border: "none",
+                            backgroundColor: "white",
+                        }}
+                    />
+                ) : (
+                    <div
+                        className="h-full flex items-center justify-center"
+                        style={{ color: "var(--text-secondary)" }}
+                    >
+                        This file is outside the active vault.
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+const headerButtonStyle = {
+    height: 22,
+    border: "1px solid var(--border)",
+    backgroundColor: "transparent",
+    color: "var(--text-secondary)",
+    cursor: "pointer",
+} as const;

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -683,6 +683,12 @@ fn is_excalidraw_path(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("excalidraw"))
 }
 
+fn is_html_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("html") || ext.eq_ignore_ascii_case("htm"))
+}
+
 fn is_text_like_mime_type(mime_type: &str) -> bool {
     mime_type.starts_with("text/")
         || matches!(
@@ -712,6 +718,7 @@ fn classify_vault_entry_path(path: &Path, kind: &str) -> VaultEntryClassificatio
         "note" => (true, "markdown"),
         "pdf" => (true, "pdf"),
         _ if is_excalidraw_path(path) => (true, "map"),
+        _ if is_html_path(path) => (true, "html"),
         _ if is_image_like => (true, "image"),
         _ if is_text_like => (true, "text"),
         _ => (false, "external"),


### PR DESCRIPTION
## Summary

Adds a dedicated in-app viewer for `.html` / `.htm` files so they render as a page (with JS) instead of falling through to the text/code viewer.

End-to-end:

- `crates/vault/src/vault.rs` — `classify_vault_entry_path` now returns `viewer_kind: "html"` for `.html` and `.htm`, ahead of the generic `text` fallback.
- `apps/desktop/src-electron/main/ipc.ts` — `registerPreviewProtocolHandler` gains an `assets` scope: `neverwrite-file://localhost/assets/<base64-vault>/<raw/relative/path>`. The trailing segments stay un-base64 so that subresources referenced from the HTML (CSS, images, `./data.json`) resolve naturally via relative URLs. Path validation still goes through `resolvePreviewFilePath`, so traversal is rejected at the main process.
- `apps/desktop/src/features/editor/HtmlTabView.tsx` — new React view. Hosts the document in an `<iframe>` with `sandbox="allow-scripts allow-same-origin allow-forms allow-modals"` and `referrerPolicy="no-referrer"`. Header reuses the local pattern from `FileTabView` for Open Externally / Reveal in Finder.
- `apps/desktop/src/features/editor/FileTabView.tsx` — routes `viewer === "html"` to `HtmlTabView`.
- `apps/desktop/src/app/store/editorTabs.ts` — `FileViewerMode` gains `"html"`, `inferFileViewer` maps `.html`/`.htm`, and `fileViewerNeedsTextContent` returns `false` for `"html"` so the file is not pre-fetched as text.
- `apps/desktop/src/app/utils/vaultEntries.ts` — adds a short-circuit alongside the existing image short-circuit so html entries open without a text read.
- `apps/desktop/src/app/utils/filePreviewUrl.ts` — `buildVaultAssetUrl` helper.
- `apps/desktop/config/desktop-security.json` — renderer CSP adds `neverwrite-file:` to `frame-src` so the parent can embed the iframe. CSP test updated.

## Security boundary

- Iframe origin is `neverwrite-file://localhost` (because of `allow-same-origin`), different from the renderer's origin. Scripts in the iframe cannot script the parent app, read parent storage/cookies, or escape into the renderer process.
- Iframe scripts CAN fetch other `neverwrite-file://localhost/...` URLs (same-scheme/host). Every such request goes through `resolvePreviewFilePath`, which validates the path against the active vault root, so a script cannot reach files outside the vault.
- To stop a malicious local document from POSTing vault contents to an external server, the protocol handler attaches a `Content-Security-Policy` response header to HTML responses that pins `connect-src` and `frame-src` to `'self' neverwrite-file:` and sets `form-action 'none'`. Local self-contained pages (including ones doing `fetch("./sibling.json")`) keep working; arbitrary outbound network is blocked.
- Pages that legitimately need full network access can still be opened in the system browser via the existing Open Externally button.

## Test plan

- [ ] Drop a `.html` file containing inline `<script>` into a vault; opening it from the file tree renders the page in-app and the script runs.
- [ ] In the page devtools console, `fetch("https://example.com")` is refused (CSP violation).
- [ ] `fetch("./sibling.json")` against a real sibling file succeeds.
- [ ] Open Externally button hands the file off to the system browser.
- [ ] `vitest run src/app/utils/desktopCsp.test.ts` passes.
- [ ] `cargo test -p neverwrite-vault` passes.