### PR TITLE
Add file tree extension filtering

### DIFF
--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -1820,7 +1820,11 @@ impl NativeBackend {
         )
         .map_err(|error| error.to_string())?;
         let state = self.state(&args)?;
-        Ok(json!(state.index.advanced_search(&params, &state.vault)))
+        Ok(json!(state.index.advanced_search(
+            &params,
+            &state.vault,
+            &state.entries
+        )))
     }
 
     fn get_graph_snapshot(&mut self, args: Value) -> Result<Value, String> {

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -36,6 +36,7 @@ describe("settingsStore developer mode", () => {
         expect(useSettingsStore.getState().agentsSidebarScale).toBe(100);
         expect(useSettingsStore.getState().fileTreeStickyFolders).toBe(true);
         expect(useSettingsStore.getState().editorAutosaveDelayMs).toBe(300);
+        expect(useSettingsStore.getState().fileTreeExtensionFilter).toEqual([]);
     });
 
     it("persists developerModeEnabled per vault", () => {
@@ -115,6 +116,35 @@ describe("settingsStore developer mode", () => {
         initializeSettingsStore();
 
         expect(useSettingsStore.getState().pdfFilter).toBe("none");
+    });
+
+    it("normalizes persisted file tree extension filters", () => {
+        localStorage.setItem(
+            "neverwrite:settings",
+            JSON.stringify({
+                state: {
+                    fileTreeExtensionFilter: [
+                        ".MD",
+                        " csv ",
+                        "md",
+                        "",
+                        42,
+                        null,
+                        ".PDF",
+                        ".csv",
+                    ],
+                },
+            }),
+        );
+
+        disposeSettingsStoreRuntime();
+        initializeSettingsStore();
+
+        expect(useSettingsStore.getState().fileTreeExtensionFilter).toEqual([
+            "md",
+            "csv",
+            "pdf",
+        ]);
     });
 
     it("keeps spellcheck languages per vault across vault changes", () => {

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -40,6 +40,7 @@ export interface Settings {
     developerTerminalEnabled: boolean;
     fileTreeContentMode: "notes_only" | "all_files";
     fileTreeShowExtensions: boolean;
+    fileTreeExtensionFilter: string[];
 }
 
 interface SettingsStore extends Settings {
@@ -178,12 +179,31 @@ const defaults: Settings = {
     developerTerminalEnabled: true,
     fileTreeContentMode: "notes_only",
     fileTreeShowExtensions: false,
+    fileTreeExtensionFilter: [],
 };
 
 function normalizeFileTreeContentMode(
     value: unknown,
 ): Settings["fileTreeContentMode"] {
     return value === "all_files" ? "all_files" : "notes_only";
+}
+
+function normalizeFileTreeExtensionFilter(value: unknown): string[] {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    const seen = new Set<string>();
+    const normalized: string[] = [];
+    for (const item of value) {
+        if (typeof item !== "string") continue;
+        const extension = item.trim().replace(/^\.+/, "").toLowerCase();
+        if (!extension || seen.has(extension)) continue;
+        seen.add(extension);
+        normalized.push(extension);
+    }
+
+    return normalized;
 }
 
 function normalizeTabOpenBehavior(value: unknown): TabOpenBehavior {
@@ -400,6 +420,9 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             fileTreeShowExtensions:
                 parsed.state.fileTreeShowExtensions ??
                 defaults.fileTreeShowExtensions,
+            fileTreeExtensionFilter: normalizeFileTreeExtensionFilter(
+                parsed.state.fileTreeExtensionFilter,
+            ),
         };
     } catch {
         return null;
@@ -466,6 +489,7 @@ function pickSettings(state: SettingsStore): Settings {
         developerTerminalEnabled: state.developerTerminalEnabled,
         fileTreeContentMode: state.fileTreeContentMode,
         fileTreeShowExtensions: state.fileTreeShowExtensions,
+        fileTreeExtensionFilter: state.fileTreeExtensionFilter,
     };
 }
 
@@ -601,6 +625,13 @@ export const useSettingsStore = create<SettingsStore>()((set) => ({
                     spellcheckPrimaryLanguage: nextPair.primary,
                     spellcheckSecondaryLanguage: nextPair.secondary,
                 } as Partial<Settings>;
+            }
+
+            if (key === "fileTreeExtensionFilter") {
+                return {
+                    fileTreeExtensionFilter:
+                        normalizeFileTreeExtensionFilter(value),
+                };
             }
 
             return { [key]: value } as Partial<Settings>;

--- a/apps/desktop/src/app/utils/vaultEntries.test.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.test.ts
@@ -4,10 +4,42 @@ import { useEditorStore } from "../store/editorStore";
 import { useVaultStore } from "../store/vaultStore";
 import {
     getVaultEntryDisplayName,
+    isAllowedByExtensionFilter,
+    isCuratedVaultEntry,
     isTextLikeVaultEntry,
     openVaultFileEntry,
+    shouldShowVaultEntryInFileTree,
 } from "./vaultEntries";
 import { setEditorTabs } from "../../test/test-utils";
+
+function buildEntry(
+    path: string,
+    options: {
+        kind?: "note" | "pdf" | "file" | "folder";
+        mimeType?: string | null;
+        isImageLike?: boolean | null;
+    } = {},
+) {
+    const fileName = path.split("/").pop() ?? path;
+    const extension = fileName.includes(".")
+        ? (fileName.split(".").pop() ?? "")
+        : "";
+
+    return {
+        id: path,
+        path: `/vault/${path}`,
+        relative_path: path,
+        title: fileName.replace(/\.[^/.]+$/, ""),
+        file_name: fileName,
+        extension,
+        kind: options.kind ?? "file",
+        modified_at: 1,
+        created_at: 1,
+        size: 1,
+        mime_type: options.mimeType ?? null,
+        is_image_like: options.isImageLike ?? null,
+    };
+}
 
 describe("vaultEntries", () => {
     beforeEach(() => {
@@ -69,6 +101,88 @@ describe("vaultEntries", () => {
                 mime_type: null,
             }),
         ).toBe(true);
+    });
+
+    it("identifies the curated default vault entry set", () => {
+        expect(
+            isCuratedVaultEntry(buildEntry("docs/reference.pdf", { kind: "pdf" })),
+        ).toBe(true);
+        expect(
+            isCuratedVaultEntry(buildEntry("docs/page.html", { mimeType: "text/html" })),
+        ).toBe(true);
+        expect(
+            isCuratedVaultEntry(buildEntry("docs/page.htm", { mimeType: "text/html" })),
+        ).toBe(true);
+        expect(
+            isCuratedVaultEntry(buildEntry("docs/data.csv", { mimeType: "text/csv" })),
+        ).toBe(true);
+        expect(
+            isCuratedVaultEntry(buildEntry("docs/readme.txt", { mimeType: "text/plain" })),
+        ).toBe(true);
+        expect(
+            isCuratedVaultEntry(
+                buildEntry("docs/photo.png", {
+                    mimeType: "image/png",
+                    isImageLike: true,
+                }),
+            ),
+        ).toBe(true);
+
+        expect(
+            isCuratedVaultEntry(
+                buildEntry("docs/config.toml", { mimeType: "application/toml" }),
+            ),
+        ).toBe(false);
+        expect(
+            isCuratedVaultEntry(
+                buildEntry("docs/package.json", { mimeType: "application/json" }),
+            ),
+        ).toBe(false);
+        expect(
+            isCuratedVaultEntry(
+                buildEntry("src/runtime.ts", { mimeType: "text/typescript" }),
+            ),
+        ).toBe(false);
+    });
+
+    it("applies all-files and explicit extension filters to file tree entries", () => {
+        const folder = buildEntry("docs", { kind: "folder" });
+        const csv = buildEntry("docs/data.csv", { mimeType: "text/csv" });
+        const toml = buildEntry("docs/config.toml", {
+            mimeType: "application/toml",
+        });
+
+        expect(
+            shouldShowVaultEntryInFileTree(folder, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldShowVaultEntryInFileTree(csv, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldShowVaultEntryInFileTree(toml, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(false);
+        expect(
+            shouldShowVaultEntryInFileTree(toml, {
+                contentMode: "all_files",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldShowVaultEntryInFileTree(toml, {
+                contentMode: "all_files",
+                extensionFilter: ["csv"],
+            }),
+        ).toBe(false);
+        expect(isAllowedByExtensionFilter(csv, ["csv"])).toBe(true);
     });
 
     it("falls back to the file name when a file title is empty", () => {

--- a/apps/desktop/src/app/utils/vaultEntries.test.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.test.ts
@@ -120,6 +120,13 @@ describe("vaultEntries", () => {
             isCuratedVaultEntry(buildEntry("docs/data.csv", { mimeType: "text/csv" })),
         ).toBe(true);
         expect(
+            isCuratedVaultEntry(
+                buildEntry("docs/diagram.excalidraw", {
+                    mimeType: "application/json",
+                }),
+            ),
+        ).toBe(true);
+        expect(
             isCuratedVaultEntry(buildEntry("docs/readme.txt", { mimeType: "text/plain" })),
         ).toBe(true);
         expect(

--- a/apps/desktop/src/app/utils/vaultEntries.test.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.test.ts
@@ -8,6 +8,9 @@ import {
     isCuratedVaultEntry,
     isTextLikeVaultEntry,
     openVaultFileEntry,
+    shouldIncludeFileSummaryInFileScope,
+    shouldIncludeMarkdownNotesInFileScope,
+    shouldIncludeVaultEntryInFileScope,
     shouldShowVaultEntryInFileTree,
 } from "./vaultEntries";
 import { setEditorTabs } from "../../test/test-utils";
@@ -145,7 +148,7 @@ describe("vaultEntries", () => {
         ).toBe(false);
     });
 
-    it("applies all-files and explicit extension filters to file tree entries", () => {
+    it("applies file scope rules to vault entries and file tree folders", () => {
         const folder = buildEntry("docs", { kind: "folder" });
         const csv = buildEntry("docs/data.csv", { mimeType: "text/csv" });
         const toml = buildEntry("docs/config.toml", {
@@ -158,6 +161,12 @@ describe("vaultEntries", () => {
                 extensionFilter: [],
             }),
         ).toBe(true);
+        expect(
+            shouldIncludeVaultEntryInFileScope(folder, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(false);
         expect(
             shouldShowVaultEntryInFileTree(csv, {
                 contentMode: "notes_only",
@@ -183,6 +192,76 @@ describe("vaultEntries", () => {
             }),
         ).toBe(false);
         expect(isAllowedByExtensionFilter(csv, ["csv"])).toBe(true);
+    });
+
+    it("decides whether markdown notes are in the current file scope", () => {
+        expect(
+            shouldIncludeMarkdownNotesInFileScope({
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldIncludeMarkdownNotesInFileScope({
+                contentMode: "all_files",
+                extensionFilter: ["csv"],
+            }),
+        ).toBe(false);
+        expect(
+            shouldIncludeMarkdownNotesInFileScope({
+                contentMode: "all_files",
+                extensionFilter: ["md"],
+            }),
+        ).toBe(true);
+    });
+
+    it("applies file scope rules to text-like file summaries", () => {
+        const csv = {
+            fileName: "data.csv",
+            relativePath: "docs/data.csv",
+            mimeType: "text/csv",
+        };
+        const toml = {
+            fileName: "config.toml",
+            relativePath: "docs/config.toml",
+            mimeType: "application/toml",
+        };
+        const image = {
+            fileName: "photo.png",
+            relativePath: "docs/photo.png",
+            mimeType: "image/png",
+        };
+
+        expect(
+            shouldIncludeFileSummaryInFileScope(csv, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldIncludeFileSummaryInFileScope(toml, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(false);
+        expect(
+            shouldIncludeFileSummaryInFileScope(toml, {
+                contentMode: "all_files",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldIncludeFileSummaryInFileScope(toml, {
+                contentMode: "all_files",
+                extensionFilter: ["csv"],
+            }),
+        ).toBe(false);
+        expect(
+            shouldIncludeFileSummaryInFileScope(image, {
+                contentMode: "all_files",
+                extensionFilter: [],
+            }),
+        ).toBe(false);
     });
 
     it("falls back to the file name when a file title is empty", () => {

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -164,6 +164,15 @@ const IMAGE_EXTENSIONS = new Set([
     "ico",
 ]);
 
+const CURATED_VAULT_ENTRY_EXTENSIONS = new Set([
+    "csv",
+    "htm",
+    "html",
+    "txt",
+]);
+
+type FileTreeContentMode = "notes_only" | "all_files";
+
 export function isTextLikeMimeType(mimeType: string | null | undefined) {
     if (!mimeType) return false;
     return (
@@ -233,6 +242,43 @@ export function isImageLikeVaultEntry(
     }
     if (isImageLikeVaultPath(entry.extension)) return true;
     return entry.mime_type?.startsWith("image/") ?? false;
+}
+
+export function isCuratedVaultEntry(
+    entry: Pick<
+        VaultEntryDto,
+        "kind" | "extension" | "mime_type" | "is_image_like"
+    >,
+) {
+    if (entry.kind === "pdf") return true;
+    if (isImageLikeVaultEntry(entry)) return true;
+    return CURATED_VAULT_ENTRY_EXTENSIONS.has(entry.extension.toLowerCase());
+}
+
+export function isAllowedByExtensionFilter(
+    entry: Pick<VaultEntryDto, "extension">,
+    extensionFilter: readonly string[],
+) {
+    return extensionFilter.includes(entry.extension.toLowerCase());
+}
+
+export function shouldShowVaultEntryInFileTree(
+    entry: Pick<
+        VaultEntryDto,
+        "kind" | "extension" | "mime_type" | "is_image_like"
+    >,
+    options: {
+        contentMode: FileTreeContentMode;
+        extensionFilter: readonly string[];
+    },
+) {
+    if (entry.kind === "note") return false;
+    if (entry.kind === "folder") return true;
+    if (options.extensionFilter.length > 0) {
+        return isAllowedByExtensionFilter(entry, options.extensionFilter);
+    }
+    if (options.contentMode === "all_files") return true;
+    return isCuratedVaultEntry(entry);
 }
 
 export function canOpenVaultFileEntryInApp(

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -171,7 +171,16 @@ const CURATED_VAULT_ENTRY_EXTENSIONS = new Set([
     "txt",
 ]);
 
-type FileTreeContentMode = "notes_only" | "all_files";
+export type VaultFileScope = {
+    contentMode: "notes_only" | "all_files";
+    extensionFilter: readonly string[];
+};
+
+type VaultFileSummaryForScope = {
+    fileName: string;
+    relativePath?: string;
+    mimeType: string | null;
+};
 
 export function isTextLikeMimeType(mimeType: string | null | undefined) {
     if (!mimeType) return false;
@@ -262,23 +271,70 @@ export function isAllowedByExtensionFilter(
     return extensionFilter.includes(entry.extension.toLowerCase());
 }
 
+export function shouldIncludeMarkdownNotesInFileScope(scope: VaultFileScope) {
+    return (
+        scope.extensionFilter.length === 0 ||
+        scope.extensionFilter.includes("md")
+    );
+}
+
+export function shouldIncludeVaultEntryInFileScope(
+    entry: Pick<
+        VaultEntryDto,
+        "kind" | "extension" | "mime_type" | "is_image_like"
+    >,
+    scope: VaultFileScope,
+) {
+    if (entry.kind === "note") return false;
+    if (entry.kind === "folder") return false;
+    if (scope.extensionFilter.length > 0) {
+        return isAllowedByExtensionFilter(entry, scope.extensionFilter);
+    }
+    if (scope.contentMode === "all_files") return true;
+    return isCuratedVaultEntry(entry);
+}
+
 export function shouldShowVaultEntryInFileTree(
     entry: Pick<
         VaultEntryDto,
         "kind" | "extension" | "mime_type" | "is_image_like"
     >,
-    options: {
-        contentMode: FileTreeContentMode;
-        extensionFilter: readonly string[];
-    },
+    scope: VaultFileScope,
 ) {
-    if (entry.kind === "note") return false;
     if (entry.kind === "folder") return true;
-    if (options.extensionFilter.length > 0) {
-        return isAllowedByExtensionFilter(entry, options.extensionFilter);
+    return shouldIncludeVaultEntryInFileScope(entry, scope);
+}
+
+function getFileSummaryExtension(file: VaultFileSummaryForScope) {
+    const fileName = file.fileName || file.relativePath || "";
+    const leafName = fileName.split(/[\\/]/).pop() ?? fileName;
+    const dotIndex = leafName.lastIndexOf(".");
+    return dotIndex > 0 ? leafName.slice(dotIndex + 1).toLowerCase() : "";
+}
+
+function isTextLikeFileSummary(file: VaultFileSummaryForScope) {
+    const fileName = file.fileName || file.relativePath || "";
+    return isTextLikeVaultPath(fileName) || isTextLikeMimeType(file.mimeType);
+}
+
+export function shouldIncludeFileSummaryInFileScope(
+    file: VaultFileSummaryForScope,
+    scope: VaultFileScope,
+) {
+    if (!isTextLikeFileSummary(file)) return false;
+
+    const extension = getFileSummaryExtension(file);
+    if (scope.extensionFilter.length > 0) {
+        return scope.extensionFilter.includes(extension);
     }
-    if (options.contentMode === "all_files") return true;
-    return isCuratedVaultEntry(entry);
+    if (scope.contentMode === "all_files") return true;
+
+    return isCuratedVaultEntry({
+        kind: "file",
+        extension,
+        mime_type: file.mimeType,
+        is_image_like: false,
+    });
 }
 
 export function canOpenVaultFileEntryInApp(

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -166,6 +166,7 @@ const IMAGE_EXTENSIONS = new Set([
 
 const CURATED_VAULT_ENTRY_EXTENSIONS = new Set([
     "csv",
+    "excalidraw",
     "htm",
     "html",
     "txt",

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -5,6 +5,7 @@ import { useSettingsStore } from "../../../app/store/settingsStore";
 import type { EditorFontFamily } from "../../../app/store/settingsStore";
 import { useEditorStore } from "../../../app/store/editorStore";
 import {
+    buildVaultFileEntry,
     renderComponent,
     setEditorTabs,
     setVaultEntries,
@@ -108,25 +109,6 @@ function setCaret(node: Node, offset: number) {
     range.collapse(true);
     selection?.removeAllRanges();
     selection?.addRange(range);
-}
-
-function buildVaultFileEntry(path: string, mimeType = "text/plain") {
-    const fileName = path.split("/").pop() ?? path;
-    const dotIndex = fileName.lastIndexOf(".");
-
-    return {
-        id: path,
-        path: `/vault/${path}`,
-        relative_path: path,
-        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
-        file_name: fileName,
-        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
-        kind: "file" as const,
-        modified_at: 1,
-        created_at: 1,
-        size: 1,
-        mime_type: mimeType,
-    };
 }
 
 describe("AIChatComposer mention picker", () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -21,6 +21,7 @@ afterEach(() => {
         useSettingsStore.setState({
             fileTreeContentMode: "notes_only",
             fileTreeShowExtensions: false,
+            fileTreeExtensionFilter: [],
         });
     });
     setEditorTabs([], null);
@@ -107,6 +108,25 @@ function setCaret(node: Node, offset: number) {
     range.collapse(true);
     selection?.removeAllRanges();
     selection?.addRange(range);
+}
+
+function buildVaultFileEntry(path: string, mimeType = "text/plain") {
+    const fileName = path.split("/").pop() ?? path;
+    const dotIndex = fileName.lastIndexOf(".");
+
+    return {
+        id: path,
+        path: `/vault/${path}`,
+        relative_path: path,
+        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
+        file_name: fileName,
+        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
+        kind: "file" as const,
+        modified_at: 1,
+        created_at: 1,
+        size: 1,
+        mime_type: mimeType,
+    };
 }
 
 describe("AIChatComposer mention picker", () => {
@@ -454,6 +474,89 @@ describe("AIChatComposer mention picker", () => {
                     relativePath: "src/main.ts",
                 }),
             );
+        });
+    });
+
+    it("shows curated text-like vault files in the @ picker with all-files mode disabled", async () => {
+        setVaultEntries([
+            buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+
+        renderComponent(
+            <AIChatComposer
+                parts={[]}
+                notes={[
+                    {
+                        id: "notes/alpha.md",
+                        title: "Alpha",
+                        path: "/vault/notes/alpha.md",
+                    },
+                ]}
+                status="idle"
+                runtimeName="Assistant"
+                composerFontFamily="system"
+                availableCommands={[]}
+                onChange={vi.fn()}
+                onMentionAttach={vi.fn()}
+                onFolderAttach={vi.fn()}
+                onSubmit={vi.fn()}
+                onStop={vi.fn()}
+            />,
+        );
+
+        const composer = screen.getByRole("textbox", {
+            name: "Message NeverWrite",
+        });
+        composer.textContent = "@data";
+        setCaret(composer.firstChild as Text, 5);
+        fireEvent.input(composer);
+
+        await waitFor(() => {
+            expect(screen.getByText("data")).toBeInTheDocument();
+            expect(screen.queryByText("config")).not.toBeInTheDocument();
+            expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+        });
+    });
+
+    it("uses the extension allowlist as the @ picker file scope", async () => {
+        act(() => {
+            useSettingsStore.setState({
+                fileTreeContentMode: "all_files",
+                fileTreeExtensionFilter: ["csv"],
+            });
+        });
+        setVaultEntries([
+            buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+
+        renderComponent(
+            <AIChatComposer
+                parts={[]}
+                notes={[]}
+                status="idle"
+                runtimeName="Assistant"
+                composerFontFamily="system"
+                availableCommands={[]}
+                onChange={vi.fn()}
+                onMentionAttach={vi.fn()}
+                onFolderAttach={vi.fn()}
+                onSubmit={vi.fn()}
+                onStop={vi.fn()}
+            />,
+        );
+
+        const composer = screen.getByRole("textbox", {
+            name: "Message NeverWrite",
+        });
+        composer.textContent = "@";
+        setCaret(composer.firstChild as Text, 1);
+        fireEvent.input(composer);
+
+        await waitFor(() => {
+            expect(screen.getByText("data")).toBeInTheDocument();
+            expect(screen.queryByText("config")).not.toBeInTheDocument();
         });
     });
 

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -47,7 +47,13 @@ import {
     type VaultEntryDto,
 } from "../../../app/store/vaultStore";
 import { AI_MESSAGE_LABEL } from "../../../app/utils/branding";
-import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
+import {
+    isCuratedVaultEntry,
+    isTextLikeMimeType,
+    isTextLikeVaultEntry,
+    isTextLikeVaultPath,
+    shouldShowVaultEntryInFileTree,
+} from "../../../app/utils/vaultEntries";
 
 const MIN_COMPOSER_HEIGHT = 64;
 const MAX_COMPOSER_HEIGHT = 480;
@@ -859,6 +865,7 @@ function getMentionSuggestions(
     files: AIChatFileSummary[],
     folderPaths: string[],
     query: string,
+    includeFiles: boolean,
     preferFileName: boolean,
     showExtensions: boolean,
     limit = 10,
@@ -901,7 +908,7 @@ function getMentionSuggestions(
         });
     }
 
-    if (preferFileName) {
+    if (includeFiles) {
         const fileSuggestions = [...files]
             .map((file) => {
                 const normalizedFileName = normalizeForSearch(file.fileName);
@@ -946,6 +953,40 @@ function getMentionSuggestions(
     return results.slice(0, limit);
 }
 
+function getFileSummaryExtension(file: AIChatFileSummary) {
+    const fileName = file.fileName || file.relativePath;
+    const leafName = fileName.split(/[\\/]/).pop() ?? fileName;
+    const dotIndex = leafName.lastIndexOf(".");
+    return dotIndex > 0 ? leafName.slice(dotIndex + 1).toLowerCase() : "";
+}
+
+function isTextLikeFileSummary(file: AIChatFileSummary) {
+    return isTextLikeVaultPath(file.fileName) || isTextLikeMimeType(file.mimeType);
+}
+
+function shouldIncludeFileSummaryInMentions(
+    file: AIChatFileSummary,
+    options: {
+        contentMode: "notes_only" | "all_files";
+        extensionFilter: readonly string[];
+    },
+) {
+    if (!isTextLikeFileSummary(file)) return false;
+
+    const extension = getFileSummaryExtension(file);
+    if (options.extensionFilter.length > 0) {
+        return options.extensionFilter.includes(extension);
+    }
+    if (options.contentMode === "all_files") return true;
+
+    return isCuratedVaultEntry({
+        kind: "file",
+        extension,
+        mime_type: file.mimeType,
+        is_image_like: false,
+    });
+}
+
 export function AIChatComposer({
     sessionId,
     parts,
@@ -980,6 +1021,9 @@ export function AIChatComposer({
     const fileTreeShowExtensions = useSettingsStore(
         (s) => s.fileTreeShowExtensions,
     );
+    const fileTreeExtensionFilter = useSettingsStore(
+        (s) => s.fileTreeExtensionFilter,
+    );
     const fallbackEntries = useVaultStore((state) => state.entries);
     const composerRef = useRef<HTMLDivElement>(null);
     const shellRef = useRef<HTMLDivElement>(null);
@@ -1010,14 +1054,29 @@ export function AIChatComposer({
         () => extractFolderPaths(notes, fallbackEntries),
         [fallbackEntries, notes],
     );
+    const visibleMentionNotes = useMemo(() => {
+        if (fileTreeExtensionFilter.length === 0) return notes;
+        return fileTreeExtensionFilter.includes("md") ? notes : [];
+    }, [fileTreeExtensionFilter, notes]);
     const mentionableFiles = useMemo(() => {
         if (files) {
-            return files;
+            return files.filter((file) =>
+                shouldIncludeFileSummaryInMentions(file, {
+                    contentMode: fileTreeContentMode,
+                    extensionFilter: fileTreeExtensionFilter,
+                }),
+            );
         }
 
         return fallbackEntries
             .filter(
-                (entry) => entry.kind === "file" && isTextLikeVaultEntry(entry),
+                (entry) =>
+                    entry.kind === "file" &&
+                    isTextLikeVaultEntry(entry) &&
+                    shouldShowVaultEntryInFileTree(entry, {
+                        contentMode: fileTreeContentMode,
+                        extensionFilter: fileTreeExtensionFilter,
+                    }),
             )
             .map((entry) => ({
                 id: entry.id,
@@ -1027,7 +1086,12 @@ export function AIChatComposer({
                 fileName: entry.file_name,
                 mimeType: entry.mime_type,
             }));
-    }, [fallbackEntries, files]);
+    }, [
+        fallbackEntries,
+        files,
+        fileTreeContentMode,
+        fileTreeExtensionFilter,
+    ]);
     const pillMetrics = useMemo(
         () => getChatPillMetrics(composerFontSize),
         [composerFontSize],
@@ -1144,10 +1208,11 @@ export function AIChatComposer({
         }
 
         const suggestions = getMentionSuggestions(
-            notes,
+            visibleMentionNotes,
             mentionableFiles,
             folderPaths,
             trigger.query,
+            mentionableFiles.length > 0,
             fileTreeContentMode === "all_files",
             fileTreeShowExtensions,
             10,

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -48,11 +48,10 @@ import {
 } from "../../../app/store/vaultStore";
 import { AI_MESSAGE_LABEL } from "../../../app/utils/branding";
 import {
-    isCuratedVaultEntry,
-    isTextLikeMimeType,
+    shouldIncludeFileSummaryInFileScope,
+    shouldIncludeMarkdownNotesInFileScope,
+    shouldIncludeVaultEntryInFileScope,
     isTextLikeVaultEntry,
-    isTextLikeVaultPath,
-    shouldShowVaultEntryInFileTree,
 } from "../../../app/utils/vaultEntries";
 
 const MIN_COMPOSER_HEIGHT = 64;
@@ -953,40 +952,6 @@ function getMentionSuggestions(
     return results.slice(0, limit);
 }
 
-function getFileSummaryExtension(file: AIChatFileSummary) {
-    const fileName = file.fileName || file.relativePath;
-    const leafName = fileName.split(/[\\/]/).pop() ?? fileName;
-    const dotIndex = leafName.lastIndexOf(".");
-    return dotIndex > 0 ? leafName.slice(dotIndex + 1).toLowerCase() : "";
-}
-
-function isTextLikeFileSummary(file: AIChatFileSummary) {
-    return isTextLikeVaultPath(file.fileName) || isTextLikeMimeType(file.mimeType);
-}
-
-function shouldIncludeFileSummaryInMentions(
-    file: AIChatFileSummary,
-    options: {
-        contentMode: "notes_only" | "all_files";
-        extensionFilter: readonly string[];
-    },
-) {
-    if (!isTextLikeFileSummary(file)) return false;
-
-    const extension = getFileSummaryExtension(file);
-    if (options.extensionFilter.length > 0) {
-        return options.extensionFilter.includes(extension);
-    }
-    if (options.contentMode === "all_files") return true;
-
-    return isCuratedVaultEntry({
-        kind: "file",
-        extension,
-        mime_type: file.mimeType,
-        is_image_like: false,
-    });
-}
-
 export function AIChatComposer({
     sessionId,
     parts,
@@ -1055,13 +1020,17 @@ export function AIChatComposer({
         [fallbackEntries, notes],
     );
     const visibleMentionNotes = useMemo(() => {
-        if (fileTreeExtensionFilter.length === 0) return notes;
-        return fileTreeExtensionFilter.includes("md") ? notes : [];
-    }, [fileTreeExtensionFilter, notes]);
+        return shouldIncludeMarkdownNotesInFileScope({
+            contentMode: fileTreeContentMode,
+            extensionFilter: fileTreeExtensionFilter,
+        })
+            ? notes
+            : [];
+    }, [fileTreeContentMode, fileTreeExtensionFilter, notes]);
     const mentionableFiles = useMemo(() => {
         if (files) {
             return files.filter((file) =>
-                shouldIncludeFileSummaryInMentions(file, {
+                shouldIncludeFileSummaryInFileScope(file, {
                     contentMode: fileTreeContentMode,
                     extensionFilter: fileTreeExtensionFilter,
                 }),
@@ -1073,7 +1042,7 @@ export function AIChatComposer({
                 (entry) =>
                     entry.kind === "file" &&
                     isTextLikeVaultEntry(entry) &&
-                    shouldShowVaultEntryInFileTree(entry, {
+                    shouldIncludeVaultEntryInFileScope(entry, {
                         contentMode: fileTreeContentMode,
                         extensionFilter: fileTreeExtensionFilter,
                     }),

--- a/apps/desktop/src/features/editor/extensions/wikilinkSuggester.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkSuggester.test.ts
@@ -16,9 +16,12 @@ describe("wikilinkSuggester", () => {
             ...state,
             vaultPath: `/vault-${crypto.randomUUID()}`,
             resolverRevision: state.resolverRevision + 1,
+            entries: [],
         }));
         useSettingsStore.setState({
             fileTreeContentMode: "notes_only",
+            fileTreeShowExtensions: false,
+            fileTreeExtensionFilter: [],
         });
     });
 
@@ -107,6 +110,112 @@ describe("wikilinkSuggester", () => {
                 title: "main.ts",
                 subtitle: "src/main.ts",
                 insertText: "/src/main.ts",
+            }),
+        ]);
+    });
+
+    it("includes curated text files in wikilink suggestions when all-files mode is disabled", async () => {
+        useVaultStore.setState((state) => ({
+            ...state,
+            entries: [
+                {
+                    id: "docs/data.csv",
+                    path: "/vault/docs/data.csv",
+                    relative_path: "docs/data.csv",
+                    title: "data",
+                    file_name: "data.csv",
+                    extension: "csv",
+                    kind: "file",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 12,
+                    mime_type: "text/csv",
+                    is_text_like: true,
+                },
+                {
+                    id: "docs/config.toml",
+                    path: "/vault/docs/config.toml",
+                    relative_path: "docs/config.toml",
+                    title: "config",
+                    file_name: "config.toml",
+                    extension: "toml",
+                    kind: "file",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 12,
+                    mime_type: "application/toml",
+                    is_text_like: true,
+                },
+            ],
+        }));
+        mockInvoke().mockResolvedValue([]);
+
+        const items = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                title: "data.csv",
+                subtitle: "docs/data.csv",
+                insertText: "/docs/data.csv",
+            }),
+        ]);
+    });
+
+    it("uses the extension allowlist as the wikilink suggestion scope", async () => {
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+        useVaultStore.setState((state) => ({
+            ...state,
+            entries: [
+                {
+                    id: "docs/data.csv",
+                    path: "/vault/docs/data.csv",
+                    relative_path: "docs/data.csv",
+                    title: "data",
+                    file_name: "data.csv",
+                    extension: "csv",
+                    kind: "file",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 12,
+                    mime_type: "text/csv",
+                    is_text_like: true,
+                },
+                {
+                    id: "docs/config.toml",
+                    path: "/vault/docs/config.toml",
+                    relative_path: "docs/config.toml",
+                    title: "config",
+                    file_name: "config.toml",
+                    extension: "toml",
+                    kind: "file",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 12,
+                    mime_type: "application/toml",
+                    is_text_like: true,
+                },
+            ],
+        }));
+        mockInvoke().mockResolvedValue([
+            {
+                id: "notes/data",
+                title: "Data Note",
+                subtitle: "notes/data",
+                insert_text: "notes/data",
+            },
+        ]);
+
+        const items = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(mockInvoke()).not.toHaveBeenCalled();
+        expect(items).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                title: "data.csv",
             }),
         ]);
     });

--- a/apps/desktop/src/features/editor/extensions/wikilinkSuggester.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkSuggester.test.ts
@@ -10,6 +10,26 @@ import {
     MAX_WIKILINK_SUGGESTION_CACHE_ENTRIES,
 } from "./wikilinkSuggester";
 
+function buildTextFileEntry(relativePath: string, mimeType = "text/plain") {
+    const fileName = relativePath.split("/").pop() ?? relativePath;
+    const dotIndex = fileName.lastIndexOf(".");
+
+    return {
+        id: relativePath,
+        path: `/vault/${relativePath}`,
+        relative_path: relativePath,
+        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
+        file_name: fileName,
+        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
+        kind: "file" as const,
+        modified_at: 0,
+        created_at: 0,
+        size: 12,
+        mime_type: mimeType,
+        is_text_like: true,
+    };
+}
+
 describe("wikilinkSuggester", () => {
     beforeEach(() => {
         useVaultStore.setState((state) => ({
@@ -218,6 +238,92 @@ describe("wikilinkSuggester", () => {
                 title: "data.csv",
             }),
         ]);
+    });
+
+    it("refreshes cached file suggestions when the vault structure changes", async () => {
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+        useVaultStore.setState((state) => ({
+            ...state,
+            structureRevision: state.structureRevision + 1,
+            entries: [buildTextFileEntry("docs/data.csv", "text/csv")],
+        }));
+
+        const first = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(first).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                title: "data.csv",
+            }),
+        ]);
+
+        useVaultStore.setState((state) => ({
+            ...state,
+            structureRevision: state.structureRevision + 1,
+            entries: [buildTextFileEntry("docs/report.csv", "text/csv")],
+        }));
+
+        const second = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(second).toEqual([]);
+    });
+
+    it("keeps backend note ordering before curated files in normal mode", async () => {
+        useVaultStore.setState((state) => ({
+            ...state,
+            entries: [buildTextFileEntry("docs/data.csv", "text/csv")],
+        }));
+        mockInvoke().mockResolvedValue([
+            {
+                id: "notes/project",
+                title: "Data Note",
+                subtitle: "notes/project",
+                insert_text: "notes/project",
+            },
+        ]);
+
+        const items = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(items).toEqual([
+            expect.objectContaining({
+                kind: "note",
+                title: "Data Note",
+            }),
+            expect.objectContaining({
+                kind: "file",
+                title: "data.csv",
+            }),
+        ]);
+    });
+
+    it("keeps file-oriented ranking for notes and files in all-files mode", async () => {
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+        });
+        useVaultStore.setState((state) => ({
+            ...state,
+            entries: [buildTextFileEntry("docs/data.csv", "text/csv")],
+        }));
+        mockInvoke().mockResolvedValue([
+            {
+                id: "notes/project",
+                title: "Data Note",
+                subtitle: "notes/project",
+                insert_text: "notes/project",
+            },
+        ]);
+
+        const items = await getWikilinkSuggestions("notes/current", "data");
+
+        expect(items[0]).toEqual(
+            expect.objectContaining({
+                kind: "file",
+                title: "data.csv",
+            }),
+        );
     });
 
     it("shows Markdown note file names with extensions in all-files mode when extensions are enabled", async () => {

--- a/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
@@ -3,7 +3,9 @@ import { useVaultStore } from "../../../app/store/vaultStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import {
     isTextLikeVaultEntry,
-    shouldShowVaultEntryInFileTree,
+    shouldIncludeMarkdownNotesInFileScope,
+    shouldIncludeVaultEntryInFileScope,
+    type VaultFileScope,
 } from "../../../app/utils/vaultEntries";
 import { vaultInvoke } from "../../../app/utils/vaultInvoke";
 import { LruCache } from "../lruCache";
@@ -67,10 +69,7 @@ function getWikilinkNoteDisplayTitle(
 function getFileSuggestions(
     query: string,
     limit: number,
-    options: {
-        contentMode: "notes_only" | "all_files";
-        extensionFilter: readonly string[];
-    },
+    scope: VaultFileScope,
 ): WikilinkSuggestionItem[] {
     const normalizedQuery = normalizeForSearch(query);
 
@@ -80,7 +79,7 @@ function getFileSuggestions(
             (entry) =>
                 entry.kind === "file" &&
                 isTextLikeVaultEntry(entry) &&
-                shouldShowVaultEntryInFileTree(entry, options),
+                shouldIncludeVaultEntryInFileScope(entry, scope),
         )
         .map((entry) => {
             const normalizedFileName = normalizeForSearch(entry.file_name);
@@ -259,9 +258,11 @@ export async function getWikilinkSuggestions(
         useSettingsStore.getState();
     const preferFileName = fileTreeContentMode === "all_files";
     const extensionFilterKey = fileTreeExtensionFilter.join(",");
-    const showMarkdownNotes =
-        fileTreeExtensionFilter.length === 0 ||
-        fileTreeExtensionFilter.includes("md");
+    const fileScope = {
+        contentMode: fileTreeContentMode,
+        extensionFilter: fileTreeExtensionFilter,
+    };
+    const showMarkdownNotes = shouldIncludeMarkdownNotesInFileScope(fileScope);
     const cacheKey = `${resolverRevision}\u0000${structureRevision}\u0000${noteId}\u0000${limit}\u0000${Number(preferFileName)}\u0000${Number(fileTreeShowExtensions)}\u0000${extensionFilterKey}\u0000${query}`;
     const cached = suggestionCache.get(cacheKey);
     if (cached) {
@@ -289,10 +290,7 @@ export async function getWikilinkSuggestions(
         insertText: item.insert_text,
     }));
 
-    const fileSuggestions = getFileSuggestions(query, limit, {
-        contentMode: fileTreeContentMode,
-        extensionFilter: fileTreeExtensionFilter,
-    });
+    const fileSuggestions = getFileSuggestions(query, limit, fileScope);
     const merged = mergeWikilinkSuggestions(
         items,
         fileSuggestions,

--- a/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
@@ -1,7 +1,10 @@
 import type { EditorState } from "@codemirror/state";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
-import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
+import {
+    isTextLikeVaultEntry,
+    shouldShowVaultEntryInFileTree,
+} from "../../../app/utils/vaultEntries";
 import { vaultInvoke } from "../../../app/utils/vaultInvoke";
 import { LruCache } from "../lruCache";
 
@@ -64,13 +67,20 @@ function getWikilinkNoteDisplayTitle(
 function getFileSuggestions(
     query: string,
     limit: number,
+    options: {
+        contentMode: "notes_only" | "all_files";
+        extensionFilter: readonly string[];
+    },
 ): WikilinkSuggestionItem[] {
     const normalizedQuery = normalizeForSearch(query);
 
     return useVaultStore
         .getState()
         .entries.filter(
-            (entry) => entry.kind === "file" && isTextLikeVaultEntry(entry),
+            (entry) =>
+                entry.kind === "file" &&
+                isTextLikeVaultEntry(entry) &&
+                shouldShowVaultEntryInFileTree(entry, options),
         )
         .map((entry) => {
             const normalizedFileName = normalizeForSearch(entry.file_name);
@@ -106,6 +116,47 @@ function getFileSuggestions(
         })
         .slice(0, limit)
         .map(({ rank: _rank, ...item }) => item);
+}
+
+function rankWikilinkSuggestions(
+    items: WikilinkSuggestionItem[],
+    query: string,
+    limit: number,
+) {
+    const normalizedQuery = normalizeForSearch(query);
+
+    return items
+        .map((item) => {
+            const normalizedTitle = normalizeForSearch(item.title);
+            const normalizedSubtitle = normalizeForSearch(item.subtitle);
+            const normalizedBaseName = normalizeForSearch(
+                item.subtitle.split("/").pop() ?? item.title,
+            );
+            const rank = !query
+                ? 100
+                : normalizedBaseName.startsWith(normalizedQuery)
+                  ? 0
+                  : normalizedSubtitle.startsWith(normalizedQuery)
+                    ? 1
+                    : normalizedBaseName.includes(normalizedQuery)
+                      ? 2
+                      : normalizedSubtitle.includes(normalizedQuery)
+                        ? 3
+                        : normalizedTitle.includes(normalizedQuery)
+                          ? 4
+                          : 5;
+
+            return { item, rank };
+        })
+        .sort((left, right) => {
+            if (left.rank !== right.rank) {
+                return left.rank - right.rank;
+            }
+
+            return left.item.subtitle.localeCompare(right.item.subtitle);
+        })
+        .slice(0, limit)
+        .map(({ item }) => item);
 }
 
 export const MAX_WIKILINK_SUGGESTION_CACHE_ENTRIES = 256;
@@ -172,24 +223,31 @@ export async function getWikilinkSuggestions(
     limit = 8,
 ): Promise<WikilinkSuggestionItem[]> {
     const resolverRevision = ensureFreshSuggestionCache();
-    const { fileTreeContentMode, fileTreeShowExtensions } =
+    const {
+        fileTreeContentMode,
+        fileTreeShowExtensions,
+        fileTreeExtensionFilter,
+    } =
         useSettingsStore.getState();
     const preferFileName = fileTreeContentMode === "all_files";
-    const cacheKey = `${resolverRevision}\u0000${noteId}\u0000${limit}\u0000${Number(preferFileName)}\u0000${Number(fileTreeShowExtensions)}\u0000${query}`;
+    const extensionFilterKey = fileTreeExtensionFilter.join(",");
+    const showMarkdownNotes =
+        fileTreeExtensionFilter.length === 0 ||
+        fileTreeExtensionFilter.includes("md");
+    const cacheKey = `${resolverRevision}\u0000${noteId}\u0000${limit}\u0000${Number(preferFileName)}\u0000${Number(fileTreeShowExtensions)}\u0000${extensionFilterKey}\u0000${query}`;
     const cached = suggestionCache.get(cacheKey);
     if (cached) {
         return cached;
     }
 
-    const suggestions = await vaultInvoke<WikilinkSuggestionDto[]>(
-        "suggest_wikilinks",
-        {
-            noteId,
-            query,
-            limit,
-            preferFileName,
-        },
-    );
+    const suggestions = showMarkdownNotes
+        ? await vaultInvoke<WikilinkSuggestionDto[]>("suggest_wikilinks", {
+              noteId,
+              query,
+              limit,
+              preferFileName,
+          })
+        : [];
 
     const items = suggestions.map((item) => ({
         id: item.id,
@@ -203,48 +261,18 @@ export async function getWikilinkSuggestions(
         insertText: item.insert_text,
     }));
 
-    const merged = preferFileName
-        ? [...items, ...getFileSuggestions(query, limit)]
-              .map((item) => {
-                  const normalizedTitle = normalizeForSearch(item.title);
-                  const normalizedSubtitle = normalizeForSearch(item.subtitle);
-                  const normalizedBaseName = normalizeForSearch(
-                      item.subtitle.split("/").pop() ?? item.title,
-                  );
-                  const rank = !query
-                      ? 100
-                      : normalizedBaseName.startsWith(normalizeForSearch(query))
-                        ? 0
-                        : normalizedSubtitle.startsWith(
-                                normalizeForSearch(query),
-                            )
-                          ? 1
-                          : normalizedBaseName.includes(
-                                  normalizeForSearch(query),
-                              )
-                            ? 2
-                            : normalizedSubtitle.includes(
-                                    normalizeForSearch(query),
-                                )
-                              ? 3
-                              : normalizedTitle.includes(
-                                      normalizeForSearch(query),
-                                  )
-                                ? 4
-                                : 5;
-
-                  return { item, rank };
-              })
-              .sort((left, right) => {
-                  if (left.rank !== right.rank) {
-                      return left.rank - right.rank;
-                  }
-
-                  return left.item.subtitle.localeCompare(right.item.subtitle);
-              })
-              .slice(0, limit)
-              .map(({ item }) => item)
-        : items;
+    const fileSuggestions = getFileSuggestions(query, limit, {
+        contentMode: fileTreeContentMode,
+        extensionFilter: fileTreeExtensionFilter,
+    });
+    const merged =
+        fileSuggestions.length === 0
+            ? items
+            : rankWikilinkSuggestions(
+                  [...items, ...fileSuggestions],
+                  query,
+                  limit,
+              );
 
     suggestionCache.set(cacheKey, merged);
     return merged;

--- a/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkSuggester.ts
@@ -159,6 +159,30 @@ function rankWikilinkSuggestions(
         .map(({ item }) => item);
 }
 
+function mergeWikilinkSuggestions(
+    noteSuggestions: WikilinkSuggestionItem[],
+    fileSuggestions: WikilinkSuggestionItem[],
+    query: string,
+    limit: number,
+    preferFileName: boolean,
+) {
+    if (fileSuggestions.length === 0) {
+        return noteSuggestions;
+    }
+
+    if (preferFileName) {
+        return rankWikilinkSuggestions(
+            [...noteSuggestions, ...fileSuggestions],
+            query,
+            limit,
+        );
+    }
+
+    // Normal mode keeps the note suggester's title-first ordering. Files are
+    // added after notes so curated files do not unexpectedly outrank note titles.
+    return [...noteSuggestions, ...fileSuggestions].slice(0, limit);
+}
+
 export const MAX_WIKILINK_SUGGESTION_CACHE_ENTRIES = 256;
 
 const suggestionCache = new LruCache<string, WikilinkSuggestionItem[]>(
@@ -167,20 +191,24 @@ const suggestionCache = new LruCache<string, WikilinkSuggestionItem[]>(
 
 let cachedVaultPath: string | null = null;
 let cachedResolverRevision: number | null = null;
+let cachedStructureRevision: number | null = null;
 
 function ensureFreshSuggestionCache() {
-    const { vaultPath, resolverRevision } = useVaultStore.getState();
+    const { vaultPath, resolverRevision, structureRevision } =
+        useVaultStore.getState();
     if (
         cachedVaultPath === vaultPath &&
-        cachedResolverRevision === resolverRevision
+        cachedResolverRevision === resolverRevision &&
+        cachedStructureRevision === structureRevision
     ) {
-        return resolverRevision;
+        return { resolverRevision, structureRevision };
     }
 
     suggestionCache.clear();
     cachedVaultPath = vaultPath;
     cachedResolverRevision = resolverRevision;
-    return resolverRevision;
+    cachedStructureRevision = structureRevision;
+    return { resolverRevision, structureRevision };
 }
 
 export function getWikilinkContext(state: EditorState): WikilinkContext | null {
@@ -222,7 +250,7 @@ export async function getWikilinkSuggestions(
     query: string,
     limit = 8,
 ): Promise<WikilinkSuggestionItem[]> {
-    const resolverRevision = ensureFreshSuggestionCache();
+    const { resolverRevision, structureRevision } = ensureFreshSuggestionCache();
     const {
         fileTreeContentMode,
         fileTreeShowExtensions,
@@ -234,7 +262,7 @@ export async function getWikilinkSuggestions(
     const showMarkdownNotes =
         fileTreeExtensionFilter.length === 0 ||
         fileTreeExtensionFilter.includes("md");
-    const cacheKey = `${resolverRevision}\u0000${noteId}\u0000${limit}\u0000${Number(preferFileName)}\u0000${Number(fileTreeShowExtensions)}\u0000${extensionFilterKey}\u0000${query}`;
+    const cacheKey = `${resolverRevision}\u0000${structureRevision}\u0000${noteId}\u0000${limit}\u0000${Number(preferFileName)}\u0000${Number(fileTreeShowExtensions)}\u0000${extensionFilterKey}\u0000${query}`;
     const cached = suggestionCache.get(cacheKey);
     if (cached) {
         return cached;
@@ -265,14 +293,13 @@ export async function getWikilinkSuggestions(
         contentMode: fileTreeContentMode,
         extensionFilter: fileTreeExtensionFilter,
     });
-    const merged =
-        fileSuggestions.length === 0
-            ? items
-            : rankWikilinkSuggestions(
-                  [...items, ...fileSuggestions],
-                  query,
-                  limit,
-              );
+    const merged = mergeWikilinkSuggestions(
+        items,
+        fileSuggestions,
+        query,
+        limit,
+        preferFileName,
+    );
 
     suggestionCache.set(cacheKey, merged);
     return merged;

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { QuickSwitcher } from "./QuickSwitcher";
 import {
+    buildVaultFileEntry,
     mockInvoke,
     renderComponent,
     setCommands,
@@ -25,25 +26,6 @@ afterEach(() => {
     setEditorTabs([]);
     setCommands([], null);
 });
-
-function buildVaultFileEntry(path: string, mimeType = "text/plain") {
-    const fileName = path.split("/").pop() ?? path;
-    const dotIndex = fileName.lastIndexOf(".");
-
-    return {
-        id: path,
-        path: `/vault/${path}`,
-        relative_path: path,
-        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
-        file_name: fileName,
-        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
-        kind: "file" as const,
-        modified_at: 1,
-        created_at: 1,
-        size: 1,
-        mime_type: mimeType,
-    };
-}
 
 describe("QuickSwitcher", () => {
     it("shows open tabs first when the query is empty", async () => {
@@ -187,6 +169,7 @@ describe("QuickSwitcher", () => {
         setVaultNotes([]);
         setVaultEntries([
             buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/diagram.excalidraw", "application/json"),
             buildVaultFileEntry("docs/config.toml", "application/toml"),
         ]);
         setEditorTabs([]);
@@ -205,6 +188,13 @@ describe("QuickSwitcher", () => {
 
         expect(screen.getByText("data")).toBeInTheDocument();
         expect(screen.queryByText("config")).not.toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "diagram.excalidraw" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText("diagram")).toBeInTheDocument();
 
         fireEvent.change(input, { target: { value: "config.toml" } });
         await act(async () => {

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
@@ -249,7 +249,7 @@ describe("QuickSwitcher", () => {
         expect(screen.getByText("config")).toBeInTheDocument();
     });
 
-    it("uses the extension allowlist as the Quick Switcher file scope", async () => {
+    it("uses the extension allowlist as the Quick Switcher vault scope", async () => {
         vi.useFakeTimers();
 
         useSettingsStore.setState({
@@ -291,6 +291,75 @@ describe("QuickSwitcher", () => {
         });
 
         expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
+    });
+
+    it("keeps open tabs searchable even when the extension allowlist excludes them", async () => {
+        vi.useFakeTimers();
+
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+        setVaultNotes([
+            {
+                id: "notes/alpha",
+                path: "/vault/notes/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "main",
+                    tabs: [
+                        {
+                            id: "tab-alpha",
+                            noteId: "notes/alpha",
+                            title: "Alpha",
+                            content: "cached alpha",
+                        },
+                        {
+                            id: "tab-config",
+                            kind: "file",
+                            relativePath: "docs/config.toml",
+                            path: "/vault/docs/config.toml",
+                            title: "config.toml",
+                            content: "enabled = true",
+                            mimeType: "application/toml",
+                            viewer: "text",
+                        },
+                    ],
+                    activeTabId: "tab-alpha",
+                },
+            ],
+            "main",
+        );
+        setCommands([], "quick-switcher");
+
+        renderComponent(<QuickSwitcher />);
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        const input = screen.getByPlaceholderText(/Search files/);
+
+        fireEvent.change(input, { target: { value: "Alpha" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+        expect(screen.getByText("Alpha")).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "config" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+        expect(screen.getByText("config")).toBeInTheDocument();
     });
 
     it("opens an already open note from the filtered results without reading it again", async () => {
@@ -341,6 +410,45 @@ describe("QuickSwitcher", () => {
             "read_note",
             expect.anything(),
         );
+    });
+
+    it("keeps open note tabs fuzzy-searchable in normal mode", async () => {
+        vi.useFakeTimers();
+
+        setVaultNotes([
+            {
+                id: "notes/open-a",
+                path: "/vault/notes/open-a.md",
+                title: "Open A",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-open-a",
+                    noteId: "notes/open-a",
+                    title: "Open A",
+                    content: "cached",
+                },
+            ],
+            "tab-open-a",
+        );
+        setCommands([], "quick-switcher");
+
+        renderComponent(<QuickSwitcher />);
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        const input = screen.getByPlaceholderText(/Search files/);
+        fireEvent.change(input, { target: { value: "oa" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText("Open A")).toBeInTheDocument();
     });
 
     it("keeps the selected result in view when keyboard navigation moves beyond the virtual window", async () => {

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QuickSwitcher } from "./QuickSwitcher";
 import {
     mockInvoke,
@@ -12,6 +12,38 @@ import {
 import { useEditorStore } from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useChatStore } from "../ai/store/chatStore";
+
+afterEach(() => {
+    vi.useRealTimers();
+    useSettingsStore.setState({
+        fileTreeContentMode: "notes_only",
+        fileTreeShowExtensions: false,
+        fileTreeExtensionFilter: [],
+    });
+    setVaultNotes([]);
+    setVaultEntries([]);
+    setEditorTabs([]);
+    setCommands([], null);
+});
+
+function buildVaultFileEntry(path: string, mimeType = "text/plain") {
+    const fileName = path.split("/").pop() ?? path;
+    const dotIndex = fileName.lastIndexOf(".");
+
+    return {
+        id: path,
+        path: `/vault/${path}`,
+        relative_path: path,
+        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
+        file_name: fileName,
+        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
+        kind: "file" as const,
+        modified_at: 1,
+        created_at: 1,
+        size: 1,
+        mime_type: mimeType,
+    };
+}
 
 describe("QuickSwitcher", () => {
     it("shows open tabs first when the query is empty", async () => {
@@ -147,6 +179,118 @@ describe("QuickSwitcher", () => {
             "diagnostico.mdnotes/diagnostico",
             "roadmap.mdnotes/roadmap",
         ]);
+    });
+
+    it("searches curated vault files by filename when all-files mode is disabled", async () => {
+        vi.useFakeTimers();
+
+        setVaultNotes([]);
+        setVaultEntries([
+            buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        setEditorTabs([]);
+        setCommands([], "quick-switcher");
+
+        renderComponent(<QuickSwitcher />);
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        const input = screen.getByPlaceholderText(/Search files/);
+        fireEvent.change(input, { target: { value: "data.csv" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "config.toml" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+        expect(screen.getByText("No matching items")).toBeInTheDocument();
+
+    });
+
+    it("includes technical files in Quick Switcher when all-files mode is active", async () => {
+        vi.useFakeTimers();
+
+        useSettingsStore.setState({ fileTreeContentMode: "all_files" });
+        setVaultNotes([
+            {
+                id: "notes/alpha",
+                path: "/vault/notes/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setVaultEntries([
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        setEditorTabs([]);
+        setCommands([], "quick-switcher");
+
+        renderComponent(<QuickSwitcher />);
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        const input = screen.getByPlaceholderText(/Search files/);
+        fireEvent.change(input, { target: { value: "config.toml" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText("config")).toBeInTheDocument();
+    });
+
+    it("uses the extension allowlist as the Quick Switcher file scope", async () => {
+        vi.useFakeTimers();
+
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+        setVaultNotes([]);
+        setVaultEntries([
+            buildVaultFileEntry("docs/data.csv", "text/csv"),
+            buildVaultFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        setEditorTabs([]);
+        setCommands([], "quick-switcher");
+
+        renderComponent(<QuickSwitcher />);
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        const input = screen.getByPlaceholderText(/Search files/);
+        fireEvent.change(input, { target: { value: "data" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.getByText("data")).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "config" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+        expect(screen.getByText("No matching items")).toBeInTheDocument();
+
+        fireEvent.change(input, { target: { value: "Alpha" } });
+        await act(async () => {
+            await vi.runAllTimersAsync();
+        });
+
+        expect(screen.queryByText("Alpha")).not.toBeInTheDocument();
     });
 
     it("opens an already open note from the filtered results without reading it again", async () => {

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
@@ -31,6 +31,7 @@ import { useVirtualList } from "../../app/hooks/useVirtualList";
 import {
     getVaultEntryDisplayName,
     openVaultFileEntry,
+    shouldShowVaultEntryInFileTree,
 } from "../../app/utils/vaultEntries";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useChatStore } from "../ai/store/chatStore";
@@ -151,6 +152,9 @@ function QuickSwitcherDialog() {
     const openPdf = useEditorStore((s) => s.openPdf);
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
     const showExtensions = useSettingsStore((s) => s.fileTreeShowExtensions);
+    const fileTreeExtensionFilter = useSettingsStore(
+        (s) => s.fileTreeExtensionFilter,
+    );
     const deferredQuery = useDeferredValue(query);
     const noteMap = useMemo(
         () => new Map(notes.map((note) => [note.id, note])),
@@ -218,8 +222,19 @@ function QuickSwitcherDialog() {
     );
 
     const results = useMemo(() => {
+        const searchableNotes =
+            fileTreeExtensionFilter.length > 0 &&
+            !fileTreeExtensionFilter.includes("md")
+                ? []
+                : notes;
         const searchableEntries = entries.filter(
-            (entry) => entry.kind !== "note" && entry.kind !== "folder",
+            (entry) =>
+                entry.kind !== "note" &&
+                entry.kind !== "folder" &&
+                shouldShowVaultEntryInFileTree(entry, {
+                    contentMode: fileTreeContentMode,
+                    extensionFilter: fileTreeExtensionFilter,
+                }),
         );
 
         if (!deferredQuery.trim()) {
@@ -267,7 +282,7 @@ function QuickSwitcherDialog() {
                 })
                 .filter((item): item is QuickSwitcherItem => item !== null);
 
-            const remainingNotes = notes
+            const remainingNotes = searchableNotes
                 .filter(
                     (note) =>
                         !ordered.some((item) => item.key === `note:${note.id}`),
@@ -314,7 +329,7 @@ function QuickSwitcherDialog() {
                         ),
                     };
                 }),
-            ...notes.map((note) => ({
+            ...searchableNotes.map((note) => ({
                 item: buildNoteItem(note),
                 score:
                     fileTreeContentMode === "all_files"
@@ -339,20 +354,11 @@ function QuickSwitcherDialog() {
             })),
             ...searchableEntries.map((entry) => ({
                 item: buildEntryItem(entry),
-                score:
-                    fileTreeContentMode === "all_files"
-                        ? fileOrientedScore(deferredQuery, {
-                              fileName: entry.file_name,
-                              path: entry.relative_path,
-                              title: entry.title,
-                          })
-                        : Math.max(
-                              fuzzyScore(
-                                  deferredQuery,
-                                  getVaultEntryDisplayName(entry, true),
-                              ),
-                              fuzzyScore(deferredQuery, entry.relative_path),
-                          ),
+                score: fileOrientedScore(deferredQuery, {
+                    fileName: entry.file_name,
+                    path: entry.relative_path,
+                    title: entry.title,
+                }),
             })),
         ]
             .filter(({ score }) => score > 0)
@@ -367,6 +373,7 @@ function QuickSwitcherDialog() {
         entries,
         entryMap,
         fileTreeContentMode,
+        fileTreeExtensionFilter,
         noteMap,
         notes,
         openTabs,

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
@@ -221,24 +221,9 @@ function QuickSwitcherDialog() {
         [],
     );
 
-    const results = useMemo(() => {
-        const searchableNotes =
-            fileTreeExtensionFilter.length > 0 &&
-            !fileTreeExtensionFilter.includes("md")
-                ? []
-                : notes;
-        const searchableEntries = entries.filter(
-            (entry) =>
-                entry.kind !== "note" &&
-                entry.kind !== "folder" &&
-                shouldShowVaultEntryInFileTree(entry, {
-                    contentMode: fileTreeContentMode,
-                    extensionFilter: fileTreeExtensionFilter,
-                }),
-        );
-
-        if (!deferredQuery.trim()) {
-            const ordered = orderedTabs
+    const openTabItems = useMemo(
+        () =>
+            orderedTabs
                 .map((tab) => {
                     if (isChatTab(tab)) {
                         return buildChatItem(tab);
@@ -280,18 +265,47 @@ function QuickSwitcherDialog() {
                     const note = noteMap.get(tab.noteId);
                     return note ? buildNoteItem(note) : null;
                 })
-                .filter((item): item is QuickSwitcherItem => item !== null);
+                .filter((item): item is QuickSwitcherItem => item !== null),
+        [
+            buildChatItem,
+            buildEntryItem,
+            buildHistoryItem,
+            buildNoteItem,
+            entryMap,
+            noteMap,
+            orderedTabs,
+        ],
+    );
 
+    const results = useMemo(() => {
+        const searchableNotes =
+            fileTreeExtensionFilter.length > 0 &&
+            !fileTreeExtensionFilter.includes("md")
+                ? []
+                : notes;
+        const searchableEntries = entries.filter(
+            (entry) =>
+                entry.kind !== "note" &&
+                entry.kind !== "folder" &&
+                shouldShowVaultEntryInFileTree(entry, {
+                    contentMode: fileTreeContentMode,
+                    extensionFilter: fileTreeExtensionFilter,
+                }),
+        );
+
+        if (!deferredQuery.trim()) {
             const remainingNotes = searchableNotes
                 .filter(
                     (note) =>
-                        !ordered.some((item) => item.key === `note:${note.id}`),
+                        !openTabItems.some(
+                            (item) => item.key === `note:${note.id}`,
+                        ),
                 )
                 .map(buildNoteItem);
             const remainingEntries = searchableEntries
                 .filter(
                     (entry) =>
-                        !ordered.some(
+                        !openTabItems.some(
                             (item) =>
                                 item.key ===
                                 `${entry.kind}:${entry.relative_path}`,
@@ -299,85 +313,104 @@ function QuickSwitcherDialog() {
                 )
                 .map(buildEntryItem);
 
-            return [...ordered, ...remainingNotes, ...remainingEntries];
+            return [...openTabItems, ...remainingNotes, ...remainingEntries];
         }
 
         return [
-            ...openTabs
-                .filter((tab): tab is ChatTab => isChatTab(tab))
-                .map((tab) => {
-                    const item = buildChatItem(tab);
-                    return {
-                        item,
-                        score: Math.max(
-                            fuzzyScore(deferredQuery, item.title),
-                            fuzzyScore(deferredQuery, tab.sessionId),
-                        ),
-                    };
-                }),
-            ...openTabs
-                .filter(
-                    (tab): tab is ChatHistoryTab => isChatHistoryTab(tab),
-                )
-                .map((tab) => {
-                    const item = buildHistoryItem(tab);
-                    return {
-                        item,
-                        score: Math.max(
-                            fuzzyScore(deferredQuery, item.title),
-                            fuzzyScore(deferredQuery, item.subtitle),
-                        ),
-                    };
-                }),
-            ...searchableNotes.map((note) => ({
-                item: buildNoteItem(note),
+            ...openTabItems.map((item) => ({
+                item,
                 score:
-                    fileTreeContentMode === "all_files"
-                        ? fileOrientedScore(deferredQuery, {
-                              fileName: getNoteFileName(note),
-                              path: note.id || note.path,
-                              title: note.title,
-                          })
-                        : Math.max(
-                              fuzzyScore(
-                                  deferredQuery,
-                                  getNoteQuickSwitcherTitle(
-                                      note,
-                                      fileTreeContentMode,
-                                      showExtensions,
+                    item.kind === "note"
+                        ? fileTreeContentMode === "all_files"
+                            ? fileOrientedScore(deferredQuery, {
+                                  fileName: getNoteFileName(item.note),
+                                  path: item.note.id || item.note.path,
+                                  title: item.note.title,
+                              })
+                            : Math.max(
+                                  fuzzyScore(
+                                      deferredQuery,
+                                      getNoteQuickSwitcherTitle(
+                                          item.note,
+                                          fileTreeContentMode,
+                                          showExtensions,
+                                      ),
                                   ),
+                                  fuzzyScore(deferredQuery, item.note.path),
+                                  fuzzyScore(deferredQuery, item.note.id),
+                                  fuzzyScore(deferredQuery, item.note.title),
+                              )
+                        : item.kind === "file" || item.kind === "pdf"
+                          ? fileOrientedScore(deferredQuery, {
+                                fileName: item.entry.file_name,
+                                path: item.entry.relative_path,
+                                title: item.entry.title,
+                            })
+                          : Math.max(
+                                fuzzyScore(deferredQuery, item.title),
+                                fuzzyScore(deferredQuery, item.subtitle),
+                            ),
+            })),
+            ...searchableNotes
+                .filter(
+                    (note) =>
+                        !openTabItems.some(
+                            (item) => item.key === `note:${note.id}`,
+                        ),
+                )
+                .map((note) => ({
+                    item: buildNoteItem(note),
+                    score:
+                        fileTreeContentMode === "all_files"
+                            ? fileOrientedScore(deferredQuery, {
+                                  fileName: getNoteFileName(note),
+                                  path: note.id || note.path,
+                                  title: note.title,
+                              })
+                            : Math.max(
+                                  fuzzyScore(
+                                      deferredQuery,
+                                      getNoteQuickSwitcherTitle(
+                                          note,
+                                          fileTreeContentMode,
+                                          showExtensions,
+                                      ),
+                                  ),
+                                  fuzzyScore(deferredQuery, note.path),
+                                  fuzzyScore(deferredQuery, note.id),
+                                  fuzzyScore(deferredQuery, note.title),
                               ),
-                              fuzzyScore(deferredQuery, note.path),
-                              fuzzyScore(deferredQuery, note.id),
-                              fuzzyScore(deferredQuery, note.title),
-                          ),
-            })),
-            ...searchableEntries.map((entry) => ({
-                item: buildEntryItem(entry),
-                score: fileOrientedScore(deferredQuery, {
-                    fileName: entry.file_name,
-                    path: entry.relative_path,
-                    title: entry.title,
-                }),
-            })),
+                })),
+            ...searchableEntries
+                .filter(
+                    (entry) =>
+                        !openTabItems.some(
+                            (item) =>
+                                item.key ===
+                                `${entry.kind}:${entry.relative_path}`,
+                        ),
+                )
+                .map((entry) => ({
+                    item: buildEntryItem(entry),
+                    score: fileOrientedScore(deferredQuery, {
+                        fileName: entry.file_name,
+                        path: entry.relative_path,
+                        title: entry.title,
+                    }),
+                })),
         ]
             .filter(({ score }) => score > 0)
             .sort((a, b) => b.score - a.score)
             .map(({ item }) => item);
     }, [
         buildEntryItem,
-        buildChatItem,
-        buildHistoryItem,
         buildNoteItem,
         deferredQuery,
         entries,
-        entryMap,
         fileTreeContentMode,
         fileTreeExtensionFilter,
-        noteMap,
         notes,
-        openTabs,
-        orderedTabs,
+        openTabItems,
         showExtensions,
     ]);
     const virtual = useVirtualList(

--- a/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
+++ b/apps/desktop/src/features/quick-switcher/QuickSwitcher.tsx
@@ -31,7 +31,9 @@ import { useVirtualList } from "../../app/hooks/useVirtualList";
 import {
     getVaultEntryDisplayName,
     openVaultFileEntry,
-    shouldShowVaultEntryInFileTree,
+    shouldIncludeMarkdownNotesInFileScope,
+    shouldIncludeVaultEntryInFileScope,
+    type VaultFileScope,
 } from "../../app/utils/vaultEntries";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useChatStore } from "../ai/store/chatStore";
@@ -139,6 +141,56 @@ type QuickSwitcherItem =
           subtitle: string;
           tab: ChatHistoryTab;
       };
+
+function getQuickSwitcherItemKey(item: QuickSwitcherItem) {
+    return item.key;
+}
+
+function scoreQuickSwitcherItem(
+    item: QuickSwitcherItem,
+    query: string,
+    options: {
+        fileScope: VaultFileScope;
+        showExtensions: boolean;
+    },
+) {
+    if (item.kind === "note") {
+        if (options.fileScope.contentMode === "all_files") {
+            return fileOrientedScore(query, {
+                fileName: getNoteFileName(item.note),
+                path: item.note.id || item.note.path,
+                title: item.note.title,
+            });
+        }
+
+        return Math.max(
+            fuzzyScore(
+                query,
+                getNoteQuickSwitcherTitle(
+                    item.note,
+                    options.fileScope.contentMode,
+                    options.showExtensions,
+                ),
+            ),
+            fuzzyScore(query, item.note.path),
+            fuzzyScore(query, item.note.id),
+            fuzzyScore(query, item.note.title),
+        );
+    }
+
+    if (item.kind === "file" || item.kind === "pdf") {
+        return fileOrientedScore(query, {
+            fileName: item.entry.file_name,
+            path: item.entry.relative_path,
+            title: item.entry.title,
+        });
+    }
+
+    return Math.max(
+        fuzzyScore(query, item.title),
+        fuzzyScore(query, item.subtitle),
+    );
+}
 
 function QuickSwitcherDialog() {
     const [query, setQuery] = useState("");
@@ -276,40 +328,34 @@ function QuickSwitcherDialog() {
             orderedTabs,
         ],
     );
+    const openItemKeys = useMemo(
+        () => new Set(openTabItems.map(getQuickSwitcherItemKey)),
+        [openTabItems],
+    );
 
     const results = useMemo(() => {
-        const searchableNotes =
-            fileTreeExtensionFilter.length > 0 &&
-            !fileTreeExtensionFilter.includes("md")
-                ? []
-                : notes;
+        const fileScope = {
+            contentMode: fileTreeContentMode,
+            extensionFilter: fileTreeExtensionFilter,
+        };
+        const searchableNotes = shouldIncludeMarkdownNotesInFileScope(fileScope)
+            ? notes
+            : [];
         const searchableEntries = entries.filter(
             (entry) =>
                 entry.kind !== "note" &&
                 entry.kind !== "folder" &&
-                shouldShowVaultEntryInFileTree(entry, {
-                    contentMode: fileTreeContentMode,
-                    extensionFilter: fileTreeExtensionFilter,
-                }),
+                shouldIncludeVaultEntryInFileScope(entry, fileScope),
         );
 
         if (!deferredQuery.trim()) {
             const remainingNotes = searchableNotes
-                .filter(
-                    (note) =>
-                        !openTabItems.some(
-                            (item) => item.key === `note:${note.id}`,
-                        ),
-                )
+                .filter((note) => !openItemKeys.has(`note:${note.id}`))
                 .map(buildNoteItem);
             const remainingEntries = searchableEntries
                 .filter(
                     (entry) =>
-                        !openTabItems.some(
-                            (item) =>
-                                item.key ===
-                                `${entry.kind}:${entry.relative_path}`,
-                        ),
+                        !openItemKeys.has(`${entry.kind}:${entry.relative_path}`),
                 )
                 .map(buildEntryItem);
 
@@ -319,85 +365,38 @@ function QuickSwitcherDialog() {
         return [
             ...openTabItems.map((item) => ({
                 item,
-                score:
-                    item.kind === "note"
-                        ? fileTreeContentMode === "all_files"
-                            ? fileOrientedScore(deferredQuery, {
-                                  fileName: getNoteFileName(item.note),
-                                  path: item.note.id || item.note.path,
-                                  title: item.note.title,
-                              })
-                            : Math.max(
-                                  fuzzyScore(
-                                      deferredQuery,
-                                      getNoteQuickSwitcherTitle(
-                                          item.note,
-                                          fileTreeContentMode,
-                                          showExtensions,
-                                      ),
-                                  ),
-                                  fuzzyScore(deferredQuery, item.note.path),
-                                  fuzzyScore(deferredQuery, item.note.id),
-                                  fuzzyScore(deferredQuery, item.note.title),
-                              )
-                        : item.kind === "file" || item.kind === "pdf"
-                          ? fileOrientedScore(deferredQuery, {
-                                fileName: item.entry.file_name,
-                                path: item.entry.relative_path,
-                                title: item.entry.title,
-                            })
-                          : Math.max(
-                                fuzzyScore(deferredQuery, item.title),
-                                fuzzyScore(deferredQuery, item.subtitle),
-                            ),
+                score: scoreQuickSwitcherItem(item, deferredQuery, {
+                    fileScope,
+                    showExtensions,
+                }),
             })),
             ...searchableNotes
-                .filter(
-                    (note) =>
-                        !openTabItems.some(
-                            (item) => item.key === `note:${note.id}`,
-                        ),
-                )
-                .map((note) => ({
-                    item: buildNoteItem(note),
-                    score:
-                        fileTreeContentMode === "all_files"
-                            ? fileOrientedScore(deferredQuery, {
-                                  fileName: getNoteFileName(note),
-                                  path: note.id || note.path,
-                                  title: note.title,
-                              })
-                            : Math.max(
-                                  fuzzyScore(
-                                      deferredQuery,
-                                      getNoteQuickSwitcherTitle(
-                                          note,
-                                          fileTreeContentMode,
-                                          showExtensions,
-                                      ),
-                                  ),
-                                  fuzzyScore(deferredQuery, note.path),
-                                  fuzzyScore(deferredQuery, note.id),
-                                  fuzzyScore(deferredQuery, note.title),
-                              ),
-                })),
+                .filter((note) => !openItemKeys.has(`note:${note.id}`))
+                .map((note) => {
+                    const item = buildNoteItem(note);
+                    return {
+                        item,
+                        score: scoreQuickSwitcherItem(item, deferredQuery, {
+                            fileScope,
+                            showExtensions,
+                        }),
+                    };
+                }),
             ...searchableEntries
                 .filter(
                     (entry) =>
-                        !openTabItems.some(
-                            (item) =>
-                                item.key ===
-                                `${entry.kind}:${entry.relative_path}`,
-                        ),
+                        !openItemKeys.has(`${entry.kind}:${entry.relative_path}`),
                 )
-                .map((entry) => ({
-                    item: buildEntryItem(entry),
-                    score: fileOrientedScore(deferredQuery, {
-                        fileName: entry.file_name,
-                        path: entry.relative_path,
-                        title: entry.title,
-                    }),
-                })),
+                .map((entry) => {
+                    const item = buildEntryItem(entry);
+                    return {
+                        item,
+                        score: scoreQuickSwitcherItem(item, deferredQuery, {
+                            fileScope,
+                            showExtensions,
+                        }),
+                    };
+                }),
         ]
             .filter(({ score }) => score > 0)
             .sort((a, b) => b.score - a.score)
@@ -410,6 +409,7 @@ function QuickSwitcherDialog() {
         fileTreeContentMode,
         fileTreeExtensionFilter,
         notes,
+        openItemKeys,
         openTabItems,
         showExtensions,
     ]);

--- a/apps/desktop/src/features/search/SearchView.test.tsx
+++ b/apps/desktop/src/features/search/SearchView.test.tsx
@@ -7,7 +7,10 @@ import { SearchView } from "./SearchView";
 
 describe("SearchView", () => {
     afterEach(() => {
-        useSettingsStore.setState({ fileTreeContentMode: "notes_only" });
+        useSettingsStore.setState({
+            fileTreeContentMode: "notes_only",
+            fileTreeExtensionFilter: [],
+        });
         mockInvoke().mockReset();
     });
 
@@ -85,7 +88,42 @@ describe("SearchView", () => {
             "advanced_search",
             expect.objectContaining({
                 params: expect.objectContaining({
+                    file_scope: {
+                        mode: "all_files",
+                        extension_filter: [],
+                    },
                     prefer_file_name: true,
+                }),
+            }),
+        );
+    });
+
+    it("passes the extension allowlist as the advanced search file scope", async () => {
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+        const invokeMock = mockInvoke().mockResolvedValue([]);
+
+        renderComponent(<SearchView tabId="search-tab-allowlist" />);
+        const input = screen.getByPlaceholderText(
+            "Search files and notes... (e.g. tag:project content:react)",
+        );
+
+        fireEvent.change(input, { target: { value: "data" } });
+        await act(async () => {
+            await new Promise((resolve) => setTimeout(resolve, 350));
+        });
+
+        expect(invokeMock).toHaveBeenCalledWith(
+            "advanced_search",
+            expect.objectContaining({
+                params: expect.objectContaining({
+                    file_scope: {
+                        mode: "all_files",
+                        extension_filter: ["csv"],
+                    },
                 }),
             }),
         );

--- a/apps/desktop/src/features/search/SearchView.tsx
+++ b/apps/desktop/src/features/search/SearchView.tsx
@@ -118,6 +118,9 @@ export function SearchView({ tabId }: SearchViewProps) {
     const insertExternalTab = useEditorStore((s) => s.insertExternalTab);
     const entries = useVaultStore((s) => s.entries);
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
+    const fileTreeExtensionFilter = useSettingsStore(
+        (s) => s.fileTreeExtensionFilter,
+    );
     const showExtensions = useSettingsStore((s) => s.fileTreeShowExtensions);
 
     const parsed = useMemo(() => parseQuery(query), [query]);
@@ -149,6 +152,10 @@ export function SearchView({ tabId }: SearchViewProps) {
                 const p = parseQuery(trimmed);
                 const params = toAdvancedSearchParams(p, sort, asc, {
                     preferFileName: fileTreeContentMode === "all_files",
+                    fileScope: {
+                        mode: fileTreeContentMode,
+                        extension_filter: fileTreeExtensionFilter,
+                    },
                 });
                 const res = await vaultInvoke<AdvancedSearchResultDto[]>(
                     "advanced_search",
@@ -169,7 +176,7 @@ export function SearchView({ tabId }: SearchViewProps) {
                 }
             }
         },
-        [fileTreeContentMode],
+        [fileTreeContentMode, fileTreeExtensionFilter],
     );
 
     useEffect(() => {

--- a/apps/desktop/src/features/search/queryToParams.ts
+++ b/apps/desktop/src/features/search/queryToParams.ts
@@ -20,6 +20,11 @@ interface PropertyFilterParam {
     is_regex: boolean;
 }
 
+interface AdvancedSearchFileScope {
+    mode: "notes_only" | "all_files";
+    extension_filter: string[];
+}
+
 export interface AdvancedSearchParams {
     terms: SearchTermParam[];
     tag_filters: SearchTermParam[];
@@ -30,10 +35,12 @@ export interface AdvancedSearchParams {
     sort_by: string;
     sort_asc: boolean;
     prefer_file_name: boolean;
+    file_scope: AdvancedSearchFileScope;
 }
 
 interface AdvancedSearchOptions {
     preferFileName?: boolean;
+    fileScope?: AdvancedSearchFileScope;
 }
 
 export function toAdvancedSearchParams(
@@ -52,6 +59,10 @@ export function toAdvancedSearchParams(
         sort_by: sortBy,
         sort_asc: sortAsc,
         prefer_file_name: options.preferFileName ?? false,
+        file_scope: options.fileScope ?? {
+            mode: "all_files",
+            extension_filter: [],
+        },
     };
 
     for (const token of parsed.tokens) {

--- a/apps/desktop/src/features/settings/ExtensionFilterInput.tsx
+++ b/apps/desktop/src/features/settings/ExtensionFilterInput.tsx
@@ -1,0 +1,145 @@
+import { useRef, useState } from "react";
+
+function parseExtensionTokens(value: string): string[] {
+    return value
+        .split(/[,\s]+/)
+        .map((item) => item.trim().replace(/^\.+/, "").toLowerCase())
+        .filter(Boolean);
+}
+
+export function ExtensionFilterInput({
+    value,
+    onChange,
+}: {
+    value: string[];
+    onChange: (value: string[]) => void;
+}) {
+    const [draft, setDraft] = useState("");
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const addExtensions = (raw: string) => {
+        const tokens = parseExtensionTokens(raw);
+        if (tokens.length === 0) return;
+
+        const seen = new Set(value);
+        const next = [...value];
+        for (const token of tokens) {
+            if (seen.has(token)) continue;
+            seen.add(token);
+            next.push(token);
+        }
+        onChange(next);
+        setDraft("");
+    };
+
+    const removeExtension = (extension: string) => {
+        onChange(value.filter((item) => item !== extension));
+    };
+
+    return (
+        <div
+            role="group"
+            aria-label="File extension filter"
+            onClick={() => inputRef.current?.focus()}
+            style={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 6,
+                width: 260,
+                minHeight: 30,
+                padding: "4px 6px",
+                borderRadius: 7,
+                border: "1px solid var(--border)",
+                backgroundColor: "var(--bg-tertiary)",
+                cursor: "text",
+            }}
+        >
+            {value.map((extension) => (
+                <span
+                    key={extension}
+                    style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                        maxWidth: 120,
+                        borderRadius: 999,
+                        padding: "2px 6px",
+                        backgroundColor:
+                            "color-mix(in srgb, var(--accent) 14%, transparent)",
+                        color: "var(--text-primary)",
+                        fontSize: 11,
+                        lineHeight: 1.2,
+                    }}
+                >
+                    <span
+                        style={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                        }}
+                    >
+                        .{extension}
+                    </span>
+                    <button
+                        type="button"
+                        aria-label={`Remove .${extension}`}
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            removeExtension(extension);
+                        }}
+                        style={{
+                            border: "none",
+                            padding: 0,
+                            background: "transparent",
+                            color: "var(--text-secondary)",
+                            cursor: "pointer",
+                            fontSize: 13,
+                            lineHeight: 1,
+                        }}
+                    >
+                        &times;
+                    </button>
+                </span>
+            ))}
+            <input
+                ref={inputRef}
+                value={draft}
+                aria-label="Add file extension"
+                placeholder={value.length === 0 ? "Add: pdf, txt, csv..." : ""}
+                onChange={(event) => setDraft(event.currentTarget.value)}
+                onPaste={(event) => {
+                    const pasted = event.clipboardData.getData("text");
+                    if (parseExtensionTokens(pasted).length <= 1) return;
+                    event.preventDefault();
+                    addExtensions(pasted);
+                }}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === ",") {
+                        event.preventDefault();
+                        addExtensions(draft);
+                        return;
+                    }
+                    if (
+                        event.key === "Backspace" &&
+                        draft.length === 0 &&
+                        value.length > 0
+                    ) {
+                        onChange(value.slice(0, -1));
+                    }
+                }}
+                onBlur={() => addExtensions(draft)}
+                style={{
+                    flex: "1 1 88px",
+                    minWidth: 74,
+                    border: "none",
+                    outline: "none",
+                    background: "transparent",
+                    color: "var(--text-primary)",
+                    fontSize: 12,
+                    fontFamily: "inherit",
+                }}
+            />
+        </div>
+    );
+}

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -202,6 +202,32 @@ describe("SettingsPanel", () => {
         expect(screen.getByDisplayValue("750")).toBeInTheDocument();
     });
 
+    it("lets users edit the file tree extension filter as chips", async () => {
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Developers" }));
+
+        const input = screen.getByRole("textbox", {
+            name: "Add file extension",
+        });
+        fireEvent.change(input, { target: { value: ".MD, csv" } });
+        fireEvent.keyDown(input, { key: "Enter" });
+
+        await waitFor(() => {
+            expect(useSettingsStore.getState().fileTreeExtensionFilter).toEqual(
+                ["md", "csv"],
+            );
+        });
+        expect(screen.getByText(".md")).toBeInTheDocument();
+        expect(screen.getByText(".csv")).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Remove .md" }));
+
+        expect(useSettingsStore.getState().fileTreeExtensionFilter).toEqual([
+            "csv",
+        ]);
+    });
+
     it("renders and persists app zoom as a percentage stepper", async () => {
         localStorage.setItem(APP_ZOOM_STORAGE_KEY, "1.1");
 

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -660,7 +660,7 @@ function ExtensionFilterInput({
                 ref={inputRef}
                 value={draft}
                 aria-label="Add file extension"
-                placeholder={value.length === 0 ? "pdf, txt, csv..." : ""}
+                placeholder={value.length === 0 ? "Add: pdf, txt, csv..." : ""}
                 onChange={(event) => setDraft(event.currentTarget.value)}
                 onPaste={(event) => {
                     const pasted = event.clipboardData.getData("text");
@@ -3305,7 +3305,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="Show all vault files"
-                description="Display every file in the vault tree, beyond the curated writing and media file set."
+                description="Display every vault file, beyond the curated writing and media set."
                 keywords={[
                     "File-oriented search is active",
                     "Search Files & Notes",
@@ -3342,7 +3342,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="File extension filter"
-                description="Optional allowlist for the file tree. Leave empty to use the current content mode."
+                description="Optional allowlist for the file tree and file pickers. When set, it overrides Show all vault files; leave empty to use the current mode."
                 keywords={["allowlist", "pdf, txt, csv"]}
                 control={
                     <ExtensionFilterInput
@@ -3362,10 +3362,10 @@ function DevelopersSettings({
                         color: "var(--text-secondary)",
                     }}
                 >
-                    File-oriented search is active. Search Files & Notes, New
-                    Tab, `@` mentions, and wikilink suggestions now match notes
-                    by file name and path before note title, and text files can
-                    also appear in `@` mentions and `[[ ]]` suggestions.
+                    Normal mode already includes Markdown notes plus curated
+                    writing and media files. All-files mode expands the file
+                    tree, New Tab, `@` mentions, and wikilink suggestions to
+                    technical project files where supported.
                 </div>
             )}
         </div>

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -554,6 +554,150 @@ function SliderField({
     );
 }
 
+function parseExtensionTokens(value: string): string[] {
+    return value
+        .split(/[,\s]+/)
+        .map((item) => item.trim().replace(/^\.+/, "").toLowerCase())
+        .filter(Boolean);
+}
+
+function ExtensionFilterInput({
+    value,
+    onChange,
+}: {
+    value: string[];
+    onChange: (value: string[]) => void;
+}) {
+    const [draft, setDraft] = useState("");
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const addExtensions = (raw: string) => {
+        const tokens = parseExtensionTokens(raw);
+        if (tokens.length === 0) return;
+
+        const seen = new Set(value);
+        const next = [...value];
+        for (const token of tokens) {
+            if (seen.has(token)) continue;
+            seen.add(token);
+            next.push(token);
+        }
+        onChange(next);
+        setDraft("");
+    };
+
+    const removeExtension = (extension: string) => {
+        onChange(value.filter((item) => item !== extension));
+    };
+
+    return (
+        <div
+            role="group"
+            aria-label="File extension filter"
+            onClick={() => inputRef.current?.focus()}
+            style={{
+                display: "flex",
+                alignItems: "center",
+                flexWrap: "wrap",
+                gap: 6,
+                width: 260,
+                minHeight: 30,
+                padding: "4px 6px",
+                borderRadius: 7,
+                border: "1px solid var(--border)",
+                backgroundColor: "var(--bg-tertiary)",
+                cursor: "text",
+            }}
+        >
+            {value.map((extension) => (
+                <span
+                    key={extension}
+                    style={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        gap: 4,
+                        maxWidth: 120,
+                        borderRadius: 999,
+                        padding: "2px 6px",
+                        backgroundColor:
+                            "color-mix(in srgb, var(--accent) 14%, transparent)",
+                        color: "var(--text-primary)",
+                        fontSize: 11,
+                        lineHeight: 1.2,
+                    }}
+                >
+                    <span
+                        style={{
+                            overflow: "hidden",
+                            textOverflow: "ellipsis",
+                            whiteSpace: "nowrap",
+                        }}
+                    >
+                        .{extension}
+                    </span>
+                    <button
+                        type="button"
+                        aria-label={`Remove .${extension}`}
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            removeExtension(extension);
+                        }}
+                        style={{
+                            border: "none",
+                            padding: 0,
+                            background: "transparent",
+                            color: "var(--text-secondary)",
+                            cursor: "pointer",
+                            fontSize: 13,
+                            lineHeight: 1,
+                        }}
+                    >
+                        ×
+                    </button>
+                </span>
+            ))}
+            <input
+                ref={inputRef}
+                value={draft}
+                aria-label="Add file extension"
+                placeholder={value.length === 0 ? "pdf, txt, csv..." : ""}
+                onChange={(event) => setDraft(event.currentTarget.value)}
+                onPaste={(event) => {
+                    const pasted = event.clipboardData.getData("text");
+                    if (parseExtensionTokens(pasted).length <= 1) return;
+                    event.preventDefault();
+                    addExtensions(pasted);
+                }}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter" || event.key === ",") {
+                        event.preventDefault();
+                        addExtensions(draft);
+                        return;
+                    }
+                    if (
+                        event.key === "Backspace" &&
+                        draft.length === 0 &&
+                        value.length > 0
+                    ) {
+                        onChange(value.slice(0, -1));
+                    }
+                }}
+                onBlur={() => addExtensions(draft)}
+                style={{
+                    flex: "1 1 88px",
+                    minWidth: 74,
+                    border: "none",
+                    outline: "none",
+                    background: "transparent",
+                    color: "var(--text-primary)",
+                    fontSize: 12,
+                    fontFamily: "inherit",
+                }}
+            />
+        </div>
+    );
+}
+
 // --- Theme Picker ---
 
 const THEME_ORDER: ThemeName[] = [
@@ -3055,6 +3199,7 @@ function DevelopersSettings({
         lineWrapping,
         fileTreeContentMode,
         fileTreeShowExtensions,
+        fileTreeExtensionFilter,
         setSetting,
     } = useSettingsStore();
     const showDeveloperMode = sectionHasSettingsSearchMatches(
@@ -3081,7 +3226,7 @@ function DevelopersSettings({
         [
             [
                 "Show all vault files",
-                "Display every file in the vault tree, not only Markdown notes and PDFs.",
+                "Display every file in the vault tree, beyond the curated writing and media file set.",
                 "File-oriented search is active",
                 "Search Files & Notes",
                 "wikilink suggestions",
@@ -3090,6 +3235,12 @@ function DevelopersSettings({
             [
                 "Show file extensions",
                 "Display full file names with their extensions in the vault tree.",
+            ],
+            [
+                "File extension filter",
+                "Optional allowlist for the file tree. Leave empty to use the current content mode.",
+                "allowlist",
+                "pdf, txt, csv",
             ],
         ],
     );
@@ -3154,7 +3305,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="Show all vault files"
-                description="Display every file in the vault tree, not only Markdown notes and PDFs."
+                description="Display every file in the vault tree, beyond the curated writing and media file set."
                 keywords={[
                     "File-oriented search is active",
                     "Search Files & Notes",
@@ -3183,6 +3334,21 @@ function DevelopersSettings({
                         value={fileTreeShowExtensions}
                         onChange={(value) =>
                             setSetting("fileTreeShowExtensions", value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="File Tree"
+                label="File extension filter"
+                description="Optional allowlist for the file tree. Leave empty to use the current content mode."
+                keywords={["allowlist", "pdf, txt, csv"]}
+                control={
+                    <ExtensionFilterInput
+                        value={fileTreeExtensionFilter}
+                        onChange={(value) =>
+                            setSetting("fileTreeExtensionFilter", value)
                         }
                     />
                 }

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3305,7 +3305,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="Show all vault files"
-                description="Display every vault file, beyond the curated writing and media set."
+                description="Display every vault file, beyond the curated writing and media set. With this off, Markdown, PDFs, images, CSV, TXT, and HTML files are shown."
                 keywords={[
                     "File-oriented search is active",
                     "Search Files & Notes",

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -52,6 +52,7 @@ import { MarkdownContent } from "../ai/components/MarkdownContent";
 import { getChatPillMetrics } from "../ai/components/chatPillMetrics";
 import { PROVIDER_CATALOG } from "../ai/utils/runtimeMetadata";
 import { AIProvidersSettings } from "./AIProvidersSettings";
+import { ExtensionFilterInput } from "./ExtensionFilterInput";
 import { useAppUpdateStore } from "../updates/store";
 import {
     isWindowOperationalStateStorageKey,
@@ -550,150 +551,6 @@ function SliderField({
             >
                 {formatValue ? formatValue(value) : value}
             </span>
-        </div>
-    );
-}
-
-function parseExtensionTokens(value: string): string[] {
-    return value
-        .split(/[,\s]+/)
-        .map((item) => item.trim().replace(/^\.+/, "").toLowerCase())
-        .filter(Boolean);
-}
-
-function ExtensionFilterInput({
-    value,
-    onChange,
-}: {
-    value: string[];
-    onChange: (value: string[]) => void;
-}) {
-    const [draft, setDraft] = useState("");
-    const inputRef = useRef<HTMLInputElement>(null);
-
-    const addExtensions = (raw: string) => {
-        const tokens = parseExtensionTokens(raw);
-        if (tokens.length === 0) return;
-
-        const seen = new Set(value);
-        const next = [...value];
-        for (const token of tokens) {
-            if (seen.has(token)) continue;
-            seen.add(token);
-            next.push(token);
-        }
-        onChange(next);
-        setDraft("");
-    };
-
-    const removeExtension = (extension: string) => {
-        onChange(value.filter((item) => item !== extension));
-    };
-
-    return (
-        <div
-            role="group"
-            aria-label="File extension filter"
-            onClick={() => inputRef.current?.focus()}
-            style={{
-                display: "flex",
-                alignItems: "center",
-                flexWrap: "wrap",
-                gap: 6,
-                width: 260,
-                minHeight: 30,
-                padding: "4px 6px",
-                borderRadius: 7,
-                border: "1px solid var(--border)",
-                backgroundColor: "var(--bg-tertiary)",
-                cursor: "text",
-            }}
-        >
-            {value.map((extension) => (
-                <span
-                    key={extension}
-                    style={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        gap: 4,
-                        maxWidth: 120,
-                        borderRadius: 999,
-                        padding: "2px 6px",
-                        backgroundColor:
-                            "color-mix(in srgb, var(--accent) 14%, transparent)",
-                        color: "var(--text-primary)",
-                        fontSize: 11,
-                        lineHeight: 1.2,
-                    }}
-                >
-                    <span
-                        style={{
-                            overflow: "hidden",
-                            textOverflow: "ellipsis",
-                            whiteSpace: "nowrap",
-                        }}
-                    >
-                        .{extension}
-                    </span>
-                    <button
-                        type="button"
-                        aria-label={`Remove .${extension}`}
-                        onClick={(event) => {
-                            event.stopPropagation();
-                            removeExtension(extension);
-                        }}
-                        style={{
-                            border: "none",
-                            padding: 0,
-                            background: "transparent",
-                            color: "var(--text-secondary)",
-                            cursor: "pointer",
-                            fontSize: 13,
-                            lineHeight: 1,
-                        }}
-                    >
-                        ×
-                    </button>
-                </span>
-            ))}
-            <input
-                ref={inputRef}
-                value={draft}
-                aria-label="Add file extension"
-                placeholder={value.length === 0 ? "Add: pdf, txt, csv..." : ""}
-                onChange={(event) => setDraft(event.currentTarget.value)}
-                onPaste={(event) => {
-                    const pasted = event.clipboardData.getData("text");
-                    if (parseExtensionTokens(pasted).length <= 1) return;
-                    event.preventDefault();
-                    addExtensions(pasted);
-                }}
-                onKeyDown={(event) => {
-                    if (event.key === "Enter" || event.key === ",") {
-                        event.preventDefault();
-                        addExtensions(draft);
-                        return;
-                    }
-                    if (
-                        event.key === "Backspace" &&
-                        draft.length === 0 &&
-                        value.length > 0
-                    ) {
-                        onChange(value.slice(0, -1));
-                    }
-                }}
-                onBlur={() => addExtensions(draft)}
-                style={{
-                    flex: "1 1 88px",
-                    minWidth: 74,
-                    border: "none",
-                    outline: "none",
-                    background: "transparent",
-                    color: "var(--text-primary)",
-                    fontSize: 12,
-                    fontFamily: "inherit",
-                }}
-            />
         </div>
     );
 }
@@ -3305,7 +3162,7 @@ function DevelopersSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="Show all vault files"
-                description="Display every vault file, beyond the curated writing and media set. With this off, Markdown, PDFs, images, CSV, TXT, and HTML files are shown."
+                description="Display every vault file, beyond the curated writing and media set. With this off, Markdown, PDFs, images, Excalidraw, CSV, TXT, and HTML files are shown."
                 keywords={[
                     "File-oriented search is active",
                     "Search Files & Notes",

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -22,6 +22,7 @@ import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { safeStorageSetItem } from "../../app/utils/safeStorage";
 import {
+    buildVaultFileEntry as buildFileEntry,
     renderComponent,
     setEditorTabs,
     setVaultEntries,
@@ -89,24 +90,6 @@ function buildFolderEntry(path: string) {
         created_at: 1,
         size: 0,
         mime_type: null,
-    };
-}
-
-function buildFileEntry(path: string, mimeType = "text/plain") {
-    const fileName = path.split("/").pop() ?? path;
-    const dotIndex = fileName.lastIndexOf(".");
-    return {
-        id: path,
-        path: `/vault/${path}`,
-        relative_path: path,
-        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
-        file_name: fileName,
-        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
-        kind: "file" as const,
-        modified_at: 1,
-        created_at: 1,
-        size: 16,
-        mime_type: mimeType,
     };
 }
 
@@ -488,6 +471,7 @@ describe("FileTree", () => {
         setVaultEntries([
             buildFolderEntry("docs"),
             buildFileEntry("docs/data.csv", "text/csv"),
+            buildFileEntry("docs/diagram.excalidraw", "application/json"),
             buildFileEntry("docs/readme.txt", "text/plain"),
             buildFileEntry("docs/page.html", "text/html"),
             {
@@ -518,6 +502,7 @@ describe("FileTree", () => {
         await expandFolder(user, "docs");
 
         expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.getByText("diagram")).toBeInTheDocument();
         expect(screen.getByText("readme")).toBeInTheDocument();
         expect(screen.getByText("page")).toBeInTheDocument();
         expect(screen.getByText("photo")).toBeInTheDocument();

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -482,6 +482,152 @@ describe("FileTree", () => {
         expect(screen.getByText("runtime")).toBeInTheDocument();
     });
 
+    it("shows curated document and media files in the default content mode", async () => {
+        const user = userEvent.setup();
+
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/data.csv", "text/csv"),
+            buildFileEntry("docs/readme.txt", "text/plain"),
+            buildFileEntry("docs/page.html", "text/html"),
+            {
+                ...buildFileEntry("docs/photo.png", "image/png"),
+                is_image_like: true,
+            },
+            {
+                id: "docs/reference.pdf",
+                path: "/vault/docs/reference.pdf",
+                relative_path: "docs/reference.pdf",
+                title: "Reference",
+                file_name: "reference.pdf",
+                extension: "pdf",
+                kind: "pdf",
+                modified_at: 1,
+                created_at: 1,
+                size: 256,
+                mime_type: "application/pdf",
+            },
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore.setState({
+            fileTreeContentMode: "notes_only",
+            fileTreeExtensionFilter: [],
+        });
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+
+        expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.getByText("readme")).toBeInTheDocument();
+        expect(screen.getByText("page")).toBeInTheDocument();
+        expect(screen.getByText("photo")).toBeInTheDocument();
+        expect(screen.getByText("Reference")).toBeInTheDocument();
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+    });
+
+    it("uses an extension allowlist as an explicit file tree mode", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([buildCreatedNote("docs/Meeting")]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/data.csv", "text/csv"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+            {
+                id: "docs/reference.pdf",
+                path: "/vault/docs/reference.pdf",
+                relative_path: "docs/reference.pdf",
+                title: "Reference",
+                file_name: "reference.pdf",
+                extension: "pdf",
+                kind: "pdf",
+                modified_at: 1,
+                created_at: 1,
+                size: 256,
+                mime_type: "application/pdf",
+            },
+        ]);
+        useSettingsStore.setState({
+            fileTreeContentMode: "notes_only",
+            fileTreeExtensionFilter: ["csv"],
+        });
+
+        renderComponent(<FileTree />);
+
+        expect(screen.getByText("docs")).toBeInTheDocument();
+        await expandFolder(user, "docs");
+
+        expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.queryByText("Meeting")).not.toBeInTheDocument();
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+        expect(screen.queryByText("Reference")).not.toBeInTheDocument();
+    });
+
+    it("keeps allowlisted files visible when all-files mode is disabled live", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([buildCreatedNote("docs/Meeting")]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/data.csv", "text/csv"),
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore.setState({
+            fileTreeContentMode: "all_files",
+            fileTreeExtensionFilter: ["csv"],
+        });
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+        expect(screen.getByText("data")).toBeInTheDocument();
+
+        act(() => {
+            useSettingsStore
+                .getState()
+                .setSetting("fileTreeContentMode", "notes_only");
+        });
+
+        expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.queryByText("Meeting")).not.toBeInTheDocument();
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+    });
+
+    it("shows markdown notes and allowed files when md is allowlisted", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([buildCreatedNote("docs/Meeting")]);
+        setVaultEntries([
+            buildFolderEntry("docs"),
+            buildFileEntry("docs/data.csv", "text/csv"),
+            {
+                id: "docs/reference.pdf",
+                path: "/vault/docs/reference.pdf",
+                relative_path: "docs/reference.pdf",
+                title: "Reference",
+                file_name: "reference.pdf",
+                extension: "PDF",
+                kind: "pdf",
+                modified_at: 1,
+                created_at: 1,
+                size: 256,
+                mime_type: "application/pdf",
+            },
+            buildFileEntry("docs/config.toml", "application/toml"),
+        ]);
+        useSettingsStore.setState({
+            fileTreeContentMode: "notes_only",
+            fileTreeExtensionFilter: ["md", "pdf", "csv"],
+        });
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "docs");
+
+        expect(screen.getByText("Meeting")).toBeInTheDocument();
+        expect(screen.getByText("Reference")).toBeInTheDocument();
+        expect(screen.getByText("data")).toBeInTheDocument();
+        expect(screen.queryByText("config")).not.toBeInTheDocument();
+    });
+
     it("renders indent guides for nested rows without affecting root rows", async () => {
         const user = userEvent.setup();
 

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -17,6 +17,7 @@ import {
     getVaultEntryDisplayName,
     moveVaultEntryToTrash,
     openVaultFileEntry,
+    shouldIncludeMarkdownNotesInFileScope,
     shouldShowVaultEntryInFileTree,
 } from "../../app/utils/vaultEntries";
 import { useSettingsStore } from "../../app/store/settingsStore";
@@ -2201,11 +2202,14 @@ export function FileTree() {
             ? `${structureRevision}:${contentRevision}`
             : structureRevision;
     const fileTreeExtensionFilterKey = fileTreeExtensionFilter.join("\n");
-    const isFileTreeExtensionFilterActive = fileTreeExtensionFilter.length > 0;
     const visibleNotes = useMemo(() => {
-        if (!isFileTreeExtensionFilterActive) return notes;
-        return fileTreeExtensionFilter.includes("md") ? notes : [];
-    }, [fileTreeExtensionFilter, isFileTreeExtensionFilterActive, notes]);
+        return shouldIncludeMarkdownNotesInFileScope({
+            contentMode: fileTreeContentMode,
+            extensionFilter: fileTreeExtensionFilter,
+        })
+            ? notes
+            : [];
+    }, [fileTreeContentMode, fileTreeExtensionFilter, notes]);
     const visibleEntries = useMemo(
         () =>
             entries.filter((entry) =>

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -505,6 +505,19 @@ function getVaultEntryFilterText(entry: VaultEntryDto) {
         .toLowerCase();
 }
 
+function isDefaultVisibleVaultEntry(entry: VaultEntryDto) {
+    if (entry.kind === "pdf") return true;
+    if (entry.is_image_like) return true;
+
+    const extension = entry.extension.toLowerCase();
+    return (
+        extension === "csv" ||
+        extension === "txt" ||
+        extension === "html" ||
+        extension === "htm"
+    );
+}
+
 function isMarkdownLeafName(name: string) {
     return name.toLowerCase().endsWith(".md");
 }
@@ -2084,6 +2097,9 @@ export function FileTree() {
     const fileTreeShowExtensions = useSettingsStore(
         (s) => s.fileTreeShowExtensions,
     );
+    const fileTreeExtensionFilter = useSettingsStore(
+        (s) => s.fileTreeExtensionFilter,
+    );
 
     // Editor/workspace toggles that the unified toolbar exposes alongside the
     // tree-specific actions. Sourced from the same stores the old utility
@@ -2196,24 +2212,43 @@ export function FileTree() {
         sortMode === "modified_desc" || sortMode === "modified_asc"
             ? `${structureRevision}:${contentRevision}`
             : structureRevision;
+    const fileTreeExtensionFilterKey = fileTreeExtensionFilter.join("\n");
+    const fileTreeExtensionFilterSet = useMemo(
+        () => new Set(fileTreeExtensionFilter),
+        [fileTreeExtensionFilter],
+    );
+    const isFileTreeExtensionFilterActive = fileTreeExtensionFilter.length > 0;
+    const visibleNotes = useMemo(() => {
+        if (!isFileTreeExtensionFilterActive) return notes;
+        return fileTreeExtensionFilterSet.has("md") ? notes : [];
+    }, [fileTreeExtensionFilterSet, isFileTreeExtensionFilterActive, notes]);
     const visibleEntries = useMemo(
         () =>
             entries.filter((entry) => {
                 if (entry.kind === "note") return false;
                 if (entry.kind === "folder") return true;
+                if (isFileTreeExtensionFilterActive) {
+                    return fileTreeExtensionFilterSet.has(
+                        entry.extension.toLowerCase(),
+                    );
+                }
                 if (fileTreeContentMode === "all_files") return true;
-                if (entry.kind === "pdf") return true;
-                return entry.extension === "html" || entry.extension === "htm";
+                return isDefaultVisibleVaultEntry(entry);
             }),
-        [entries, fileTreeContentMode],
+        [
+            entries,
+            fileTreeContentMode,
+            fileTreeExtensionFilterSet,
+            isFileTreeExtensionFilterActive,
+        ],
     );
     // Intentionally keyed by revisions instead of the full notes array to avoid
     // rebuilding the folder tree for content-only updates.
     const tree = useMemo(
-        () => buildTree(notes, visibleEntries),
-        // visibleEntries changes only when entries/settings change
+        () => buildTree(visibleNotes, visibleEntries),
+        // visibleEntries and the filter key change only when entries/settings change.
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [treeRevision, visibleEntries],
+        [treeRevision, visibleEntries, fileTreeExtensionFilterKey],
     );
     const allFolderPaths = useMemo(() => getAllFolderPaths(tree), [tree]);
     const revealedFolders = useMemo(() => {

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -17,6 +17,7 @@ import {
     getVaultEntryDisplayName,
     moveVaultEntryToTrash,
     openVaultFileEntry,
+    shouldShowVaultEntryInFileTree,
 } from "../../app/utils/vaultEntries";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { REVEAL_NOTE_IN_TREE_EVENT } from "../../app/utils/navigation";
@@ -503,19 +504,6 @@ function getVaultEntryFilterText(entry: VaultEntryDto) {
         .filter(Boolean)
         .join("\n")
         .toLowerCase();
-}
-
-function isDefaultVisibleVaultEntry(entry: VaultEntryDto) {
-    if (entry.kind === "pdf") return true;
-    if (entry.is_image_like) return true;
-
-    const extension = entry.extension.toLowerCase();
-    return (
-        extension === "csv" ||
-        extension === "txt" ||
-        extension === "html" ||
-        extension === "htm"
-    );
 }
 
 function isMarkdownLeafName(name: string) {
@@ -2213,34 +2201,20 @@ export function FileTree() {
             ? `${structureRevision}:${contentRevision}`
             : structureRevision;
     const fileTreeExtensionFilterKey = fileTreeExtensionFilter.join("\n");
-    const fileTreeExtensionFilterSet = useMemo(
-        () => new Set(fileTreeExtensionFilter),
-        [fileTreeExtensionFilter],
-    );
     const isFileTreeExtensionFilterActive = fileTreeExtensionFilter.length > 0;
     const visibleNotes = useMemo(() => {
         if (!isFileTreeExtensionFilterActive) return notes;
-        return fileTreeExtensionFilterSet.has("md") ? notes : [];
-    }, [fileTreeExtensionFilterSet, isFileTreeExtensionFilterActive, notes]);
+        return fileTreeExtensionFilter.includes("md") ? notes : [];
+    }, [fileTreeExtensionFilter, isFileTreeExtensionFilterActive, notes]);
     const visibleEntries = useMemo(
         () =>
-            entries.filter((entry) => {
-                if (entry.kind === "note") return false;
-                if (entry.kind === "folder") return true;
-                if (isFileTreeExtensionFilterActive) {
-                    return fileTreeExtensionFilterSet.has(
-                        entry.extension.toLowerCase(),
-                    );
-                }
-                if (fileTreeContentMode === "all_files") return true;
-                return isDefaultVisibleVaultEntry(entry);
-            }),
-        [
-            entries,
-            fileTreeContentMode,
-            fileTreeExtensionFilterSet,
-            isFileTreeExtensionFilterActive,
-        ],
+            entries.filter((entry) =>
+                shouldShowVaultEntryInFileTree(entry, {
+                    contentMode: fileTreeContentMode,
+                    extensionFilter: fileTreeExtensionFilter,
+                }),
+            ),
+        [entries, fileTreeContentMode, fileTreeExtensionFilter],
     );
     // Intentionally keyed by revisions instead of the full notes array to avoid
     // rebuilding the folder tree for content-only updates.

--- a/apps/desktop/src/test/test-utils.tsx
+++ b/apps/desktop/src/test/test-utils.tsx
@@ -64,6 +64,50 @@ export function setVaultEntries(
     }));
 }
 
+export function buildVaultFileEntry(
+    path: string,
+    options:
+        | string
+        | null
+        | {
+              kind?: VaultEntryDto["kind"];
+              mimeType?: string | null;
+              size?: number;
+              isImageLike?: boolean | null;
+              isTextLike?: boolean | null;
+          } = {},
+): VaultEntryDto {
+    const fileName = path.split("/").pop() ?? path;
+    const dotIndex = fileName.lastIndexOf(".");
+    const entryOptions =
+        typeof options === "string" || options === null
+            ? { mimeType: options }
+            : options;
+
+    const entry: VaultEntryDto = {
+        id: path,
+        path: `/vault/${path}`,
+        relative_path: path,
+        title: dotIndex > 0 ? fileName.slice(0, dotIndex) : fileName,
+        file_name: fileName,
+        extension: dotIndex > 0 ? fileName.slice(dotIndex + 1) : "",
+        kind: entryOptions.kind ?? "file",
+        modified_at: 1,
+        created_at: 1,
+        size: entryOptions.size ?? 1,
+        mime_type: entryOptions.mimeType ?? "text/plain",
+    };
+
+    if (entryOptions.isImageLike !== undefined) {
+        entry.is_image_like = entryOptions.isImageLike;
+    }
+    if (entryOptions.isTextLike !== undefined) {
+        entry.is_text_like = entryOptions.isTextLike;
+    }
+
+    return entry;
+}
+
 export function setCommands(
     commands: Command[],
     activeModal: "command-palette" | "quick-switcher" | null,

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -183,9 +183,7 @@ impl VaultIndex {
                     .file_name()
                     .and_then(|value| value.to_str())
                     .map(|value| value.to_lowercase())
-                    .unwrap_or_else(|| {
-                        id.0.rsplit('/').next().unwrap_or(&id.0).to_lowercase()
-                    }),
+                    .unwrap_or_else(|| id.0.rsplit('/').next().unwrap_or(&id.0).to_lowercase()),
             },
         );
         self.pdf_metadata.insert(

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -127,6 +127,7 @@ impl VaultIndex {
         &self,
         params: &AdvancedSearchParams,
         vault: &Vault,
+        vault_entries: &[VaultEntryDto],
     ) -> Vec<AdvancedSearchResultDto> {
         let file_scope = FileScopeMatcher::new(&params.file_scope);
         // Start with all notes as candidates
@@ -353,9 +354,9 @@ impl VaultIndex {
             && params.property_filters.is_empty()
             && params.content_searches.is_empty()
         {
-            let generic_entries = vault.discover_vault_entries().unwrap_or_default();
-
-            for entry in generic_entries
+            // Use the runtime's cached vault entries; advanced search is called
+            // from debounced UI flows and must not walk the vault per query.
+            for entry in vault_entries
                 .iter()
                 .filter(|entry| entry.kind == "file" && file_scope.allows_entry(entry))
             {

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -1,8 +1,8 @@
 use std::collections::HashSet;
 
 use neverwrite_types::{
-    AdvancedSearchParams, AdvancedSearchResultDto, ContentMatchDto, ContentSearchParam, NoteId,
-    NoteMetadata, PropertyFilterParam,
+    AdvancedSearchFileScope, AdvancedSearchParams, AdvancedSearchResultDto, ContentMatchDto,
+    ContentSearchParam, NoteId, NoteMetadata, PropertyFilterParam, VaultEntryDto,
 };
 use neverwrite_vault::Vault;
 use regex::Regex;
@@ -128,8 +128,12 @@ impl VaultIndex {
         params: &AdvancedSearchParams,
         vault: &Vault,
     ) -> Vec<AdvancedSearchResultDto> {
+        let file_scope = FileScopeMatcher::new(&params.file_scope);
         // Start with all notes as candidates
         let mut candidates: HashSet<&NoteId> = self.metadata.keys().collect();
+        if !file_scope.allows_notes() {
+            candidates.clear();
+        }
 
         // Phase 1: Fast in-memory filtering
 
@@ -294,7 +298,8 @@ impl VaultIndex {
 
         // Phase 2b: PDF search
         // PDFs participate only in lightweight title/path matching.
-        if params.tag_filters.is_empty()
+        if file_scope.allows_extension("pdf")
+            && params.tag_filters.is_empty()
             && params.property_filters.is_empty()
             && params.content_searches.is_empty()
         {
@@ -395,7 +400,10 @@ impl VaultIndex {
         {
             let generic_entries = vault.discover_vault_entries().unwrap_or_default();
 
-            for entry in generic_entries.iter().filter(|entry| entry.kind == "file") {
+            for entry in generic_entries
+                .iter()
+                .filter(|entry| entry.kind == "file" && file_scope.allows_entry(entry))
+            {
                 let title_lower = entry.title.to_lowercase();
                 let path_lower = entry.relative_path.to_lowercase();
                 let file_name_lower = entry.file_name.to_lowercase();
@@ -631,6 +639,60 @@ fn search_entry_file_name(entry: &SearchEntry) -> &str {
         file_name_from_path(&entry.path_lower)
     } else {
         &entry.file_name_lower
+    }
+}
+
+struct FileScopeMatcher {
+    mode: String,
+    extension_filter: HashSet<String>,
+}
+
+impl FileScopeMatcher {
+    fn new(scope: &AdvancedSearchFileScope) -> Self {
+        Self {
+            mode: scope.mode.clone(),
+            extension_filter: scope
+                .extension_filter
+                .iter()
+                .map(|value| value.trim().trim_start_matches('.').to_ascii_lowercase())
+                .filter(|value| !value.is_empty())
+                .collect(),
+        }
+    }
+
+    fn allows_extension(&self, extension: &str) -> bool {
+        let extension = extension.to_ascii_lowercase();
+        if !self.extension_filter.is_empty() {
+            return self.extension_filter.contains(&extension);
+        }
+        if self.mode == "all_files" {
+            return true;
+        }
+
+        matches!(extension.as_str(), "pdf" | "csv" | "txt" | "html" | "htm")
+    }
+
+    fn allows_notes(&self) -> bool {
+        self.extension_filter.is_empty() || self.extension_filter.contains("md")
+    }
+
+    fn allows_entry(&self, entry: &VaultEntryDto) -> bool {
+        if !self.extension_filter.is_empty() {
+            return self
+                .extension_filter
+                .contains(&entry.extension.to_ascii_lowercase());
+        }
+        if self.mode == "all_files" {
+            return true;
+        }
+        if entry.is_image_like.unwrap_or(false) {
+            return true;
+        }
+
+        matches!(
+            entry.extension.to_ascii_lowercase().as_str(),
+            "csv" | "txt" | "html" | "htm"
+        )
     }
 }
 

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use neverwrite_types::{
     AdvancedSearchFileScope, AdvancedSearchParams, AdvancedSearchResultDto, ContentMatchDto,
-    ContentSearchParam, NoteId, NoteMetadata, PropertyFilterParam, VaultEntryDto,
+    ContentSearchParam, NoteId, NoteMetadata, PropertyFilterParam, SearchTermParam, VaultEntryDto,
 };
 use neverwrite_vault::Vault;
 use regex::Regex;
@@ -305,47 +305,15 @@ impl VaultIndex {
         {
             let mut pdf_candidates: HashSet<&NoteId> = self.pdf_metadata.keys().collect();
 
-            for filter in &params.file_filters {
-                let matcher = build_matcher(&filter.value, filter.is_regex);
-                pdf_candidates.retain(|id| {
-                    let entry = match self.pdf_search_index.get(*id) {
-                        Some(e) => e,
-                        None => return false,
-                    };
-                    let filename = search_entry_file_name(entry);
-                    matcher.matches(filename) != filter.negated
-                });
-            }
-
-            for filter in &params.path_filters {
-                let matcher = build_matcher(&filter.value, filter.is_regex);
-                pdf_candidates.retain(|id| {
-                    let entry = match self.pdf_search_index.get(*id) {
-                        Some(e) => e,
-                        None => return false,
-                    };
-                    matcher.matches(&entry.path_lower) != filter.negated
-                });
-            }
-
-            for term in &params.terms {
-                let matcher = build_matcher(&term.value, term.is_regex);
-                pdf_candidates.retain(|id| {
-                    let entry = match self.pdf_search_index.get(*id) {
-                        Some(e) => e,
-                        None => return false,
-                    };
-                    let filename = search_entry_file_name(entry);
-                    let found = if params.prefer_file_name {
-                        matcher.matches(filename)
-                            || matcher.matches(&entry.path_lower)
-                            || matcher.matches(&entry.title_lower)
-                    } else {
-                        matcher.matches(&entry.title_lower) || matcher.matches(&entry.path_lower)
-                    };
-                    found != term.negated
-                });
-            }
+            pdf_candidates.retain(|id| {
+                let entry = match self.pdf_search_index.get(*id) {
+                    Some(e) => e,
+                    None => return false,
+                };
+                let fields = file_search_fields_for_entry(entry);
+                file_search_filters_match(&fields, params)
+                    && file_search_terms_match(&fields, &params.terms, params.prefer_file_name)
+            });
 
             for pdf_id in &pdf_candidates {
                 let pdf_meta = match self.pdf_metadata.get(*pdf_id) {
@@ -355,21 +323,8 @@ impl VaultIndex {
 
                 let entry = self.pdf_search_index.get(*pdf_id);
                 let title_path_score = if let Some(entry) = entry {
-                    let mut best = 0.0f64;
-                    for term in &params.terms {
-                        if !term.negated {
-                            let score = compute_entry_score_match(
-                                &term.value,
-                                &entry.title_lower,
-                                &entry.path_lower,
-                                search_entry_file_name(entry),
-                                term.is_regex,
-                                params.prefer_file_name,
-                            );
-                            best = best.max(score);
-                        }
-                    }
-                    best
+                    let fields = file_search_fields_for_entry(entry);
+                    score_file_search_fields(&fields, &params.terms, params.prefer_file_name)
                 } else {
                     0.0
                 };
@@ -407,53 +362,22 @@ impl VaultIndex {
                 let title_lower = entry.title.to_lowercase();
                 let path_lower = entry.relative_path.to_lowercase();
                 let file_name_lower = entry.file_name.to_lowercase();
+                let fields = FileSearchFields {
+                    title: &title_lower,
+                    path: &path_lower,
+                    file_name: &file_name_lower,
+                };
 
-                let file_filter_match = params.file_filters.iter().all(|filter| {
-                    let matcher = build_matcher(&filter.value, filter.is_regex);
-                    matcher.matches(&entry.file_name.to_lowercase()) != filter.negated
-                });
-                if !file_filter_match {
+                if !file_search_filters_match(&fields, params) {
                     continue;
                 }
 
-                let path_filter_match = params.path_filters.iter().all(|filter| {
-                    let matcher = build_matcher(&filter.value, filter.is_regex);
-                    matcher.matches(&path_lower) != filter.negated
-                });
-                if !path_filter_match {
+                if !file_search_terms_match(&fields, &params.terms, params.prefer_file_name) {
                     continue;
                 }
 
-                let term_match = params.terms.iter().all(|term| {
-                    let matcher = build_matcher(&term.value, term.is_regex);
-                    let found = if params.prefer_file_name {
-                        matcher.matches(&file_name_lower)
-                            || matcher.matches(&path_lower)
-                            || matcher.matches(&title_lower)
-                    } else {
-                        matcher.matches(&title_lower) || matcher.matches(&path_lower)
-                    };
-                    found != term.negated
-                });
-                if !term_match {
-                    continue;
-                }
-
-                let mut best = 0.0f64;
-                for term in &params.terms {
-                    if term.negated {
-                        continue;
-                    }
-                    let score = compute_file_oriented_score_match(
-                        &term.value,
-                        &file_name_lower,
-                        &path_lower,
-                        &title_lower,
-                        term.is_regex,
-                        params.prefer_file_name,
-                    );
-                    best = best.max(score);
-                }
+                let best =
+                    score_file_search_fields(&fields, &params.terms, params.prefer_file_name);
 
                 results.push(AdvancedSearchResultDto {
                     id: entry.id.clone(),
@@ -642,7 +566,77 @@ fn search_entry_file_name(entry: &SearchEntry) -> &str {
     }
 }
 
-const CURATED_SEARCH_ENTRY_EXTENSIONS: &[&str] = &["csv", "txt", "html", "htm"];
+struct FileSearchFields<'a> {
+    title: &'a str,
+    path: &'a str,
+    file_name: &'a str,
+}
+
+fn file_search_fields_for_entry(entry: &SearchEntry) -> FileSearchFields<'_> {
+    FileSearchFields {
+        title: &entry.title_lower,
+        path: &entry.path_lower,
+        file_name: search_entry_file_name(entry),
+    }
+}
+
+fn file_search_filters_match(fields: &FileSearchFields<'_>, params: &AdvancedSearchParams) -> bool {
+    let file_filter_match = params.file_filters.iter().all(|filter| {
+        let matcher = build_matcher(&filter.value, filter.is_regex);
+        matcher.matches(fields.file_name) != filter.negated
+    });
+    if !file_filter_match {
+        return false;
+    }
+
+    params.path_filters.iter().all(|filter| {
+        let matcher = build_matcher(&filter.value, filter.is_regex);
+        matcher.matches(fields.path) != filter.negated
+    })
+}
+
+fn file_search_terms_match(
+    fields: &FileSearchFields<'_>,
+    terms: &[SearchTermParam],
+    prefer_file_name: bool,
+) -> bool {
+    terms.iter().all(|term| {
+        let matcher = build_matcher(&term.value, term.is_regex);
+        let found = if prefer_file_name {
+            matcher.matches(fields.file_name)
+                || matcher.matches(fields.path)
+                || matcher.matches(fields.title)
+        } else {
+            matcher.matches(fields.title) || matcher.matches(fields.path)
+        };
+        found != term.negated
+    })
+}
+
+fn score_file_search_fields(
+    fields: &FileSearchFields<'_>,
+    terms: &[SearchTermParam],
+    prefer_file_name: bool,
+) -> f64 {
+    let mut best = 0.0f64;
+    for term in terms {
+        if term.negated {
+            continue;
+        }
+        let score = compute_entry_score_match(
+            &term.value,
+            fields.title,
+            fields.path,
+            fields.file_name,
+            term.is_regex,
+            prefer_file_name,
+        );
+        best = best.max(score);
+    }
+    best
+}
+
+const CURATED_SEARCH_ENTRY_EXTENSIONS: &[&str] = &["csv", "excalidraw", "txt", "html", "htm"];
 const CURATED_SEARCH_PDF_EXTENSION: &str = "pdf";
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -642,15 +642,34 @@ fn search_entry_file_name(entry: &SearchEntry) -> &str {
     }
 }
 
+const CURATED_SEARCH_ENTRY_EXTENSIONS: &[&str] = &["csv", "txt", "html", "htm"];
+const CURATED_SEARCH_PDF_EXTENSION: &str = "pdf";
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SearchFileScopeMode {
+    NotesOnly,
+    AllFiles,
+}
+
+impl SearchFileScopeMode {
+    fn from_scope_mode(value: &str) -> Self {
+        if value == "all_files" {
+            Self::AllFiles
+        } else {
+            Self::NotesOnly
+        }
+    }
+}
+
 struct FileScopeMatcher {
-    mode: String,
+    mode: SearchFileScopeMode,
     extension_filter: HashSet<String>,
 }
 
 impl FileScopeMatcher {
     fn new(scope: &AdvancedSearchFileScope) -> Self {
         Self {
-            mode: scope.mode.clone(),
+            mode: SearchFileScopeMode::from_scope_mode(&scope.mode),
             extension_filter: scope
                 .extension_filter
                 .iter()
@@ -665,11 +684,12 @@ impl FileScopeMatcher {
         if !self.extension_filter.is_empty() {
             return self.extension_filter.contains(&extension);
         }
-        if self.mode == "all_files" {
+        if self.mode == SearchFileScopeMode::AllFiles {
             return true;
         }
 
-        matches!(extension.as_str(), "pdf" | "csv" | "txt" | "html" | "htm")
+        CURATED_SEARCH_ENTRY_EXTENSIONS.contains(&extension.as_str())
+            || extension == CURATED_SEARCH_PDF_EXTENSION
     }
 
     fn allows_notes(&self) -> bool {
@@ -682,17 +702,14 @@ impl FileScopeMatcher {
                 .extension_filter
                 .contains(&entry.extension.to_ascii_lowercase());
         }
-        if self.mode == "all_files" {
+        if self.mode == SearchFileScopeMode::AllFiles {
             return true;
         }
         if entry.is_image_like.unwrap_or(false) {
             return true;
         }
 
-        matches!(
-            entry.extension.to_ascii_lowercase().as_str(),
-            "csv" | "txt" | "html" | "htm"
-        )
+        CURATED_SEARCH_ENTRY_EXTENSIONS.contains(&entry.extension.to_ascii_lowercase().as_str())
     }
 }
 

--- a/crates/index/tests/integration.rs
+++ b/crates/index/tests/integration.rs
@@ -3,8 +3,8 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 use neverwrite_index::VaultIndex;
 use neverwrite_types::{
-    AdvancedSearchParams, NoteDocument, NoteId, NotePath, PdfDocument, SearchTermParam, TextRange,
-    WikiLink,
+    AdvancedSearchFileScope, AdvancedSearchParams, NoteDocument, NoteId, NotePath, PdfDocument,
+    SearchTermParam, TextRange, WikiLink,
 };
 use neverwrite_vault::Vault;
 
@@ -47,6 +47,18 @@ fn make_search_params(query: &str, prefer_file_name: bool) -> AdvancedSearchPara
         sort_by: "relevance".to_string(),
         sort_asc: false,
         prefer_file_name,
+        file_scope: AdvancedSearchFileScope::default(),
+    }
+}
+
+fn make_search_params_with_scope(
+    query: &str,
+    prefer_file_name: bool,
+    file_scope: AdvancedSearchFileScope,
+) -> AdvancedSearchParams {
+    AdvancedSearchParams {
+        file_scope,
+        ..make_search_params(query, prefer_file_name)
     }
 }
 
@@ -379,6 +391,101 @@ fn advanced_search_keeps_title_as_file_oriented_fallback() {
     let ids: Vec<&str> = results.iter().map(|result| result.id.as_str()).collect();
 
     assert_eq!(ids, vec!["docs/roadmap"]);
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn advanced_search_respects_curated_file_scope() {
+    let index = VaultIndex::build(vec![]);
+    let (vault, root) = make_empty_temp_vault("advanced-search-curated-scope");
+    std::fs::create_dir_all(root.join("docs")).unwrap();
+    std::fs::write(root.join("docs/data.csv"), "name,value\nalice,1").unwrap();
+    std::fs::write(root.join("docs/config.toml"), "enabled = true").unwrap();
+
+    let curated_params = make_search_params_with_scope(
+        "data",
+        false,
+        AdvancedSearchFileScope {
+            mode: "notes_only".to_string(),
+            extension_filter: vec![],
+        },
+    );
+    let curated_results = index.advanced_search(&curated_params, &vault);
+    let curated_ids: Vec<&str> = curated_results
+        .iter()
+        .map(|result| result.id.as_str())
+        .collect();
+
+    assert_eq!(curated_ids, vec!["docs/data.csv"]);
+
+    let hidden_params = make_search_params_with_scope(
+        "config",
+        true,
+        AdvancedSearchFileScope {
+            mode: "notes_only".to_string(),
+            extension_filter: vec![],
+        },
+    );
+    let hidden_results = index.advanced_search(&hidden_params, &vault);
+
+    assert!(hidden_results.is_empty());
+
+    let all_files_params = make_search_params_with_scope(
+        "config",
+        true,
+        AdvancedSearchFileScope {
+            mode: "all_files".to_string(),
+            extension_filter: vec![],
+        },
+    );
+    let all_files_results = index.advanced_search(&all_files_params, &vault);
+    let all_files_ids: Vec<&str> = all_files_results
+        .iter()
+        .map(|result| result.id.as_str())
+        .collect();
+
+    assert_eq!(all_files_ids, vec!["docs/config.toml"]);
+
+    std::fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn advanced_search_respects_extension_allowlist_scope() {
+    let index = VaultIndex::build(vec![make_note("docs/data", "Data Note", vec![], vec![])]);
+    let (vault, root) = make_empty_temp_vault("advanced-search-allowlist-scope");
+    std::fs::create_dir_all(root.join("docs")).unwrap();
+    std::fs::write(root.join("docs/data.csv"), "name,value\nalice,1").unwrap();
+    std::fs::write(root.join("docs/config.toml"), "enabled = true").unwrap();
+
+    let csv_params = make_search_params_with_scope(
+        "data",
+        true,
+        AdvancedSearchFileScope {
+            mode: "all_files".to_string(),
+            extension_filter: vec!["csv".to_string()],
+        },
+    );
+    let csv_results = index.advanced_search(&csv_params, &vault);
+    let csv_ids: Vec<&str> = csv_results
+        .iter()
+        .map(|result| result.id.as_str())
+        .collect();
+
+    assert_eq!(csv_ids, vec!["docs/data.csv"]);
+
+    let md_params = make_search_params_with_scope(
+        "data",
+        true,
+        AdvancedSearchFileScope {
+            mode: "all_files".to_string(),
+            extension_filter: vec!["md".to_string()],
+        },
+    );
+    let md_results = index.advanced_search(&md_params, &vault);
+    let md_ids: Vec<&str> = md_results.iter().map(|result| result.id.as_str()).collect();
+
+    assert_eq!(md_ids, vec!["docs/data"]);
 
     std::fs::remove_dir_all(root).unwrap();
 }

--- a/crates/index/tests/integration.rs
+++ b/crates/index/tests/integration.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use neverwrite_index::VaultIndex;
 use neverwrite_types::{
     AdvancedSearchFileScope, AdvancedSearchParams, NoteDocument, NoteId, NotePath, PdfDocument,
-    SearchTermParam, TextRange, WikiLink,
+    SearchTermParam, TextRange, VaultEntryDto, WikiLink,
 };
 use neverwrite_vault::Vault;
 
@@ -70,6 +70,10 @@ fn make_empty_temp_vault(name: &str) -> (Vault, PathBuf) {
     let root = std::env::temp_dir().join(format!("neverwrite-index-{name}-{unique}"));
     std::fs::create_dir_all(&root).unwrap();
     (Vault { root: root.clone() }, root)
+}
+
+fn discover_entries(vault: &Vault) -> Vec<VaultEntryDto> {
+    vault.discover_vault_entries().unwrap()
 }
 
 fn build_sample_index() -> VaultIndex {
@@ -359,13 +363,13 @@ fn advanced_search_prefers_file_name_before_title_when_file_oriented() {
     let (vault, root) = make_empty_temp_vault("advanced-search-file-oriented-rank");
     let params = make_search_params("diagnostico", true);
 
-    let results = index.advanced_search(&params, &vault);
+    let results = index.advanced_search(&params, &vault, &[]);
     let ids: Vec<&str> = results.iter().map(|result| result.id.as_str()).collect();
 
     assert_eq!(ids, vec!["docs/diagnostico", "docs/roadmap"]);
 
     let extension_params = make_search_params("diagnostico.md", true);
-    let extension_results = index.advanced_search(&extension_params, &vault);
+    let extension_results = index.advanced_search(&extension_params, &vault, &[]);
     let extension_ids: Vec<&str> = extension_results
         .iter()
         .map(|result| result.id.as_str())
@@ -387,7 +391,7 @@ fn advanced_search_keeps_title_as_file_oriented_fallback() {
     let (vault, root) = make_empty_temp_vault("advanced-search-title-fallback");
     let params = make_search_params("strategy", true);
 
-    let results = index.advanced_search(&params, &vault);
+    let results = index.advanced_search(&params, &vault, &[]);
     let ids: Vec<&str> = results.iter().map(|result| result.id.as_str()).collect();
 
     assert_eq!(ids, vec!["docs/roadmap"]);
@@ -403,6 +407,7 @@ fn advanced_search_respects_curated_file_scope() {
     std::fs::write(root.join("docs/data.csv"), "name,value\nalice,1").unwrap();
     std::fs::write(root.join("docs/diagram.excalidraw"), "{}").unwrap();
     std::fs::write(root.join("docs/config.toml"), "enabled = true").unwrap();
+    let entries = discover_entries(&vault);
 
     let curated_params = make_search_params_with_scope(
         "data",
@@ -412,7 +417,7 @@ fn advanced_search_respects_curated_file_scope() {
             extension_filter: vec![],
         },
     );
-    let curated_results = index.advanced_search(&curated_params, &vault);
+    let curated_results = index.advanced_search(&curated_params, &vault, &entries);
     let curated_ids: Vec<&str> = curated_results
         .iter()
         .map(|result| result.id.as_str())
@@ -428,7 +433,7 @@ fn advanced_search_respects_curated_file_scope() {
             extension_filter: vec![],
         },
     );
-    let map_results = index.advanced_search(&map_params, &vault);
+    let map_results = index.advanced_search(&map_params, &vault, &entries);
     let map_ids: Vec<&str> = map_results
         .iter()
         .map(|result| result.id.as_str())
@@ -444,7 +449,7 @@ fn advanced_search_respects_curated_file_scope() {
             extension_filter: vec![],
         },
     );
-    let hidden_results = index.advanced_search(&hidden_params, &vault);
+    let hidden_results = index.advanced_search(&hidden_params, &vault, &entries);
 
     assert!(hidden_results.is_empty());
 
@@ -456,7 +461,7 @@ fn advanced_search_respects_curated_file_scope() {
             extension_filter: vec![],
         },
     );
-    let all_files_results = index.advanced_search(&all_files_params, &vault);
+    let all_files_results = index.advanced_search(&all_files_params, &vault, &entries);
     let all_files_ids: Vec<&str> = all_files_results
         .iter()
         .map(|result| result.id.as_str())
@@ -474,6 +479,7 @@ fn advanced_search_respects_extension_allowlist_scope() {
     std::fs::create_dir_all(root.join("docs")).unwrap();
     std::fs::write(root.join("docs/data.csv"), "name,value\nalice,1").unwrap();
     std::fs::write(root.join("docs/config.toml"), "enabled = true").unwrap();
+    let entries = discover_entries(&vault);
 
     let csv_params = make_search_params_with_scope(
         "data",
@@ -483,7 +489,7 @@ fn advanced_search_respects_extension_allowlist_scope() {
             extension_filter: vec!["csv".to_string()],
         },
     );
-    let csv_results = index.advanced_search(&csv_params, &vault);
+    let csv_results = index.advanced_search(&csv_params, &vault, &entries);
     let csv_ids: Vec<&str> = csv_results
         .iter()
         .map(|result| result.id.as_str())
@@ -499,7 +505,7 @@ fn advanced_search_respects_extension_allowlist_scope() {
             extension_filter: vec!["md".to_string()],
         },
     );
-    let md_results = index.advanced_search(&md_params, &vault);
+    let md_results = index.advanced_search(&md_params, &vault, &entries);
     let md_ids: Vec<&str> = md_results.iter().map(|result| result.id.as_str()).collect();
 
     assert_eq!(md_ids, vec!["docs/data"]);

--- a/crates/index/tests/integration.rs
+++ b/crates/index/tests/integration.rs
@@ -401,6 +401,7 @@ fn advanced_search_respects_curated_file_scope() {
     let (vault, root) = make_empty_temp_vault("advanced-search-curated-scope");
     std::fs::create_dir_all(root.join("docs")).unwrap();
     std::fs::write(root.join("docs/data.csv"), "name,value\nalice,1").unwrap();
+    std::fs::write(root.join("docs/diagram.excalidraw"), "{}").unwrap();
     std::fs::write(root.join("docs/config.toml"), "enabled = true").unwrap();
 
     let curated_params = make_search_params_with_scope(
@@ -418,6 +419,22 @@ fn advanced_search_respects_curated_file_scope() {
         .collect();
 
     assert_eq!(curated_ids, vec!["docs/data.csv"]);
+
+    let map_params = make_search_params_with_scope(
+        "diagram",
+        false,
+        AdvancedSearchFileScope {
+            mode: "notes_only".to_string(),
+            extension_filter: vec![],
+        },
+    );
+    let map_results = index.advanced_search(&map_params, &vault);
+    let map_ids: Vec<&str> = map_results
+        .iter()
+        .map(|result| result.id.as_str())
+        .collect();
+
+    assert_eq!(map_ids, vec!["docs/diagram.excalidraw"]);
 
     let hidden_params = make_search_params_with_scope(
         "config",

--- a/crates/types/src/dto.rs
+++ b/crates/types/src/dto.rs
@@ -223,6 +223,27 @@ pub struct AdvancedSearchParams {
     /// Prefer filename/path matches over note title matches for file-oriented UI.
     #[serde(default)]
     pub prefer_file_name: bool,
+    /// Controls which non-note files participate in file-oriented search.
+    #[serde(default)]
+    pub file_scope: AdvancedSearchFileScope,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AdvancedSearchFileScope {
+    /// "notes_only" uses the curated writing/media set; "all_files" includes every file.
+    pub mode: String,
+    /// Explicit extension allowlist. When non-empty, it overrides mode.
+    #[serde(default)]
+    pub extension_filter: Vec<String>,
+}
+
+impl Default for AdvancedSearchFileScope {
+    fn default() -> Self {
+        Self {
+            mode: "all_files".to_string(),
+            extension_filter: Vec::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Adds a file tree extension allowlist setting for power users with mixed vaults.

- Adds `fileTreeExtensionFilter` settings storage, normalization, and UI chips.
- Makes a non-empty allowlist act as an explicit file-navigation/search scope that overrides `Show all vault files`.
- Expands the default non-all-files mode to a curated writing/media set: Markdown notes, PDFs, images, Excalidraw, CSV, TXT, HTML/HTM, and folders.
- Keeps `Show all vault files` for showing every vault file beyond the curated set.
- Aligns curated/all-files/allowlist behavior across the file tree, `@` mentions, New Tab / Quick Switcher, Search Files & Notes, and wikilink suggestions.
- Keeps already-open Quick Switcher tabs searchable even when the current allowlist would exclude them from vault results.

## Why

Closes #116. The previous `notes_only` vs `all_files` split was too coarse for vaults that include useful research or writing-adjacent files like CSV, TXT, PDFs, HTML, images, and Excalidraw maps without wanting every project/config file in the tree.

## Implementation Notes

- `advanced_search` now accepts an explicit file scope so backend search results match the same curated/all-files/allowlist semantics as the UI.
- Existing callers that do not provide a scope keep the default all-files-compatible behavior.
- File scope rules are centralized in shared vault-entry helpers, so the file tree, mentions, Quick Switcher, wikilinks, and search do not each reinterpret allowlist/all-files/curated behavior.
- File tree-specific behavior is now limited to the tree itself, primarily keeping folders visible while other scoped surfaces only consider file-like targets.
- The Rust search matcher now normalizes scope mode once and shares file filter/scoring helpers across PDFs and generic files.
- The extension allowlist input now lives in its own settings component, and repeated vault-entry test builders were consolidated into shared test utilities.

## Validation

- `npm test -- src/features/search/SearchView.test.tsx src/app/utils/vaultEntries.test.ts src/features/vault/FileTree.test.tsx src/features/ai/components/AIChatComposer.test.tsx src/features/quick-switcher/QuickSwitcher.test.tsx src/features/editor/extensions/wikilinkSuggester.test.ts src/features/settings/SettingsPanel.test.tsx`
- `cargo test -p neverwrite-index advanced_search`
- `cargo check -p neverwrite-index -p neverwrite-types -p neverwrite-native-backend`
- `npx eslint src/app/utils/vaultEntries.ts src/app/utils/vaultEntries.test.ts src/features/search/SearchView.tsx src/features/search/SearchView.test.tsx src/features/search/queryToParams.ts src/features/vault/FileTree.tsx src/features/vault/FileTree.test.tsx src/features/ai/components/AIChatComposer.tsx src/features/ai/components/AIChatComposer.test.tsx src/features/quick-switcher/QuickSwitcher.tsx src/features/quick-switcher/QuickSwitcher.test.tsx src/features/editor/extensions/wikilinkSuggester.ts src/features/editor/extensions/wikilinkSuggester.test.ts src/features/settings/SettingsPanel.tsx src/features/settings/SettingsPanel.test.tsx src/features/settings/ExtensionFilterInput.tsx src/test/test-utils.tsx`
- `npx tsc -b`
- `git diff --check`
