### PR TITLE
docs(settings): update Developer Mode copy to reflect terminal tabs

### DIFF
--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3054,11 +3054,11 @@ function DevelopersSettings({
         [
             [
                 "Enable Developer Mode",
-                "Show experimental developer-facing surfaces such as the integrated terminal panel.",
+                "Show experimental developer-facing surfaces such as the integrated terminal.",
             ],
             [
                 "Enable Integrated Terminal",
-                "Show the bottom developer terminal panel and its related commands.",
+                "Enable terminal tabs in the editor workspace and related commands.",
                 "terminal",
             ],
         ],
@@ -3098,7 +3098,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="Developer Mode"
                 label="Enable Developer Mode"
-                description="Show experimental developer-facing surfaces such as the integrated terminal panel."
+                description="Show experimental developer-facing surfaces such as the integrated terminal."
                 control={
                     <Toggle
                         value={developerModeEnabled}
@@ -3112,7 +3112,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="Developer Mode"
                 label="Enable Integrated Terminal"
-                description="Show the bottom developer terminal panel and its related commands."
+                description="Enable terminal tabs in the editor workspace and related commands."
                 disabled={!developerModeEnabled}
                 keywords={["terminal"]}
                 control={


### PR DESCRIPTION
## Summary

Issue #37 noticed that the Settings copy under Developer Mode still describes the integrated terminal as a "bottom developer terminal panel," even though the current implementation opens terminals as editor/workspace tabs (via "New Terminal" mounted into the active pane). This PR updates the four affected description strings in `SettingsPanel.tsx` so the copy matches what the user actually sees.

## Changes

`apps/desktop/src/features/settings/SettingsPanel.tsx`:

- `Enable Developer Mode` description: "Show experimental developer-facing surfaces such as the integrated terminal." (drops the stale "panel" wording)
- `Enable Integrated Terminal` description: "Enable terminal tabs in the editor workspace and related commands." (the wording suggested in the issue)

Both strings appear twice in the file: once inside `sectionHasSettingsSearchMatches(...)` (where they drive Settings-search matching) and once on the matching `SearchableRow` prop. All four occurrences are updated so the search behavior and rendered description stay in sync.

## Verification

The old strings are no longer referenced anywhere else under `apps/desktop/`:

    $ grep -rn "bottom developer terminal\|integrated terminal panel" apps/
    (no matches)

No tests assert the old copy, so no test changes are required:

    $ grep -n "integrated terminal\|terminal panel\|bottom developer" \
        apps/desktop/src/features/settings/SettingsPanel.test.tsx
    (no matches)

I did not run `npm run lint` / `npm test` locally because this is a pure string change with no logic, type, or test surface touched, and the `apps/desktop` install was skipped to keep the change minimal.

Closes #37

AI disclosure: authored with Claude as a coding assistant; I reviewed the change before pushing.
