### PR TITLE
Fix frontmatter property spaces

### DIFF
--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -416,6 +416,41 @@ describe("Editor", () => {
         expect(screen.getAllByDisplayValue("Updated title")).toHaveLength(2);
     });
 
+    it("allows inserting spaces while editing text properties", async () => {
+        setEditorTabs([
+            {
+                id: "tab-1",
+                noteId: "notes/current",
+                title: "Frontmatter title",
+                content: "---\ntitle: Frontmatter title\n---\nBody",
+            },
+        ]);
+
+        renderComponent(<Editor />);
+
+        await act(async () => {
+            fireEvent.click(screen.getByRole("button", { name: "Properties" }));
+        });
+
+        const view = getEditorView();
+        const propertyInput = screen.getAllByDisplayValue(
+            "Frontmatter title",
+        )[1];
+
+        await act(async () => {
+            fireEvent.change(propertyInput, {
+                target: { value: "Frontmatter title " },
+            });
+        });
+
+        expect((propertyInput as HTMLInputElement).value).toBe(
+            "Frontmatter title ",
+        );
+        expect(view.state.doc.toString()).toContain(
+            'title: "Frontmatter title "',
+        );
+    });
+
     it("does not underline markdown headings in source mode", async () => {
         setEditorTabs([
             {

--- a/apps/desktop/src/features/editor/FrontmatterPanel.helpers.test.ts
+++ b/apps/desktop/src/features/editor/FrontmatterPanel.helpers.test.ts
@@ -38,4 +38,18 @@ tags:
 ---
 `);
     });
+
+    it("preserves a trailing space while text properties are being edited", () => {
+        const raw = serializeFrontmatterRaw([
+            { key: "title", value: "Roadmap " },
+        ]);
+
+        expect(raw).toBe(`---
+title: "Roadmap "
+---
+`);
+        expect(parseFrontmatterRaw(raw ?? "")).toEqual([
+            { key: "title", value: "Roadmap " },
+        ]);
+    });
 });

--- a/apps/desktop/src/features/editor/FrontmatterPanel.tsx
+++ b/apps/desktop/src/features/editor/FrontmatterPanel.tsx
@@ -78,14 +78,15 @@ export function serializeFrontmatterRaw(
             key: key.trim(),
             value: Array.isArray(value)
                 ? value.map((item) => item.trim()).filter(Boolean)
-                : typeof value === "string"
-                  ? value.trim()
-                  : value,
+                : value,
         }))
         .filter(({ key, value }) => {
             if (!key) return false;
             if (Array.isArray(value)) return value.length > 0;
-            return value !== null && value !== "";
+            return (
+                value !== null &&
+                (typeof value !== "string" || value.trim() !== "")
+            );
         });
 
     if (!cleaned.length) return null;
@@ -104,7 +105,12 @@ export function serializeFrontmatterRaw(
 
 function quoteYaml(value: string): string {
     if (!value) return '""';
-    if (/^[A-Za-z0-9 _./:@#%+,-]+$/.test(value)) return value;
+    if (
+        value.trim() === value &&
+        /^[A-Za-z0-9 _./:@#%+,-]+$/.test(value)
+    ) {
+        return value;
+    }
     return JSON.stringify(value);
 }
 


### PR DESCRIPTION
## Summary

Fixes #43.

This fixes text editing in the live preview Properties/frontmatter panel so trailing spaces are not immediately stripped while the user is typing. The root cause was that `serializeFrontmatterRaw` trimmed string values on every keystroke; because the panel is controlled by the serialized frontmatter, typing a space at the end of a property value was instantly normalized away.

The serializer now preserves string values during editing, still drops values that are empty after trimming, and quotes YAML values when leading or trailing whitespace must be preserved.

## Validation

- `npm test -- --run src/features/editor/FrontmatterPanel.helpers.test.ts src/features/editor/Editor.test.tsx --testNamePattern "allows inserting spaces|properties|Frontmatter helpers"`
- `npm run lint -- src/features/editor/FrontmatterPanel.tsx src/features/editor/FrontmatterPanel.helpers.test.ts src/features/editor/Editor.test.tsx`
