### PR TITLE
Add keyboard navigation to the file tree

### DIFF
--- a/apps/desktop/src/app/shortcuts/format.test.ts
+++ b/apps/desktop/src/app/shortcuts/format.test.ts
@@ -32,6 +32,10 @@ describe("shortcut registry formatting", () => {
         expect(formatShortcutAction("find_in_note", "windows")).toBe("Ctrl+F");
         expect(formatShortcutAction("go_back", "windows")).toBe("Ctrl+[");
         expect(formatShortcutAction("go_forward", "macos")).toBe("⌘]");
+        expect(formatShortcutAction("next_file", "macos")).toBe("⌘⇧Arrow Down");
+        expect(formatShortcutAction("previous_file", "windows")).toBe(
+            "Ctrl+Shift+Arrow Up",
+        );
         expect(formatShortcutAction("heading_1", "windows")).toBe("Ctrl+1");
         expect(formatShortcutAction("remove_heading", "windows")).toBe(
             "Ctrl+Shift+0",
@@ -80,6 +84,13 @@ describe("shortcut registry formatting", () => {
             category: "Editor",
             shortcut: "Ctrl+F",
         });
+        expect(entries.find((entry) => entry.id === "next_file")).toMatchObject(
+            {
+                label: "Next File",
+                category: "Navigation",
+                shortcut: "Ctrl+Shift+Arrow Down",
+            },
+        );
         expect(
             entries.find((entry) => entry.id === "remove_heading"),
         ).toMatchObject({

--- a/apps/desktop/src/app/shortcuts/registry.ts
+++ b/apps/desktop/src/app/shortcuts/registry.ts
@@ -21,6 +21,8 @@ export type ShortcutActionId =
     | "reopen_closed_tab"
     | "next_tab"
     | "previous_tab"
+    | "next_file"
+    | "previous_file"
     | "go_back"
     | "go_forward"
     | "toggle_left_sidebar"
@@ -177,6 +179,24 @@ const shortcutDefinitions = [
         },
         aliases: {
             macos: [{ key: "tab", modifiers: ["ctrl", "shift"] }],
+        },
+    },
+    {
+        id: "next_file",
+        label: "Next File",
+        category: "Navigation",
+        bindings: {
+            macos: [{ key: "ArrowDown", modifiers: ["meta", "shift"] }],
+            windows: [{ key: "ArrowDown", modifiers: ["ctrl", "shift"] }],
+        },
+    },
+    {
+        id: "previous_file",
+        label: "Previous File",
+        category: "Navigation",
+        bindings: {
+            macos: [{ key: "ArrowUp", modifiers: ["meta", "shift"] }],
+            windows: [{ key: "ArrowUp", modifiers: ["ctrl", "shift"] }],
         },
     },
     {
@@ -413,6 +433,8 @@ export const SHORTCUT_SETTINGS_ORDER: ShortcutActionId[] = [
     "search_in_vault",
     "next_tab",
     "previous_tab",
+    "next_file",
+    "previous_file",
     "go_back",
     "go_forward",
     "open_vault",
@@ -450,6 +472,10 @@ function normalizeShortcutKey(key: string): string {
 function formatShortcutKey(key: string): string {
     const normalized = normalizeShortcutKey(key);
     if (normalized === "tab") return "Tab";
+    if (normalized === "arrowup") return "Arrow Up";
+    if (normalized === "arrowdown") return "Arrow Down";
+    if (normalized === "arrowleft") return "Arrow Left";
+    if (normalized === "arrowright") return "Arrow Right";
     if (normalized.length === 1) return normalized.toUpperCase();
     return normalized.charAt(0).toUpperCase() + normalized.slice(1);
 }

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -1548,7 +1548,7 @@ describe("FileTree", () => {
         });
     });
 
-    it("uses Cmd+Shift+ArrowDown to open the next visible file without stealing focus", async () => {
+    it("uses Cmd+Shift+ArrowDown to open the next file without stealing focus", async () => {
         setVaultNotes([
             {
                 id: "alpha",
@@ -1624,7 +1624,7 @@ describe("FileTree", () => {
         expect(document.activeElement).toBe(editor);
     });
 
-    it("respects the current visible sort order when using file navigation shortcuts", async () => {
+    it("respects the current sort order when using file navigation shortcuts", async () => {
         const user = userEvent.setup();
 
         setVaultNotes([
@@ -1693,6 +1693,74 @@ describe("FileTree", () => {
                 activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
             ).toBe("alpha");
         });
+    });
+
+    it("expands collapsed folders when the next-file shortcut enters them", async () => {
+        const user = userEvent.setup();
+        vi.mocked(invoke).mockResolvedValue({ content: "Loaded note" });
+
+        setVaultNotes([
+            {
+                id: "A/alpha",
+                path: "/vault/A/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "B/beta",
+                path: "/vault/B/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-alpha",
+                    noteId: "A/alpha",
+                    title: "Alpha",
+                    content: "Alpha",
+                },
+                {
+                    id: "tab-beta",
+                    noteId: "B/beta",
+                    title: "Beta",
+                    content: "Beta",
+                },
+            ],
+            "tab-alpha",
+        );
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "A");
+
+        expect(screen.queryByText("Beta")).not.toBeInTheDocument();
+
+        fireEvent.keyDown(document, {
+            key: "ArrowDown",
+            metaKey: true,
+            shiftKey: true,
+        });
+        fireEvent.keyDown(document, {
+            key: "ArrowDown",
+            ctrlKey: true,
+            shiftKey: true,
+        });
+
+        await waitFor(() => {
+            const activeTab = useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) => tab.id === useEditorStore.getState().activeTabId,
+                );
+            expect(
+                activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+            ).toBe("B/beta");
+        });
+        expect(screen.getByText("B")).toBeInTheDocument();
+        expect(screen.getByText("Beta")).toBeInTheDocument();
     });
 
     it("opens a note in a new tab on middle click", async () => {

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -1475,6 +1475,226 @@ describe("FileTree", () => {
         ).toBe("notes/beta");
     });
 
+    it("opens notes while navigating visible tree rows with arrow keys", async () => {
+        vi.mocked(invoke).mockResolvedValue({ content: "Loaded note" });
+
+        setVaultNotes([
+            {
+                id: "alpha",
+                path: "/vault/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "beta",
+                path: "/vault/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-alpha",
+                    noteId: "alpha",
+                    title: "Alpha",
+                    content: "Alpha",
+                },
+                {
+                    id: "tab-beta",
+                    noteId: "beta",
+                    title: "Beta",
+                    content: "Beta",
+                },
+            ],
+            "tab-alpha",
+        );
+
+        renderComponent(<FileTree />);
+        await screen.findByText("Alpha");
+
+        const viewport = screen.getByTestId("file-tree-viewport");
+        viewport.focus();
+        fireEvent.keyDown(viewport, { key: "ArrowDown" });
+
+        await waitFor(() => {
+            const activeTab = useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) => tab.id === useEditorStore.getState().activeTabId,
+                );
+            expect(
+                activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+            ).toBe("beta");
+        });
+        expect(getNoteRow("Beta")).toHaveAttribute(
+            "data-keyboard-focus",
+            "true",
+        );
+
+        fireEvent.keyDown(viewport, { key: "ArrowUp" });
+
+        await waitFor(() => {
+            const activeTab = useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) => tab.id === useEditorStore.getState().activeTabId,
+                );
+            expect(
+                activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+            ).toBe("alpha");
+        });
+    });
+
+    it("uses Cmd+Shift+ArrowDown to open the next visible file without stealing focus", async () => {
+        setVaultNotes([
+            {
+                id: "alpha",
+                path: "/vault/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "beta",
+                path: "/vault/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-alpha",
+                    noteId: "alpha",
+                    title: "Alpha",
+                    content: "Alpha",
+                },
+                {
+                    id: "tab-beta",
+                    noteId: "beta",
+                    title: "Beta",
+                    content: "Beta",
+                },
+            ],
+            "tab-alpha",
+        );
+
+        renderComponent(
+            <>
+                <div
+                    data-testid="mock-editor-focus"
+                    contentEditable
+                    suppressContentEditableWarning
+                    tabIndex={0}
+                >
+                    Editor
+                </div>
+                <FileTree />
+            </>,
+        );
+        await screen.findByText("Alpha");
+
+        const editor = screen.getByTestId("mock-editor-focus");
+        editor.focus();
+        fireEvent.keyDown(editor, {
+            key: "ArrowDown",
+            metaKey: true,
+            shiftKey: true,
+        });
+        fireEvent.keyDown(editor, {
+            key: "ArrowDown",
+            ctrlKey: true,
+            shiftKey: true,
+        });
+
+        await waitFor(() => {
+            const activeTab = useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) => tab.id === useEditorStore.getState().activeTabId,
+                );
+            expect(
+                activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+            ).toBe("beta");
+        });
+        expect(document.activeElement).toBe(editor);
+    });
+
+    it("respects the current visible sort order when using file navigation shortcuts", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([
+            {
+                id: "alpha",
+                path: "/vault/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "beta",
+                path: "/vault/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-alpha",
+                    noteId: "alpha",
+                    title: "Alpha",
+                    content: "Alpha",
+                },
+                {
+                    id: "tab-beta",
+                    noteId: "beta",
+                    title: "Beta",
+                    content: "Beta",
+                },
+            ],
+            "tab-beta",
+        );
+
+        renderComponent(<FileTree />);
+        await user.click(screen.getByTitle("Sort order"));
+
+        const menu = screen.getByRole("menu", { name: "Sort order" });
+        fireEvent.keyDown(menu, { key: "ArrowDown" });
+        fireEvent.keyDown(menu, { key: "Enter" });
+
+        await waitFor(() => {
+            expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+        });
+
+        fireEvent.keyDown(document, {
+            key: "ArrowDown",
+            metaKey: true,
+            shiftKey: true,
+        });
+        fireEvent.keyDown(document, {
+            key: "ArrowDown",
+            ctrlKey: true,
+            shiftKey: true,
+        });
+
+        await waitFor(() => {
+            const activeTab = useEditorStore
+                .getState()
+                .tabs.find(
+                    (tab) => tab.id === useEditorStore.getState().activeTabId,
+                );
+            expect(
+                activeTab && isNoteTab(activeTab) ? activeTab.noteId : null,
+            ).toBe("alpha");
+        });
+    });
+
     it("opens a note in a new tab on middle click", async () => {
         const user = userEvent.setup();
         vi.mocked(invoke).mockResolvedValue({ content: "Beta body" });

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -75,6 +75,7 @@ import {
 } from "../../app/utils/safeStorage";
 import { logError } from "../../app/utils/runtimeLog";
 import { getViewportSafeMenuPosition } from "../../app/utils/menuPosition";
+import { matchesShortcutAction } from "../../app/shortcuts/registry";
 
 // --- Sort ---
 
@@ -200,6 +201,21 @@ function getSelectableRowKey(row: FlatTreeRow): string | null {
         return `entry:${row.entry.path}`;
     }
     return null;
+}
+
+function canKeyboardOpenRow(row: FlatTreeRow) {
+    return row.kind === "note" || row.kind === "pdf" || row.kind === "file";
+}
+
+function isEditableKeyboardTarget(target: EventTarget | null) {
+    return (
+        target instanceof HTMLElement &&
+        Boolean(
+            target.closest(
+                "input, textarea, select, [contenteditable='true']",
+            ),
+        )
+    );
 }
 
 function buildSelectionFromRows(rows: FlatTreeRow[]): TreeSelectionState {
@@ -689,26 +705,74 @@ function SortMenu({
     onClose: () => void;
 }) {
     const ref = useRef<HTMLDivElement>(null);
+    const optionRefs = useRef<Array<HTMLButtonElement | null>>([]);
+    const [focusedIndex, setFocusedIndex] = useState(() =>
+        Math.max(
+            0,
+            SORT_OPTIONS.findIndex((option) => option.id === current),
+        ),
+    );
+
+    useEffect(() => {
+        optionRefs.current[focusedIndex]?.focus();
+    }, [focusedIndex]);
 
     useEffect(() => {
         const handleDown = (e: MouseEvent) => {
             if (ref.current && !ref.current.contains(e.target as Node))
                 onClose();
         };
-        const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
-        };
         document.addEventListener("mousedown", handleDown);
-        document.addEventListener("keydown", handleKey);
         return () => {
             document.removeEventListener("mousedown", handleDown);
-            document.removeEventListener("keydown", handleKey);
         };
     }, [onClose]);
+
+    const focusOption = (index: number) => {
+        const lastIndex = SORT_OPTIONS.length - 1;
+        setFocusedIndex(Math.min(lastIndex, Math.max(0, index)));
+    };
+
+    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+        switch (event.key) {
+            case "ArrowDown":
+                event.preventDefault();
+                focusOption((focusedIndex + 1) % SORT_OPTIONS.length);
+                break;
+            case "ArrowUp":
+                event.preventDefault();
+                focusOption(
+                    focusedIndex === 0
+                        ? SORT_OPTIONS.length - 1
+                        : focusedIndex - 1,
+                );
+                break;
+            case "Home":
+                event.preventDefault();
+                focusOption(0);
+                break;
+            case "End":
+                event.preventDefault();
+                focusOption(SORT_OPTIONS.length - 1);
+                break;
+            case "Enter":
+            case " ":
+                event.preventDefault();
+                onSelect(SORT_OPTIONS[focusedIndex].id);
+                break;
+            case "Escape":
+                event.preventDefault();
+                onClose();
+                break;
+        }
+    };
 
     return (
         <div
             ref={ref}
+            role="menu"
+            aria-label="Sort order"
+            onKeyDown={handleKeyDown}
             style={{
                 position: "absolute",
                 top: "100%",
@@ -723,16 +787,24 @@ function SortMenu({
                 padding: 4,
             }}
         >
-            {SORT_OPTIONS.map((opt) => (
+            {SORT_OPTIONS.map((opt, index) => (
                 <button
                     key={opt.id}
+                    ref={(element) => {
+                        optionRefs.current[index] = element;
+                    }}
+                    role="menuitemradio"
+                    aria-checked={opt.id === current}
+                    tabIndex={index === focusedIndex ? 0 : -1}
                     onClick={() => onSelect(opt.id)}
+                    onFocus={() => setFocusedIndex(index)}
                     className="w-full text-left px-3 py-1.5 text-xs rounded flex items-center gap-2"
                     style={{ color: "var(--text-primary)" }}
-                    onMouseEnter={(e) =>
+                    onMouseEnter={(e) => {
+                        setFocusedIndex(index);
                         (e.currentTarget.style.backgroundColor =
-                            "var(--bg-tertiary)")
-                    }
+                            "var(--bg-tertiary)");
+                    }}
                     onMouseLeave={(e) =>
                         (e.currentTarget.style.backgroundColor = "transparent")
                     }
@@ -769,6 +841,7 @@ interface FlatTreeRowViewProps {
     metrics: TreeMetrics;
     activeNoteId: string | null;
     activeEntryPath: string | null;
+    keyboardCursorKey: string | null;
     expandedFolders: Set<string>;
     selectedNoteIds: Set<string>;
     selectedEntryPaths: Set<string>;
@@ -826,6 +899,7 @@ const FlatTreeRowView = memo(
         metrics,
         activeNoteId,
         activeEntryPath,
+        keyboardCursorKey,
         expandedFolders,
         selectedNoteIds,
         selectedEntryPaths,
@@ -886,6 +960,18 @@ const FlatTreeRowView = memo(
             row.kind === "file" && row.entry.path === renamingEntryPath;
         const isRenamingNote =
             row.kind === "note" && row.note.id === renamingNoteId;
+        const rowKey = getSelectableRowKey(row);
+        const hasKeyboardCursor =
+            rowKey !== null && rowKey === keyboardCursorKey;
+        const keyboardCursorOutline = hasKeyboardCursor
+            ? "1px solid color-mix(in srgb, var(--accent) 58%, transparent)"
+            : undefined;
+        const keyboardCursorStyle: React.CSSProperties = hasKeyboardCursor
+            ? {
+                  outline: keyboardCursorOutline,
+                  outlineOffset: -1,
+              }
+            : {};
 
         useEffect(() => {
             if (
@@ -996,6 +1082,7 @@ const FlatTreeRowView = memo(
                             ? "true"
                             : "false"
                     }
+                    data-keyboard-focus={hasKeyboardCursor ? "true" : "false"}
                     className="file-tree-row flex items-center gap-1.5 text-left text-xs rounded"
                     style={{
                         position: "relative",
@@ -1018,7 +1105,8 @@ const FlatTreeRowView = memo(
                               : {}),
                         outline: isDragOver
                             ? "1px solid var(--accent)"
-                            : "none",
+                            : (keyboardCursorOutline ?? "none"),
+                        outlineOffset: hasKeyboardCursor ? -1 : undefined,
                         opacity: isDraggingFolder ? 0.4 : 1,
                     }}
                 >
@@ -1106,6 +1194,7 @@ const FlatTreeRowView = memo(
                     data-note-id={entry.id}
                     data-selected={isSelected ? "true" : "false"}
                     data-active={isActive ? "true" : "false"}
+                    data-keyboard-focus={hasKeyboardCursor ? "true" : "false"}
                     onMouseDown={(e) => onPdfMouseDown(entry, e)}
                     onClick={(e) =>
                         onPdfClick(entry, {
@@ -1139,6 +1228,7 @@ const FlatTreeRowView = memo(
                         boxShadow: isActive
                             ? "inset 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)"
                             : "none",
+                        ...keyboardCursorStyle,
                         minHeight: metrics.rowHeight,
                         fontSize: metrics.fontSize,
                         ...TREE_ROW_BOX_STYLE,
@@ -1234,6 +1324,7 @@ const FlatTreeRowView = memo(
                     data-file-path={entry.relative_path}
                     data-selected={isSelected ? "true" : "false"}
                     data-active={isActive ? "true" : "false"}
+                    data-keyboard-focus={hasKeyboardCursor ? "true" : "false"}
                     onMouseDown={(e) => onFileMouseDown(entry, e)}
                     onClick={(e) =>
                         onFileClick(entry, {
@@ -1267,6 +1358,7 @@ const FlatTreeRowView = memo(
                         boxShadow: isActive
                             ? "inset 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)"
                             : "none",
+                        ...keyboardCursorStyle,
                         minHeight: metrics.rowHeight,
                         fontSize: metrics.fontSize,
                         ...TREE_ROW_BOX_STYLE,
@@ -1353,6 +1445,7 @@ const FlatTreeRowView = memo(
                 data-folder-path={getParentPath(note.id)}
                 data-selected={isSelected ? "true" : "false"}
                 data-active={isActive ? "true" : "false"}
+                data-keyboard-focus={hasKeyboardCursor ? "true" : "false"}
                 data-drag-over={isDragOver ? "true" : "false"}
                 onMouseDown={(e) => onNoteMouseDown(note, e)}
                 onClick={(e) =>
@@ -1387,6 +1480,7 @@ const FlatTreeRowView = memo(
                     boxShadow: isActive
                         ? "inset 0 0 0 1px color-mix(in srgb, var(--accent) 40%, transparent)"
                         : "none",
+                    ...keyboardCursorStyle,
                     opacity: isDraggingThis ? 0.4 : 1,
                     minHeight: metrics.rowHeight,
                     fontSize: metrics.fontSize,
@@ -1414,6 +1508,12 @@ const FlatTreeRowView = memo(
         // Callback props are stable (ref-backed) so they don't need comparison.
         if (prev.row !== next.row) return false;
         if (prev.metrics !== next.metrics) return false;
+        if (
+            (getSelectableRowKey(prev.row) === prev.keyboardCursorKey) !==
+            (getSelectableRowKey(next.row) === next.keyboardCursorKey)
+        ) {
+            return false;
+        }
         if (prev.stickyContentOffsetX !== next.stickyContentOffsetX) {
             return false;
         }
@@ -2006,6 +2106,9 @@ export function FileTree() {
     const [, setClipboardVersion] = useState(0);
     const [focusedFolderPath, setFocusedFolderPath] = useState("");
     const [filterText, setFilterText] = useState("");
+    const [keyboardCursorKey, setKeyboardCursorKey] = useState<string | null>(
+        null,
+    );
 
     const treeScrollRef = useRef<HTMLDivElement>(null);
     const dragStateRef = useRef<DragState | null>(null);
@@ -2017,6 +2120,7 @@ export function FileTree() {
     const lastClickedEntryPathRef = useRef<string | null>(null);
     const lastClickedRowKeyRef = useRef<string | null>(null);
     const flatRowsRef = useRef<FlatTreeRow[]>([]);
+    const displayRowsRef = useRef<FlatTreeRow[]>([]);
     const renameGuardRef = useRef(false);
     const expandedFoldersVaultPathRef = useRef(vaultPath);
     const skipExpandedFoldersPersistRef = useRef(false);
@@ -2175,6 +2279,28 @@ export function FileTree() {
             ...flatRows.slice(folderIndex + 1),
         ];
     }, [creatingMode, creatingParentPath, flatRows]);
+    displayRowsRef.current = displayRows;
+
+    useEffect(() => {
+        const visibleKeys = new Set(
+            displayRows
+                .map((row) => getSelectableRowKey(row))
+                .filter((key): key is string => key !== null),
+        );
+
+        setKeyboardCursorKey((current) => {
+            if (activeNoteId && visibleKeys.has(`note:${activeNoteId}`)) {
+                return `note:${activeNoteId}`;
+            }
+            if (
+                activeEntryPath &&
+                visibleKeys.has(`entry:${activeEntryPath}`)
+            ) {
+                return `entry:${activeEntryPath}`;
+            }
+            return current && visibleKeys.has(current) ? current : null;
+        });
+    }, [activeEntryPath, activeNoteId, displayRows]);
     const canCollapseAll = expandedFolders.size > 0;
     const treeClipboard = readFileTreeClipboard(vaultPath);
     const treeScale = fileTreeScale / 100;
@@ -3027,6 +3153,7 @@ export function FileTree() {
             if (wasJustDraggingRef.current) return;
             setFocusedFolderPath(path);
             const rowKey = `folder:${path}`;
+            setKeyboardCursorKey(rowKey);
 
             if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
                 return;
@@ -3182,6 +3309,7 @@ export function FileTree() {
             if (wasJustDraggingRef.current) return;
             setFocusedFolderPath(getParentPath(entry.relative_path));
             const rowKey = `entry:${entry.path}`;
+            setKeyboardCursorKey(rowKey);
             if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
                 return;
             }
@@ -3300,6 +3428,7 @@ export function FileTree() {
             if (wasJustDraggingRef.current) return;
             setFocusedFolderPath(getParentPath(entry.relative_path));
             const rowKey = `entry:${entry.path}`;
+            setKeyboardCursorKey(rowKey);
             if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
                 return;
             }
@@ -3527,34 +3656,38 @@ export function FileTree() {
         [insertExternalTab, readNoteContent],
     );
 
-    const handleNoteClick = async (
-        note: NoteDto,
-        modifiers: { cmd: boolean; shift: boolean },
-    ) => {
-        if (wasJustDraggingRef.current) return;
-        setFocusedFolderPath(getParentPath(note.id));
-        const rowKey = `note:${note.id}`;
+    const handleNoteClick = useCallback(
+        async (
+            note: NoteDto,
+            modifiers: { cmd: boolean; shift: boolean },
+        ) => {
+            if (wasJustDraggingRef.current) return;
+            setFocusedFolderPath(getParentPath(note.id));
+            const rowKey = `note:${note.id}`;
+            setKeyboardCursorKey(rowKey);
 
-        if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
-            return;
-        }
+            if (modifiers.shift && selectRowRange(rowKey, modifiers.cmd)) {
+                return;
+            }
 
-        if (modifiers.cmd) {
-            setSelectedNoteIds((prev) => {
-                const next = new Set(prev);
-                if (next.has(note.id)) next.delete(note.id);
-                else next.add(note.id);
-                return next;
-            });
+            if (modifiers.cmd) {
+                setSelectedNoteIds((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(note.id)) next.delete(note.id);
+                    else next.add(note.id);
+                    return next;
+                });
+                lastClickedRowKeyRef.current = rowKey;
+                return;
+            }
+
+            clearEntrySelection();
+            setSelectedNoteIds(new Set([note.id]));
             lastClickedRowKeyRef.current = rowKey;
-            return;
-        }
-
-        clearEntrySelection();
-        setSelectedNoteIds(new Set([note.id]));
-        lastClickedRowKeyRef.current = rowKey;
-        await openTreeNote(note);
-    };
+            await openTreeNote(note);
+        },
+        [clearEntrySelection, openTreeNote, selectRowRange],
+    );
 
     const handleNoteAuxClick = useCallback(
         (note: NoteDto, event: React.MouseEvent) => {
@@ -4156,12 +4289,318 @@ export function FileTree() {
         [vaultPath],
     );
 
+    const getKeyboardRowKey = useCallback(() => {
+        if (keyboardCursorKey) return keyboardCursorKey;
+        if (activeNoteId) return `note:${activeNoteId}`;
+        if (activeEntryPath) return `entry:${activeEntryPath}`;
+        return lastClickedRowKeyRef.current;
+    }, [activeEntryPath, activeNoteId, keyboardCursorKey]);
+
+    const getKeyboardRowIndex = useCallback(() => {
+        const key = getKeyboardRowKey();
+        if (!key) return -1;
+        return displayRowsRef.current.findIndex(
+            (row) => getSelectableRowKey(row) === key,
+        );
+    }, [getKeyboardRowKey]);
+
+    const selectKeyboardRow = useCallback((row: FlatTreeRow) => {
+        const rowKey = getSelectableRowKey(row);
+        if (!rowKey) return;
+
+        setKeyboardCursorKey(rowKey);
+        lastClickedRowKeyRef.current = rowKey;
+
+        if (row.kind === "folder") {
+            setFocusedFolderPath(row.path);
+            setSelectedNoteIds(new Set());
+            setSelectedEntryPaths(new Set());
+            setSelectedFolderPaths(new Set([row.path]));
+            return;
+        }
+
+        if (row.kind === "note") {
+            setFocusedFolderPath(getParentPath(row.note.id));
+            clearEntrySelection();
+            setSelectedNoteIds(new Set([row.note.id]));
+            return;
+        }
+
+        if (row.kind === "pdf" || row.kind === "file") {
+            setFocusedFolderPath(getParentPath(row.entry.relative_path));
+            setSelectedNoteIds(new Set());
+            setSelectedEntryPaths(new Set([row.entry.path]));
+            setSelectedFolderPaths(new Set());
+            lastClickedEntryPathRef.current = row.entry.path;
+        }
+    }, [clearEntrySelection]);
+
+    const activateKeyboardRow = useCallback(
+        (row: FlatTreeRow) => {
+            if (row.kind === "folder") {
+                handleFolderClick(row.path, { cmd: false, shift: false });
+                return;
+            }
+            if (row.kind === "note") {
+                void handleNoteClick(row.note, { cmd: false, shift: false });
+                return;
+            }
+            if (row.kind === "pdf") {
+                handlePdfClick(row.entry, { cmd: false, shift: false });
+                return;
+            }
+            if (row.kind === "file") {
+                handleFileClick(row.entry, { cmd: false, shift: false });
+            }
+        },
+        [handleFileClick, handleFolderClick, handleNoteClick, handlePdfClick],
+    );
+
+    const navigateKeyboardToRow = useCallback(
+        (rowIndex: number, options?: { openFileRows?: boolean }) => {
+            const row = displayRowsRef.current[rowIndex];
+            if (!row || row.kind === "create") return false;
+
+            selectKeyboardRow(row);
+            scrollToRow(rowIndex, "instant");
+            if (options?.openFileRows && canKeyboardOpenRow(row)) {
+                activateKeyboardRow(row);
+            }
+            return true;
+        },
+        [activateKeyboardRow, scrollToRow, selectKeyboardRow],
+    );
+
+    const navigateKeyboardByDelta = useCallback(
+        (delta: -1 | 1) => {
+            const rows = displayRowsRef.current;
+            if (rows.length === 0) return false;
+
+            const currentIndex = getKeyboardRowIndex();
+            const fallbackIndex = delta > 0 ? -1 : rows.length;
+            let nextIndex = currentIndex === -1 ? fallbackIndex : currentIndex;
+
+            do {
+                nextIndex += delta;
+            } while (rows[nextIndex]?.kind === "create");
+
+            if (nextIndex < 0 || nextIndex >= rows.length) return false;
+            return navigateKeyboardToRow(nextIndex, { openFileRows: true });
+        },
+        [getKeyboardRowIndex, navigateKeyboardToRow],
+    );
+
+    const navigateKeyboardToEdge = useCallback(
+        (edge: "first" | "last") => {
+            const rows = displayRowsRef.current;
+            const start = edge === "first" ? 0 : rows.length - 1;
+            const delta = edge === "first" ? 1 : -1;
+            for (
+                let index = start;
+                index >= 0 && index < rows.length;
+                index += delta
+            ) {
+                if (rows[index].kind !== "create") {
+                    return navigateKeyboardToRow(index, {
+                        openFileRows: true,
+                    });
+                }
+            }
+            return false;
+        },
+        [navigateKeyboardToRow],
+    );
+
+    const navigateKeyboardToOpenableRow = useCallback(
+        (direction: -1 | 1) => {
+            const rows = displayRowsRef.current;
+            if (rows.length === 0) return false;
+
+            const currentIndex = getKeyboardRowIndex();
+            const fallbackIndex = direction > 0 ? -1 : rows.length;
+            for (
+                let index =
+                    (currentIndex === -1 ? fallbackIndex : currentIndex) +
+                    direction;
+                index >= 0 && index < rows.length;
+                index += direction
+            ) {
+                if (canKeyboardOpenRow(rows[index])) {
+                    return navigateKeyboardToRow(index, {
+                        openFileRows: true,
+                    });
+                }
+            }
+
+            return false;
+        },
+        [getKeyboardRowIndex, navigateKeyboardToRow],
+    );
+
+    const navigateKeyboardIntoFolder = useCallback(() => {
+        const rows = displayRowsRef.current;
+        const currentIndex = getKeyboardRowIndex();
+        const currentRow = rows[currentIndex];
+        if (!currentRow || currentRow.kind !== "folder") return false;
+
+        if (!visibleExpandedFolders.has(currentRow.path)) {
+            selectKeyboardRow(currentRow);
+            setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                next.add(currentRow.path);
+                return next;
+            });
+            return true;
+        }
+
+        const childIndex = currentIndex + 1;
+        if (
+            childIndex < rows.length &&
+            rows[childIndex].depth > currentRow.depth
+        ) {
+            return navigateKeyboardToRow(childIndex, { openFileRows: true });
+        }
+
+        return false;
+    }, [
+        getKeyboardRowIndex,
+        navigateKeyboardToRow,
+        selectKeyboardRow,
+        visibleExpandedFolders,
+    ]);
+
+    const navigateKeyboardToParent = useCallback(() => {
+        const rows = displayRowsRef.current;
+        const currentIndex = getKeyboardRowIndex();
+        const currentRow = rows[currentIndex];
+        if (!currentRow) return false;
+
+        if (
+            currentRow.kind === "folder" &&
+            visibleExpandedFolders.has(currentRow.path)
+        ) {
+            selectKeyboardRow(currentRow);
+            setExpandedFolders((prev) => {
+                const next = new Set(prev);
+                next.delete(currentRow.path);
+                return next;
+            });
+            return true;
+        }
+
+        for (let index = currentIndex - 1; index >= 0; index -= 1) {
+            const row = rows[index];
+            if (
+                row.kind === "folder" &&
+                row.depth < currentRow.depth &&
+                currentRow.path.startsWith(`${row.path}/`)
+            ) {
+                return navigateKeyboardToRow(index);
+            }
+        }
+
+        return false;
+    }, [
+        getKeyboardRowIndex,
+        navigateKeyboardToRow,
+        selectKeyboardRow,
+        visibleExpandedFolders,
+    ]);
+
+    useEffect(() => {
+        const handleDocumentKeyDown = (event: KeyboardEvent) => {
+            if (
+                event.target instanceof HTMLElement &&
+                event.target.closest("input, textarea, select")
+            ) {
+                return;
+            }
+
+            const direction = matchesShortcutAction(event, "next_file")
+                ? 1
+                : matchesShortcutAction(event, "previous_file")
+                  ? -1
+                  : null;
+            if (direction === null) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            navigateKeyboardToOpenableRow(direction);
+        };
+
+        document.addEventListener("keydown", handleDocumentKeyDown, true);
+        return () =>
+            document.removeEventListener(
+                "keydown",
+                handleDocumentKeyDown,
+                true,
+            );
+    }, [navigateKeyboardToOpenableRow]);
+
     const handleTreeKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {
             const target = event.target;
-            if (target instanceof HTMLInputElement) return;
+            if (isEditableKeyboardTarget(target)) return;
+
+            if (
+                !event.metaKey &&
+                !event.ctrlKey &&
+                !event.altKey &&
+                !event.shiftKey
+            ) {
+                let handled = false;
+                const canActivateFromViewport =
+                    event.target === event.currentTarget;
+                switch (event.key) {
+                    case "ArrowDown":
+                        handled = navigateKeyboardByDelta(1);
+                        break;
+                    case "ArrowUp":
+                        handled = navigateKeyboardByDelta(-1);
+                        break;
+                    case "ArrowRight":
+                        handled = navigateKeyboardIntoFolder();
+                        break;
+                    case "ArrowLeft":
+                        handled = navigateKeyboardToParent();
+                        break;
+                    case "Home":
+                        handled = navigateKeyboardToEdge("first");
+                        break;
+                    case "End":
+                        handled = navigateKeyboardToEdge("last");
+                        break;
+                    case "Enter": {
+                        if (!canActivateFromViewport) break;
+                        const row =
+                            displayRowsRef.current[getKeyboardRowIndex()];
+                        if (row && row.kind !== "create") {
+                            activateKeyboardRow(row);
+                            handled = true;
+                        }
+                        break;
+                    }
+                    case " ": {
+                        if (!canActivateFromViewport) break;
+                        const row =
+                            displayRowsRef.current[getKeyboardRowIndex()];
+                        if (row && row.kind !== "create") {
+                            activateKeyboardRow(row);
+                            handled = true;
+                        }
+                        break;
+                    }
+                }
+
+                if (handled) {
+                    event.preventDefault();
+                    event.stopPropagation();
+                }
+                return;
+            }
+
             if (!(event.metaKey || event.ctrlKey)) return;
-            if (event.altKey) return;
+            if (event.altKey || event.shiftKey) return;
 
             const lowerKey = event.key.toLowerCase();
             if (lowerKey === "c") {
@@ -4196,10 +4635,16 @@ export function FileTree() {
             }
         },
         [
+            activateKeyboardRow,
             focusedFolderPath,
+            getKeyboardRowIndex,
             handleCopyFolder,
             handleCopyNotes,
             handlePasteIntoFolder,
+            navigateKeyboardByDelta,
+            navigateKeyboardIntoFolder,
+            navigateKeyboardToEdge,
+            navigateKeyboardToParent,
             notes,
             selectedNoteIds,
             treeClipboard,
@@ -5149,6 +5594,9 @@ export function FileTree() {
                                             metrics={metrics}
                                             activeNoteId={activeNoteId}
                                             activeEntryPath={activeEntryPath}
+                                            keyboardCursorKey={
+                                                keyboardCursorKey
+                                            }
                                             expandedFolders={
                                                 visibleExpandedFolders
                                             }
@@ -5279,6 +5727,9 @@ export function FileTree() {
                                             metrics={metrics}
                                             activeNoteId={activeNoteId}
                                             activeEntryPath={activeEntryPath}
+                                            keyboardCursorKey={
+                                                keyboardCursorKey
+                                            }
                                             expandedFolders={
                                                 visibleExpandedFolders
                                             }

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -203,6 +203,44 @@ function getSelectableRowKey(row: FlatTreeRow): string | null {
     return null;
 }
 
+function getFlatTreeRowFilterText(row: FlatTreeRow): string {
+    if (row.kind === "folder") {
+        return `${row.name}\n${row.path}`.toLowerCase();
+    }
+    if (row.kind === "note") return getNoteFilterText(row.note);
+    if (row.kind === "pdf" || row.kind === "file") {
+        return getVaultEntryFilterText(row.entry);
+    }
+    return "";
+}
+
+function filterFlatTreeRows(rows: FlatTreeRow[], normalizedFilter: string) {
+    if (!normalizedFilter) return rows;
+
+    const keepExactPaths = new Set<string>();
+    const keepSubtreePrefixes: string[] = [];
+    for (const row of rows) {
+        if (row.kind === "create") continue;
+        if (!getFlatTreeRowFilterText(row).includes(normalizedFilter)) {
+            continue;
+        }
+        keepExactPaths.add(row.path);
+        const parts = row.path.split("/");
+        for (let i = 1; i < parts.length; i++) {
+            keepExactPaths.add(parts.slice(0, i).join("/"));
+        }
+        if (row.kind === "folder") {
+            keepSubtreePrefixes.push(`${row.path}/`);
+        }
+    }
+    if (keepExactPaths.size === 0) return [];
+
+    return rows.filter((row) => {
+        if (keepExactPaths.has(row.path)) return true;
+        return keepSubtreePrefixes.some((prefix) => row.path.startsWith(prefix));
+    });
+}
+
 function canKeyboardOpenRow(row: FlatTreeRow) {
     return row.kind === "note" || row.kind === "pdf" || row.kind === "file";
 }
@@ -2121,6 +2159,7 @@ export function FileTree() {
     const lastClickedRowKeyRef = useRef<string | null>(null);
     const flatRowsRef = useRef<FlatTreeRow[]>([]);
     const displayRowsRef = useRef<FlatTreeRow[]>([]);
+    const shortcutNavigableRowsRef = useRef<FlatTreeRow[]>([]);
     const renameGuardRef = useRef(false);
     const expandedFoldersVaultPathRef = useRef(vaultPath);
     const skipExpandedFoldersPersistRef = useRef(false);
@@ -2194,6 +2233,10 @@ export function FileTree() {
         return next;
     }, [expandedFolders, revealedFolders]);
     const normalizedFilter = filterText.trim().toLowerCase();
+    const fullyExpandedRows = useMemo(
+        () => flattenTreeRows(tree, new Set(allFolderPaths), sortMode),
+        [allFolderPaths, sortMode, tree],
+    );
     const flatRows = useMemo(() => {
         // Without a filter, honor the user's expansion state as usual.
         if (!normalizedFilter) {
@@ -2203,50 +2246,20 @@ export function FileTree() {
         // buried inside collapsed folders surface. Then keep only rows that
         // match directly, their ancestor folders (to preserve hierarchy),
         // and — if a folder itself matches — all of its descendants.
-        const fullRows = flattenTreeRows(
-            tree,
-            new Set(allFolderPaths),
-            sortMode,
-        );
-        const rowNameLower = (row: FlatTreeRow): string => {
-            if (row.kind === "folder") {
-                return `${row.name}\n${row.path}`.toLowerCase();
-            }
-            if (row.kind === "note") return getNoteFilterText(row.note);
-            if (row.kind === "pdf" || row.kind === "file") {
-                return getVaultEntryFilterText(row.entry);
-            }
-            return "";
-        };
-        const keepExactPaths = new Set<string>();
-        const keepSubtreePrefixes: string[] = [];
-        for (const row of fullRows) {
-            if (row.kind === "create") continue;
-            if (!rowNameLower(row).includes(normalizedFilter)) continue;
-            keepExactPaths.add(row.path);
-            const parts = row.path.split("/");
-            for (let i = 1; i < parts.length; i++) {
-                keepExactPaths.add(parts.slice(0, i).join("/"));
-            }
-            if (row.kind === "folder") {
-                keepSubtreePrefixes.push(`${row.path}/`);
-            }
-        }
-        if (keepExactPaths.size === 0) return [];
-        return fullRows.filter((row) => {
-            if (keepExactPaths.has(row.path)) return true;
-            return keepSubtreePrefixes.some((prefix) =>
-                row.path.startsWith(prefix),
-            );
-        });
+        return filterFlatTreeRows(fullyExpandedRows, normalizedFilter);
     }, [
-        allFolderPaths,
+        fullyExpandedRows,
         normalizedFilter,
         sortMode,
         tree,
         visibleExpandedFolders,
     ]);
     flatRowsRef.current = flatRows;
+    const shortcutNavigableRows = useMemo(
+        () => filterFlatTreeRows(fullyExpandedRows, normalizedFilter),
+        [fullyExpandedRows, normalizedFilter],
+    );
+    shortcutNavigableRowsRef.current = shortcutNavigableRows;
     const displayRows = useMemo(() => {
         if (!creatingMode) return flatRows;
 
@@ -4304,6 +4317,27 @@ export function FileTree() {
         );
     }, [getKeyboardRowKey]);
 
+    const expandKeyboardRowAncestors = useCallback((row: FlatTreeRow) => {
+        const parts = row.path.split("/");
+        if (parts.length <= 1) return;
+
+        const ancestorPaths = parts
+            .slice(0, -1)
+            .map((_, index) => parts.slice(0, index + 1).join("/"));
+        if (ancestorPaths.length === 0) return;
+
+        setExpandedFolders((prev) => {
+            const next = new Set(prev);
+            let changed = false;
+            for (const path of ancestorPaths) {
+                if (next.has(path)) continue;
+                next.add(path);
+                changed = true;
+            }
+            return changed ? next : prev;
+        });
+    }, []);
+
     const selectKeyboardRow = useCallback((row: FlatTreeRow) => {
         const rowKey = getSelectableRowKey(row);
         if (!rowKey) return;
@@ -4411,13 +4445,17 @@ export function FileTree() {
         [navigateKeyboardToRow],
     );
 
-    const navigateKeyboardToOpenableRow = useCallback(
+    const navigateShortcutToOpenableRow = useCallback(
         (direction: -1 | 1) => {
-            const rows = displayRowsRef.current;
+            const rows = shortcutNavigableRowsRef.current;
             if (rows.length === 0) return false;
 
-            const currentIndex = getKeyboardRowIndex();
+            const currentKey = getKeyboardRowKey();
+            const currentIndex = currentKey
+                ? rows.findIndex((row) => getSelectableRowKey(row) === currentKey)
+                : -1;
             const fallbackIndex = direction > 0 ? -1 : rows.length;
+
             for (
                 let index =
                     (currentIndex === -1 ? fallbackIndex : currentIndex) +
@@ -4425,16 +4463,22 @@ export function FileTree() {
                 index >= 0 && index < rows.length;
                 index += direction
             ) {
-                if (canKeyboardOpenRow(rows[index])) {
-                    return navigateKeyboardToRow(index, {
-                        openFileRows: true,
-                    });
-                }
+                const row = rows[index];
+                if (!canKeyboardOpenRow(row)) continue;
+                expandKeyboardRowAncestors(row);
+                selectKeyboardRow(row);
+                activateKeyboardRow(row);
+                return true;
             }
 
             return false;
         },
-        [getKeyboardRowIndex, navigateKeyboardToRow],
+        [
+            activateKeyboardRow,
+            expandKeyboardRowAncestors,
+            getKeyboardRowKey,
+            selectKeyboardRow,
+        ],
     );
 
     const navigateKeyboardIntoFolder = useCallback(() => {
@@ -4525,7 +4569,7 @@ export function FileTree() {
 
             event.preventDefault();
             event.stopPropagation();
-            navigateKeyboardToOpenableRow(direction);
+            navigateShortcutToOpenableRow(direction);
         };
 
         document.addEventListener("keydown", handleDocumentKeyDown, true);
@@ -4535,7 +4579,7 @@ export function FileTree() {
                 handleDocumentKeyDown,
                 true,
             );
-    }, [navigateKeyboardToOpenableRow]);
+    }, [navigateShortcutToOpenableRow]);
 
     const handleTreeKeyDown = useCallback(
         (event: React.KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary
- Adds keyboard-first navigation for the FileTree, including arrow-key row movement, folder expand/collapse, Home/End, Enter, and Space activation.
- Adds Previous File / Next File shortcuts using Cmd+Shift+ArrowUp/ArrowDown on macOS and Ctrl+Shift+ArrowUp/ArrowDown on Windows/Linux.
- Makes the FileTree sort menu keyboard accessible with ARIA menu roles and radio-style options.

Closes #95.

## Validation
- npm test -- --run src/features/vault/FileTree.test.tsx
- npm test -- --run src/app/shortcuts/format.test.ts
- npm run lint -- src/features/vault/FileTree.tsx src/features/vault/FileTree.test.tsx src/app/shortcuts/registry.ts src/app/shortcuts/format.test.ts
- git diff --check

## Notes
This keeps the navigation logic tied to the visible FileTree rows so current sort, filter, and expansion state are respected without duplicating tree ordering rules.