### PR TITLE
Fix YouTube theater mode embeds

### DIFF
--- a/apps/desktop/src-electron/main/index.ts
+++ b/apps/desktop/src-electron/main/index.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, protocol } from "electron";
+import { app, BrowserWindow, protocol, session } from "electron";
 import { installNativeMenus, refreshDockMenu } from "./menu";
 import { createAppWindow, getWindowByLabel } from "./window";
 import {
@@ -15,6 +15,7 @@ import {
     installProcessDiagnostics,
     writeAppLog,
 } from "./appLogger";
+import { installYouTubeEmbedIdentityHeaders } from "./youtubeEmbedIdentity";
 
 const WINDOWS_APP_USER_MODEL_ID =
     process.env.NEVERWRITE_ELECTRON_APP_ID?.trim() || "com.neverwrite";
@@ -99,6 +100,7 @@ if (!hasLock) {
 
     void app.whenReady().then(() => {
         writeAppLog("main", "info", "Electron app ready");
+        installYouTubeEmbedIdentityHeaders(session.defaultSession);
         protocol.handle("neverwrite-file", registerPreviewProtocolHandler());
         registerIpcHandlers();
         void installNativeMenus();

--- a/apps/desktop/src-electron/main/youtubeEmbedIdentity.test.ts
+++ b/apps/desktop/src-electron/main/youtubeEmbedIdentity.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+    installYouTubeEmbedIdentityHeaders,
+    withYouTubeEmbedIdentityHeaders,
+} from "./youtubeEmbedIdentity";
+
+describe("withYouTubeEmbedIdentityHeaders", () => {
+    it("adds a stable Referer when Electron does not provide one", () => {
+        expect(withYouTubeEmbedIdentityHeaders({ Accept: "text/html" })).toEqual(
+            {
+                Accept: "text/html",
+                Referer: "https://neverwrite.localhost/",
+            },
+        );
+    });
+
+    it("preserves an existing non-empty Referer", () => {
+        const headers = {
+            Referer: "http://127.0.0.1:5173/",
+        };
+
+        expect(withYouTubeEmbedIdentityHeaders(headers)).toBe(headers);
+    });
+
+    it("reuses existing header casing when the Referer is empty", () => {
+        expect(withYouTubeEmbedIdentityHeaders({ referer: "" })).toEqual({
+            referer: "https://neverwrite.localhost/",
+        });
+    });
+});
+
+describe("installYouTubeEmbedIdentityHeaders", () => {
+    it("registers only YouTube embed requests for header injection", () => {
+        let registeredFilter: { urls: string[] } | null = null;
+
+        installYouTubeEmbedIdentityHeaders({
+            webRequest: {
+                onBeforeSendHeaders(filter) {
+                    registeredFilter = filter;
+                },
+            },
+        });
+
+        expect(registeredFilter).toEqual({
+            urls: [
+                "https://www.youtube.com/embed/*",
+                "https://www.youtube-nocookie.com/embed/*",
+            ],
+        });
+    });
+});

--- a/apps/desktop/src-electron/main/youtubeEmbedIdentity.ts
+++ b/apps/desktop/src-electron/main/youtubeEmbedIdentity.ts
@@ -1,0 +1,64 @@
+const YOUTUBE_EMBED_REFERER = "https://neverwrite.localhost/";
+const YOUTUBE_EMBED_URLS = [
+    "https://www.youtube.com/embed/*",
+    "https://www.youtube-nocookie.com/embed/*",
+];
+
+type RequestHeaders = Record<string, string>;
+
+interface BeforeSendHeadersDetails {
+    url: string;
+    requestHeaders: RequestHeaders;
+}
+
+type BeforeSendHeadersCallback = (response: {
+    requestHeaders: RequestHeaders;
+}) => void;
+
+interface HeaderInstallingSession {
+    webRequest: {
+        onBeforeSendHeaders: (
+            filter: { urls: string[] },
+            listener: (
+                details: BeforeSendHeadersDetails,
+                callback: BeforeSendHeadersCallback,
+            ) => void,
+        ) => void;
+    };
+}
+
+function findHeaderKey(headers: RequestHeaders, name: string) {
+    const normalizedName = name.toLowerCase();
+    return Object.keys(headers).find(
+        (key) => key.toLowerCase() === normalizedName,
+    );
+}
+
+export function withYouTubeEmbedIdentityHeaders(
+    headers: RequestHeaders,
+): RequestHeaders {
+    const refererKey = findHeaderKey(headers, "referer");
+    if (refererKey && headers[refererKey]?.trim()) {
+        return headers;
+    }
+
+    return {
+        ...headers,
+        [refererKey ?? "Referer"]: YOUTUBE_EMBED_REFERER,
+    };
+}
+
+export function installYouTubeEmbedIdentityHeaders(
+    targetSession: HeaderInstallingSession,
+) {
+    targetSession.webRequest.onBeforeSendHeaders(
+        { urls: YOUTUBE_EMBED_URLS },
+        (details, callback) => {
+            callback({
+                requestHeaders: withYouTubeEmbedIdentityHeaders(
+                    details.requestHeaders,
+                ),
+            });
+        },
+    );
+}


### PR DESCRIPTION
## Summary

Fixes YouTube theater mode embeds in the desktop app by adding a narrow Electron request-header hook for YouTube embed URLs.

## Root cause

YouTube embedded players now require API client identity through the `HTTP Referer` request header or an equivalent signal. In packaged Electron builds, the renderer can be loaded from a non-HTTP app/file origin, so the iframe request to `youtube.com/embed` or `youtube-nocookie.com/embed` may arrive without a useful `Referer`, which produces YouTube error 153.

## Changes

- Adds a main-process helper that injects a stable `Referer` only for YouTube embed player requests when Electron does not already provide one.
- Registers the hook before creating the main app window.
- Covers the header behavior and URL filter with unit tests.

## Validation

- `npm test -- youtubeEmbedIdentity.test.ts youtube.test.tsx desktopCsp.test.ts`
- `npm run build`

Fixes #104
