### PR TITLE
Preserve Claude/Open Code structured diff hunks

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -352,11 +352,10 @@ describe("AIChatMessageItem tool diffs", () => {
 
         fireEvent.click(screen.getByRole("button", { name: /watcher.rs/i }));
 
-        expect(screen.getAllByText("12").length).toBeGreaterThanOrEqual(1);
         expect(screen.getAllByText("13").length).toBeGreaterThanOrEqual(1);
         expect(screen.queryByText("+ old line")).not.toBeInTheDocument();
         expect(screen.queryByText("- new line")).not.toBeInTheDocument();
-        expect(screen.getByText("shared line")).toBeInTheDocument();
+        expect(screen.queryByText("shared line")).not.toBeInTheDocument();
         expect(screen.getByText("old line")).toBeInTheDocument();
         expect(screen.getByText("new line")).toBeInTheDocument();
     });
@@ -782,7 +781,9 @@ describe("AIChatMessageItem tool diffs", () => {
 
         fireEvent.click(screen.getByRole("button", { name: /exact.md/i }));
 
-        expect(screen.getAllByText("101")).toHaveLength(1);
+        expect(screen.queryByText("alpha")).not.toBeInTheDocument();
+        expect(screen.queryByText("101")).not.toBeInTheDocument();
+        expect(screen.getAllByText("102")).toHaveLength(2);
         expect(screen.getByText("before")).toBeInTheDocument();
         expect(screen.getByText("after")).toBeInTheDocument();
     });

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -1964,6 +1964,7 @@ function ChangeReviewFileRow({
                         testId={`diff-content:${diff.path}`}
                         showWhenEmpty={false}
                         compactLineNumbers
+                        compactContextLines={0}
                     />
                 </ResizableDiffContainer>
             )}
@@ -2614,6 +2615,7 @@ function ChangeReviewPanel({
                         testId={`diff-content:${singleDiff.path}`}
                         showWhenEmpty={false}
                         compactLineNumbers
+                        compactContextLines={0}
                     />
                 </ResizableDiffContainer>
             )}

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -2282,18 +2282,16 @@ function ChangeReviewPanel({
     readOnly?: boolean;
 }) {
     const messageDiffs = message.diffs ?? [];
+    const messageReviewDiffs = message.reviewDiffs;
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const trackedFiles = useChatStore((state) =>
         selectVisibleTrackedFiles(state, sessionId ?? null),
     );
     const diffs = useMemo(
         () =>
-            deriveChatChangeReviewDiffs(
-                messageDiffs,
-                trackedFiles,
-                vaultPath,
-            ),
-        [messageDiffs, trackedFiles, vaultPath],
+            messageReviewDiffs ??
+            deriveChatChangeReviewDiffs(messageDiffs, trackedFiles, vaultPath),
+        [messageDiffs, messageReviewDiffs, trackedFiles, vaultPath],
     );
     const editDiffZoom = useChatStore((state) => state.editDiffZoom);
     const setEditDiffZoom = useChatStore((state) => state.setEditDiffZoom);

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -23,6 +23,7 @@ import { MarkdownContent } from "./MarkdownContent";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 import type { ChatPillVariant } from "./chatPillPalette";
 import { useChatStore } from "../store/chatStore";
+import { selectVisibleTrackedFiles } from "../store/editedFilesBufferModel";
 import {
     resolveChatRowUiSessionId,
     useChatRowUiStore,
@@ -34,6 +35,7 @@ import {
     formatDiffStat,
     getFileNameFromPath,
 } from "../diff/reviewDiff";
+import { deriveChatChangeReviewDiffs } from "../diff/chatChangeReviewModel";
 import { decodeSerializedPillValue } from "../composerParts";
 import { DiffZoomControls } from "./DiffZoomControls";
 import { EditedFileDiffPreview } from "./editedFilesPresentation";
@@ -44,6 +46,7 @@ import {
 } from "../chatFileNavigation";
 import { openChatSessionInWorkspace } from "../chatPaneMovement";
 import { useSettingsStore } from "../../../app/store/settingsStore";
+import { useVaultStore } from "../../../app/store/vaultStore";
 import { buildCodexGeneratedImagePreviewUrl } from "../../../app/utils/filePreviewUrl";
 import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 
@@ -2278,7 +2281,20 @@ function ChangeReviewPanel({
     onPermissionResponse?: (requestId: string, optionId?: string) => void;
     readOnly?: boolean;
 }) {
-    const diffs = message.diffs ?? [];
+    const messageDiffs = message.diffs ?? [];
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+    const trackedFiles = useChatStore((state) =>
+        selectVisibleTrackedFiles(state, sessionId ?? null),
+    );
+    const diffs = useMemo(
+        () =>
+            deriveChatChangeReviewDiffs(
+                messageDiffs,
+                trackedFiles,
+                vaultPath,
+            ),
+        [messageDiffs, trackedFiles, vaultPath],
+    );
     const editDiffZoom = useChatStore((state) => state.editDiffZoom);
     const setEditDiffZoom = useChatStore((state) => state.setEditDiffZoom);
     const lineWrapping = useSettingsStore((state) => state.lineWrapping);

--- a/apps/desktop/src/features/ai/components/editedFilesPresentation.tsx
+++ b/apps/desktop/src/features/ai/components/editedFilesPresentation.tsx
@@ -438,6 +438,55 @@ function getDiffLineTextStyles(lineWrapping: boolean) {
     };
 }
 
+function compactExactDiffContext(
+    lines: DiffLine[],
+    contextLines: number | undefined,
+) {
+    if (contextLines == null || contextLines < 0) {
+        return lines;
+    }
+
+    const clampedContextLines = Math.floor(contextLines);
+    const changedIndexesByHunk = new Map<number, number[]>();
+    lines.forEach((line, index) => {
+        if (
+            line.hunkIndex == null ||
+            line.type === "context" ||
+            line.type === "separator"
+        ) {
+            return;
+        }
+
+        const changedIndexes = changedIndexesByHunk.get(line.hunkIndex) ?? [];
+        changedIndexes.push(index);
+        changedIndexesByHunk.set(line.hunkIndex, changedIndexes);
+    });
+
+    if (changedIndexesByHunk.size === 0) {
+        return lines;
+    }
+
+    return lines.filter((line, index) => {
+        if (
+            line.hunkIndex == null ||
+            line.type !== "context" ||
+            !line.exact
+        ) {
+            return true;
+        }
+
+        const changedIndexes = changedIndexesByHunk.get(line.hunkIndex);
+        if (!changedIndexes) {
+            return false;
+        }
+
+        return changedIndexes.some(
+            (changedIndex) =>
+                Math.abs(changedIndex - index) <= clampedContextLines,
+        );
+    });
+}
+
 export function DiffLineView({
     line,
     compactLineNumbers = false,
@@ -686,6 +735,7 @@ export function EditedFileDiffPreview({
     emptyLabel = "Path-only change",
     showWhenEmpty = true,
     compactLineNumbers = false,
+    compactContextLines,
     file,
     reviewHunks,
     onResolveReviewHunks,
@@ -698,6 +748,7 @@ export function EditedFileDiffPreview({
     emptyLabel?: string;
     showWhenEmpty?: boolean;
     compactLineNumbers?: boolean;
+    compactContextLines?: number;
     file?: TrackedFile;
     reviewHunks?: ReviewHunk[];
     onResolveReviewHunks?: (
@@ -708,8 +759,14 @@ export function EditedFileDiffPreview({
     ) => void | Promise<void>;
 }) {
     const lines = useMemo(
-        () => (expanded ? computeDiffLines(diff) : []),
-        [diff, expanded],
+        () =>
+            expanded
+                ? compactExactDiffContext(
+                      computeDiffLines(diff),
+                      compactContextLines,
+                  )
+                : [],
+        [compactContextLines, diff, expanded],
     );
     const languageSupport = useCodeLanguageSupport(
         file?.path ?? diff.path,

--- a/apps/desktop/src/features/ai/diff/chatChangeReviewModel.test.ts
+++ b/apps/desktop/src/features/ai/diff/chatChangeReviewModel.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+import type { TrackedFile } from "./actionLogTypes";
+import { deriveChatChangeReviewDiffs } from "./chatChangeReviewModel";
+import { buildPatchFromTexts } from "../store/actionLogModel";
+import type { AIFileDiff } from "../types";
+
+function makeTrackedFile(
+    path: string,
+    diffBase: string,
+    currentText: string,
+): TrackedFile {
+    return {
+        identityKey: path,
+        originPath: path,
+        path,
+        previousPath: null,
+        status: { kind: "modified" },
+        reviewState: "pending",
+        diffBase,
+        currentText,
+        unreviewedEdits: buildPatchFromTexts(diffBase, currentText),
+        version: 1,
+        isText: true,
+        updatedAt: 1,
+    };
+}
+
+describe("deriveChatChangeReviewDiffs", () => {
+    it("prefers matched tracked-file diffs over verbose activity hunks", () => {
+        const path = "/vault/posts/article.md";
+        const activityDiff: AIFileDiff = {
+            path,
+            kind: "update",
+            old_text: "old snippet",
+            new_text: "new snippet",
+            hunks: [
+                {
+                    old_start: 20,
+                    old_count: 3,
+                    new_start: 20,
+                    new_count: 3,
+                    lines: [
+                        { type: "context", text: "before" },
+                        { type: "remove", text: "old snippet" },
+                        { type: "add", text: "new snippet" },
+                        { type: "context", text: "after" },
+                    ],
+                },
+            ],
+        };
+        const trackedFile = makeTrackedFile(
+            path,
+            "before\nold snippet\nafter",
+            "before\nnew snippet\nafter",
+        );
+
+        const [diff] = deriveChatChangeReviewDiffs(
+            [activityDiff],
+            [trackedFile],
+            "/vault",
+        );
+
+        expect(diff?.old_text).toBe("before\nold snippet\nafter");
+        expect(diff?.new_text).toBe("before\nnew snippet\nafter");
+        expect(diff?.hunks).toEqual([
+            {
+                old_start: 2,
+                old_count: 1,
+                new_start: 2,
+                new_count: 1,
+                lines: [
+                    { type: "remove", text: "old snippet" },
+                    { type: "add", text: "new snippet" },
+                ],
+            },
+        ]);
+    });
+
+    it("keeps the activity diff when tracked-file matching is ambiguous", () => {
+        const activityDiff: AIFileDiff = {
+            path: "/vault/posts/article.md",
+            kind: "update",
+            old_text: "old",
+            new_text: "new",
+        };
+        const left = makeTrackedFile(
+            "/vault/posts/article.md",
+            "left old",
+            "left new",
+        );
+        const right = makeTrackedFile(
+            "/vault/posts/article.md",
+            "right old",
+            "right new",
+        );
+        right.identityKey = "/vault/posts/article-copy.md";
+
+        const [diff] = deriveChatChangeReviewDiffs(
+            [activityDiff],
+            [left, right],
+            "/vault",
+        );
+
+        expect(diff).toBe(activityDiff);
+    });
+});

--- a/apps/desktop/src/features/ai/diff/chatChangeReviewModel.ts
+++ b/apps/desktop/src/features/ai/diff/chatChangeReviewModel.ts
@@ -1,0 +1,106 @@
+import { pathsMatchVaultScoped } from "../../../app/utils/vaultPaths";
+import type { TrackedFile } from "./actionLogTypes";
+import { createDiffFromTrackedFile } from "./reviewDiff";
+import type { AIFileDiff } from "../types";
+
+export function deriveChatChangeReviewDiffs(
+    diffs: readonly AIFileDiff[],
+    trackedFiles: readonly TrackedFile[],
+    vaultPath: string | null,
+): AIFileDiff[] {
+    const unmatchedTrackedFiles = new Map(
+        trackedFiles.map((file) => [file.identityKey, file]),
+    );
+
+    return diffs.map((diff) => {
+        const file = matchTrackedFileToDiff(
+            diff,
+            [...unmatchedTrackedFiles.values()],
+            vaultPath,
+        );
+        if (!file) {
+            return diff;
+        }
+
+        unmatchedTrackedFiles.delete(file.identityKey);
+        return createDiffFromTrackedFile(file);
+    });
+}
+
+function matchTrackedFileToDiff(
+    diff: AIFileDiff,
+    trackedFiles: readonly TrackedFile[],
+    vaultPath: string | null,
+): TrackedFile | null {
+    let bestCandidate: TrackedFile | null = null;
+    let bestScore = -1;
+    let hasTie = false;
+
+    for (const trackedFile of trackedFiles) {
+        const score = scoreTrackedFileMatch(diff, trackedFile, vaultPath);
+        if (score < 0) {
+            continue;
+        }
+
+        if (score > bestScore) {
+            bestCandidate = trackedFile;
+            bestScore = score;
+            hasTie = false;
+            continue;
+        }
+
+        if (score === bestScore) {
+            hasTie = true;
+        }
+    }
+
+    return hasTie ? null : bestCandidate;
+}
+
+function scoreTrackedFileMatch(
+    diff: AIFileDiff,
+    trackedFile: TrackedFile,
+    vaultPath: string | null,
+) {
+    const previousPath = diff.previous_path ?? null;
+    if (
+        pathsMatch(trackedFile.path, diff.path, vaultPath) &&
+        ((trackedFile.previousPath ?? null) === previousPath ||
+            (trackedFile.previousPath != null &&
+                previousPath != null &&
+                pathsMatch(trackedFile.previousPath, previousPath, vaultPath)))
+    ) {
+        return 4;
+    }
+
+    if (pathsMatch(trackedFile.path, diff.path, vaultPath)) {
+        return 3;
+    }
+
+    if (
+        previousPath != null &&
+        trackedFile.previousPath != null &&
+        pathsMatch(trackedFile.previousPath, previousPath, vaultPath)
+    ) {
+        return 2;
+    }
+
+    if (
+        previousPath != null &&
+        pathsMatch(trackedFile.path, previousPath, vaultPath)
+    ) {
+        return 1;
+    }
+
+    return -1;
+}
+
+function pathsMatch(
+    left: string,
+    right: string,
+    vaultPath: string | null,
+) {
+    return pathsMatchVaultScoped(left, right, vaultPath, {
+        includeLegacyLeadingSlashRelative: true,
+    });
+}

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7175,6 +7175,15 @@ describe("chatStore", () => {
             old_text: "original",
             new_text: "first edit",
         });
+        const secondMessage =
+            useChatStore.getState().sessionsById[activeSessionId]!.messages.find(
+                (message) => message.id === "tool:tool-cycle-b",
+            );
+        expect(secondMessage?.reviewDiffs?.[0]).toMatchObject({
+            path: "/notes/file.md",
+            old_text: "first edit",
+            new_text: "second edit",
+        });
     });
 
     it("freezes non-trackable tool diff cards before later tracked edits touch the same file", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -6251,6 +6251,98 @@ describe("chatStore", () => {
         ]);
     });
 
+    it("stores chat tool fragment hunks with file-relative line numbers", async () => {
+        const oldLines = Array.from(
+            { length: 1180 },
+            (_, index) => `line ${index + 1}`,
+        );
+        oldLines[1176] = "old target";
+        const oldText = oldLines.join("\n");
+        const newLines = [...oldLines];
+        newLines[1176] = "new target";
+        const newText = newLines.join("\n");
+
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [],
+        });
+        useEditorStore.setState({
+            tabs: [
+                {
+                    id: "tab-1",
+                    kind: "file",
+                    relativePath: "posts/article.md",
+                    path: "/vault/posts/article.md",
+                    title: "article.md",
+                    content: oldText,
+                    mimeType: "text/markdown",
+                    viewer: "text",
+                    history: [],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "tab-1",
+            activationHistory: ["tab-1"],
+            tabNavigationHistory: ["tab-1"],
+            tabNavigationIndex: 0,
+        });
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-fragment-hunk-lines",
+            title: "Edit article.md",
+            kind: "edit",
+            status: "completed",
+            target: "/vault/posts/article.md",
+            diffs: [
+                {
+                    path: "/vault/posts/article.md",
+                    kind: "update",
+                    old_text: "old target",
+                    new_text: "new target",
+                    reversible: true,
+                    hunks: [
+                        {
+                            old_start: 1,
+                            old_count: 1,
+                            new_start: 1,
+                            new_count: 1,
+                            lines: [
+                                { type: "remove", text: "old target" },
+                                { type: "add", text: "new target" },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const message =
+            useChatStore.getState().sessionsById[activeSessionId]!
+                .messages.find(
+                    (item) => item.id === "tool:tool-fragment-hunk-lines",
+                );
+        const diff = message?.diffs?.[0];
+
+        expect(diff).toMatchObject({
+            old_text: oldText,
+            new_text: newText,
+        });
+        expect(diff?.hunks?.[0]).toMatchObject({
+            old_start: 1177,
+            new_start: 1177,
+        });
+        expect(getVisibleBuffer(activeSessionId)).toMatchObject([
+            {
+                diffBase: oldText,
+                currentText: newText,
+            },
+        ]);
+    });
+
     it("treats fragmentary delete diffs as inline updates when the file still has content", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -6256,7 +6256,10 @@ describe("chatStore", () => {
             { length: 1180 },
             (_, index) => `line ${index + 1}`,
         );
+        oldLines[1] = "old target";
+        oldLines[1175] = "unique context before target";
         oldLines[1176] = "old target";
+        oldLines[1177] = "unique context after target";
         const oldText = oldLines.join("\n");
         const newLines = [...oldLines];
         newLines[1176] = "new target";
@@ -6301,14 +6304,16 @@ describe("chatStore", () => {
                 {
                     path: "/vault/posts/article.md",
                     kind: "update",
-                    old_text: "old target",
-                    new_text: "new target",
+                    old_text:
+                        "unique context before target\nold target\nunique context after target",
+                    new_text:
+                        "unique context before target\nnew target\nunique context after target",
                     reversible: true,
                     hunks: [
                         {
-                            old_start: 1,
+                            old_start: 2,
                             old_count: 1,
-                            new_start: 1,
+                            new_start: 2,
                             new_count: 1,
                             lines: [
                                 { type: "remove", text: "old target" },

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7177,6 +7177,57 @@ describe("chatStore", () => {
         });
     });
 
+    it("freezes non-trackable tool diff cards before later tracked edits touch the same file", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-untracked-preview",
+            title: "Edit file",
+            kind: "edit",
+            status: "completed",
+            diffs: [
+                {
+                    path: "/notes/file.md",
+                    kind: "update",
+                    old_text: "opaque old",
+                    new_text: "opaque preview",
+                    reversible: false,
+                },
+            ],
+        });
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-later-tracked",
+            title: "Edit file again",
+            kind: "edit",
+            status: "completed",
+            diffs: [
+                {
+                    path: "/notes/file.md",
+                    kind: "update",
+                    old_text: "base",
+                    new_text: "later tracked edit",
+                },
+            ],
+        });
+
+        const firstMessage =
+            useChatStore.getState().sessionsById[activeSessionId]!.messages.find(
+                (message) => message.id === "tool:tool-untracked-preview",
+            );
+        expect(firstMessage?.reviewDiffs).toEqual(firstMessage?.diffs);
+        expect(firstMessage?.reviewDiffs?.[0]).toMatchObject({
+            path: "/notes/file.md",
+            old_text: "opaque old",
+            new_text: "opaque preview",
+            reversible: false,
+        });
+    });
+
     it("keeps earlier agent hunks rejectable when the user edits the file and the agent edits it again later", async () => {
         await useChatStore.getState().initialize();
         invokeMock.mockImplementation(async (command) => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7228,6 +7228,57 @@ describe("chatStore", () => {
         });
     });
 
+    it("does not freeze a later non-trackable tool card from an earlier tracked edit on the same file", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-earlier-tracked",
+            title: "Edit file",
+            kind: "edit",
+            status: "completed",
+            diffs: [
+                {
+                    path: "/notes/file.md",
+                    kind: "update",
+                    old_text: "tracked old",
+                    new_text: "tracked new",
+                },
+            ],
+        });
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-later-untracked-preview",
+            title: "Edit file again",
+            kind: "edit",
+            status: "completed",
+            diffs: [
+                {
+                    path: "/notes/file.md",
+                    kind: "update",
+                    old_text: "opaque old",
+                    new_text: "opaque preview",
+                    reversible: false,
+                },
+            ],
+        });
+
+        const laterMessage =
+            useChatStore.getState().sessionsById[activeSessionId]!.messages.find(
+                (message) => message.id === "tool:tool-later-untracked-preview",
+            );
+        expect(laterMessage?.reviewDiffs).toEqual(laterMessage?.diffs);
+        expect(laterMessage?.reviewDiffs?.[0]).toMatchObject({
+            path: "/notes/file.md",
+            old_text: "opaque old",
+            new_text: "opaque preview",
+            reversible: false,
+        });
+    });
+
     it("keeps earlier agent hunks rejectable when the user edits the file and the agent edits it again later", async () => {
         await useChatStore.getState().initialize();
         invokeMock.mockImplementation(async (command) => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -6348,6 +6348,84 @@ describe("chatStore", () => {
         ]);
     });
 
+    it("derives chat tool hunks for normalized large fragment diffs", async () => {
+        const oldLines = Array.from(
+            { length: 1200 },
+            (_, index) => `line ${index + 1}`,
+        );
+        oldLines[1094] = "paragraph to remove";
+        const oldText = oldLines.join("\n");
+        const newLines = oldLines.filter((_, index) => index !== 1094);
+        const newText = newLines.join("\n");
+
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [],
+        });
+        useEditorStore.setState({
+            tabs: [
+                {
+                    id: "tab-1",
+                    kind: "file",
+                    relativePath: "posts/article.md",
+                    path: "/vault/posts/article.md",
+                    title: "article.md",
+                    content: oldText,
+                    mimeType: "text/markdown",
+                    viewer: "text",
+                    history: [],
+                    historyIndex: 0,
+                },
+            ],
+            activeTabId: "tab-1",
+            activationHistory: ["tab-1"],
+            tabNavigationHistory: ["tab-1"],
+            tabNavigationIndex: 0,
+        });
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-fragment-derived-hunk",
+            title: "Edit article.md",
+            kind: "edit",
+            status: "completed",
+            target: "/vault/posts/article.md",
+            diffs: [
+                {
+                    path: "/vault/posts/article.md",
+                    kind: "update",
+                    old_text: "paragraph to remove\n",
+                    new_text: "",
+                    reversible: true,
+                },
+            ],
+        });
+
+        const message =
+            useChatStore.getState().sessionsById[activeSessionId]!
+                .messages.find(
+                    (item) => item.id === "tool:tool-fragment-derived-hunk",
+                );
+        const diff = message?.diffs?.[0];
+
+        expect(diff).toMatchObject({
+            old_text: oldText,
+            new_text: newText,
+        });
+        expect(diff?.hunks).toEqual([
+            {
+                old_start: 1095,
+                old_count: 1,
+                new_start: 1095,
+                new_count: 0,
+                lines: [{ type: "remove", text: "paragraph to remove" }],
+            },
+        ]);
+    });
+
     it("treats fragmentary delete diffs as inline updates when the file still has content", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7125,6 +7125,15 @@ describe("chatStore", () => {
                 },
             ],
         });
+        const firstMessageBeforeCycleB =
+            useChatStore.getState().sessionsById[activeSessionId]!.messages.find(
+                (message) => message.id === "tool:tool-cycle-a",
+            );
+        expect(firstMessageBeforeCycleB?.reviewDiffs?.[0]).toMatchObject({
+            path: "/notes/file.md",
+            old_text: "original",
+            new_text: "first edit",
+        });
 
         // Start cycle B
         useChatStore.getState().setComposerParts(createTextParts("Next turn"));
@@ -7157,6 +7166,15 @@ describe("chatStore", () => {
                 currentText: "second edit",
             },
         ]);
+        const firstMessageAfterCycleB =
+            useChatStore.getState().sessionsById[activeSessionId]!.messages.find(
+                (message) => message.id === "tool:tool-cycle-a",
+            );
+        expect(firstMessageAfterCycleB?.reviewDiffs?.[0]).toMatchObject({
+            path: "/notes/file.md",
+            old_text: "original",
+            new_text: "first edit",
+        });
     });
 
     it("keeps earlier agent hunks rejectable when the user edits the file and the agent edits it again later", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -88,7 +88,6 @@ import {
     type ReviewHunkId,
     resolveReviewHunkIdsToExactSpans,
 } from "../diff/reviewProjectionIndex";
-import { deriveChatChangeReviewDiffs } from "../diff/chatChangeReviewModel";
 import {
     type EditorTarget,
     resolveEditorTargetForTrackedPath,
@@ -4086,35 +4085,12 @@ function normalizeIncomingTrackedDiffs(
     );
 }
 
-function deriveMessageReviewDiffs(
-    session: AIChatSession,
-    messageDiffs: AIFileDiff[] | undefined,
-    vaultPath: string | null,
-) {
-    if (!messageDiffs || messageDiffs.length === 0 || !session.actionLog) {
-        return messageDiffs;
-    }
-
-    return deriveChatChangeReviewDiffs(
-        messageDiffs,
-        Object.values(getTrackedFilesForSession(session.actionLog)),
-        vaultPath,
-    );
-}
-
-function freezeMessageReviewDiffs(
-    session: AIChatSession,
-    messageDiffs: AIFileDiff[] | undefined,
-    vaultPath: string | null,
-    deriveFromActionLog: boolean,
-) {
+function freezeMessageReviewDiffs(messageDiffs: AIFileDiff[] | undefined) {
     if (!messageDiffs || messageDiffs.length === 0) {
         return undefined;
     }
 
-    return deriveFromActionLog
-        ? deriveMessageReviewDiffs(session, messageDiffs, vaultPath)
-        : messageDiffs;
+    return messageDiffs;
 }
 
 function summarizeTrackedFileForDebug(file: TrackedFile | null | undefined) {
@@ -8036,12 +8012,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 let reviewVaultPath =
                     consolidated.vaultPath ??
                     useVaultStore.getState().vaultPath;
-                let reviewDiffs = freezeMessageReviewDiffs(
-                    consolidated,
-                    messageDiffs,
-                    reviewVaultPath,
-                    false,
-                );
+                let reviewDiffs = freezeMessageReviewDiffs(messageDiffs);
                 if (shouldConsolidate) {
                     consolidated = ensureActionLog(consolidated);
                     const currentFiles = getTrackedFilesForSession(
@@ -8068,12 +8039,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                             workCycleId,
                         );
                     }
-                    reviewDiffs = freezeMessageReviewDiffs(
-                        consolidated,
-                        messageDiffs,
-                        reviewVaultPath,
-                        true,
-                    );
+                    reviewDiffs = freezeMessageReviewDiffs(messageDiffs);
                 }
 
                 const nextMessage: AIChatMessage = {
@@ -8298,12 +8264,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 let reviewVaultPath =
                     sessionWithBuffer.vaultPath ??
                     useVaultStore.getState().vaultPath;
-                let reviewDiffs = freezeMessageReviewDiffs(
-                    sessionWithBuffer,
-                    messageDiffs,
-                    reviewVaultPath,
-                    false,
-                );
+                let reviewDiffs = freezeMessageReviewDiffs(messageDiffs);
                 if (hasDiffs) {
                     sessionWithBuffer = ensureActionLog(sessionWithBuffer);
                     const currentFiles = getTrackedFilesForSession(
@@ -8324,12 +8285,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         eventTimestamp,
                         { normalized: true },
                     );
-                    reviewDiffs = freezeMessageReviewDiffs(
-                        sessionWithBuffer,
-                        messageDiffs,
-                        reviewVaultPath,
-                        true,
-                    );
+                    reviewDiffs = freezeMessageReviewDiffs(messageDiffs);
                 }
 
                 const messageId = `permission:${payload.request_id}`;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -4106,12 +4106,15 @@ function freezeMessageReviewDiffs(
     session: AIChatSession,
     messageDiffs: AIFileDiff[] | undefined,
     vaultPath: string | null,
+    deriveFromActionLog: boolean,
 ) {
     if (!messageDiffs || messageDiffs.length === 0) {
         return undefined;
     }
 
-    return deriveMessageReviewDiffs(session, messageDiffs, vaultPath);
+    return deriveFromActionLog
+        ? deriveMessageReviewDiffs(session, messageDiffs, vaultPath)
+        : messageDiffs;
 }
 
 function summarizeTrackedFileForDebug(file: TrackedFile | null | undefined) {
@@ -8037,6 +8040,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     consolidated,
                     messageDiffs,
                     reviewVaultPath,
+                    false,
                 );
                 if (shouldConsolidate) {
                     consolidated = ensureActionLog(consolidated);
@@ -8068,6 +8072,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         consolidated,
                         messageDiffs,
                         reviewVaultPath,
+                        true,
                     );
                 }
 
@@ -8297,6 +8302,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     sessionWithBuffer,
                     messageDiffs,
                     reviewVaultPath,
+                    false,
                 );
                 if (hasDiffs) {
                     sessionWithBuffer = ensureActionLog(sessionWithBuffer);
@@ -8322,6 +8328,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         sessionWithBuffer,
                         messageDiffs,
                         reviewVaultPath,
+                        true,
                     );
                 }
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -4102,6 +4102,18 @@ function deriveMessageReviewDiffs(
     );
 }
 
+function freezeMessageReviewDiffs(
+    session: AIChatSession,
+    messageDiffs: AIFileDiff[] | undefined,
+    vaultPath: string | null,
+) {
+    if (!messageDiffs || messageDiffs.length === 0) {
+        return undefined;
+    }
+
+    return deriveMessageReviewDiffs(session, messageDiffs, vaultPath);
+}
+
 function summarizeTrackedFileForDebug(file: TrackedFile | null | undefined) {
     if (!file) {
         return null;
@@ -8018,19 +8030,26 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 // are not allowed to rewrite the domain state.
                 let consolidated = nextSession;
                 let messageDiffs = payload.diffs;
-                let reviewDiffs: AIFileDiff[] | undefined;
+                let reviewVaultPath =
+                    consolidated.vaultPath ??
+                    useVaultStore.getState().vaultPath;
+                let reviewDiffs = freezeMessageReviewDiffs(
+                    consolidated,
+                    messageDiffs,
+                    reviewVaultPath,
+                );
                 if (shouldConsolidate) {
                     consolidated = ensureActionLog(consolidated);
                     const currentFiles = getTrackedFilesForSession(
                         consolidated.actionLog,
                     );
-                    const vaultPath =
+                    reviewVaultPath =
                         consolidated.vaultPath ??
                         useVaultStore.getState().vaultPath;
                     messageDiffs = normalizeIncomingTrackedDiffs(
                         currentFiles,
                         payload.diffs ?? [],
-                        vaultPath,
+                        reviewVaultPath,
                     );
                     consolidated = consolidateActionLogDiffs(
                         consolidated,
@@ -8045,10 +8064,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                             workCycleId,
                         );
                     }
-                    reviewDiffs = deriveMessageReviewDiffs(
+                    reviewDiffs = freezeMessageReviewDiffs(
                         consolidated,
                         messageDiffs,
-                        vaultPath,
+                        reviewVaultPath,
                     );
                 }
 
@@ -8271,19 +8290,26 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     Boolean(workCycleId);
                 let sessionWithBuffer = nextSession;
                 let messageDiffs = payload.diffs;
-                let reviewDiffs: AIFileDiff[] | undefined;
+                let reviewVaultPath =
+                    sessionWithBuffer.vaultPath ??
+                    useVaultStore.getState().vaultPath;
+                let reviewDiffs = freezeMessageReviewDiffs(
+                    sessionWithBuffer,
+                    messageDiffs,
+                    reviewVaultPath,
+                );
                 if (hasDiffs) {
                     sessionWithBuffer = ensureActionLog(sessionWithBuffer);
                     const currentFiles = getTrackedFilesForSession(
                         sessionWithBuffer.actionLog,
                     );
-                    const vaultPath =
+                    reviewVaultPath =
                         sessionWithBuffer.vaultPath ??
                         useVaultStore.getState().vaultPath;
                     messageDiffs = normalizeIncomingTrackedDiffs(
                         currentFiles,
                         payload.diffs,
-                        vaultPath,
+                        reviewVaultPath,
                     );
                     sessionWithBuffer = consolidateActionLogDiffs(
                         sessionWithBuffer,
@@ -8292,10 +8318,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         eventTimestamp,
                         { normalized: true },
                     );
-                    reviewDiffs = deriveMessageReviewDiffs(
+                    reviewDiffs = freezeMessageReviewDiffs(
                         sessionWithBuffer,
                         messageDiffs,
-                        vaultPath,
+                        reviewVaultPath,
                     );
                 }
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -108,6 +108,7 @@ import {
     type AIChatMessage,
     type AIChatMessageKind,
     type AIFileDiff,
+    type AIFileDiffHunk,
     type AIChatNoteSummary,
     type AIChatRole,
     type AIChatSession,
@@ -3777,6 +3778,118 @@ function replaceTextExactlyOnce(
     );
 }
 
+function countLinesBeforeOffset(text: string, offset: number) {
+    if (offset <= 0) return 0;
+    let lineCount = 0;
+    const boundedOffset = Math.min(offset, text.length);
+    for (let index = 0; index < boundedOffset; index += 1) {
+        if (text.charCodeAt(index) === 10) {
+            lineCount += 1;
+        }
+    }
+    return lineCount;
+}
+
+function getHunkSideLines(
+    hunk: AIFileDiffHunk,
+    side: "old" | "new",
+): string[] {
+    return hunk.lines
+        .filter((line) =>
+            side === "old" ? line.type !== "add" : line.type !== "remove",
+        )
+        .map((line) => line.text);
+}
+
+function hunkSideMatchesText(
+    text: string,
+    hunk: AIFileDiffHunk,
+    side: "old" | "new",
+) {
+    const expectedLines = getHunkSideLines(hunk, side);
+    if (expectedLines.length === 0) {
+        return true;
+    }
+
+    const start = side === "old" ? hunk.old_start : hunk.new_start;
+    if (start <= 0) {
+        return false;
+    }
+
+    const actualLines = text.split("\n").slice(start - 1);
+    return expectedLines.every((line, index) => actualLines[index] === line);
+}
+
+function hunkMatchesTexts(
+    hunk: AIFileDiffHunk,
+    oldText: string,
+    newText: string,
+) {
+    return (
+        hunkSideMatchesText(oldText, hunk, "old") &&
+        hunkSideMatchesText(newText, hunk, "new")
+    );
+}
+
+function shiftHunkStarts(
+    hunk: AIFileDiffHunk,
+    oldLineOffset: number,
+    newLineOffset: number,
+): AIFileDiffHunk {
+    return {
+        ...hunk,
+        old_start: hunk.old_start > 0 ? hunk.old_start + oldLineOffset : 0,
+        new_start: hunk.new_start > 0 ? hunk.new_start + newLineOffset : 0,
+    };
+}
+
+function normalizeFragmentHunksToSnapshot(
+    diff: AIFileDiff,
+    oldSnapshot: string,
+    newSnapshot: string,
+    fragmentOffset: number,
+): AIFileDiff {
+    if (!diff.hunks || diff.hunks.length === 0) {
+        return diff;
+    }
+
+    const oldLineOffset = countLinesBeforeOffset(oldSnapshot, fragmentOffset);
+    if (oldLineOffset === 0) {
+        return diff;
+    }
+
+    const newLineOffset = countLinesBeforeOffset(newSnapshot, fragmentOffset);
+    const rebasedHunks: AIFileDiffHunk[] = [];
+
+    for (const hunk of diff.hunks) {
+        if (hunkMatchesTexts(hunk, oldSnapshot, newSnapshot)) {
+            rebasedHunks.push(hunk);
+            continue;
+        }
+
+        const rebased = shiftHunkStarts(hunk, oldLineOffset, newLineOffset);
+        if (hunkMatchesTexts(rebased, oldSnapshot, newSnapshot)) {
+            rebasedHunks.push(rebased);
+            continue;
+        }
+
+        // A fragment hunk that cannot be reconciled with the full snapshot is
+        // less trustworthy than the snapshot itself. Dropping it lets the diff
+        // renderer derive correct file-relative line numbers from old/new text.
+        return {
+            ...diff,
+            hunks: undefined,
+        };
+    }
+
+    return {
+        ...diff,
+        old_text: oldSnapshot,
+        new_text: newSnapshot,
+        hunks: rebasedHunks,
+    };
+}
+
 function findTrackedFileForIncomingDiff(
     files: Record<string, TrackedFile>,
     diff: AIFileDiff,
@@ -3873,6 +3986,7 @@ function normalizeIncomingTrackedDiff(
             continue;
         }
 
+        const fragmentOffset = candidate.indexOf(canonicalDiff.old_text);
         const reconstructed = replaceTextExactlyOnce(
             candidate,
             canonicalDiff.old_text,
@@ -3882,7 +3996,7 @@ function normalizeIncomingTrackedDiff(
             continue;
         }
 
-        return {
+        const normalizedDiff = {
             ...canonicalDiff,
             old_text: candidate,
             kind:
@@ -3897,6 +4011,13 @@ function normalizeIncomingTrackedDiff(
                       : reconstructed,
             reversible: true,
         };
+
+        return normalizeFragmentHunksToSnapshot(
+            normalizedDiff,
+            candidate,
+            normalizedDiff.new_text ?? "",
+            fragmentOffset,
+        );
     }
 
     return canonicalDiff;
@@ -3995,16 +4116,15 @@ function consolidateActionLogDiffs(
     diffs: AIFileDiff[],
     workCycleId: string | null | undefined,
     timestamp = Date.now(),
+    options?: { normalized?: boolean },
 ): AIChatSession {
     if (!workCycleId || diffs.length === 0) return session;
     const actionLog = session.actionLog ?? emptyActionLogState();
     const currentFiles = getTrackedFilesForSession(actionLog);
     const vaultPath = session.vaultPath ?? useVaultStore.getState().vaultPath;
-    const normalizedDiffs = normalizeIncomingTrackedDiffs(
-        currentFiles,
-        diffs,
-        vaultPath,
-    );
+    const normalizedDiffs = options?.normalized
+        ? diffs
+        : normalizeIncomingTrackedDiffs(currentFiles, diffs, vaultPath);
     const nextFiles = consolidateTrackedFiles(
         currentFiles,
         normalizedDiffs,
@@ -7821,34 +7941,31 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     Boolean(workCycleId);
 
                 const messageId = `tool:${payload.tool_call_id}`;
-                const nextMessage: AIChatMessage = {
-                    id: messageId,
-                    role: "assistant",
-                    kind: "tool",
-                    title: payload.title,
-                    content: payload.summary ?? payload.title,
-                    timestamp: eventTimestamp,
-                    workCycleId: nextSession.activeWorkCycleId,
-                    diffs: payload.diffs,
-                    toolAction: payload.action ?? null,
-                    meta: {
-                        tool: payload.kind,
-                        status: payload.status,
-                        target: payload.target ?? null,
-                    },
-                };
 
                 // Consolidate diffs into ActionLog synchronously from the
                 // accumulated tracked-file state. Delayed precomputed patches
                 // are not allowed to rewrite the domain state.
                 let consolidated = nextSession;
+                let messageDiffs = payload.diffs;
                 if (shouldConsolidate) {
                     consolidated = ensureActionLog(consolidated);
+                    const currentFiles = getTrackedFilesForSession(
+                        consolidated.actionLog,
+                    );
+                    const vaultPath =
+                        consolidated.vaultPath ??
+                        useVaultStore.getState().vaultPath;
+                    messageDiffs = normalizeIncomingTrackedDiffs(
+                        currentFiles,
+                        payload.diffs ?? [],
+                        vaultPath,
+                    );
                     consolidated = consolidateActionLogDiffs(
                         consolidated,
-                        payload.diffs ?? [],
+                        messageDiffs,
                         workCycleId,
                         eventTimestamp,
+                        { normalized: true },
                     );
                     if (!isSessionBusy(nextSession)) {
                         consolidated = finalizeActionLogForWorkCycle(
@@ -7857,6 +7974,23 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         );
                     }
                 }
+
+                const nextMessage: AIChatMessage = {
+                    id: messageId,
+                    role: "assistant",
+                    kind: "tool",
+                    title: payload.title,
+                    content: payload.summary ?? payload.title,
+                    timestamp: eventTimestamp,
+                    workCycleId: nextSession.activeWorkCycleId,
+                    diffs: messageDiffs,
+                    toolAction: payload.action ?? null,
+                    meta: {
+                        tool: payload.kind,
+                        status: payload.status,
+                        target: payload.target ?? null,
+                    },
+                };
 
                 return {
                     sessionsById: {
@@ -8058,13 +8192,26 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     payload.diffs.some(diffCanBeTracked) &&
                     Boolean(workCycleId);
                 let sessionWithBuffer = nextSession;
+                let messageDiffs = payload.diffs;
                 if (hasDiffs) {
                     sessionWithBuffer = ensureActionLog(sessionWithBuffer);
+                    const currentFiles = getTrackedFilesForSession(
+                        sessionWithBuffer.actionLog,
+                    );
+                    const vaultPath =
+                        sessionWithBuffer.vaultPath ??
+                        useVaultStore.getState().vaultPath;
+                    messageDiffs = normalizeIncomingTrackedDiffs(
+                        currentFiles,
+                        payload.diffs,
+                        vaultPath,
+                    );
                     sessionWithBuffer = consolidateActionLogDiffs(
                         sessionWithBuffer,
-                        payload.diffs,
+                        messageDiffs,
                         workCycleId,
                         eventTimestamp,
+                        { normalized: true },
                     );
                 }
 
@@ -8079,7 +8226,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     workCycleId: nextSession.activeWorkCycleId,
                     permissionRequestId: payload.request_id,
                     permissionOptions: payload.options,
-                    diffs: payload.diffs.length > 0 ? payload.diffs : undefined,
+                    diffs: messageDiffs.length > 0 ? messageDiffs : undefined,
                     meta: {
                         status: "pending",
                         target: payload.target ?? null,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -88,6 +88,7 @@ import {
     type ReviewHunkId,
     resolveReviewHunkIdsToExactSpans,
 } from "../diff/reviewProjectionIndex";
+import { deriveChatChangeReviewDiffs } from "../diff/chatChangeReviewModel";
 import {
     type EditorTarget,
     resolveEditorTargetForTrackedPath,
@@ -4085,6 +4086,22 @@ function normalizeIncomingTrackedDiffs(
     );
 }
 
+function deriveMessageReviewDiffs(
+    session: AIChatSession,
+    messageDiffs: AIFileDiff[] | undefined,
+    vaultPath: string | null,
+) {
+    if (!messageDiffs || messageDiffs.length === 0 || !session.actionLog) {
+        return messageDiffs;
+    }
+
+    return deriveChatChangeReviewDiffs(
+        messageDiffs,
+        Object.values(getTrackedFilesForSession(session.actionLog)),
+        vaultPath,
+    );
+}
+
 function summarizeTrackedFileForDebug(file: TrackedFile | null | undefined) {
     if (!file) {
         return null;
@@ -5406,6 +5423,7 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
             permission_request_id: m.permissionRequestId,
             permission_options: m.permissionOptions,
             diffs: m.diffs,
+            review_diffs: m.reviewDiffs,
             user_input_request_id: m.userInputRequestId,
             user_input_questions: m.userInputQuestions,
             plan_entries: m.planEntries,
@@ -5794,6 +5812,7 @@ function restoreMessagesFromHistory(
         permissionRequestId: m.permission_request_id,
         permissionOptions: m.permission_options,
         diffs: m.diffs,
+        reviewDiffs: m.review_diffs,
         userInputRequestId: m.user_input_request_id,
         userInputQuestions: m.user_input_questions,
         planEntries: m.plan_entries,
@@ -7999,6 +8018,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 // are not allowed to rewrite the domain state.
                 let consolidated = nextSession;
                 let messageDiffs = payload.diffs;
+                let reviewDiffs: AIFileDiff[] | undefined;
                 if (shouldConsolidate) {
                     consolidated = ensureActionLog(consolidated);
                     const currentFiles = getTrackedFilesForSession(
@@ -8025,6 +8045,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                             workCycleId,
                         );
                     }
+                    reviewDiffs = deriveMessageReviewDiffs(
+                        consolidated,
+                        messageDiffs,
+                        vaultPath,
+                    );
                 }
 
                 const nextMessage: AIChatMessage = {
@@ -8036,6 +8061,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     timestamp: eventTimestamp,
                     workCycleId: nextSession.activeWorkCycleId,
                     diffs: messageDiffs,
+                    reviewDiffs,
                     toolAction: payload.action ?? null,
                     meta: {
                         tool: payload.kind,
@@ -8245,6 +8271,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     Boolean(workCycleId);
                 let sessionWithBuffer = nextSession;
                 let messageDiffs = payload.diffs;
+                let reviewDiffs: AIFileDiff[] | undefined;
                 if (hasDiffs) {
                     sessionWithBuffer = ensureActionLog(sessionWithBuffer);
                     const currentFiles = getTrackedFilesForSession(
@@ -8265,6 +8292,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         eventTimestamp,
                         { normalized: true },
                     );
+                    reviewDiffs = deriveMessageReviewDiffs(
+                        sessionWithBuffer,
+                        messageDiffs,
+                        vaultPath,
+                    );
                 }
 
                 const messageId = `permission:${payload.request_id}`;
@@ -8279,6 +8311,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     permissionRequestId: payload.request_id,
                     permissionOptions: payload.options,
                     diffs: messageDiffs.length > 0 ? messageDiffs : undefined,
+                    reviewDiffs,
                     meta: {
                         status: "pending",
                         target: payload.target ?? null,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -64,6 +64,7 @@ import {
 } from "./editedFilesBufferModel";
 import {
     applyNonConflictingEdits,
+    buildPatchFromTexts,
     computeRestoreAction,
     consolidateTrackedFiles,
     emptyActionLogState,
@@ -109,6 +110,7 @@ import {
     type AIChatMessageKind,
     type AIFileDiff,
     type AIFileDiffHunk,
+    type AIFileDiffHunkLine,
     type AIChatNoteSummary,
     type AIChatRole,
     type AIChatSession,
@@ -3843,6 +3845,49 @@ function shiftHunkStarts(
     };
 }
 
+function deriveSnapshotDiffHunks(diff: AIFileDiff): AIFileDiffHunk[] {
+    if (
+        typeof diff.old_text !== "string" ||
+        typeof diff.new_text !== "string"
+    ) {
+        return [];
+    }
+
+    const patch = buildPatchFromTexts(diff.old_text, diff.new_text);
+    if (patchIsEmpty(patch)) {
+        return [];
+    }
+
+    const oldLines = diff.old_text.split("\n");
+    const newLines = diff.new_text.split("\n");
+    return patch.edits.map((edit) => {
+        const lines: AIFileDiffHunkLine[] = [];
+        for (let index = edit.oldStart; index < edit.oldEnd; index += 1) {
+            lines.push({ type: "remove", text: oldLines[index] ?? "" });
+        }
+        for (let index = edit.newStart; index < edit.newEnd; index += 1) {
+            lines.push({ type: "add", text: newLines[index] ?? "" });
+        }
+
+        return {
+            old_start: edit.oldStart + 1,
+            old_count: edit.oldEnd - edit.oldStart,
+            new_start: edit.newStart + 1,
+            new_count: edit.newEnd - edit.newStart,
+            lines,
+        };
+    });
+}
+
+function withDerivedSnapshotDiffHunks(diff: AIFileDiff): AIFileDiff {
+    if (diff.hunks && diff.hunks.length > 0) {
+        return diff;
+    }
+
+    const hunks = deriveSnapshotDiffHunks(diff);
+    return hunks.length > 0 ? { ...diff, hunks } : diff;
+}
+
 function normalizeFragmentHunksToSnapshot(
     diff: AIFileDiff,
     oldFragment: string,
@@ -3852,7 +3897,7 @@ function normalizeFragmentHunksToSnapshot(
     fragmentOffset: number,
 ): AIFileDiff {
     if (!diff.hunks || diff.hunks.length === 0) {
-        return diff;
+        return withDerivedSnapshotDiffHunks(diff);
     }
 
     const oldLineOffset = countLinesBeforeOffset(oldSnapshot, fragmentOffset);
@@ -3879,12 +3924,12 @@ function normalizeFragmentHunksToSnapshot(
         }
 
         // A fragment hunk that cannot be reconciled with the full snapshot is
-        // less trustworthy than the snapshot itself. Dropping it lets the diff
-        // renderer derive correct file-relative line numbers from old/new text.
-        return {
+        // less trustworthy than the snapshot itself. Re-derive display hunks
+        // from the normalized snapshot so large-file previews stay anchored.
+        return withDerivedSnapshotDiffHunks({
             ...diff,
             hunks: undefined,
-        };
+        });
     }
 
     return {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -3845,6 +3845,8 @@ function shiftHunkStarts(
 
 function normalizeFragmentHunksToSnapshot(
     diff: AIFileDiff,
+    oldFragment: string,
+    newFragment: string,
     oldSnapshot: string,
     newSnapshot: string,
     fragmentOffset: number,
@@ -3862,14 +3864,17 @@ function normalizeFragmentHunksToSnapshot(
     const rebasedHunks: AIFileDiffHunk[] = [];
 
     for (const hunk of diff.hunks) {
-        if (hunkMatchesTexts(hunk, oldSnapshot, newSnapshot)) {
-            rebasedHunks.push(hunk);
+        const rebased = shiftHunkStarts(hunk, oldLineOffset, newLineOffset);
+        if (
+            hunkMatchesTexts(hunk, oldFragment, newFragment) &&
+            hunkMatchesTexts(rebased, oldSnapshot, newSnapshot)
+        ) {
+            rebasedHunks.push(rebased);
             continue;
         }
 
-        const rebased = shiftHunkStarts(hunk, oldLineOffset, newLineOffset);
-        if (hunkMatchesTexts(rebased, oldSnapshot, newSnapshot)) {
-            rebasedHunks.push(rebased);
+        if (hunkMatchesTexts(hunk, oldSnapshot, newSnapshot)) {
+            rebasedHunks.push(hunk);
             continue;
         }
 
@@ -4014,6 +4019,8 @@ function normalizeIncomingTrackedDiff(
 
         return normalizeFragmentHunksToSnapshot(
             normalizedDiff,
+            canonicalDiff.old_text,
+            nextFragment,
             candidate,
             normalizedDiff.new_text ?? "",
             fragmentOffset,

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -310,6 +310,7 @@ export interface AIChatMessage {
     permissionRequestId?: string;
     permissionOptions?: AIPermissionOption[];
     diffs?: AIFileDiff[];
+    reviewDiffs?: AIFileDiff[];
     userInputRequestId?: string;
     userInputQuestions?: AIUserInputQuestion[];
     planEntries?: AIPlanEntry[];
@@ -634,6 +635,7 @@ export interface PersistedMessage {
     permission_request_id?: string;
     permission_options?: AIPermissionOption[];
     diffs?: AIFileDiff[];
+    review_diffs?: AIFileDiff[];
     user_input_request_id?: string;
     user_input_questions?: AIUserInputQuestion[];
     plan_entries?: AIPlanEntry[];

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -39,6 +39,8 @@ pub struct PersistedMessage {
     pub permission_options: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diffs: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub review_diffs: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_input_request_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1678,6 +1680,7 @@ mod tests {
                     permission_request_id: None,
                     permission_options: None,
                     diffs: None,
+                    review_diffs: None,
                     user_input_request_id: None,
                     user_input_questions: None,
                     plan_entries: None,
@@ -1695,6 +1698,7 @@ mod tests {
                     permission_request_id: None,
                     permission_options: None,
                     diffs: None,
+                    review_diffs: None,
                     user_input_request_id: None,
                     user_input_questions: None,
                     plan_entries: None,
@@ -2143,6 +2147,7 @@ mod tests {
                     permission_request_id: None,
                     permission_options: None,
                     diffs: None,
+                    review_diffs: None,
                     user_input_request_id: None,
                     user_input_questions: None,
                     plan_entries: None,
@@ -2160,6 +2165,7 @@ mod tests {
                     permission_request_id: None,
                     permission_options: None,
                     diffs: None,
+                    review_diffs: None,
                     user_input_request_id: None,
                     user_input_questions: None,
                     plan_entries: None,
@@ -2366,6 +2372,7 @@ mod tests {
             permission_request_id: None,
             permission_options: None,
             diffs: None,
+            review_diffs: None,
             user_input_request_id: None,
             user_input_questions: None,
             plan_entries: None,
@@ -2404,6 +2411,14 @@ mod tests {
                     "new_text": "new line"
                 }
             ])),
+            review_diffs: Some(serde_json::json!([
+                {
+                    "path": "/vault/src/watcher.rs",
+                    "kind": "update",
+                    "old_text": "old line",
+                    "new_text": "review line"
+                }
+            ])),
             user_input_request_id: None,
             user_input_questions: None,
             plan_entries: None,
@@ -2423,6 +2438,7 @@ mod tests {
             permission_request_id: None,
             permission_options: None,
             diffs: None,
+            review_diffs: None,
             user_input_request_id: Some("input-1".to_string()),
             user_input_questions: Some(serde_json::json!([
                 {
@@ -2448,6 +2464,7 @@ mod tests {
             permission_request_id: None,
             permission_options: None,
             diffs: None,
+            review_diffs: None,
             user_input_request_id: None,
             user_input_questions: None,
             plan_entries: Some(serde_json::json!([

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -617,8 +617,8 @@ fn build_claude_structured_patch_hunks_by_content_index(
             .find_map(|(index, candidate)| {
                 if used_candidate_indexes.contains(&index)
                     || candidate.path != path
-                    || candidate.old_text.as_deref() != old_text
-                    || candidate.new_text != diff.new_text
+                    || !claude_old_text_matches(candidate.old_text.as_deref(), old_text)
+                    || !claude_new_text_matches(&candidate.new_text, &diff.new_text)
                 {
                     return None;
                 }
@@ -742,7 +742,7 @@ fn claude_structured_patch_hunk_to_diff_texts(
     let mut new_text = Vec::new();
 
     for line in &hunk.lines {
-        if line == CLAUDE_NO_NEWLINE_MARKER {
+        if claude_marker_text_matches(line) {
             continue;
         }
 
@@ -766,6 +766,36 @@ fn claude_structured_patch_hunk_to_diff_texts(
     Some(((!old_text.is_empty()).then_some(old_text), new_text))
 }
 
+fn claude_marker_text_matches(line: &str) -> bool {
+    line == CLAUDE_NO_NEWLINE_MARKER
+        || line
+            == CLAUDE_NO_NEWLINE_MARKER
+                .strip_prefix('\\')
+                .unwrap_or(CLAUDE_NO_NEWLINE_MARKER)
+}
+
+fn strip_claude_no_newline_marker_lines(text: &str) -> String {
+    text.split('\n')
+        .filter(|line| !claude_marker_text_matches(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn normalize_claude_old_text(text: Option<&str>) -> Option<String> {
+    let normalized = strip_claude_no_newline_marker_lines(text?);
+    (!normalized.is_empty()).then_some(normalized)
+}
+
+fn claude_old_text_matches(candidate: Option<&str>, actual: Option<&str>) -> bool {
+    candidate == actual || normalize_claude_old_text(candidate) == normalize_claude_old_text(actual)
+}
+
+fn claude_new_text_matches(candidate: &str, actual: &str) -> bool {
+    candidate == actual
+        || strip_claude_no_newline_marker_lines(candidate)
+            == strip_claude_no_newline_marker_lines(actual)
+}
+
 fn claude_structured_patch_to_ai_diff_hunks(
     structured_patch: &[ClaudeStructuredPatchHunk],
 ) -> Option<Vec<AiFileDiffHunkPayload>> {
@@ -776,7 +806,7 @@ fn claude_structured_patch_to_ai_diff_hunks(
                 .lines
                 .iter()
                 .filter_map(|raw_line| {
-                    if raw_line == CLAUDE_NO_NEWLINE_MARKER {
+                    if claude_marker_text_matches(raw_line) {
                         return None;
                     }
 
@@ -1241,6 +1271,47 @@ mod tests {
             .status(ToolCallStatus::Completed)
             .content(vec![ToolCallContent::Diff(
                 Diff::new("src/app.ts", "new").old_text("old"),
+            )]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Edit",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 1,
+                            "oldLines": 1,
+                            "newStart": 1,
+                            "newLines": 1,
+                            "lines": [
+                                "-old",
+                                "+new",
+                                "\\ No newline at end of file"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!((hunk.old_start, hunk.new_start), (1, 1));
+        assert_eq!(hunk.lines.len(), 2);
+        assert_eq!(hunk.lines[0].text, "old");
+        assert_eq!(hunk.lines[1].text, "new");
+    }
+
+    #[test]
+    fn claude_structured_patch_matches_content_diff_with_stripped_no_newline_marker() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Edit file")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/app.ts", "new\n No newline at end of file")
+                    .old_text("old\n No newline at end of file"),
             )]);
         call.meta = Some(Meta::from_iter([(
             CLAUDE_CODE_META_KEY.to_string(),

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -193,10 +193,17 @@ impl ToolDiffState {
             return;
         };
 
+        let key = call_key(session_id, tool_call_id);
+        let diffs = vec![diff];
         if let Ok(mut guard) = self.write_diffs.lock() {
-            guard
-                .entry(call_key(session_id, tool_call_id))
-                .or_insert(vec![diff]);
+            let Some(existing) = guard.get(&key).cloned() else {
+                guard.insert(key, diffs);
+                return;
+            };
+
+            if let Some(merged) = reconcile_cached_diffs(&existing, &diffs) {
+                guard.insert(key, merged);
+            }
         }
     }
 
@@ -209,38 +216,13 @@ impl ToolDiffState {
 
         let key = call_key(session_id, &tool_call.tool_call_id.0);
         if let Ok(mut guard) = self.write_diffs.lock() {
-            let incoming_quality = diff_cache_quality(&diffs);
             let Some(existing) = guard.get(&key).cloned() else {
                 guard.insert(key, diffs);
                 return;
             };
-            let existing_quality = diff_cache_quality(&existing);
 
-            if incoming_quality == DiffCacheQuality::Anchored
-                && should_merge_anchored_diffs_into_cached(&existing, &diffs)
-            {
-                guard.insert(
-                    key,
-                    merge_anchored_hunks_into_cached_diffs(&existing, &diffs),
-                );
-                return;
-            }
-            if incoming_quality == DiffCacheQuality::Anchored
-                && existing_quality >= DiffCacheQuality::ReliableSnapshot
-            {
-                // If we cannot safely attach the anchored metadata onto the
-                // canonical snapshot, keep the existing full-text diff intact.
-                return;
-            }
-
-            // Exact anchored hunks are review metadata and must not be blocked
-            // by an earlier weaker diff, but full-text snapshots still own the
-            // canonical old/new text used for accept/reject safety.
-            if incoming_quality > existing_quality
-                || (incoming_quality == DiffCacheQuality::Anchored
-                    && existing_quality == DiffCacheQuality::Anchored)
-            {
-                guard.insert(key, diffs);
+            if let Some(merged) = reconcile_cached_diffs(&existing, &diffs) {
+                guard.insert(key, merged);
             }
         }
     }
@@ -485,6 +467,49 @@ fn diff_payload_quality(diff: &AiFileDiffPayload) -> DiffCacheQuality {
     DiffCacheQuality::Weak
 }
 
+fn reconcile_cached_diffs(
+    existing: &[AiFileDiffPayload],
+    incoming: &[AiFileDiffPayload],
+) -> Option<Vec<AiFileDiffPayload>> {
+    let incoming_quality = diff_cache_quality(incoming);
+    let existing_quality = diff_cache_quality(existing);
+
+    if incoming_quality == DiffCacheQuality::ReliableSnapshot
+        && existing_quality == DiffCacheQuality::Anchored
+    {
+        // Full snapshots are the canonical accept/reject text. Existing exact
+        // hunks are presentation metadata, so keep them only when they still
+        // match inside the incoming snapshot.
+        return Some(merge_anchored_hunks_into_cached_diffs(incoming, existing));
+    }
+
+    if incoming_quality == DiffCacheQuality::Anchored
+        && should_merge_anchored_diffs_into_cached(existing, incoming)
+    {
+        return Some(merge_anchored_hunks_into_cached_diffs(existing, incoming));
+    }
+
+    if incoming_quality == DiffCacheQuality::Anchored
+        && existing_quality >= DiffCacheQuality::ReliableSnapshot
+    {
+        // If we cannot safely attach the anchored metadata onto the canonical
+        // snapshot, keep the existing full-text diff intact.
+        return None;
+    }
+
+    // Exact anchored hunks are review metadata and must not be blocked by an
+    // earlier weaker diff, but full-text snapshots still own the canonical
+    // old/new text used for accept/reject safety.
+    if incoming_quality > existing_quality
+        || (incoming_quality == DiffCacheQuality::Anchored
+            && existing_quality == DiffCacheQuality::Anchored)
+    {
+        return Some(incoming.to_vec());
+    }
+
+    None
+}
+
 fn merge_anchored_hunks_into_cached_diffs(
     cached: &[AiFileDiffPayload],
     anchored: &[AiFileDiffPayload],
@@ -676,9 +701,9 @@ fn read_claude_structured_patch_hunk(
     candidate: &serde_json::Value,
 ) -> Option<ClaudeStructuredPatchHunk> {
     let candidate = candidate.as_object()?;
-    let old_start = read_finite_usize(candidate.get("oldStart")?, 1)?;
+    let old_start = read_finite_usize(candidate.get("oldStart")?, 0)?;
     let old_lines = read_finite_usize(candidate.get("oldLines")?, 0)?;
-    let new_start = read_finite_usize(candidate.get("newStart")?, 1)?;
+    let new_start = read_finite_usize(candidate.get("newStart")?, 0)?;
     let new_lines = read_finite_usize(candidate.get("newLines")?, 0)?;
     let lines = candidate
         .get("lines")?
@@ -1034,7 +1059,10 @@ fn map_diff_payload(
 
 #[cfg(test)]
 mod tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::{
+        sync::atomic::{AtomicU64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    };
 
     use agent_client_protocol::schema::{
         Content, Diff, Meta, ToolCallContent, ToolCallId, ToolCallStatus, ToolCallUpdate,
@@ -1043,12 +1071,15 @@ mod tests {
 
     use super::*;
 
+    static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
     fn unique_temp_dir() -> PathBuf {
         let suffix = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap()
             .as_nanos();
-        std::env::temp_dir().join(format!("neverwrite-tool-diffs-{suffix}"))
+        let counter = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("neverwrite-tool-diffs-{suffix}-{counter}"))
     }
 
     #[test]
@@ -1161,6 +1192,101 @@ mod tests {
     }
 
     #[test]
+    fn claude_structured_patch_preserves_zero_start_lines_for_creation_hunks() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Write file")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(Diff::new(
+                "src/new.ts",
+                "first line",
+            ))]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Write",
+                "toolResponse": {
+                    "filePath": "src/new.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 0,
+                            "oldLines": 0,
+                            "newStart": 0,
+                            "newLines": 1,
+                            "lines": [
+                                "+first line"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!((hunk.old_start, hunk.new_start), (0, 0));
+        assert_eq!((hunk.old_count, hunk.new_count), (0, 1));
+        assert_eq!(hunk.lines[0].r#type, "add");
+        assert_eq!(hunk.lines[0].text, "first line");
+    }
+
+    #[test]
+    fn claude_structured_patch_matches_multiple_identical_content_diffs_by_position() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Edit all matches")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![
+                ToolCallContent::Diff(Diff::new("src/app.ts", "newValue").old_text("oldValue")),
+                ToolCallContent::Diff(Diff::new("src/app.ts", "newValue").old_text("oldValue")),
+            ]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Edit",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 3,
+                            "oldLines": 1,
+                            "newStart": 3,
+                            "newLines": 1,
+                            "lines": [
+                                "-oldValue",
+                                "+newValue"
+                            ]
+                        },
+                        {
+                            "oldStart": 15,
+                            "oldLines": 1,
+                            "newStart": 15,
+                            "newLines": 1,
+                            "lines": [
+                                "-oldValue",
+                                "+newValue"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        assert_eq!(diffs.len(), 2);
+        assert_eq!(
+            diffs
+                .iter()
+                .map(|diff| {
+                    let hunk = diff.hunks.as_ref().unwrap().first().unwrap();
+                    (hunk.old_start, hunk.new_start)
+                })
+                .collect::<Vec<_>>(),
+            vec![(3, 3), (15, 15)]
+        );
+    }
+
+    #[test]
     fn claude_structured_patch_update_attaches_hunks_to_cached_snapshot_diff() {
         let state = ToolDiffState::default();
         state.register_file_baseline(
@@ -1230,6 +1356,78 @@ mod tests {
         );
         let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
         assert_eq!((hunk.old_start, hunk.new_start), (2, 2));
+    }
+
+    #[test]
+    fn reliable_snapshot_replaces_prior_anchored_snippet_and_preserves_hunks() {
+        let state = ToolDiffState::default();
+        state.register_file_baseline(
+            "session-1",
+            "src/app.ts",
+            "header\nalpha\nold\nomega\nfooter".to_string(),
+        );
+
+        let mut anchored = ToolCall::new(ToolCallId::from("tool-write"), "Write app.ts")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/app.ts", "alpha\nnew\nomega").old_text("alpha\nold\nomega"),
+            )]);
+        anchored.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Write",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 2,
+                            "oldLines": 3,
+                            "newStart": 2,
+                            "newLines": 3,
+                            "lines": [
+                                " alpha",
+                                "-old",
+                                "+new",
+                                " omega"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+        let anchored = state.upsert_tool_call("session-1", anchored);
+        let anchored_diffs = state.normalized_diffs_for_tool_call("session-1", &anchored);
+        assert_eq!(
+            anchored_diffs[0].old_text.as_deref(),
+            Some("alpha\nold\nomega")
+        );
+
+        let snapshot_update = ToolCallUpdate::new(
+            "tool-write",
+            ToolCallUpdateFields::new().raw_input(serde_json::json!({
+                "file_path": "src/app.ts",
+                "content": "header\nalpha\nnew\nomega\nfooter",
+            })),
+        );
+
+        let completed = state
+            .apply_tool_update("session-1", snapshot_update)
+            .unwrap();
+        let diffs = state.normalized_diffs_for_tool_call("session-1", &completed);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert_eq!(
+            diffs[0].new_text.as_deref(),
+            Some("header\nalpha\nnew\nomega\nfooter")
+        );
+        let hunks = diffs[0].hunks.as_ref().unwrap();
+        assert_eq!(hunks.len(), 1);
+        assert_eq!((hunks[0].old_start, hunks[0].new_start), (2, 2));
     }
 
     #[test]

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -742,7 +742,7 @@ fn claude_structured_patch_hunk_to_diff_texts(
     let mut new_text = Vec::new();
 
     for line in &hunk.lines {
-        if claude_marker_text_matches(line) {
+        if claude_structured_patch_marker_matches(line) {
             continue;
         }
 
@@ -766,8 +766,12 @@ fn claude_structured_patch_hunk_to_diff_texts(
     Some(((!old_text.is_empty()).then_some(old_text), new_text))
 }
 
-fn claude_marker_text_matches(line: &str) -> bool {
+fn claude_structured_patch_marker_matches(line: &str) -> bool {
     line == CLAUDE_NO_NEWLINE_MARKER
+}
+
+fn claude_diff_text_marker_matches(line: &str) -> bool {
+    claude_structured_patch_marker_matches(line)
         || line
             == CLAUDE_NO_NEWLINE_MARKER
                 .strip_prefix('\\')
@@ -776,7 +780,7 @@ fn claude_marker_text_matches(line: &str) -> bool {
 
 fn strip_claude_no_newline_marker_lines(text: &str) -> String {
     text.split('\n')
-        .filter(|line| !claude_marker_text_matches(line))
+        .filter(|line| !claude_diff_text_marker_matches(line))
         .collect::<Vec<_>>()
         .join("\n")
 }
@@ -806,7 +810,7 @@ fn claude_structured_patch_to_ai_diff_hunks(
                 .lines
                 .iter()
                 .filter_map(|raw_line| {
-                    if claude_marker_text_matches(raw_line) {
+                    if claude_structured_patch_marker_matches(raw_line) {
                         return None;
                     }
 
@@ -1343,6 +1347,48 @@ mod tests {
         assert_eq!(hunk.lines.len(), 2);
         assert_eq!(hunk.lines[0].text, "old");
         assert_eq!(hunk.lines[1].text, "new");
+    }
+
+    #[test]
+    fn claude_structured_patch_preserves_context_line_named_like_no_newline_marker() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Edit file")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/app.ts", "No newline at end of file\nnew")
+                    .old_text("No newline at end of file\nold"),
+            )]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Edit",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 1,
+                            "oldLines": 2,
+                            "newStart": 1,
+                            "newLines": 2,
+                            "lines": [
+                                " No newline at end of file",
+                                "-old",
+                                "+new"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!(hunk.lines.len(), 3);
+        assert_eq!(hunk.lines[0].r#type, "context");
+        assert_eq!(hunk.lines[0].text, "No newline at end of file");
+        assert_eq!(hunk.lines[1].text, "old");
+        assert_eq!(hunk.lines[2].text, "new");
     }
 
     #[test]

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -217,7 +217,7 @@ impl ToolDiffState {
             let existing_quality = diff_cache_quality(&existing);
 
             if incoming_quality == DiffCacheQuality::Anchored
-                && existing_quality == DiffCacheQuality::ReliableSnapshot
+                && should_merge_anchored_diffs_into_cached(&existing, &diffs)
             {
                 guard.insert(
                     key,
@@ -497,13 +497,33 @@ fn merge_anchored_hunks_into_cached_diffs(
             continue;
         };
 
-        cached_diff
-            .hunks
-            .get_or_insert_with(Vec::new)
-            .extend(incoming_hunks.iter().cloned());
+        let merged_hunks =
+            merge_unique_hunks(cached_diff.hunks.as_deref().unwrap_or(&[]), incoming_hunks);
+        cached_diff.hunks = (!merged_hunks.is_empty()).then_some(merged_hunks);
     }
 
     next
+}
+
+fn should_merge_anchored_diffs_into_cached(
+    cached: &[AiFileDiffPayload],
+    anchored: &[AiFileDiffPayload],
+) -> bool {
+    anchored
+        .iter()
+        .filter(|incoming| {
+            incoming
+                .hunks
+                .as_ref()
+                .is_some_and(|hunks| !hunks.is_empty())
+        })
+        .all(|incoming| {
+            cached.iter().any(|candidate| {
+                candidate.path == incoming.path
+                    && candidate.previous_path == incoming.previous_path
+                    && cached_diff_contains_incoming_snippet(candidate, incoming)
+            })
+        })
 }
 
 fn cached_diff_contains_incoming_snippet(
@@ -522,6 +542,21 @@ fn cached_diff_contains_incoming_snippet(
     };
 
     old_matches && new_matches
+}
+
+fn merge_unique_hunks(
+    existing: &[AiFileDiffHunkPayload],
+    incoming: &[AiFileDiffHunkPayload],
+) -> Vec<AiFileDiffHunkPayload> {
+    let mut merged = existing.to_vec();
+
+    for hunk in incoming {
+        if !merged.iter().any(|candidate| candidate == hunk) {
+            merged.push(hunk.clone());
+        }
+    }
+
+    merged
 }
 
 fn build_claude_structured_patch_hunks_by_content_index(
@@ -1188,6 +1223,78 @@ mod tests {
         );
         let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
         assert_eq!((hunk.old_start, hunk.new_start), (2, 2));
+    }
+
+    #[test]
+    fn repeated_claude_structured_patch_updates_preserve_full_snapshot_and_deduplicate_hunks() {
+        let state = ToolDiffState::default();
+        state.register_file_baseline(
+            "session-1",
+            "src/app.ts",
+            "header\nalpha\nold\nomega\nfooter".to_string(),
+        );
+
+        let initial = ToolCall::new(ToolCallId::from("tool-write"), "Write app.ts")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!({
+                "file_path": "src/app.ts",
+                "content": "header\nalpha\nnew\nomega\nfooter",
+            }));
+        state.upsert_tool_call("session-1", initial);
+
+        let make_update = || {
+            let mut update = ToolCallUpdate::new(
+                "tool-write",
+                ToolCallUpdateFields::new()
+                    .status(ToolCallStatus::Completed)
+                    .content(vec![ToolCallContent::Diff(
+                        Diff::new("src/app.ts", "alpha\nnew\nomega").old_text("alpha\nold\nomega"),
+                    )]),
+            );
+            update.meta = Some(Meta::from_iter([(
+                CLAUDE_CODE_META_KEY.to_string(),
+                serde_json::json!({
+                    "toolName": "Write",
+                    "toolResponse": {
+                        "filePath": "src/app.ts",
+                        "structuredPatch": [
+                            {
+                                "oldStart": 2,
+                                "oldLines": 3,
+                                "newStart": 2,
+                                "newLines": 3,
+                                "lines": [
+                                    " alpha",
+                                    "-old",
+                                    "+new",
+                                    " omega"
+                                ]
+                            }
+                        ]
+                    }
+                }),
+            )]));
+            update
+        };
+
+        let first = state.apply_tool_update("session-1", make_update()).unwrap();
+        let second = state.apply_tool_update("session-1", make_update()).unwrap();
+        let diffs = state.normalized_diffs_for_tool_call("session-1", &second);
+
+        assert_eq!(first.tool_call_id.0, second.tool_call_id.0);
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert_eq!(
+            diffs[0].new_text.as_deref(),
+            Some("header\nalpha\nnew\nomega\nfooter")
+        );
+        let hunks = diffs[0].hunks.as_ref().unwrap();
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(hunks[0].lines.len(), 4);
     }
 
     #[test]

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -742,6 +742,10 @@ fn claude_structured_patch_hunk_to_diff_texts(
     let mut new_text = Vec::new();
 
     for line in &hunk.lines {
+        if line == CLAUDE_NO_NEWLINE_MARKER {
+            continue;
+        }
+
         if let Some(text) = line.strip_prefix('-') {
             old_text.push(text.to_string());
         } else if let Some(text) = line.strip_prefix('+') {
@@ -1228,6 +1232,46 @@ mod tests {
         assert_eq!((hunk.old_count, hunk.new_count), (0, 1));
         assert_eq!(hunk.lines[0].r#type, "add");
         assert_eq!(hunk.lines[0].text, "first line");
+    }
+
+    #[test]
+    fn claude_structured_patch_ignores_no_newline_marker_when_matching_content_diff() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Edit file")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/app.ts", "new").old_text("old"),
+            )]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Edit",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 1,
+                            "oldLines": 1,
+                            "newStart": 1,
+                            "newLines": 1,
+                            "lines": [
+                                "-old",
+                                "+new",
+                                "\\ No newline at end of file"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!((hunk.old_start, hunk.new_start), (1, 1));
+        assert_eq!(hunk.lines.len(), 2);
+        assert_eq!(hunk.lines[0].text, "old");
+        assert_eq!(hunk.lines[1].text, "new");
     }
 
     #[test]

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -225,6 +225,13 @@ impl ToolDiffState {
                 );
                 return;
             }
+            if incoming_quality == DiffCacheQuality::Anchored
+                && existing_quality >= DiffCacheQuality::ReliableSnapshot
+            {
+                // If we cannot safely attach the anchored metadata onto the
+                // canonical snapshot, keep the existing full-text diff intact.
+                return;
+            }
 
             // Exact anchored hunks are review metadata and must not be blocked
             // by an earlier weaker diff, but full-text snapshots still own the
@@ -1295,6 +1302,76 @@ mod tests {
         let hunks = diffs[0].hunks.as_ref().unwrap();
         assert_eq!(hunks.len(), 1);
         assert_eq!(hunks[0].lines.len(), 4);
+    }
+
+    #[test]
+    fn unmatched_claude_structured_patch_update_preserves_cached_full_snapshot() {
+        let state = ToolDiffState::default();
+        state.register_file_baseline(
+            "session-1",
+            "src/app.ts",
+            "header\nalpha\nold\nomega\nfooter".to_string(),
+        );
+
+        let initial = ToolCall::new(ToolCallId::from("tool-write"), "Write app.ts")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!({
+                "file_path": "src/app.ts",
+                "content": "header\nalpha\nnew\nomega\nfooter",
+            }));
+        let initial = state.upsert_tool_call("session-1", initial);
+        let initial_diffs = state.normalized_diffs_for_tool_call("session-1", &initial);
+        assert_eq!(
+            initial_diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert!(initial_diffs[0].hunks.is_none());
+
+        let mut update = ToolCallUpdate::new(
+            "tool-write",
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Completed)
+                .content(vec![ToolCallContent::Diff(
+                    Diff::new("src/app.ts", "different\nsnippet").old_text("different\nsource"),
+                )]),
+        );
+        update.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Write",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 20,
+                            "oldLines": 2,
+                            "newStart": 20,
+                            "newLines": 2,
+                            "lines": [
+                                " different",
+                                "-source",
+                                "+snippet"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let completed = state.apply_tool_update("session-1", update).unwrap();
+        let diffs = state.normalized_diffs_for_tool_call("session-1", &completed);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert_eq!(
+            diffs[0].new_text.as_deref(),
+            Some("header\nalpha\nnew\nomega\nfooter")
+        );
+        assert!(diffs[0].hunks.is_none());
     }
 
     #[test]

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     sync::{Arc, Mutex},
@@ -15,6 +15,12 @@ use crate::{AiFileDiffHunkPayload, AiFileDiffPayload};
 const FILE_DELETED_PLACEHOLDER: &str = "[file deleted]";
 const ACP_DIFF_PREVIOUS_PATH_KEY: &str = "neverwritePreviousPath";
 const ACP_DIFF_HUNKS_KEY: &str = "neverwriteHunks";
+const CLAUDE_CODE_META_KEY: &str = "claudeCode";
+const CLAUDE_CODE_TOOL_NAME_KEY: &str = "toolName";
+const CLAUDE_CODE_TOOL_RESPONSE_KEY: &str = "toolResponse";
+const CLAUDE_CODE_STRUCTURED_PATCH_KEY: &str = "structuredPatch";
+const CLAUDE_CODE_FILE_PATH_KEY: &str = "filePath";
+const CLAUDE_NO_NEWLINE_MARKER: &str = "\\ No newline at end of file";
 
 #[derive(Debug, Clone, Default)]
 pub struct ToolDiffState {
@@ -203,24 +209,31 @@ impl ToolDiffState {
 
         let key = call_key(session_id, &tool_call.tool_call_id.0);
         if let Ok(mut guard) = self.write_diffs.lock() {
-            let has_old_text = diffs.iter().any(|diff| diff.old_text.is_some());
-            let existing_is_reliable = guard
-                .get(&key)
-                .map(|cached| {
-                    cached
-                        .iter()
-                        .any(|diff| diff.old_text.is_some() && diff.reversible)
-                })
-                .unwrap_or(false);
+            let incoming_quality = diff_cache_quality(&diffs);
+            let Some(existing) = guard.get(&key).cloned() else {
+                guard.insert(key, diffs);
+                return;
+            };
+            let existing_quality = diff_cache_quality(&existing);
 
-            if existing_is_reliable {
+            if incoming_quality == DiffCacheQuality::Anchored
+                && existing_quality == DiffCacheQuality::ReliableSnapshot
+            {
+                guard.insert(
+                    key,
+                    merge_anchored_hunks_into_cached_diffs(&existing, &diffs),
+                );
                 return;
             }
 
-            if has_old_text {
+            // Exact anchored hunks are review metadata and must not be blocked
+            // by an earlier weaker diff, but full-text snapshots still own the
+            // canonical old/new text used for accept/reject safety.
+            if incoming_quality > existing_quality
+                || (incoming_quality == DiffCacheQuality::Anchored
+                    && existing_quality == DiffCacheQuality::Anchored)
+            {
                 guard.insert(key, diffs);
-            } else {
-                guard.entry(key).or_insert(diffs);
             }
         }
     }
@@ -362,6 +375,30 @@ struct ReadToolInput {
     file_path: String,
 }
 
+#[derive(Debug, Clone)]
+struct ClaudeStructuredPatchHunk {
+    old_start: usize,
+    old_lines: usize,
+    new_start: usize,
+    new_lines: usize,
+    lines: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ClaudeStructuredPatchDiffCandidate {
+    hunk: ClaudeStructuredPatchHunk,
+    new_text: String,
+    old_text: Option<String>,
+    path: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+enum DiffCacheQuality {
+    Weak,
+    ReliableSnapshot,
+    Anchored,
+}
+
 enum ExistingTextSnapshot {
     Missing,
     Text(String),
@@ -369,12 +406,25 @@ enum ExistingTextSnapshot {
 }
 
 pub fn collect_tool_call_diffs(tool_call: &ToolCall, cwd: Option<&Path>) -> Vec<AiFileDiffPayload> {
+    // Claude emits structuredPatch in tool-call meta, while the display diffs
+    // remain regular ToolCallContent::Diff entries. Match them by path + text.
+    let anchored_hunks_by_content_index = build_claude_structured_patch_hunks_by_content_index(
+        &tool_call.content,
+        tool_call.meta.as_ref(),
+        cwd,
+    );
+
     tool_call
         .content
         .iter()
-        .filter_map(|item| match item {
+        .enumerate()
+        .filter_map(|(content_index, item)| match item {
             ToolCallContent::Diff(diff) => {
-                Some(map_diff_payload(diff, tool_call.raw_input.as_ref(), cwd))
+                let mut payload = map_diff_payload(diff, tool_call.raw_input.as_ref(), cwd);
+                if let Some(hunks) = anchored_hunks_by_content_index.get(&content_index) {
+                    payload.hunks = Some(hunks.clone());
+                }
+                Some(payload)
             }
             _ => None,
         })
@@ -406,6 +456,299 @@ fn edit_tool_input(raw_input: Option<&serde_json::Value>) -> Option<EditToolInpu
 
 fn read_tool_input(raw_input: Option<&serde_json::Value>) -> Option<ReadToolInput> {
     serde_json::from_value(raw_input?.clone()).ok()
+}
+
+fn diff_cache_quality(diffs: &[AiFileDiffPayload]) -> DiffCacheQuality {
+    diffs
+        .iter()
+        .map(diff_payload_quality)
+        .max()
+        .unwrap_or(DiffCacheQuality::Weak)
+}
+
+fn diff_payload_quality(diff: &AiFileDiffPayload) -> DiffCacheQuality {
+    if diff.hunks.as_ref().is_some_and(|hunks| !hunks.is_empty()) {
+        return DiffCacheQuality::Anchored;
+    }
+
+    if diff.old_text.is_some() && diff.reversible {
+        return DiffCacheQuality::ReliableSnapshot;
+    }
+
+    DiffCacheQuality::Weak
+}
+
+fn merge_anchored_hunks_into_cached_diffs(
+    cached: &[AiFileDiffPayload],
+    anchored: &[AiFileDiffPayload],
+) -> Vec<AiFileDiffPayload> {
+    let mut next = cached.to_vec();
+
+    for incoming in anchored {
+        let Some(incoming_hunks) = incoming.hunks.as_ref().filter(|hunks| !hunks.is_empty()) else {
+            continue;
+        };
+
+        let Some(cached_diff) = next.iter_mut().find(|candidate| {
+            candidate.path == incoming.path
+                && candidate.previous_path == incoming.previous_path
+                && cached_diff_contains_incoming_snippet(candidate, incoming)
+        }) else {
+            continue;
+        };
+
+        cached_diff
+            .hunks
+            .get_or_insert_with(Vec::new)
+            .extend(incoming_hunks.iter().cloned());
+    }
+
+    next
+}
+
+fn cached_diff_contains_incoming_snippet(
+    cached: &AiFileDiffPayload,
+    incoming: &AiFileDiffPayload,
+) -> bool {
+    let old_matches = match (cached.old_text.as_deref(), incoming.old_text.as_deref()) {
+        (_, None) => true,
+        (Some(cached_text), Some(incoming_text)) => cached_text.contains(incoming_text),
+        (None, Some(_)) => false,
+    };
+    let new_matches = match (cached.new_text.as_deref(), incoming.new_text.as_deref()) {
+        (_, None) => true,
+        (Some(cached_text), Some(incoming_text)) => cached_text.contains(incoming_text),
+        (None, Some(_)) => false,
+    };
+
+    old_matches && new_matches
+}
+
+fn build_claude_structured_patch_hunks_by_content_index(
+    content: &[ToolCallContent],
+    meta: Option<&Meta>,
+    cwd: Option<&Path>,
+) -> HashMap<usize, Vec<AiFileDiffHunkPayload>> {
+    let candidates = read_claude_structured_patch_diff_candidates(meta, cwd);
+    if candidates.is_empty() {
+        return HashMap::new();
+    }
+
+    let mut anchored_hunks_by_content_index = HashMap::new();
+    let mut used_candidate_indexes = HashSet::new();
+
+    for (content_index, entry) in content.iter().enumerate() {
+        let ToolCallContent::Diff(diff) = entry else {
+            continue;
+        };
+
+        let path = to_display_path(&diff.path, cwd);
+        let old_text = diff.old_text.as_deref();
+        let candidate_index = candidates
+            .iter()
+            .enumerate()
+            .find_map(|(index, candidate)| {
+                if used_candidate_indexes.contains(&index)
+                    || candidate.path != path
+                    || candidate.old_text.as_deref() != old_text
+                    || candidate.new_text != diff.new_text
+                {
+                    return None;
+                }
+
+                Some(index)
+            });
+
+        let Some(candidate_index) = candidate_index else {
+            continue;
+        };
+
+        used_candidate_indexes.insert(candidate_index);
+        let candidate = &candidates[candidate_index];
+        if let Some(hunks) = claude_structured_patch_to_ai_diff_hunks(&[candidate.hunk.clone()]) {
+            anchored_hunks_by_content_index.insert(content_index, hunks);
+        }
+    }
+
+    anchored_hunks_by_content_index
+}
+
+fn read_claude_structured_patch_diff_candidates(
+    meta: Option<&Meta>,
+    cwd: Option<&Path>,
+) -> Vec<ClaudeStructuredPatchDiffCandidate> {
+    let Some(claude_code) = meta
+        .and_then(|meta| meta.get(CLAUDE_CODE_META_KEY))
+        .and_then(|value| value.as_object())
+    else {
+        return Vec::new();
+    };
+
+    let tool_name = claude_code
+        .get(CLAUDE_CODE_TOOL_NAME_KEY)
+        .and_then(|value| value.as_str());
+    if !matches!(tool_name, Some("Edit" | "Write")) {
+        return Vec::new();
+    }
+
+    let Some(tool_response) = claude_code
+        .get(CLAUDE_CODE_TOOL_RESPONSE_KEY)
+        .and_then(|value| value.as_object())
+    else {
+        return Vec::new();
+    };
+
+    let Some(file_path) = tool_response
+        .get(CLAUDE_CODE_FILE_PATH_KEY)
+        .and_then(|value| value.as_str())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    else {
+        return Vec::new();
+    };
+
+    let Some(structured_patch) = tool_response
+        .get(CLAUDE_CODE_STRUCTURED_PATCH_KEY)
+        .and_then(|value| value.as_array())
+    else {
+        return Vec::new();
+    };
+
+    let path = to_display_path(&resolve_tool_path(file_path, cwd), cwd);
+    structured_patch
+        .iter()
+        .filter_map(|candidate| {
+            let hunk = read_claude_structured_patch_hunk(candidate)?;
+            let (old_text, new_text) = claude_structured_patch_hunk_to_diff_texts(&hunk)?;
+            Some(ClaudeStructuredPatchDiffCandidate {
+                hunk,
+                new_text,
+                old_text,
+                path: path.clone(),
+            })
+        })
+        .collect()
+}
+
+fn read_claude_structured_patch_hunk(
+    candidate: &serde_json::Value,
+) -> Option<ClaudeStructuredPatchHunk> {
+    let candidate = candidate.as_object()?;
+    let old_start = read_finite_usize(candidate.get("oldStart")?, 1)?;
+    let old_lines = read_finite_usize(candidate.get("oldLines")?, 0)?;
+    let new_start = read_finite_usize(candidate.get("newStart")?, 1)?;
+    let new_lines = read_finite_usize(candidate.get("newLines")?, 0)?;
+    let lines = candidate
+        .get("lines")?
+        .as_array()?
+        .iter()
+        .filter_map(|line| line.as_str().map(str::to_string))
+        .collect();
+
+    Some(ClaudeStructuredPatchHunk {
+        old_start,
+        old_lines,
+        new_start,
+        new_lines,
+        lines,
+    })
+}
+
+fn read_finite_usize(value: &serde_json::Value, minimum: usize) -> Option<usize> {
+    let number = value.as_f64()?;
+    if !number.is_finite() {
+        return None;
+    }
+
+    let clamped = number.trunc().max(minimum as f64);
+    if clamped > usize::MAX as f64 {
+        return None;
+    }
+
+    Some(clamped as usize)
+}
+
+fn claude_structured_patch_hunk_to_diff_texts(
+    hunk: &ClaudeStructuredPatchHunk,
+) -> Option<(Option<String>, String)> {
+    let mut old_text = Vec::new();
+    let mut new_text = Vec::new();
+
+    for line in &hunk.lines {
+        if let Some(text) = line.strip_prefix('-') {
+            old_text.push(text.to_string());
+        } else if let Some(text) = line.strip_prefix('+') {
+            new_text.push(text.to_string());
+        } else {
+            let text = strip_first_char(line).to_string();
+            old_text.push(text.clone());
+            new_text.push(text);
+        }
+    }
+
+    if old_text.is_empty() && new_text.is_empty() {
+        return None;
+    }
+
+    let old_text = old_text.join("\n");
+    let new_text = new_text.join("\n");
+    Some(((!old_text.is_empty()).then_some(old_text), new_text))
+}
+
+fn claude_structured_patch_to_ai_diff_hunks(
+    structured_patch: &[ClaudeStructuredPatchHunk],
+) -> Option<Vec<AiFileDiffHunkPayload>> {
+    let hunks = structured_patch
+        .iter()
+        .filter_map(|hunk| {
+            let lines: Vec<_> = hunk
+                .lines
+                .iter()
+                .filter_map(|raw_line| {
+                    if raw_line == CLAUDE_NO_NEWLINE_MARKER {
+                        return None;
+                    }
+
+                    let (line_type, text) = if let Some(text) = raw_line.strip_prefix('+') {
+                        ("add", text.to_string())
+                    } else if let Some(text) = raw_line.strip_prefix('-') {
+                        ("remove", text.to_string())
+                    } else if let Some(text) = raw_line.strip_prefix(' ') {
+                        ("context", text.to_string())
+                    } else {
+                        ("context", raw_line.clone())
+                    };
+
+                    Some(crate::AiFileDiffHunkLinePayload {
+                        r#type: line_type.to_string(),
+                        text,
+                    })
+                })
+                .collect();
+
+            if lines.is_empty() {
+                return None;
+            }
+
+            Some(AiFileDiffHunkPayload {
+                old_start: hunk.old_start,
+                old_count: hunk.old_lines,
+                new_start: hunk.new_start,
+                new_count: hunk.new_lines,
+                lines,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    (!hunks.is_empty()).then_some(hunks)
+}
+
+fn strip_first_char(value: &str) -> &str {
+    let Some((first_index, _)) = value.char_indices().nth(1) else {
+        return "";
+    };
+
+    &value[first_index..]
 }
 
 fn is_edit_tool_input(raw_input: Option<&serde_json::Value>) -> bool {
@@ -725,6 +1068,126 @@ mod tests {
         let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
         assert_eq!(hunk.old_start, 1);
         assert_eq!(hunk.lines.len(), 2);
+    }
+
+    #[test]
+    fn claude_structured_patch_attaches_anchored_hunks_to_matching_content_diff() {
+        let mut call = ToolCall::new(ToolCallId::from("tool-1"), "Edit file")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![ToolCallContent::Diff(
+                Diff::new("src/app.ts", "alpha\nnew\nomega").old_text("alpha\nold\nomega"),
+            )]);
+        call.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Edit",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 12,
+                            "oldLines": 3,
+                            "newStart": 12,
+                            "newLines": 3,
+                            "lines": [
+                                " alpha",
+                                "-old",
+                                "+new",
+                                " omega"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(diffs[0].old_text.as_deref(), Some("alpha\nold\nomega"));
+        assert_eq!(diffs[0].new_text.as_deref(), Some("alpha\nnew\nomega"));
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!((hunk.old_start, hunk.new_start), (12, 12));
+        assert_eq!((hunk.old_count, hunk.new_count), (3, 3));
+        assert_eq!(hunk.lines[0].r#type, "context");
+        assert_eq!(hunk.lines[0].text, "alpha");
+        assert_eq!(hunk.lines[1].r#type, "remove");
+        assert_eq!(hunk.lines[1].text, "old");
+        assert_eq!(hunk.lines[2].r#type, "add");
+        assert_eq!(hunk.lines[2].text, "new");
+    }
+
+    #[test]
+    fn claude_structured_patch_update_attaches_hunks_to_cached_snapshot_diff() {
+        let state = ToolDiffState::default();
+        state.register_file_baseline(
+            "session-1",
+            "src/app.ts",
+            "header\nalpha\nold\nomega\nfooter".to_string(),
+        );
+
+        let initial = ToolCall::new(ToolCallId::from("tool-write"), "Write app.ts")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!({
+                "file_path": "src/app.ts",
+                "content": "header\nalpha\nnew\nomega\nfooter",
+            }));
+        let initial = state.upsert_tool_call("session-1", initial);
+        let initial_diffs = state.normalized_diffs_for_tool_call("session-1", &initial);
+        assert_eq!(
+            initial_diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert!(initial_diffs[0].hunks.is_none());
+
+        let mut update = ToolCallUpdate::new(
+            "tool-write",
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Completed)
+                .content(vec![ToolCallContent::Diff(
+                    Diff::new("src/app.ts", "alpha\nnew\nomega").old_text("alpha\nold\nomega"),
+                )]),
+        );
+        update.meta = Some(Meta::from_iter([(
+            CLAUDE_CODE_META_KEY.to_string(),
+            serde_json::json!({
+                "toolName": "Write",
+                "toolResponse": {
+                    "filePath": "src/app.ts",
+                    "structuredPatch": [
+                        {
+                            "oldStart": 2,
+                            "oldLines": 3,
+                            "newStart": 2,
+                            "newLines": 3,
+                            "lines": [
+                                " alpha",
+                                "-old",
+                                "+new",
+                                " omega"
+                            ]
+                        }
+                    ]
+                }
+            }),
+        )]));
+
+        let completed = state.apply_tool_update("session-1", update).unwrap();
+        let diffs = state.normalized_diffs_for_tool_call("session-1", &completed);
+
+        assert_eq!(diffs.len(), 1);
+        assert_eq!(
+            diffs[0].old_text.as_deref(),
+            Some("header\nalpha\nold\nomega\nfooter")
+        );
+        assert_eq!(
+            diffs[0].new_text.as_deref(),
+            Some("header\nalpha\nnew\nomega\nfooter")
+        );
+        let hunk = diffs[0].hunks.as_ref().unwrap().first().unwrap();
+        assert_eq!((hunk.old_start, hunk.new_start), (2, 2));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Preserves Claude structured diff hunks and makes chat review snippets render the same focused change the review system sees, without leaking future/accumulated edits into older cards.

## Why

Claude sends precise `structuredPatch` hunk data in `meta.claudeCode.toolResponse`, but the chat was often rendering the raw/broad tool diff instead of the relevant changed hunk. Pending Review already had the more trustworthy tracked-file view, so chat snippets and review cards could disagree.

## Changes

- Extract Claude `structuredPatch` hunks for `Edit` and `Write` tool updates.
- Normalize fragment diffs into file-relative snapshots/hunks so line numbers stay anchored.
- Freeze `reviewDiffs` per chat message and persist them through history restore.
- Keep chat snippets compact by hiding unrelated exact hunk context.
- Preserve Pending Review / accept / reject behavior on the ActionLog source of truth.
- Handle Claude `\\ No newline at end of file` markers without dropping real context lines.

## Validation

- `cargo fmt --package neverwrite-ai`
- `cargo test -p neverwrite-ai tool_diffs --lib`
- `cargo test -p neverwrite-ai --lib`
- `npm test -- src/features/ai/store/chatStore.test.ts`
- `npm test -- src/features/ai/diff/chatChangeReviewModel.test.ts src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/components/editedFilesPresentation.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`

## Manual QA Checklist

- [x] Claude edit of a large Markdown file shows only the relevant changed hunk in the chat snippet, not the whole file.
- [x] Claude delete/edit around high line numbers shows the same line numbers in the chat snippet and Pending Review.
- [x] Same file edited twice in one conversation: the first card stays on the first delta, and the second card shows only the second delta.
- [x] Accept and reject from Pending Review still apply the expected file changes.
- [x] Reload/resume the session after Claude edits: old chat review cards still show their frozen snippets.
- [x] Claude edit on a file without trailing newline still shows anchored hunks instead of falling back to broad diff output.
- [x] Quick Codex/ACP edit smoke test still renders normal snippets and does not regress Pending Review.
