### PR TITLE
Improve subagent review titles and inline decisions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 - Fixed chat Markdown rendering so slash-prefixed text is no longer converted into a clickable vault pill unless it resolves to a valid vault reference.
 - Fixed dragging agent chats from the collapsed sidebar so the sidebar overlay stays active while the drag starts.
+- Fixed inline file-review Accept and Reject buttons so decisions run on click release instead of immediately on press.
+- Fixed review tabs for subagents so pending-change reviews show the subagent name instead of the generic runtime label.
 - Fixed provider quota, rate-limit, and usage-limit failures so the chat shows a clear provider-limit message instead of treating the error like a setup or authentication failure.
 - Fixed oversized saved AI session transcripts by compacting new saves and repairing previously inflated saved chats on load.
 - Fixed vault scans, text-file reads, and watcher/upsert hashing for Markdown and text files that contain invalid UTF-8 bytes by decoding them lossily instead of failing the vault operation. Thanks to @kwojtaszek.

--- a/apps/desktop/src/features/ai/sessionPresentation.test.ts
+++ b/apps/desktop/src/features/ai/sessionPresentation.test.ts
@@ -25,6 +25,31 @@ function createSession(
     };
 }
 
+const runtimes: AIRuntimeDescriptor[] = [
+    {
+        runtime: {
+            id: "codex-acp",
+            name: "Codex ACP",
+            description: "Codex runtime",
+            capabilities: [],
+        },
+        models: [],
+        modes: [],
+        configOptions: [],
+    },
+    {
+        runtime: {
+            id: "kilo-acp",
+            name: "Kilo ACP",
+            description: "Kilo runtime",
+            capabilities: [],
+        },
+        models: [],
+        modes: [],
+        configOptions: [],
+    },
+];
+
 describe("sessionPresentation history selection", () => {
     it("uses historySessionId as the stable history selection key", () => {
         const session = createSession("live-session-1", "history-1");
@@ -55,25 +80,37 @@ describe("sessionPresentation history selection", () => {
         ).toBe("persisted:history-1");
     });
 
+    it("formats root review tab titles with normalized runtime names for Codex", () => {
+        const session = createSession("live-session-2", "history-2");
+
+        expect(getReviewTabTitle(session, runtimes)).toBe("Review Codex");
+    });
+
     it("formats review tab titles with normalized runtime names for Kilo", () => {
         const session = {
-            ...createSession("live-session-2", "history-2"),
+            ...createSession("live-session-3", "history-3"),
             runtimeId: "kilo-acp",
         };
-        const runtimes: AIRuntimeDescriptor[] = [
-            {
-                runtime: {
-                    id: "kilo-acp",
-                    name: "Kilo ACP",
-                    description: "Kilo runtime",
-                    capabilities: [],
-                },
-                models: [],
-                modes: [],
-                configOptions: [],
-            },
-        ];
 
         expect(getReviewTabTitle(session, runtimes)).toBe("Review Kilo");
+    });
+
+    it("formats subagent review tab titles with the visible session name", () => {
+        const session = {
+            ...createSession("live-session-4", "history-4"),
+            parentSessionId: "parent-session",
+            customTitle: "Descartes",
+        };
+
+        expect(getReviewTabTitle(session, runtimes)).toBe("Review: Descartes");
+    });
+
+    it("uses a subagent fallback when the visible session name is not useful", () => {
+        const session = {
+            ...createSession("live-session-5", "history-5"),
+            parentSessionId: "parent-session",
+        };
+
+        expect(getReviewTabTitle(session, runtimes)).toBe("Review: Subagent");
     });
 });

--- a/apps/desktop/src/features/ai/sessionPresentation.ts
+++ b/apps/desktop/src/features/ai/sessionPresentation.ts
@@ -15,15 +15,34 @@ function truncateText(value: string, maxLength: number) {
     return `${value.slice(0, maxLength - 1).trimEnd()}…`;
 }
 
-export function getSessionTitle(session: AIChatSession) {
+type SessionTitleSession = Pick<
+    AIChatSession,
+    | "customTitle"
+    | "persistedTitle"
+    | "messages"
+    | "messageOrder"
+    | "messagesById"
+    | "messageIndexById"
+    | "lastAssistantMessageId"
+    | "lastTurnStartedMessageId"
+    | "activePlanMessageId"
+>;
+
+type ReviewTabTitleSession = Pick<
+    AIChatSession,
+    "runtimeId" | "parentSessionId"
+> &
+    SessionTitleSession;
+
+export function getSessionTitle(session: SessionTitleSession) {
     return truncateText(getSessionTitleText(session), 42);
 }
 
-export function getSessionTitleText(session: AIChatSession) {
+export function getSessionTitleText(session: SessionTitleSession) {
     const custom = session.customTitle?.trim();
     if (custom) return custom;
 
-    const firstUserText = getFirstUserTextMessage(session);
+    const firstUserText = getFirstUserTextMessage(session as AIChatSession);
     const fallbackTitle = session.persistedTitle?.trim();
 
     if (!firstUserText) {
@@ -166,9 +185,16 @@ function normalizeReviewAgentName(name?: string | null) {
 }
 
 export function getReviewTabTitle(
-    session: Pick<AIChatSession, "runtimeId"> | null | undefined,
+    session: ReviewTabTitleSession | null | undefined,
     runtimes: AIRuntimeDescriptor[],
 ) {
+    if (session?.parentSessionId?.trim()) {
+        const sessionTitle = getSessionTitle(session);
+        const subagentName =
+            sessionTitle === "New chat" ? "Subagent" : sessionTitle;
+        return `Review: ${subagentName}`;
+    }
+
     const runtimeName = runtimes.find(
         (descriptor) => descriptor.runtime.id === session?.runtimeId,
     )?.runtime.name;

--- a/apps/desktop/src/features/editor/extensions/mergeViewDiff.test.ts
+++ b/apps/desktop/src/features/editor/extensions/mergeViewDiff.test.ts
@@ -254,7 +254,7 @@ describe("mergeViewDiff", () => {
 
     expect(rejectButton).not.toBeNull();
     if (rejectButton) {
-      fireEvent.mouseDown(rejectButton);
+      fireEvent.click(rejectButton);
     }
 
     expect(calls).toHaveLength(1);
@@ -670,7 +670,7 @@ describe("mergeViewDiff", () => {
     ) as HTMLButtonElement | null;
     expect(rejectButton?.dataset.reviewDecisionScope).toBe("chunk");
     if (rejectButton) {
-      fireEvent.mouseDown(rejectButton);
+      fireEvent.click(rejectButton);
     }
 
     expect(calls).toHaveLength(1);
@@ -747,7 +747,7 @@ describe("mergeViewDiff", () => {
 
     expect(acceptButton).not.toBeNull();
     if (acceptButton) {
-      fireEvent.mouseDown(acceptButton);
+      fireEvent.click(acceptButton);
     }
 
     expect(calls).toHaveLength(1);

--- a/apps/desktop/src/features/editor/extensions/reviewProjectionControls.ts
+++ b/apps/desktop/src/features/editor/extensions/reviewProjectionControls.ts
@@ -651,6 +651,10 @@ function createDecisionButton(
     button.onmousedown = (event) => {
         event.preventDefault();
         event.stopPropagation();
+    };
+    button.onclick = (event) => {
+        event.preventDefault();
+        event.stopPropagation();
         onClick();
     };
     return button;

--- a/apps/desktop/src/features/editor/mergeViewSync.test.ts
+++ b/apps/desktop/src/features/editor/mergeViewSync.test.ts
@@ -467,9 +467,11 @@ describe("mergeViewSync", () => {
 
             if (acceptButton) {
                 fireEvent.mouseDown(acceptButton);
+                expect(resolveReviewHunks).not.toHaveBeenCalled();
+                fireEvent.click(acceptButton);
             }
             if (rejectButton) {
-                fireEvent.mouseDown(rejectButton);
+                fireEvent.click(rejectButton);
             }
 
             expect(resolveReviewHunks).toHaveBeenNthCalledWith(
@@ -525,7 +527,7 @@ describe("mergeViewSync", () => {
             expect(rejectButton).not.toBeNull();
 
             if (rejectButton) {
-                fireEvent.mouseDown(rejectButton);
+                fireEvent.click(rejectButton);
             }
 
             expect(resolveReviewHunks).toHaveBeenCalledWith(
@@ -597,7 +599,7 @@ describe("mergeViewSync", () => {
             ) as HTMLButtonElement | null;
             expect(freshAccept).not.toBeNull();
             if (freshAccept) {
-                fireEvent.mouseDown(freshAccept);
+                fireEvent.click(freshAccept);
             }
             expect(resolveReviewHunks).toHaveBeenCalledTimes(1);
 
@@ -745,7 +747,7 @@ describe("mergeViewSync", () => {
             expect(acceptButton).not.toBeNull();
 
             if (acceptButton) {
-                fireEvent.mouseDown(acceptButton);
+                fireEvent.click(acceptButton);
             }
 
             expect(resolveReviewHunks).toHaveBeenCalledWith(
@@ -898,7 +900,7 @@ describe("mergeViewSync", () => {
 
             expect(memberAcceptButton).not.toBeNull();
             if (memberAcceptButton) {
-                fireEvent.mouseDown(memberAcceptButton);
+                fireEvent.click(memberAcceptButton);
             }
 
             expect(resolveReviewHunks).toHaveBeenCalledWith(
@@ -968,7 +970,7 @@ describe("mergeViewSync", () => {
 
                 expect(acceptButton).not.toBeNull();
                 if (acceptButton) {
-                    fireEvent.mouseDown(acceptButton);
+                    fireEvent.click(acceptButton);
                 }
 
                 expect(resolveReviewHunks).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Show subagent names in pending-change review tab titles while preserving root runtime review labels.
- Run inline file-review Accept and Reject decisions on click release instead of mouse press.
- Update review title and inline decision tests to cover the new behavior.

## Validation
- npm run test -- src/features/ai/sessionPresentation.test.ts
- npm run test -- src/features/ai/components/EditedFilesBufferPanel.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx
- npm run test -- src/features/editor/mergeViewSync.test.ts
- npm run test -- src/features/editor/extensions/mergeViewDiff.test.ts
- npx tsc -b --pretty false
