### PR TITLE
Add cross-tab editor isolation tests

### DIFF
--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -2988,4 +2988,67 @@ describe("Editor", () => {
         expect(view.state.doc.toString()).toBe("[[/src/main.ts]]");
         expect(screen.queryByText("main.ts")).not.toBeInTheDocument();
     });
+
+    it("does not leak edits from one note tab into a different note tab", async () => {
+        vi.useFakeTimers();
+        mockInvoke().mockImplementation(async (command, args) => {
+            if (command === "save_note") {
+                const payload = args as { noteId: string; content: string };
+                return {
+                    id: payload.noteId,
+                    path: `${payload.noteId}.md`,
+                    title: payload.noteId.endsWith("/a") ? "A" : "B",
+                    content: payload.content,
+                };
+            }
+            return undefined;
+        });
+        setEditorTabs(
+            [
+                {
+                    id: "tab-a",
+                    noteId: "notes/a",
+                    title: "A",
+                    content: "Alpha",
+                },
+                {
+                    id: "tab-b",
+                    noteId: "notes/b",
+                    title: "B",
+                    content: "Beta",
+                },
+            ],
+            "tab-a",
+        );
+
+        renderComponent(<Editor />);
+
+        const view = getEditorView();
+        await act(async () => {
+            view.dispatch({
+                changes: {
+                    from: view.state.doc.length,
+                    to: view.state.doc.length,
+                    insert: " edited",
+                },
+            });
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await flushPromises();
+        });
+
+        await act(async () => {
+            useEditorStore.getState().switchTab("tab-b");
+            await flushPromises();
+        });
+
+        expect(getEditorView().state.doc.toString()).toBe("Beta");
+        const tabB = useEditorStore
+            .getState()
+            .tabs.find((tab) => tab.id === "tab-b");
+        expect(tabB && "content" in tabB ? tabB.content : null).toBe("Beta");
+        expect(useEditorStore.getState().dirtyTabIds.has("tab-b")).toBe(false);
+    });
 });

--- a/apps/desktop/src/features/editor/FileTabView.test.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.test.tsx
@@ -1277,4 +1277,74 @@ describe("FileTabView", () => {
         expect(getChunks(view!.state)).toBeNull();
         expect(view!.state.doc.toString()).toBe('name = "NeverWrite"');
     });
+
+    it("does not leak edits from one text file tab into a different text file tab", async () => {
+        vi.useFakeTimers();
+        setEditorTabs(
+            [
+                {
+                    id: "text-tab-a",
+                    kind: "file",
+                    relativePath: "src/a.toml",
+                    title: "a.toml",
+                    path: "/vault/src/a.toml",
+                    mimeType: "application/toml",
+                    viewer: "text",
+                    content: 'name = "A"',
+                },
+                {
+                    id: "text-tab-b",
+                    kind: "file",
+                    relativePath: "src/b.toml",
+                    title: "b.toml",
+                    path: "/vault/src/b.toml",
+                    mimeType: "application/toml",
+                    viewer: "text",
+                    content: 'name = "B"',
+                },
+            ],
+            "text-tab-a",
+        );
+
+        renderComponent(<FileTabView />);
+
+        const view = EditorView.findFromDOM(
+            document.querySelector(".cm-editor") as HTMLElement,
+        );
+        expect(view).not.toBeNull();
+        await act(async () => {
+            view!.dispatch({
+                changes: {
+                    from: view!.state.doc.length,
+                    to: view!.state.doc.length,
+                    insert: "\nchanged = true",
+                },
+            });
+        });
+
+        await act(async () => {
+            vi.advanceTimersByTime(300);
+            await Promise.resolve();
+        });
+
+        await act(async () => {
+            useEditorStore.getState().switchTab("text-tab-b");
+            await Promise.resolve();
+        });
+
+        const nextView = EditorView.findFromDOM(
+            document.querySelector(".cm-editor") as HTMLElement,
+        );
+        expect(nextView).not.toBeNull();
+        expect(nextView!.state.doc.toString()).toBe('name = "B"');
+        const tabB = useEditorStore
+            .getState()
+            .tabs.find((tab) => tab.id === "text-tab-b");
+        expect(tabB && "content" in tabB ? tabB.content : null).toBe(
+            'name = "B"',
+        );
+        expect(useEditorStore.getState().dirtyTabIds.has("text-tab-b")).toBe(
+            false,
+        );
+    });
 });


### PR DESCRIPTION
## Summary

Adds regression coverage for cross-tab editor isolation across distinct resources.

- Verifies that editing one note tab does not mutate a different note tab's visible document, stored content, or dirty state.
- Verifies the same isolation behavior for two distinct text file tabs.

## Context

Refs #108. During investigation, the broader report that editing one document mutates another distinct document was not reproduced in the basic two-tab flows. These tests preserve that expected boundary so future editor lifecycle changes do not accidentally introduce the leak.

## Validation

```bash
npm test -- src/features/editor/Editor.test.tsx src/features/editor/FileTabView.test.tsx -t "does not leak edits from one note tab into a different note tab|does not leak edits from one text file tab into a different text file tab"
```

Result: 2 passed.
