### PR TITLE
Fix agent sidebar drag lifecycle

### DIFF
--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -55,6 +55,29 @@ function createSession(
     };
 }
 
+function firePointer(
+    target: Element | Window,
+    type: string,
+    init: {
+        button?: number;
+        buttons?: number;
+        clientX: number;
+        clientY: number;
+        pointerId: number;
+    },
+) {
+    const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        button: init.button ?? 0,
+        buttons: init.buttons ?? 0,
+        clientX: init.clientX,
+        clientY: init.clientY,
+    });
+    Object.defineProperty(event, "pointerId", { value: init.pointerId });
+    fireEvent(target, event);
+}
+
 describe("AgentsSidebarPanel", () => {
     beforeEach(() => {
         resetChatStore();
@@ -213,7 +236,7 @@ describe("AgentsSidebarPanel", () => {
         });
     });
 
-    it("emits agent drag events from a sidebar row without opening it", () => {
+    it("completes an agent row drag when pointerup is received on window", () => {
         const alpha = createSession("session-alpha", "Alpha task");
         useChatStore.setState((state) => ({
             ...state,
@@ -235,21 +258,23 @@ describe("AgentsSidebarPanel", () => {
             renderComponent(<AgentsSidebarPanel />);
 
             const row = screen.getByRole("option");
-            fireEvent.pointerDown(row, {
+            firePointer(row, "pointerdown", {
                 button: 0,
+                buttons: 1,
                 pointerId: 1,
                 clientX: 10,
                 clientY: 10,
             });
-            fireEvent.pointerMove(row, {
+            firePointer(window, "pointermove", {
                 pointerId: 1,
+                buttons: 1,
                 clientX: 20,
                 clientY: 10,
             });
             expect(
                 screen.getByText("Drag to open in pane · Codex"),
             ).toBeInTheDocument();
-            fireEvent.pointerUp(row, {
+            firePointer(window, "pointerup", {
                 pointerId: 1,
                 clientX: 24,
                 clientY: 12,
@@ -263,6 +288,10 @@ describe("AgentsSidebarPanel", () => {
                 "move",
                 "end",
             ]);
+            expect(dragEvents[2]).toMatchObject({
+                x: 24,
+                y: 12,
+            });
             expect(dragEvents[0]).toMatchObject({
                 sessionId: alpha.sessionId,
                 title: "Alpha task",
@@ -270,6 +299,175 @@ describe("AgentsSidebarPanel", () => {
             expect(
                 chatPaneMovementMock.openChatSessionInWorkspace,
             ).not.toHaveBeenCalled();
+        } finally {
+            window.removeEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+        }
+    });
+
+    it("cancels an active agent row drag when pointercancel is received on window", () => {
+        const alpha = createSession("session-alpha", "Alpha task");
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                [alpha.sessionId]: alpha,
+            },
+            sessionOrder: [alpha.sessionId],
+        }));
+
+        const dragEvents: AgentSidebarDragDetail[] = [];
+        const handleDrag = (event: Event) => {
+            dragEvents.push(
+                (event as CustomEvent<AgentSidebarDragDetail>).detail,
+            );
+        };
+        window.addEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+
+        try {
+            renderComponent(<AgentsSidebarPanel />);
+
+            const row = screen.getByRole("option");
+            firePointer(row, "pointerdown", {
+                button: 0,
+                buttons: 1,
+                pointerId: 2,
+                clientX: 10,
+                clientY: 10,
+            });
+            firePointer(window, "pointermove", {
+                pointerId: 2,
+                buttons: 1,
+                clientX: 20,
+                clientY: 10,
+            });
+            expect(
+                screen.getByText("Drag to open in pane · Codex"),
+            ).toBeInTheDocument();
+
+            firePointer(window, "pointercancel", {
+                pointerId: 2,
+                clientX: 20,
+                clientY: 10,
+            });
+
+            expect(
+                screen.queryByText("Drag to open in pane · Codex"),
+            ).toBeNull();
+            expect(dragEvents.map((event) => event.phase)).toEqual([
+                "start",
+                "move",
+                "cancel",
+            ]);
+        } finally {
+            window.removeEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+        }
+    });
+
+    it("completes an active agent row drag when movement reports the button was released", () => {
+        const alpha = createSession("session-alpha", "Alpha task");
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                [alpha.sessionId]: alpha,
+            },
+            sessionOrder: [alpha.sessionId],
+        }));
+
+        const dragEvents: AgentSidebarDragDetail[] = [];
+        const handleDrag = (event: Event) => {
+            dragEvents.push(
+                (event as CustomEvent<AgentSidebarDragDetail>).detail,
+            );
+        };
+        window.addEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+
+        try {
+            renderComponent(<AgentsSidebarPanel />);
+
+            const row = screen.getByRole("option");
+            firePointer(row, "pointerdown", {
+                button: 0,
+                buttons: 1,
+                pointerId: 4,
+                clientX: 10,
+                clientY: 10,
+            });
+            firePointer(window, "pointermove", {
+                pointerId: 4,
+                buttons: 1,
+                clientX: 20,
+                clientY: 10,
+            });
+            firePointer(window, "pointermove", {
+                pointerId: 4,
+                buttons: 0,
+                clientX: 28,
+                clientY: 12,
+            });
+
+            expect(
+                screen.queryByText("Drag to open in pane · Codex"),
+            ).toBeNull();
+            expect(dragEvents.map((event) => event.phase)).toEqual([
+                "start",
+                "move",
+                "end",
+            ]);
+            expect(dragEvents[2]).toMatchObject({
+                x: 28,
+                y: 12,
+            });
+        } finally {
+            window.removeEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+        }
+    });
+
+    it("cancels an active agent row drag when the sidebar unmounts", () => {
+        const alpha = createSession("session-alpha", "Alpha task");
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                [alpha.sessionId]: alpha,
+            },
+            sessionOrder: [alpha.sessionId],
+        }));
+
+        const dragEvents: AgentSidebarDragDetail[] = [];
+        const handleDrag = (event: Event) => {
+            dragEvents.push(
+                (event as CustomEvent<AgentSidebarDragDetail>).detail,
+            );
+        };
+        window.addEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
+
+        try {
+            const { unmount } = renderComponent(<AgentsSidebarPanel />);
+
+            const row = screen.getByRole("option");
+            firePointer(row, "pointerdown", {
+                button: 0,
+                buttons: 1,
+                pointerId: 3,
+                clientX: 10,
+                clientY: 10,
+            });
+            firePointer(window, "pointermove", {
+                pointerId: 3,
+                buttons: 1,
+                clientX: 20,
+                clientY: 10,
+            });
+            expect(
+                screen.getByText("Drag to open in pane · Codex"),
+            ).toBeInTheDocument();
+
+            unmount();
+
+            expect(
+                dragEvents.map((event) => event.phase),
+            ).toContain("cancel");
+            expect(
+                screen.queryByText("Drag to open in pane · Codex"),
+            ).toBeNull();
         } finally {
             window.removeEventListener(AGENT_SIDEBAR_DRAG_EVENT, handleDrag);
         }

--- a/apps/desktop/src/features/ai/components/AgentsSidebarItem.tsx
+++ b/apps/desktop/src/features/ai/components/AgentsSidebarItem.tsx
@@ -1,7 +1,7 @@
 import {
+    useEffect,
     useRef,
     type MouseEvent as ReactMouseEvent,
-    type PointerEvent as ReactPointerEvent,
 } from "react";
 import type { AIChatSession } from "../types";
 
@@ -78,6 +78,34 @@ function isInteractiveDragTarget(target: EventTarget | null) {
         : false;
 }
 
+const AGENT_SIDEBAR_DRAG_THRESHOLD_PX = 5;
+
+function toDragCoordinates(event: PointerEvent) {
+    return {
+        clientX: event.clientX,
+        clientY: event.clientY,
+    };
+}
+
+function safelySetPointerCapture(target: HTMLElement, pointerId: number) {
+    try {
+        target.setPointerCapture?.(pointerId);
+    } catch {
+        // Pointer capture can fail if the pointer was already released.
+    }
+}
+
+function safelyReleasePointerCapture(
+    target: HTMLElement | null,
+    pointerId: number,
+) {
+    try {
+        target?.releasePointerCapture?.(pointerId);
+    } catch {
+        // The pointer may no longer be captured; global listeners still clean up.
+    }
+}
+
 export function AgentsSidebarItem({
     title,
     preview,
@@ -115,7 +143,15 @@ export function AgentsSidebarItem({
         startX: number;
         startY: number;
         active: boolean;
+        captureTarget: HTMLElement | null;
     } | null>(null);
+    const dragCallbacksRef = useRef({
+        onDragStart,
+        onDragMove,
+        onDragEnd,
+        onDragCancel,
+    });
+    const globalDragCleanupRef = useRef<(() => void) | null>(null);
     const suppressClickRef = useRef(false);
     const hasChildren = childCount > 0;
     const hierarchyAdornmentWidth =
@@ -125,6 +161,126 @@ export function AgentsSidebarItem({
         : 0;
     const subagentTextColumnOffset =
         depth > 0 ? hierarchyAdornmentWidth + activityAdornmentWidth : 0;
+
+    useEffect(() => {
+        dragCallbacksRef.current = {
+            onDragStart,
+            onDragMove,
+            onDragEnd,
+            onDragCancel,
+        };
+    }, [onDragStart, onDragMove, onDragEnd, onDragCancel]);
+
+    useEffect(() => {
+        return () => {
+            const state = dragStateRef.current;
+            dragStateRef.current = null;
+            globalDragCleanupRef.current?.();
+            globalDragCleanupRef.current = null;
+            if (!state) return;
+
+            safelyReleasePointerCapture(state.captureTarget, state.pointerId);
+            if (state.active) {
+                dragCallbacksRef.current.onDragCancel?.();
+            }
+        };
+    }, []);
+
+    const suppressNextClick = () => {
+        suppressClickRef.current = true;
+        window.requestAnimationFrame(() => {
+            suppressClickRef.current = false;
+        });
+    };
+
+    const clearDragSession = () => {
+        const state = dragStateRef.current;
+        dragStateRef.current = null;
+        globalDragCleanupRef.current?.();
+        globalDragCleanupRef.current = null;
+        if (state) {
+            safelyReleasePointerCapture(state.captureTarget, state.pointerId);
+        }
+        return state;
+    };
+
+    const completeDrag = (
+        pointerId: number,
+        coords: AgentsSidebarItemDragCoordinates,
+    ) => {
+        const state = dragStateRef.current;
+        if (!state || state.pointerId !== pointerId) return;
+
+        clearDragSession();
+        if (!state.active) return;
+
+        suppressNextClick();
+        dragCallbacksRef.current.onDragEnd?.(coords);
+    };
+
+    const cancelDrag = (pointerId: number) => {
+        const state = dragStateRef.current;
+        if (!state || state.pointerId !== pointerId) return;
+
+        clearDragSession();
+        if (state.active) {
+            dragCallbacksRef.current.onDragCancel?.();
+        }
+    };
+
+    const processDragMove = (event: PointerEvent) => {
+        const state = dragStateRef.current;
+        if (!state || state.pointerId !== event.pointerId) return;
+
+        const coords = toDragCoordinates(event);
+
+        if (event.buttons === 0) {
+            if (state.active) {
+                completeDrag(event.pointerId, coords);
+            } else {
+                clearDragSession();
+            }
+            return;
+        }
+
+        if (!state.active) {
+            const dx = event.clientX - state.startX;
+            const dy = event.clientY - state.startY;
+            if (Math.hypot(dx, dy) < AGENT_SIDEBAR_DRAG_THRESHOLD_PX) {
+                return;
+            }
+
+            state.active = true;
+            dragCallbacksRef.current.onDragStart?.(coords);
+        }
+
+        event.preventDefault();
+        dragCallbacksRef.current.onDragMove?.(coords);
+    };
+
+    const startGlobalDragTracking = () => {
+        globalDragCleanupRef.current?.();
+
+        const handlePointerMove = (event: PointerEvent) => {
+            processDragMove(event);
+        };
+        const handlePointerUp = (event: PointerEvent) => {
+            completeDrag(event.pointerId, toDragCoordinates(event));
+        };
+        const handlePointerCancel = (event: PointerEvent) => {
+            cancelDrag(event.pointerId);
+        };
+
+        window.addEventListener("pointermove", handlePointerMove);
+        window.addEventListener("pointerup", handlePointerUp);
+        window.addEventListener("pointercancel", handlePointerCancel);
+        globalDragCleanupRef.current = () => {
+            window.removeEventListener("pointermove", handlePointerMove);
+            window.removeEventListener("pointerup", handlePointerUp);
+            window.removeEventListener("pointercancel", handlePointerCancel);
+        };
+    };
+
     return (
         <div
             role="option"
@@ -160,69 +316,36 @@ export function AgentsSidebarItem({
                     return;
                 }
 
+                const previousState = clearDragSession();
+                if (previousState?.active) {
+                    dragCallbacksRef.current.onDragCancel?.();
+                }
+
                 dragStateRef.current = {
                     pointerId: event.pointerId,
                     startX: event.clientX,
                     startY: event.clientY,
                     active: false,
+                    captureTarget: event.currentTarget,
                 };
-                event.currentTarget.setPointerCapture?.(event.pointerId);
+                safelySetPointerCapture(event.currentTarget, event.pointerId);
+                startGlobalDragTracking();
             }}
-            onPointerMove={(event: ReactPointerEvent<HTMLElement>) => {
+            onLostPointerCapture={(event) => {
                 const state = dragStateRef.current;
                 if (!state || state.pointerId !== event.pointerId) {
                     return;
                 }
 
-                const coords = {
-                    clientX: event.clientX,
-                    clientY: event.clientY,
-                };
-                if (!state.active) {
-                    const dx = event.clientX - state.startX;
-                    const dy = event.clientY - state.startY;
-                    if (Math.hypot(dx, dy) < 5) {
-                        return;
-                    }
-
-                    state.active = true;
-                    onDragStart?.(coords);
-                }
-
-                event.preventDefault();
-                onDragMove?.(coords);
-            }}
-            onPointerUp={(event) => {
-                const state = dragStateRef.current;
-                if (!state || state.pointerId !== event.pointerId) {
+                if (event.buttons !== 0) {
                     return;
                 }
 
-                dragStateRef.current = null;
-                event.currentTarget.releasePointerCapture?.(event.pointerId);
-                if (!state.active) {
-                    return;
+                const wasActive = state.active;
+                clearDragSession();
+                if (wasActive) {
+                    dragCallbacksRef.current.onDragCancel?.();
                 }
-
-                event.preventDefault();
-                event.stopPropagation();
-                suppressClickRef.current = true;
-                window.requestAnimationFrame(() => {
-                    suppressClickRef.current = false;
-                });
-                onDragEnd?.({
-                    clientX: event.clientX,
-                    clientY: event.clientY,
-                });
-            }}
-            onPointerCancel={(event) => {
-                const state = dragStateRef.current;
-                if (!state || state.pointerId !== event.pointerId) {
-                    return;
-                }
-
-                dragStateRef.current = null;
-                onDragCancel?.();
             }}
             onDoubleClick={(event) => {
                 if (isRenaming || !canRename) return;


### PR DESCRIPTION
## Summary
- Make agent sidebar row drags own their full pointer lifecycle with window-level tracking.
- Clean up active drags on global pointerup, pointercancel, lost pointer capture, unmount, and missed pointerup detected via buttons === 0.
- Add regression coverage for global completion/cancel paths so multi-pane previews and sidebar drag UI cannot stay stuck.

## Root Cause
Agent thread dragging depended on pointerup/pointercancel reaching the sidebar row. When the pointer was released outside that element or the event was missed, the drag never emitted a terminal end/cancel event, leaving multi-pane drop previews and sidebar drag state alive.

## Validation
- npm test -- src/features/ai/AgentsSidebarPanel.test.tsx src/features/editor/MultiPaneWorkspace.test.tsx src/features/ai/chatPaneMovement.test.ts
- npm run lint -- --max-warnings=0 src/features/ai/components/AgentsSidebarItem.tsx src/features/ai/AgentsSidebarPanel.test.tsx
- npx tsc -b --pretty false

Closes #105