### PR TITLE
Fix restored chat transcript hydration

### DIFF
--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -2250,6 +2250,156 @@ describe("chatStore", () => {
         ]);
     });
 
+    it("loads every restored workspace chat tab after history metadata is reconciled", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        const pages = {
+            "history-active": [
+                {
+                    id: "active-m1",
+                    role: "user",
+                    kind: "text",
+                    content: "Active recovered prompt",
+                    timestamp: 10,
+                },
+            ],
+            "history-background": [
+                {
+                    id: "background-m1",
+                    role: "assistant",
+                    kind: "text",
+                    content: "Background recovered reply",
+                    timestamp: 20,
+                },
+            ],
+        } as const;
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_list_runtimes") {
+                return runtimePayload;
+            }
+
+            if (command === "ai_get_setup_status") {
+                return readySetupStatus;
+            }
+
+            if (command === "ai_list_sessions") {
+                return [
+                    {
+                        ...sessionPayload,
+                        session_id: "session-active",
+                        models: [],
+                        modes: [],
+                        config_options: [],
+                    },
+                    {
+                        ...sessionPayload,
+                        session_id: "session-background",
+                        models: [],
+                        modes: [],
+                        config_options: [],
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session_histories") {
+                return [
+                    {
+                        version: 1,
+                        session_id: "history-active",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 10,
+                        updated_at: 0,
+                        message_count: 1,
+                        title: "Active restored",
+                        preview: "Active recovered prompt",
+                        messages: [],
+                    },
+                    {
+                        version: 1,
+                        session_id: "history-background",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 20,
+                        updated_at: 0,
+                        message_count: 1,
+                        title: "Background restored",
+                        preview: "Background recovered reply",
+                        messages: [],
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session_history_page") {
+                const sessionId =
+                    (args as { sessionId?: keyof typeof pages } | undefined)
+                        ?.sessionId ?? "history-active";
+                const messages = pages[sessionId] ?? [];
+                return {
+                    session_id: sessionId,
+                    total_messages: messages.length,
+                    start_index: 0,
+                    end_index: messages.length,
+                    messages,
+                };
+            }
+
+            return sessionPayload;
+        });
+
+        await useChatStore.getState().initialize();
+
+        await useChatStore.getState().reconcileRestoredWorkspaceTabs(
+            [
+                {
+                    id: "tab-active",
+                    sessionId: "session-active",
+                    historySessionId: "history-active",
+                    runtimeId: "codex-acp",
+                },
+                {
+                    id: "tab-background",
+                    sessionId: "session-background",
+                    historySessionId: "history-background",
+                    runtimeId: "codex-acp",
+                },
+            ],
+            "tab-active",
+        );
+
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById["session-active"]?.messages.map(
+                    (message) => message.id,
+                ),
+        ).toEqual(["active-m1"]);
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById["session-background"]?.messages.map(
+                    (message) => message.id,
+                ),
+        ).toEqual(["background-m1"]);
+        expect(
+            invokeMock.mock.calls
+                .filter(
+                    ([command]) => command === "ai_load_session_history_page",
+                )
+                .map(([, args]) => (args as { sessionId?: string }).sessionId)
+                .sort(),
+        ).toEqual(["history-active", "history-background"]);
+    });
+
     it("loads only the latest persisted transcript page for the active live session on initialize", async () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
 
@@ -2331,6 +2481,244 @@ describe("chatStore", () => {
                 limit: 60,
             },
         );
+    });
+
+    it("preserves loaded persisted transcripts when initialize refreshes metadata-only histories", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("session-active", []),
+                historySessionId: "session-active",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+            },
+            true,
+        );
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles(
+                    "persisted:history-background",
+                    [],
+                ),
+                historySessionId: "history-background",
+                runtimeId: "codex-acp",
+                runtimeState: "persisted_only",
+                isPersistedSession: true,
+                persistedMessageCount: 1,
+                loadedPersistedMessageStart: 0,
+                messages: [
+                    {
+                        id: "background-loaded",
+                        role: "assistant",
+                        kind: "text",
+                        content: "Already loaded background transcript",
+                        timestamp: 30,
+                    },
+                ],
+            },
+            false,
+            { allowUnknownSession: true },
+        );
+
+        invokeMock.mockImplementation(async (command) => {
+            if (command === "ai_list_runtimes") {
+                return runtimePayload;
+            }
+
+            if (command === "ai_get_setup_status") {
+                return readySetupStatus;
+            }
+
+            if (command === "ai_list_sessions") {
+                return [
+                    {
+                        ...sessionPayload,
+                        session_id: "session-active",
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session_histories") {
+                return [
+                    {
+                        version: 1,
+                        session_id: "history-background",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 10,
+                        updated_at: 20,
+                        message_count: 1,
+                        title: "Background restored",
+                        preview: "Already loaded background transcript",
+                        messages: [],
+                    },
+                ];
+            }
+
+            return sessionPayload;
+        });
+
+        await useChatStore.getState().initialize();
+
+        const background =
+            useChatStore.getState().sessionsById[
+                "persisted:history-background"
+            ]!;
+        expect(background.messages.map((message) => message.id)).toEqual([
+            "background-loaded",
+        ]);
+        expect(background.loadedPersistedMessageStart).toBe(0);
+        expect(background.persistedTitle).toBe("Background restored");
+    });
+
+    it("replaces stale persisted transcript windows when refreshed metadata grows", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        const refreshedPersistedMessages = [
+            ...Array.from({ length: 5 }, (_, index) => ({
+                id: `persisted-new-${index}`,
+                role: index % 2 === 0 ? "user" : "assistant",
+                kind: "text",
+                content: `New persisted message ${index}`,
+                timestamp: 100 + index,
+            })),
+            {
+                id: "live-tail-persisted",
+                role: "assistant",
+                kind: "text",
+                content: "Live tail already persisted",
+                timestamp: 105,
+            },
+        ];
+
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles("session-growing", []),
+                historySessionId: "session-growing",
+                runtimeId: "codex-acp",
+                runtimeState: "live",
+                modelId: "test-model",
+                modeId: "default",
+                persistedMessageCount: 4,
+                loadedPersistedMessageStart: 1,
+                messages: [
+                    {
+                        id: "persisted-old-1",
+                        role: "user",
+                        kind: "text",
+                        content: "Old persisted message 1",
+                        timestamp: 10,
+                    },
+                    {
+                        id: "persisted-old-2",
+                        role: "assistant",
+                        kind: "text",
+                        content: "Old persisted message 2",
+                        timestamp: 11,
+                    },
+                    {
+                        id: "persisted-old-3",
+                        role: "user",
+                        kind: "text",
+                        content: "Old persisted message 3",
+                        timestamp: 12,
+                    },
+                    {
+                        id: "live-tail-persisted",
+                        role: "assistant",
+                        kind: "text",
+                        content: "Live tail that was persisted after metadata refresh",
+                        timestamp: 13,
+                    },
+                    {
+                        id: "live-tail-local",
+                        role: "assistant",
+                        kind: "text",
+                        content: "Live tail that is not persisted yet",
+                        timestamp: 14,
+                    },
+                ],
+            },
+            true,
+        );
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_list_runtimes") {
+                return runtimePayload;
+            }
+
+            if (command === "ai_get_setup_status") {
+                return readySetupStatus;
+            }
+
+            if (command === "ai_list_sessions") {
+                return [
+                    {
+                        ...sessionPayload,
+                        session_id: "session-growing",
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session_histories") {
+                return [
+                    {
+                        version: 1,
+                        session_id: "session-growing",
+                        runtime_id: "codex-acp",
+                        model_id: "test-model",
+                        mode_id: "default",
+                        models: acpModels,
+                        modes: acpModes,
+                        config_options: acpConfigOptions,
+                        created_at: 10,
+                        updated_at: 200,
+                        message_count: 6,
+                        title: "Growing history",
+                        preview: "New persisted message 5",
+                        messages: [],
+                    },
+                ];
+            }
+
+            if (command === "ai_load_session_history_page") {
+                expect(args).toMatchObject({
+                    vaultPath: "/vault",
+                    sessionId: "session-growing",
+                    startIndex: 0,
+                    limit: 6,
+                });
+                return {
+                    session_id: "session-growing",
+                    total_messages: 6,
+                    start_index: 0,
+                    end_index: 6,
+                    messages: refreshedPersistedMessages,
+                };
+            }
+
+            return sessionPayload;
+        });
+
+        await useChatStore.getState().initialize();
+
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById["session-growing"]?.messages.map(
+                    (message) => message.id,
+                ),
+        ).toEqual([
+            ...refreshedPersistedMessages.map((message) => message.id),
+            "live-tail-local",
+        ]);
     });
 
     it("does not replace an already-normalized empty persisted transcript session", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -4508,30 +4508,87 @@ function ensurePersistedTranscriptWindowAnchor(session: AIChatSession) {
     };
 }
 
+function resolveLoadedPersistedMessageStartForMetadata(
+    session: AIChatSession,
+    persistedMessageCount: number,
+) {
+    if (persistedMessageCount === 0) {
+        return 0;
+    }
+
+    const loadedStart = session.loadedPersistedMessageStart;
+    if (loadedStart == null) {
+        return null;
+    }
+    if (loadedStart < 0 || loadedStart > persistedMessageCount) {
+        return null;
+    }
+
+    // Persisted window markers are tied to the metadata count they were loaded
+    // against. If the count changed, reload the latest page and preserve only
+    // the live tail that sat after the old persisted window.
+    if ((session.persistedMessageCount ?? 0) !== persistedMessageCount) {
+        return null;
+    }
+
+    // Metadata can arrive after an earlier "empty history" pass. Keep the
+    // window marker only when the transcript still proves that window exists.
+    const loadedPersistedCount = persistedMessageCount - loadedStart;
+    return getSessionTranscriptLength(session) >= loadedPersistedCount
+        ? loadedStart
+        : null;
+}
+
 function applyPersistedHistoryMetadata(
     session: AIChatSession,
     history: PersistedSessionHistorySummary,
 ) {
     const persistedCatalog = getPersistedHistoryCatalogSnapshot(history);
+    const persistedMessageCount = getPersistedHistoryMessageCount(history);
+    const loadedPersistedMessageStart =
+        resolveLoadedPersistedMessageStartForMetadata(
+            session,
+            persistedMessageCount,
+        );
+    let nextSession = session;
+    if (
+        persistedMessageCount > 0 &&
+        session.loadedPersistedMessageStart != null &&
+        loadedPersistedMessageStart === null
+    ) {
+        // The persisted window marker no longer matches the refreshed history
+        // metadata. Drop the stale persisted window, but keep any live tail
+        // that was appended after it.
+        const previousPersistedWindowLength = Math.max(
+            0,
+            (session.persistedMessageCount ?? 0) -
+                session.loadedPersistedMessageStart,
+        );
+        const liveTail =
+            getSessionTranscriptMessages(session).slice(
+                previousPersistedWindowLength,
+            );
+        nextSession = replaceSessionTranscript(session, liveTail);
+    }
+
     if (hasRuntimeCatalog(persistedCatalog)) {
         saveRuntimeCatalogCache(session.runtimeId, persistedCatalog);
     }
 
     return hydrateSessionCatalogFromSnapshot(
         {
-            ...session,
+            ...nextSession,
             parentSessionId:
-                history.parent_session_id ?? session.parentSessionId ?? null,
+                history.parent_session_id ??
+                nextSession.parentSessionId ??
+                null,
             persistedCreatedAt: history.created_at,
             persistedUpdatedAt: history.updated_at,
             persistedTitle: history.title ?? null,
             customTitle: history.custom_title ?? null,
             persistedPreview: history.preview ?? null,
-            persistedMessageCount: getPersistedHistoryMessageCount(history),
-            loadedPersistedMessageStart:
-                getPersistedHistoryMessageCount(history) === 0
-                    ? 0
-                    : (session.loadedPersistedMessageStart ?? null),
+            persistedMessageCount,
+            loadedPersistedMessageStart,
         },
         persistedCatalog,
     );
@@ -4565,6 +4622,10 @@ function applyPersistedHistoryPage(
         preview: session.persistedPreview ?? undefined,
         messages: page.messages,
     });
+    const pageMessageIds = new Set(pageMessages.map((message) => message.id));
+    const liveTailNotInPage = liveTail.filter(
+        (message) => !pageMessageIds.has(message.id),
+    );
 
     const nextSession = {
         ...session,
@@ -4577,7 +4638,7 @@ function applyPersistedHistoryPage(
         nextSession,
         mode === "prepend"
             ? [...pageMessages, ...currentMessages]
-            : [...pageMessages, ...liveTail],
+            : [...pageMessages, ...liveTailNotInPage],
     );
 }
 
@@ -5660,11 +5721,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     const shouldPrepend =
                         mode === "older" ||
                         (currentSession.messages.length > 0 &&
-                            (currentSession.loadedPersistedMessageStart ==
-                                null ||
-                                currentSession.loadedPersistedMessageStart >=
-                                    (currentSession.persistedMessageCount ??
-                                        0)));
+                            currentSession.loadedPersistedMessageStart != null &&
+                            currentSession.loadedPersistedMessageStart >=
+                                (currentSession.persistedMessageCount ?? 0));
 
                     return applyPersistedHistoryPage(
                         currentSession,
@@ -6432,6 +6491,19 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
                 if (sessions.length || histories.length) {
                     set((state) => {
+                        const existingSessionByHistoryId = new Map(
+                            Object.values(state.sessionsById).flatMap(
+                                (session) =>
+                                    session.historySessionId
+                                        ? [
+                                              [
+                                                  session.historySessionId,
+                                                  session,
+                                              ] as const,
+                                          ]
+                                        : [],
+                            ),
+                        );
                         const nextSessionsById = sessions.reduce<
                             Record<string, AIChatSession>
                         >((accumulator, session) => {
@@ -6440,7 +6512,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                                 vaultPath,
                             );
                             const existing =
-                                state.sessionsById[scopedSession.sessionId];
+                                state.sessionsById[scopedSession.sessionId] ??
+                                existingSessionByHistoryId.get(
+                                    scopedSession.historySessionId,
+                                );
                             let merged = mergeSession(existing, scopedSession);
                             const persisted = persistedBySessionId.get(
                                 merged.historySessionId,
@@ -6491,7 +6566,13 @@ export const useChatStore = create<ChatStore>((set, get) => {
                                 vaultPath,
                             );
                             if (!restored) continue;
-                            nextSessionsById[restored.sessionId] = restored;
+                            const existing =
+                                state.sessionsById[restored.sessionId] ??
+                                existingSessionByHistoryId.get(
+                                    restored.historySessionId,
+                                );
+                            nextSessionsById[restored.sessionId] =
+                                mergeSession(existing, restored);
                         }
 
                         const nextSessionOrder =
@@ -6607,8 +6688,17 @@ export const useChatStore = create<ChatStore>((set, get) => {
             }
 
             const sessionIdsNeedingCatalog = new Set<string>();
+            const restoredSessionIds: string[] = [];
+            const restoredSessionIdSet = new Set<string>();
             const vaultPath = useVaultStore.getState().vaultPath;
             const resolvedSessionIdByTabId = new Map<string, string>();
+            const rememberRestoredSessionId = (sessionId: string) => {
+                if (restoredSessionIdSet.has(sessionId)) {
+                    return;
+                }
+                restoredSessionIdSet.add(sessionId);
+                restoredSessionIds.push(sessionId);
+            };
 
             set((state) => {
                 const nextSessionsById = { ...state.sessionsById };
@@ -6641,6 +6731,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     if (!currentSession) {
                         continue;
                     }
+                    rememberRestoredSessionId(resolvedSessionId);
 
                     let nextSession = currentSession;
                     if (
@@ -6704,37 +6795,52 @@ export const useChatStore = create<ChatStore>((set, get) => {
                   null)
                 : null;
             if (!activeSessionId) {
+                for (const sessionId of restoredSessionIds) {
+                    await get().ensureSessionTranscriptLoaded(
+                        sessionId,
+                        "latest",
+                    );
+                }
                 return;
             }
 
             let activeSession: AIChatSession | null =
                 get().sessionsById[activeSessionId] ?? null;
-            if (!activeSession) {
-                return;
+            if (activeSession) {
+                if (
+                    !isLiveRuntimeSession(activeSession) &&
+                    !activeSession.isResumingSession
+                ) {
+                    const resumedSessionId =
+                        await get().resumeSession(activeSessionId);
+                    activeSession =
+                        (resumedSessionId
+                            ? get().sessionsById[resumedSessionId]
+                            : null) ?? null;
+                }
+
+                if (activeSession) {
+                    await ensureSessionAgentCatalogLoaded(
+                        activeSession.sessionId,
+                    );
+                    if (isLiveRuntimeSession(activeSession)) {
+                        await get().ensureSessionTranscriptLoaded(
+                            activeSession.sessionId,
+                            "latest",
+                        );
+                    }
+                }
             }
 
-            if (
-                !isLiveRuntimeSession(activeSession) &&
-                !activeSession.isResumingSession
-            ) {
-                const resumedSessionId =
-                    await get().resumeSession(activeSessionId);
-                activeSession =
-                    (resumedSessionId
-                        ? get().sessionsById[resumedSessionId]
-                        : null) ?? null;
-            }
-
-            if (!activeSession) {
-                return;
-            }
-
-            await ensureSessionAgentCatalogLoaded(activeSession.sessionId);
-            if (isLiveRuntimeSession(activeSession)) {
-                await get().ensureSessionTranscriptLoaded(
-                    activeSession.sessionId,
-                    "latest",
-                );
+            for (const sessionId of restoredSessionIds) {
+                if (sessionId === activeSessionId) {
+                    continue;
+                }
+                const session = get().sessionsById[sessionId];
+                if (!session || session.isResumingSession) {
+                    continue;
+                }
+                await get().ensureSessionTranscriptLoaded(sessionId, "latest");
             }
         },
 


### PR DESCRIPTION
## Summary

Fixes cold-start hydration for restored chat tabs so previously opened threads refresh their content without requiring a user click.

## Root Cause

Restored workspace tabs were reconciled with history metadata, but transcript hydration only reliably happened for the active/focused session. Background restored tabs could remain with metadata-only state until focus changed. A second edge case also let stale persisted transcript window markers survive metadata growth, which could leave old windows in place or duplicate live-tail messages once those messages were persisted.

## Changes

- Hydrate every restored workspace chat tab after history metadata reconciliation.
- Preserve already-loaded persisted transcripts when initialization refreshes metadata-only histories.
- Invalidate stale persisted window markers when `message_count` changes and reload the latest persisted page.
- Deduplicate restored persisted pages against the live tail by message id, keeping live-only messages while avoiding duplicates once they are persisted.
- Add regression coverage for restored background tabs, metadata refresh preservation, and live-tail deduplication.

## Validation

- `npm test -- src/features/ai/store/chatStore.test.ts`
- `npm run lint -- src/features/ai/store/chatStore.ts src/features/ai/store/chatStore.test.ts`
- `npm run build`
- `git diff --check`

Fixes #36
