### PR TITLE
Fix live preview table gaps

### DIFF
--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -41,6 +41,50 @@ describe("resolvePreviewAssetPath", () => {
 });
 
 describe("code block live preview", () => {
+    it("compacts inactive blank lines around rendered tables", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = [
+            "## Table",
+            "",
+            "| A | B |",
+            "| --- | --- |",
+            "| 1 | 2 |",
+            "",
+            "After",
+        ].join("\n");
+        const state = EditorState.create({
+            doc,
+            selection: EditorSelection.cursor(0),
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                livePreviewExtension(null, {
+                    resolveWikilink: () => false,
+                    navigateWikilink: () => {},
+                    getNoteLinkTarget: () => null,
+                    openLinkContextMenu: () => {},
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent });
+
+        expect(view.dom.querySelector(".cm-lp-table-widget")).not.toBeNull();
+        const blankLines = [...view.dom.querySelectorAll(".cm-line")].filter(
+            (line) => line.textContent?.trim() === "",
+        );
+        expect(blankLines).toHaveLength(2);
+        expect(
+            blankLines.every((line) =>
+                line.classList.contains("cm-lp-block-gap-hidden"),
+            ),
+        ).toBe(true);
+
+        view.destroy();
+        parent.remove();
+    });
+
     it("shows the code block header even when the caret is on the fence line", () => {
         const parent = document.createElement("div");
         document.body.appendChild(parent);

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -43,7 +43,10 @@ import {
     parseLinkChildren,
     resolveLinkHref,
 } from "./livePreviewHelpers";
-import { selectionTouchesRange } from "./selectionActivity";
+import {
+    selectionTouchesLine,
+    selectionTouchesRange,
+} from "./selectionActivity";
 
 const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif)([?#].*)?$/i;
 const PDF_EXTENSION = /\.pdf([?#].*)?$/i;
@@ -1523,6 +1526,67 @@ function parseMarkdownTable(source: string) {
     };
 }
 
+function getInactiveAdjacentBlankLineRange(
+    state: EditorState,
+    from: number,
+    to: number,
+) {
+    let replaceFrom = from;
+    let replaceTo = to;
+
+    const startLine = state.doc.lineAt(from);
+    if (startLine.number > 1) {
+        const previousLine = state.doc.line(startLine.number - 1);
+        if (
+            previousLine.text.trim().length === 0 &&
+            !selectionTouchesLine(state, previousLine.from, previousLine.to)
+        ) {
+            replaceFrom = previousLine.from;
+        }
+    }
+
+    const endLine = state.doc.lineAt(Math.max(from, to - 1));
+    if (endLine.number < state.doc.lines) {
+        const nextLine = state.doc.line(endLine.number + 1);
+        if (
+            nextLine.text.trim().length === 0 &&
+            !selectionTouchesLine(state, nextLine.from, nextLine.to)
+        ) {
+            replaceTo = nextLine.to;
+        }
+    }
+
+    return { from: replaceFrom, to: replaceTo };
+}
+
+function addInactiveAdjacentBlankLineDecorations(
+    decos: DecoEntry[],
+    state: EditorState,
+    from: number,
+    to: number,
+) {
+    const addIfInactiveBlank = (lineNumber: number) => {
+        if (lineNumber < 1 || lineNumber > state.doc.lines) return;
+
+        const line = state.doc.line(lineNumber);
+        if (
+            line.text.trim().length > 0 ||
+            selectionTouchesLine(state, line.from, line.to)
+        ) {
+            return;
+        }
+
+        decos.push({
+            from: line.from,
+            to: line.from,
+            deco: Decoration.line({ class: "cm-lp-block-gap-hidden" }),
+        });
+    };
+
+    addIfInactiveBlank(state.doc.lineAt(from).number - 1);
+    addIfInactiveBlank(state.doc.lineAt(Math.max(from, to - 1)).number + 1);
+}
+
 function createTableCell(
     tagName: "div",
     cellInfo: ParsedTableCell,
@@ -2154,9 +2218,23 @@ function buildTableDecorations(
             }
 
             const source = state.doc.sliceString(node.from, node.to);
+            // CodeMirror keeps visual line boxes for inactive blank lines around
+            // block widgets unless the replacement range and line styling both
+            // account for them.
+            const replacementRange = getInactiveAdjacentBlankLineRange(
+                state,
+                node.from,
+                node.to,
+            );
+            addInactiveAdjacentBlankLineDecorations(
+                decos,
+                state,
+                node.from,
+                node.to,
+            );
             decos.push({
-                from: node.from,
-                to: node.to,
+                from: replacementRange.from,
+                to: replacementRange.to,
                 deco: Decoration.replace({
                     widget: new TableWidget(
                         source,

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -691,6 +691,15 @@ export const livePreviewTheme = EditorView.baseTheme({
         textDecorationStyle: "dotted",
         textUnderlineOffset: "2px",
     },
+    ".cm-lp-block-gap-hidden": {
+        height: "0",
+        minHeight: "0",
+        paddingTop: "0 !important",
+        paddingBottom: "0 !important",
+        lineHeight: "0",
+        fontSize: "0",
+        overflow: "hidden",
+    },
     ".cm-lp-table-widget": {
         display: "block",
         padding: "12px 0",


### PR DESCRIPTION
## Summary

Fixes the extra vertical space around rendered Markdown tables in live preview.

## Root Cause

CodeMirror was keeping visual line boxes for inactive blank lines adjacent to table block widgets. The table itself was replaced by a live preview widget, but the surrounding blank Markdown lines still occupied editor height.

## Changes

- Expand the table replacement range to account for inactive adjacent blank lines.
- Add a `cm-lp-block-gap-hidden` line decoration to collapse those retained placeholder lines.
- Add a focused regression test covering blank lines before and after a rendered table.

## Validation

- `npm test -- --run src/features/editor/extensions/livePreviewBlocks.test.ts src/features/editor/extensions/livePreviewInline.test.ts`
- `git diff --check`
