### PR TITLE
Prepare 0.2.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.2.7] - 2026-05-19
+
+### Added
+
+- Added keyboard navigation for the file tree, including Next File and Previous File shortcuts (`Cmd/Ctrl+Shift+Down` and `Cmd/Ctrl+Shift+Up`) that can move through files inside collapsed folders.
+- Added a New Terminal shortcut (`Cmd+R` on macOS, `Ctrl+R` on Windows/Linux), available from the app menu and shortcut settings.
+- Added Fliege Mono as an editor font option.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to upstream `0.35.0`, including the `0.34.0` gateway and authorization compatibility updates.
+- Polished app chrome and core controls with more tactile hover, press, focus, and open states across sidebar tabs, agent controls, settings controls, the vault switcher, tab close buttons, and the chat composer.
+- Changed the expanded chat composer so it collapses after sending and keeps its action row stable during queued sends or stop actions.
+
+### Fixed
+
+- Fixed frontmatter property editing so values keep their intended spaces.
+- Fixed live preview rendering around tables, inline markup boundaries, and empty list items so caret placement, marker alignment, and spacing remain stable while editing.
+- Fixed YouTube embeds opened in theater mode so their video identity is recognized correctly.
+- Fixed restored AI chat sessions so transcript hydration preserves usable conversation history.
+- Fixed the agent sidebar drag lifecycle so thread dragging, previews, and cleanup behave consistently.
+
 ## [0.2.6] - 2026-05-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1704,7 +1704,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "agent-client-protocol",
  "keyring",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.2.6"
+version = "0.2.7"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.2.6",
+    "version": "0.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.2.6",
+            "version": "0.2.7",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.2.6",
+    "version": "0.2.7",
     "type": "module",
     "main": "out/electron/main/index.js",
     "engines": {

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.2.6",
+    "version": "0.2.7",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

Prepare the NeverWrite 0.2.7 desktop release.

This PR aligns the release metadata with the 0.2.7 changelog entry, including the Electron app version, package lock version, native backend Cargo metadata, root Cargo.lock entry, and Web Clipper package version.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.2.7`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`
