### PR TITLE
Prepare 0.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.2.6] - 2026-05-15
+
+### Added
+
+- Added per-theme syntax highlighting for CodeMirror source mode, live preview markup, chat code blocks, and static diff/code rendering, with shared `--code-*` CSS variables so theme changes stay consistent across editor surfaces.
+- Added a compact searchable Move to Folder destination picker for notes, PDFs, generic files, folders, and mixed selections from the file-tree context menu.
+- Added pane-scoped tab context menu actions for `Close Others` and `Close Tabs to the Right`, including active-agent close confirmation and disabled states when the actions do not apply.
+
+### Changed
+
+- Updated Developer Mode settings copy to describe terminal tabs in the editor workspace instead of the old bottom terminal panel. Thanks to @mvanhorn.
+- Added a README notice about Claude subscription usage in NeverWrite starting June 15, 2026.
+
+### Fixed
+
+- Fixed Move to Folder behavior so context menu moves and drag/drop moves share the same move executor and support notes, PDFs, generic files, folders, and mixed selections consistently.
+
 ## [0.2.5] - 2026-05-12
 
 **Security note:** NeverWrite's repository was audited for the May 2026 **Mini Shai-Hulud** npm supply-chain attack and no exposure was found. The repo does not contain the known malware indicators, does not depend on the affected TanStack/Mistral/UiPath/Squawk package sets, and its own GitHub workflows do not use the risky `pull_request_target` plus trusted-publishing/OIDC pattern involved in the attack. **Cloning the repository and updating the app through this channel is safe**.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.2.5"
+version = "0.2.6"
 dependencies = [
  "agent-client-protocol",
  "keyring",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.2.5"
+version = "0.2.6"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.2.5",
+    "version": "0.2.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.2.5",
+            "version": "0.2.6",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.2.5",
+    "version": "0.2.6",
     "type": "module",
     "main": "out/electron/main/index.js",
     "engines": {

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.2.5",
+    "version": "0.2.6",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary
- Bump desktop, native backend, package lock, and web clipper versions to 0.2.6.
- Add 0.2.6 release notes to the changelog.

## Validation
- `cargo update -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.2.6`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`