### PR TITLE
Persist review view state

### DIFF
--- a/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
@@ -517,7 +517,7 @@ describe("AIReviewView", () => {
         ).toBeInTheDocument();
     });
 
-    it("restores persisted expansion and scroll anchor state when reopening the same review session", async () => {
+    it("restores persisted expansion, wide mode, and scroll state when reopening the same review session", async () => {
         const sessionId = "sess-review-persist";
         const file = makeTrackedFile({
             identityKey: "persist-1",
@@ -544,6 +544,11 @@ describe("AIReviewView", () => {
                 screen.queryByRole("button", { name: "Reject hunk 1" }),
             ).not.toBeInTheDocument();
 
+            fireEvent.click(screen.getByRole("button", { name: "Wide" }));
+            expect(
+                screen.getByRole("button", { name: "Center" }),
+            ).toBeInTheDocument();
+
             const scrollContainer = screen.getByTestId(
                 "ai-review-scroll-container",
             );
@@ -562,6 +567,7 @@ describe("AIReviewView", () => {
             ).toMatchObject({
                 expandedIdentityKeys: [],
                 scrollTop: 196,
+                wideMode: true,
             });
 
             firstRender.unmount();
@@ -572,6 +578,60 @@ describe("AIReviewView", () => {
             expect(
                 screen.getByRole("button", { name: "Expand" }),
             ).toBeInTheDocument();
+            expect(
+                screen.getByRole("button", { name: "Center" }),
+            ).toBeInTheDocument();
+            await waitFor(() => {
+                expect(
+                    screen.getByTestId("ai-review-scroll-container").scrollTop,
+                ).toBe(196);
+            });
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("flushes pending scroll persistence when the review tab unmounts before the debounce fires", () => {
+        const sessionId = "sess-review-scroll-flush";
+        const file = makeTrackedFile({
+            identityKey: "persist-flush-1",
+            path: "/vault/notes/persist-flush.md",
+            originPath: "/vault/notes/persist-flush.md",
+            diffBase: "line a\nline b\nline c",
+            currentText: "line a\nline B\nline c",
+        });
+
+        setupReviewTab(sessionId);
+        useChatStore.setState({
+            sessionsById: {
+                [sessionId]: makeSession(sessionId, [file]),
+            },
+            activeSessionId: sessionId,
+        });
+
+        vi.useFakeTimers();
+        try {
+            const view = renderComponent(<AIReviewView />);
+            const scrollContainer = screen.getByTestId(
+                "ai-review-scroll-container",
+            );
+            Object.defineProperty(scrollContainer, "scrollTop", {
+                configurable: true,
+                writable: true,
+                value: 321,
+            });
+            fireEvent.scroll(scrollContainer);
+
+            view.unmount();
+
+            expect(
+                readPersistedReviewViewState(
+                    useVaultStore.getState().vaultPath,
+                    sessionId,
+                ),
+            ).toMatchObject({
+                scrollTop: 321,
+            });
         } finally {
             vi.useRealTimers();
         }

--- a/apps/desktop/src/features/ai/components/AIReviewView.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.tsx
@@ -265,7 +265,10 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
             return keys;
         })(),
     });
-    const [wideMode, setWideMode] = useState(false);
+    const [wideMode, setWideMode] = useState(
+        () => persistedState?.wideMode ?? false,
+    );
+    const wideModeRef = useRef(wideMode);
     const scrollContainerRef = useRef<HTMLDivElement | null>(null);
     const persistedAnchorRef = useRef<PersistedReviewAnchor | null>(
         initialAnchor,
@@ -277,6 +280,7 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
     const scrollPersistTimerRef = useRef<number | null>(null);
     const storageRefreshTimerRef = useRef<number | null>(null);
     const pendingScrollTopRef = useRef<number | null>(null);
+    const latestScrollTopRef = useRef(persistedState?.scrollTop ?? 0);
     const persistViewState = useCallback(
         (nextScrollTop?: number) => {
             const persisted = persistReviewViewState(
@@ -287,8 +291,8 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
                     scrollTop:
                         nextScrollTop ??
                         scrollContainerRef.current?.scrollTop ??
-                        persistedState?.scrollTop ??
-                        0,
+                        latestScrollTopRef.current,
+                    wideMode: wideModeRef.current,
                     anchor: persistedAnchorRef.current,
                 },
                 {
@@ -309,12 +313,19 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
     );
 
     const flushScheduledScrollPersist = useCallback(() => {
+        const pendingScrollTop = pendingScrollTopRef.current;
         if (scrollPersistTimerRef.current != null) {
             window.clearTimeout(scrollPersistTimerRef.current);
             scrollPersistTimerRef.current = null;
         }
         pendingScrollTopRef.current = null;
-    }, []);
+        if (pendingScrollTop != null) {
+            latestScrollTopRef.current = pendingScrollTop;
+            persistViewState(pendingScrollTop);
+            return true;
+        }
+        return false;
+    }, [persistViewState]);
 
     const schedulePersistedStateRefresh = useCallback(() => {
         if (storageRefreshTimerRef.current != null) {
@@ -329,6 +340,7 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
 
     const schedulePersistFromScroll = useCallback(
         (scrollTop: number) => {
+            latestScrollTopRef.current = scrollTop;
             pendingScrollTopRef.current = scrollTop;
             if (scrollPersistTimerRef.current != null) {
                 return;
@@ -342,6 +354,17 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
         },
         [persistViewState],
     );
+
+    const toggleWideMode = useCallback(() => {
+        const nextWideMode = !wideModeRef.current;
+        wideModeRef.current = nextWideMode;
+        setWideMode(nextWideMode);
+        persistViewState();
+    }, [persistViewState]);
+
+    useEffect(() => {
+        wideModeRef.current = wideMode;
+    }, [wideMode]);
 
     useEffect(() => {
         if (persistedState?.updatedAt) {
@@ -405,7 +428,8 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
         }
 
         restoreAppliedRef.current = true;
-        if (persistedState?.scrollTop) {
+        if (persistedState?.scrollTop != null) {
+            latestScrollTopRef.current = persistedState.scrollTop;
             container.scrollTop = persistedState.scrollTop;
         }
 
@@ -464,12 +488,14 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
 
     useEffect(
         () => () => {
-            flushScheduledScrollPersist();
+            const flushedPendingScroll = flushScheduledScrollPersist();
             if (storageRefreshTimerRef.current != null) {
                 window.clearTimeout(storageRefreshTimerRef.current);
                 storageRefreshTimerRef.current = null;
             }
-            persistViewState();
+            if (!flushedPendingScroll) {
+                persistViewState();
+            }
         },
         [flushScheduledScrollPersist, persistViewState],
     );
@@ -560,7 +586,7 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
                             </button>
                             <button
                                 type="button"
-                                onClick={() => setWideMode((prev) => !prev)}
+                                onClick={toggleWideMode}
                                 className="review-action-btn rounded-sm px-2 py-0.5"
                                 style={{
                                     ...getNeutralButtonStyle(),

--- a/apps/desktop/src/features/ai/components/reviewTabPersistence.ts
+++ b/apps/desktop/src/features/ai/components/reviewTabPersistence.ts
@@ -28,6 +28,7 @@ export interface PersistedReviewViewState {
     version: number;
     expandedIdentityKeys: string[];
     scrollTop: number;
+    wideMode: boolean;
     anchor: PersistedReviewAnchor | null;
     writerId?: string;
     updatedAt: number;
@@ -94,6 +95,7 @@ function persistedReviewStateSemanticallyEqual(
             right.expandedIdentityKeys,
         ) &&
         left.scrollTop === right.scrollTop &&
+        left.wideMode === right.wideMode &&
         anchorsEqual(left.anchor, right.anchor)
     );
 }
@@ -266,6 +268,7 @@ function normalizePersistedState(
             (entry): entry is string => typeof entry === "string",
         ),
         scrollTop: Math.max(0, scrollTop),
+        wideMode: (raw as { wideMode?: unknown }).wideMode === true,
         anchor: normalizeAnchor((raw as { anchor?: unknown }).anchor),
         writerId: typeof writerId === "string" ? writerId : undefined,
         updatedAt,
@@ -295,6 +298,7 @@ export function persistReviewViewState(
     next: {
         expandedIdentityKeys: Iterable<string>;
         scrollTop: number;
+        wideMode?: boolean;
         anchor: PersistedReviewAnchor | null;
     },
     options?: {
@@ -311,6 +315,7 @@ export function persistReviewViewState(
             0,
             Number.isFinite(next.scrollTop) ? next.scrollTop : 0,
         ),
+        wideMode: next.wideMode === true,
         anchor: next.anchor,
         writerId: options?.writerId,
         updatedAt: Date.now(),
@@ -331,6 +336,7 @@ export function persistReviewViewState(
                       ]),
                   ],
                   scrollTop: existing.scrollTop,
+                  wideMode: existing.wideMode,
                   anchor: existing.anchor,
               }
             : requested;


### PR DESCRIPTION
## Summary

- Persist the Pending Changes wide/center mode with the existing review view state.
- Make scroll persistence resilient when the review tab unmounts before the debounce fires.
- Add regression coverage for restoring expansion, wide mode, and scroll position.

## Root cause

The review tab already had persisted scroll infrastructure, but `wideMode` lived only in local React state. The scroll cleanup path also cleared pending debounced scroll updates before persisting them, so switching tabs quickly could restore from stale state or jump back to the top.

## Validation

- `npm test -- src/features/ai/components/AIReviewView.test.tsx src/features/ai/components/reviewTabPersistence.test.ts`
