### PR TITLE
Update Codex ACP runtime vendor to 0.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,13 +30,14 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
- "anyhow",
+ "async-process",
+ "blocking",
  "futures",
  "futures-concurrency",
  "jsonrpcmsg",
@@ -45,7 +46,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "shell-words",
  "tokio",
  "tokio-util",
  "tracing",
@@ -54,20 +55,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -326,6 +326,15 @@ dependencies = [
  "futures-io",
  "futures-lite",
  "piper",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -718,7 +727,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2461,7 +2470,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2518,7 +2527,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2741,11 +2750,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -2760,9 +2770,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2873,7 +2883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3004,7 +3014,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3296,7 +3306,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3579,7 +3589,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.7"
 edition = "2021"
 
 [dependencies]
-agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
+agent-client-protocol = { version = "=0.12.1", features = ["unstable"] }
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-async-persistent", "async-io", "crypto-rust"] }
 neverwrite-diff = { path = "../../../crates/diff" }
 neverwrite-ai = { path = "../../../crates/ai" }

--- a/crates/ai/Cargo.toml
+++ b/crates/ai/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
+agent-client-protocol = { version = "=0.12.1", features = ["unstable"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10.9"

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -36,15 +36,20 @@ That means the directory is intentionally reproducible, but not yet minimal.
 ## Current Baselines
 
 - `codex-acp/`
-  - upstream baseline: `zed-industries/codex-acp` `0.12.0`
-  - synced against upstream commit `ee9418a65befdf08c3793d9a92dd4a083f545fcf`
-  - OpenAI Codex Rust crates: `rust-v0.124.0` (`e9fb49366c93a1478ec71cc41ecee415a197d036`)
-  - vendor ACP SDK: `agent-client-protocol` `0.11.1`
+  - upstream baseline: `zed-industries/codex-acp` `0.15.0`
+  - synced against upstream commit `863d433fc91855d0b5427372bf635c894bf68cb6`
+  - latest upstream sync from `0.14.0` brought in 5 commits:
+    `d9bf1c1`, `0c2d828`, `8aef91b`, `f67ca5f`, `863d433`
+  - OpenAI Codex Rust crates: `rust-v0.133.0` (`9474e5cfc4494b0ba319352aa86ce436c59e65c8`)
+  - vendor ACP SDK: `agent-client-protocol` `0.12.1`
+  - upstream snapshot includes `vendor/codex-utils-pty/` plus the matching
+    `[patch."https://github.com/openai/codex"]` entry required by the OpenAI Codex crate graph
   - local NeverWrite delta remains intentionally bounded and currently lives in:
     - `vendor/codex-acp/Cargo.toml`
     - `vendor/codex-acp/src/lib.rs`
     - `vendor/codex-acp/src/codex_agent.rs`
     - `vendor/codex-acp/src/prompt_args.rs`
+    - `vendor/codex-acp/src/subagents.rs`
     - `vendor/codex-acp/src/thread.rs`
 - `Claude-agent-acp-upstream/`
   - vendored snapshot is currently based on `@agentclientprotocol/claude-agent-acp` `0.37.0`
@@ -64,11 +69,12 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - custom slash-prompt expansion and Fast service-tier controls exposed to the desktop UI
 - session-config synchronization from Codex `SessionConfiguredEvent` back into the ACP session config
 - actor lifecycle behavior that does not keep the internal message channel alive after external senders disappear
+- subagent thread projection for collaboration events surfaced through the desktop ACP session
 
-When updating Codex again, treat `ee9418a` plus the current OpenAI Codex crate tag as the comparison base, and review those files intentionally instead of replacing the whole directory blindly.
+When updating Codex again, treat `863d433` plus the current OpenAI Codex crate tag as the comparison base, and review those files intentionally instead of replacing the whole directory blindly.
 
 The desktop backend and `crates/ai` are now aligned with
-`agent-client-protocol = 0.11.1`, matching the vendored Codex ACP runtime.
+`agent-client-protocol = 0.12.1`, matching the vendored Codex ACP runtime.
 The native backend tests cover the reconstructed diff, permission, and status
 metadata paths that NeverWrite depends on.
 

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -198,13 +198,14 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.11.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+checksum = "4361ba6627e51de955b10f3c77fb9eb959c85191a236c1c2c84e32f4ff240faf"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
- "anyhow",
+ "async-process",
+ "blocking",
  "futures",
  "futures-concurrency",
  "jsonrpcmsg",
@@ -213,7 +214,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "shell-words",
  "tokio",
  "tokio-util",
  "tracing",
@@ -222,20 +223,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+checksum = "cabdc9d845d08ec7ed2d0c9de1ae4a1b198301407d55855261572761be90ec9f"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.117",
 ]
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.12.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+checksum = "b957d8391ac3933e2a940446171c508d2b8ffc386d8fa7d0b9c936a2575b463e"
 dependencies = [
  "anyhow",
  "derive_more 2.1.1",
@@ -626,6 +626,7 @@ checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
+ "aws-sdk-signin",
  "aws-sdk-sso",
  "aws-sdk-ssooidc",
  "aws-sdk-sts",
@@ -636,15 +637,20 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "aws-types",
+ "base64-simd",
  "bytes",
  "fastrand",
  "hex",
  "http 1.4.0",
+ "p256",
+ "rand 0.8.6",
  "sha1",
+ "sha2 0.10.9",
  "time",
  "tokio",
  "tracing",
  "url",
+ "uuid",
  "zeroize",
 ]
 
@@ -706,6 +712,30 @@ dependencies = [
  "pin-project-lite",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "aws-sdk-signin"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6c8ee580b0c24a1e16e63efc2d96d0d0e6f9ecfd397818467d247b628a7cad5"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
 ]
 
 [[package]]
@@ -994,6 +1024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1012,8 +1043,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1053,6 +1086,12 @@ dependencies = [
  "rustc-demangle",
  "windows-link",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
@@ -1212,6 +1251,15 @@ checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
@@ -1519,9 +1567,10 @@ checksum = "e9b18233253483ce2f65329a24072ec414db782531bdbb7d0bbc4bd2ce6b7e21"
 
 [[package]]
 name = "codex-acp"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "agent-client-protocol",
+ "allocative",
  "anyhow",
  "clap",
  "codex-apply-patch",
@@ -1529,6 +1578,7 @@ dependencies = [
  "codex-config",
  "codex-core",
  "codex-exec-server",
+ "codex-extension-api",
  "codex-features",
  "codex-login",
  "codex-mcp-server",
@@ -1538,9 +1588,7 @@ dependencies = [
  "codex-utils-approval-presets",
  "codex-utils-cli",
  "diffy",
- "gix-actor",
  "heck",
- "icu_calendar",
  "itertools 0.14.0",
  "regex-lite",
  "serde",
@@ -1556,8 +1604,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "base64",
@@ -1575,8 +1623,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1594,8 +1642,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1614,17 +1662,17 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tracing",
- "tungstenite",
+ "tungstenite 0.27.0",
  "url",
 ]
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -1647,8 +1695,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1662,8 +1710,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1680,8 +1728,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1690,8 +1738,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1703,20 +1751,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-builtin-mcps"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
-dependencies = [
- "anyhow",
- "codex-config",
- "codex-memories-mcp",
- "codex-utils-absolute-path",
-]
-
-[[package]]
 name = "codex-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1741,8 +1778,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -1758,13 +1795,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-config"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1784,17 +1821,19 @@ dependencies = [
  "dunce",
  "futures",
  "gethostname",
+ "indexmap 2.14.0",
  "libc",
  "multimap",
  "prost",
  "schemars 0.8.22",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_path_to_error",
  "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "toml_edit 0.24.1+spec-1.1.0",
  "tonic",
  "tonic-prost",
@@ -1806,19 +1845,22 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol",
  "serde",
+ "serde_json",
+ "sha1",
+ "tracing",
  "urlencoding",
 ]
 
 [[package]]
 name = "codex-core"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1840,6 +1882,7 @@ dependencies = [
  "codex-core-skills",
  "codex-exec-server",
  "codex-execpolicy",
+ "codex-extension-api",
  "codex-features",
  "codex-feedback",
  "codex-git-utils",
@@ -1873,7 +1916,6 @@ dependencies = [
  "codex-utils-path",
  "codex-utils-plugins",
  "codex-utils-pty",
- "codex-utils-readiness",
  "codex-utils-stream-parser",
  "codex-utils-string",
  "codex-utils-template",
@@ -1881,7 +1923,6 @@ dependencies = [
  "csv",
  "dirs",
  "dunce",
- "env-flags",
  "eventsource-stream",
  "futures",
  "http 1.4.0",
@@ -1889,7 +1930,6 @@ dependencies = [
  "image",
  "indexmap 2.14.0",
  "libc",
- "notify",
  "once_cell",
  "openssl-sys",
  "rand 0.9.4",
@@ -1904,9 +1944,9 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "toml_edit 0.24.1+spec-1.1.0",
  "tracing",
  "url",
@@ -1917,8 +1957,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1928,6 +1968,7 @@ dependencies = [
  "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
+ "codex-hooks",
  "codex-login",
  "codex-model-provider",
  "codex-otel",
@@ -1938,13 +1979,14 @@ dependencies = [
  "dirs",
  "flate2",
  "reqwest",
+ "semver",
  "serde",
  "serde_json",
  "tar",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "url",
  "zip",
@@ -1952,8 +1994,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -1975,20 +2017,22 @@ dependencies = [
  "serde_yaml",
  "shlex",
  "tokio",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
  "zip",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "arc-swap",
  "async-trait",
+ "axum",
  "base64",
  "bytes",
+ "codex-api",
  "codex-app-server-protocol",
  "codex-client",
  "codex-file-system",
@@ -1996,23 +2040,25 @@ dependencies = [
  "codex-sandboxing",
  "codex-utils-absolute-path",
  "codex-utils-pty",
+ "codex-utils-rustls-provider",
  "futures",
+ "prost",
  "reqwest",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tokio-util",
+ "toml",
  "tracing",
  "uuid",
 ]
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2027,8 +2073,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2036,22 +2082,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-extension-api"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
+dependencies = [
+ "async-trait",
+ "codex-protocol",
+ "codex-tools",
+]
+
+[[package]]
 name = "codex-features"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-otel",
  "codex-protocol",
  "schemars 0.8.22",
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "tracing",
 ]
 
 [[package]]
 name = "codex-feedback"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -2063,8 +2119,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2078,8 +2134,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-protocol",
@@ -2089,8 +2145,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2113,8 +2169,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2134,9 +2190,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-install-context"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
+dependencies = [
+ "codex-utils-absolute-path",
+ "codex-utils-home-dir",
+]
+
+[[package]]
 name = "codex-keyring-store"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "keyring",
  "tracing",
@@ -2144,10 +2209,11 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "clap",
+ "codex-install-context",
  "codex-process-hardening",
  "codex-protocol",
  "codex-sandboxing",
@@ -2164,8 +2230,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "base64",
@@ -2198,14 +2264,13 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-channel",
  "codex-api",
  "codex-async-utils",
- "codex-builtin-mcps",
  "codex-config",
  "codex-exec-server",
  "codex-login",
@@ -2230,14 +2295,15 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-arg0",
  "codex-config",
  "codex-core",
  "codex-exec-server",
+ "codex-extension-api",
  "codex-login",
  "codex-protocol",
  "codex-utils-cli",
@@ -2253,25 +2319,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-memories-mcp"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
-dependencies = [
- "anyhow",
- "codex-utils-absolute-path",
- "codex-utils-output-truncation",
- "rmcp 0.15.0",
- "schemars 0.8.22",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
-]
-
-[[package]]
 name = "codex-memories-read"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -2283,8 +2333,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "codex-agent-identity",
@@ -2305,8 +2355,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-api",
  "codex-app-server-protocol",
@@ -2318,8 +2368,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2338,8 +2388,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2368,8 +2418,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2392,7 +2442,7 @@ dependencies = [
  "strum_macros 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -2400,8 +2450,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-config",
  "codex-utils-absolute-path",
@@ -2411,16 +2461,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-protocol"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2430,7 +2480,6 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-string",
- "codex-utils-template",
  "encoding_rs",
  "globset",
  "icu_decimal",
@@ -2457,8 +2506,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64",
  "codex-api",
@@ -2468,11 +2517,12 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "axum",
+ "base64",
  "bytes",
  "codex-api",
  "codex-client",
@@ -2502,8 +2552,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2526,12 +2576,13 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "codex-code-mode",
  "codex-protocol",
+ "http 1.4.0",
  "serde",
  "serde_json",
  "tracing",
@@ -2540,8 +2591,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -2557,8 +2608,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64",
  "codex-protocol",
@@ -2576,8 +2627,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2596,8 +2647,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -2606,8 +2657,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2628,16 +2679,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2645,37 +2696,39 @@ dependencies = [
  "codex-protocol",
  "codex-rollout",
  "codex-state",
- "prost",
+ "codex-utils-path",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
- "tonic-prost",
  "tracing",
 ]
 
 [[package]]
 name = "codex-tools"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
+ "async-trait",
  "codex-app-server-protocol",
  "codex-code-mode",
  "codex-features",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-output-truncation",
  "codex-utils-pty",
+ "codex-utils-string",
  "rmcp 0.15.0",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "dirs",
  "dunce",
@@ -2686,16 +2739,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "lru",
  "sha1",
@@ -2704,19 +2757,20 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "clap",
  "codex-protocol",
+ "codex-shell-command",
  "serde",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -2724,8 +2778,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "base64",
  "codex-utils-cache",
@@ -2737,17 +2791,17 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "serde_json",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2755,8 +2809,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -2765,8 +2819,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "codex-exec-server",
  "codex-login",
@@ -2777,8 +2831,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -2792,33 +2845,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "codex-utils-readiness"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
-dependencies = [
- "async-trait",
- "thiserror 2.0.18",
- "time",
- "tokio",
-]
-
-[[package]]
 name = "codex-utils-rustls-provider"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "regex-lite",
  "serde",
@@ -2827,13 +2869,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.129.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.129.0#2808a4deb181e5ca2b1293a1a5980938cb746861"
+version = "0.133.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.133.0#9474e5cfc4494b0ba319352aa86ce436c59e65c8"
 dependencies = [
  "anyhow",
  "base64",
@@ -2853,7 +2895,6 @@ dependencies = [
  "tokio",
  "windows 0.58.0",
  "windows-sys 0.52.0",
- "winres",
 ]
 
 [[package]]
@@ -3116,6 +3157,18 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -3544,9 +3597,9 @@ dependencies = [
 
 [[package]]
 name = "diplomat"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9adb46b05e2f53dcf6a7dfc242e4ce9eb60c369b6b6eb10826a01e93167f59c6"
+checksum = "7935649d00000f5c5d735448ad3dc07b9738160727017914cf42138b8e8e6611"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
@@ -3556,15 +3609,15 @@ dependencies = [
 
 [[package]]
 name = "diplomat-runtime"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0569bd3caaf13829da7ee4e83dbf9197a0e1ecd72772da6d08f0b4c9285c8d29"
+checksum = "970ac38ad677632efcee6d517e783958da9bc78ec206d8d5e35b459ffc5e4864"
 
 [[package]]
 name = "diplomat_core"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51731530ed7f2d4495019abc7df3744f53338e69e2863a6a64ae91821c763df1"
+checksum = "9cf41b94101a4bce993febaf0098092b0bb31deaf0ecaf6e0a2562465f61b383"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3713,6 +3766,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,6 +3810,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468 0.7.0",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3813,12 +3900,6 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
-
-[[package]]
-name = "env-flags"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbfd0e7fc632dec5e6c9396a27bc9f9975b4e039720e1fd3e34021d3ce28c415"
 
 [[package]]
 name = "equivalent"
@@ -3931,6 +4012,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -4083,15 +4174,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fsevent-sys"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "fslock"
@@ -5204,6 +5286,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gzip-header"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5642,9 +5735,9 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.1.1"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
+checksum = "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
@@ -5652,25 +5745,25 @@ dependencies = [
  "icu_locale",
  "icu_locale_core",
  "icu_provider",
- "ixdtf",
  "tinystr",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_calendar_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "527f04223b17edfe0bd43baf14a0cb1b017830db65f3950dc00224860a9a446d"
+checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -5678,14 +5771,16 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a38c52231bc348f9b982c1868a2af3195199623007ba2c7650f432038f5b3e8e"
+checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
 dependencies = [
+ "displaydoc",
  "fixed_decimal",
  "icu_decimal_data",
  "icu_locale",
  "icu_locale_core",
+ "icu_plurals",
  "icu_provider",
  "writeable",
  "zerovec",
@@ -5693,15 +5788,15 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2905b4044eab2dd848fe84199f9195567b63ab3a93094711501363f63546fef7"
+checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
 
 [[package]]
 name = "icu_locale"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5728,15 +5823,15 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c5f1d16b4c3a2642d3a719f18f6b06070ab0aef246a6418130c955ae08aa831"
+checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -5748,15 +5843,34 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_plurals"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+dependencies = [
+ "fixed_decimal",
+ "icu_locale",
+ "icu_plurals_data",
+ "icu_provider",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_plurals_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5768,9 +5882,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
@@ -5937,26 +6051,6 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "inotify"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
-dependencies = [
- "bitflags 2.11.1",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
-name = "inotify-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -6242,26 +6336,6 @@ name = "konst_macro_rules"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
-
-[[package]]
-name = "kqueue"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
-dependencies = [
- "kqueue-sys",
- "libc",
-]
-
-[[package]]
-name = "kqueue-sys"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b65860415f949f23fa882e669f2dbd4a0f0eeb1acdd56790b30494afd7da2f"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
-]
 
 [[package]]
 name = "kstring"
@@ -6823,33 +6897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
-name = "notify"
-version = "8.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
-dependencies = [
- "bitflags 2.11.1",
- "fsevent-sys",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types",
- "walkdir",
- "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "notify-types"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7398,6 +7445,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7691,6 +7750,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -8496,6 +8564,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8907,6 +8985,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "seccompiler"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9153,6 +9245,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9211,11 +9313,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -9230,9 +9333,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.19.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10001,14 +10104,14 @@ dependencies = [
 
 [[package]]
 name = "temporal_capi"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a151e402c2bdb6a3a2a2f3f225eddaead2e7ce7dd5d3fa2090deb11b17aa4ed8"
+checksum = "8a2a1f001e756a9f5f2d175a9965c4c0b3a054f09f30de3a75ab49765f2deb36"
 dependencies = [
  "diplomat",
  "diplomat-runtime",
  "icu_calendar",
- "icu_locale",
+ "icu_locale_core",
  "num-traits",
  "temporal_rs",
  "timezone_provider",
@@ -10018,13 +10121,14 @@ dependencies = [
 
 [[package]]
 name = "temporal_rs"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88afde3bd75d2fc68d77a914bece426aa08aa7649ffd0cdd4a11c3d4d33474d1"
+checksum = "9a902a45282e5175186b21d355efc92564601efe6e2d92818dc9e333d50bd4de"
 dependencies = [
+ "calendrical_calculations",
  "core_maths",
  "icu_calendar",
- "icu_locale",
+ "icu_locale_core",
  "ixdtf",
  "num-traits",
  "timezone_provider",
@@ -10155,9 +10259,9 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.1.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9ba0000e9e73862f3e7ca1ff159e2ddf915c9d8bb11e38a7874760f445d993"
+checksum = "c48f9b04628a2b813051e4dfe97c65281e49625eabd09ec343190e31e399a8c2"
 dependencies = [
  "tinystr",
  "zerotrie",
@@ -10307,7 +10411,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.27.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -10323,15 +10439,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -10654,6 +10761,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10857,9 +10980,9 @@ dependencies = [
 
 [[package]]
 name = "v8"
-version = "146.4.0"
+version = "147.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97bcac5cdc5a195a4813f1855a6bc658f240452aac36caa12fd6c6f16026ab1"
+checksum = "2df8fffd507fb18ed000673a83d937f58e60fb07f3306b2274284125b15137cd"
 dependencies = [
  "bindgen",
  "bitflags 2.11.1",
@@ -11644,15 +11767,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winres"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
-dependencies = [
- "toml 0.5.11",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12036,9 +12150,9 @@ checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zoneinfo64"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2e5597efbe7c421da8a7fd396b20b571704e787c21a272eecf35dfe9d386f0"
+checksum = "ed6eb2607e906160c457fd573e9297e65029669906b9ac8fb1b5cd5e055f0705"
 dependencies = [
  "calendrical_calculations",
  "icu_locale_core",

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-acp"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2024"
 authors = ["Zed <hi@zed.dev>"]
 license = "Apache-2.0"
@@ -18,41 +18,33 @@ name = "codex_acp"
 path = "src/lib.rs"
 
 [dependencies]
-agent-client-protocol = { version = "=0.11.1", features = ["unstable"] }
+agent-client-protocol = { version = "=0.12.1", features = ["unstable"] }
 anyhow = "1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.129.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.133.0" }
+# Pin allocative to 0.3.4 because starlark_map 0.13.0 exposes hashbrown 0.14
+# internals that need allocative's matching hashbrown implementation.
+allocative = "=0.3.4"
 diffy = { version = "0.5.0", features = ["std"] }
-# Pin gix-actor to 0.40.0 because 0.40.1 bumped winnow to 1.0 in what is
-# technically a patch release, which makes it incompatible with gix-object
-# 0.58.0 (reached transitively via gix 0.81.0 -> codex-git-utils). Both crates
-# expose winnow types in their public APIs, so they must agree on the winnow
-# major version. Remove this pin once gix-object publishes a release compatible
-# with winnow 1.0 and the rest of the gix stack has picked it up.
-gix-actor = "=0.40.0"
-# Pin icu_calendar to 2.1.x because 2.2.x broke API compatibility with
-# temporal_rs 0.1.2, which is transitively required by
-# codex-code-mode -> v8 146.4.0 -> temporal_capi 0.1.2 -> temporal_rs ^0.1.2.
-# See https://github.com/boa-dev/temporal/issues/703
-icu_calendar = "~2.1"
 itertools = "0.14.0"
-regex-lite = "0.1"
 serde = { version = "1", features = ["derive"] }
 # codex-cli depends on codex-tui, which enables serde_json/preserve_order; match
 # that behavior here because it affects MCP keychain account hashing.
 serde_json = { version = "1", features = ["preserve_order"] }
+regex-lite = "0.1.9"
 shlex = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "io-std", "io-util"] }
 tokio-util = { version = "0.7", features = ["compat"] }
@@ -70,3 +62,6 @@ unused = "warn"
 [patch.crates-io]
 tokio-tungstenite = { git = "https://github.com/openai-oss-forks/tokio-tungstenite", rev = "132f5b39c862e3a970f731d709608b3e6276d5f6" }
 tungstenite = { git = "https://github.com/openai-oss-forks/tungstenite-rs", rev = "9200079d3b54a1ff51072e24d81fd354f085156f" }
+
+[patch."https://github.com/openai/codex"]
+codex-utils-pty = { path = "vendor/codex-utils-pty" }

--- a/vendor/codex-acp/npm/package.json
+++ b/vendor/codex-acp/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zed-industries/codex-acp",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "type": "module",
   "description": "An ACP-compatible coding agent powered by Codex",
   "license": "Apache-2.0",
@@ -28,11 +28,11 @@
     "bin"
   ],
   "optionalDependencies": {
-    "@zed-industries/codex-acp-darwin-arm64": "0.14.0",
-    "@zed-industries/codex-acp-darwin-x64": "0.14.0",
-    "@zed-industries/codex-acp-linux-arm64": "0.14.0",
-    "@zed-industries/codex-acp-linux-x64": "0.14.0",
-    "@zed-industries/codex-acp-win32-arm64": "0.14.0",
-    "@zed-industries/codex-acp-win32-x64": "0.14.0"
+    "@zed-industries/codex-acp-darwin-arm64": "0.15.0",
+    "@zed-industries/codex-acp-darwin-x64": "0.15.0",
+    "@zed-industries/codex-acp-linux-arm64": "0.15.0",
+    "@zed-industries/codex-acp-linux-x64": "0.15.0",
+    "@zed-industries/codex-acp-win32-arm64": "0.15.0",
+    "@zed-industries/codex-acp-win32-x64": "0.15.0"
   }
 }

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -15,10 +15,13 @@ use agent_client_protocol as acp;
 use codex_config::{McpServerConfig, McpServerTransportConfig};
 use codex_core::{
     NewThread, RolloutRecorder, SortDirection, StateDbHandle, ThreadConfigSnapshot, ThreadManager,
-    ThreadSortKey, config::Config, find_thread_path_by_id_str, init_state_db, parse_cursor,
-    resolve_installation_id, thread_store_from_config,
+    ThreadSortKey,
+    config::{Config, PermissionProfileSnapshot},
+    find_thread_path_by_id_str, init_state_db, parse_cursor, resolve_installation_id,
+    thread_store_from_config,
 };
-use codex_exec_server::{EnvironmentManager, EnvironmentManagerArgs, ExecServerRuntimePaths};
+use codex_exec_server::{EnvironmentManager, ExecServerRuntimePaths};
+use codex_extension_api::empty_extension_registry;
 use codex_login::{
     CODEX_API_KEY_ENV_VAR, OPENAI_API_KEY_ENV_VAR,
     auth::{AuthManager, CodexAuth, read_codex_api_key_from_env, read_openai_api_key_from_env},
@@ -84,12 +87,12 @@ impl CodexAgent {
         let client_capabilities: Arc<Mutex<ClientCapabilities>> = Arc::default();
         let session_roots: Arc<Mutex<HashMap<SessionId, PathBuf>>> = Arc::default();
         let state_db = init_state_db(&config).await;
+        let local_runtime_paths =
+            ExecServerRuntimePaths::new(std::env::current_exe()?, codex_linux_sandbox_exe)?;
         let environment_manager = Arc::new(
-            EnvironmentManager::new(EnvironmentManagerArgs::new(ExecServerRuntimePaths::new(
-                std::env::current_exe()?,
-                codex_linux_sandbox_exe,
-            )?))
-            .await,
+            EnvironmentManager::from_codex_home(&config.codex_home, Some(local_runtime_paths))
+                .await
+                .map_err(std::io::Error::other)?,
         );
         let thread_store = thread_store_from_config(&config, state_db.clone());
         let installation_id = resolve_installation_id(&config.codex_home).await?;
@@ -98,10 +101,12 @@ impl CodexAgent {
             auth_manager.clone(),
             SessionSource::Unknown,
             environment_manager,
+            empty_extension_registry(),
             None,
             thread_store,
             state_db.clone(),
             installation_id,
+            None,
         ));
         Ok(Self {
             auth_manager,
@@ -385,7 +390,6 @@ impl CodexAgent {
         mcp_servers: Vec<McpServer>,
     ) -> Result<Config, Error> {
         let mut config = self.config.clone();
-        config.include_apply_patch_tool = true;
         config.cwd = cwd.try_into().map_err(Error::into_internal_error)?;
         let cwd = config.cwd.clone();
 
@@ -421,6 +425,7 @@ impl CodexAgent {
                             enabled_tools: None,
                             disabled_reason: None,
                             scopes: None,
+                            oauth: None,
                             oauth_resource: None,
                             tools: Default::default(),
                             experimental_environment: None,
@@ -460,6 +465,7 @@ impl CodexAgent {
                             enabled_tools: None,
                             disabled_reason: None,
                             scopes: None,
+                            oauth: None,
                             oauth_resource: None,
                             tools: Default::default(),
                             experimental_environment: None,
@@ -500,7 +506,12 @@ impl CodexAgent {
             .map_err(Error::into_internal_error)?;
         config
             .permissions
-            .set_permission_profile(session_configured.permission_profile.clone())
+            .set_permission_profile_from_session_snapshot(
+                PermissionProfileSnapshot::from_session_snapshot(
+                    session_configured.permission_profile.clone(),
+                    session_configured.active_permission_profile.clone(),
+                ),
+            )
             .map_err(Error::into_internal_error)?;
         Ok(())
     }
@@ -521,7 +532,12 @@ impl CodexAgent {
             .map_err(Error::into_internal_error)?;
         config
             .permissions
-            .set_permission_profile(snapshot.permission_profile.clone())
+            .set_permission_profile_from_session_snapshot(
+                PermissionProfileSnapshot::from_session_snapshot(
+                    snapshot.permission_profile.clone(),
+                    snapshot.active_permission_profile.clone(),
+                ),
+            )
             .map_err(Error::into_internal_error)?;
         Ok(())
     }

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -598,7 +598,9 @@ fn agent_status_label(status: &AgentStatus) -> String {
 mod tests {
     use super::*;
     use codex_protocol::{
-        config_types::ApprovalsReviewer, models::PermissionProfile, openai_models::ReasoningEffort,
+        config_types::{ApprovalsReviewer, CollaborationMode, ModeKind, Settings},
+        models::PermissionProfile,
+        openai_models::ReasoningEffort,
         protocol::AskForApproval,
     };
 
@@ -615,9 +617,20 @@ mod tests {
                 .expect("current dir should be available")
                 .try_into()
                 .expect("current dir should be absolute"),
+            workspace_roots: Vec::new(),
+            profile_workspace_roots: Vec::new(),
             ephemeral: false,
             reasoning_effort: Some(ReasoningEffort::High),
+            reasoning_summary: None,
             personality: None,
+            collaboration_mode: CollaborationMode {
+                mode: ModeKind::Default,
+                settings: Settings {
+                    model: "gpt-5.5".to_string(),
+                    reasoning_effort: Some(ReasoningEffort::High),
+                    developer_instructions: None,
+                },
+            },
             session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
                 parent_thread_id,
                 depth: 1,

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -26,7 +26,7 @@ use agent_client_protocol::{
 use codex_apply_patch::parse_patch;
 use codex_core::{
     CodexThread,
-    config::{Config, set_project_trust_level},
+    config::{Config, PermissionProfileSnapshot, set_project_trust_level},
     review_format::format_review_findings_block,
     review_prompts::user_facing_hint,
 };
@@ -44,8 +44,8 @@ use codex_protocol::protocol::{
     McpToolCallEndEvent, ModelRerouteEvent, Op, PatchApplyBeginEvent, PatchApplyEndEvent,
     PatchApplyStatus, PlanDeltaEvent, ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent,
     ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget, StreamErrorEvent,
-    TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent, TokenCountEvent,
-    TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
+    TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent, ThreadSettingsOverrides,
+    TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
     ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
 };
 use codex_protocol::{
@@ -176,7 +176,7 @@ fn untrusted_read_only_mode_id(config: &Config) -> Option<SessionModeId> {
 }
 
 fn semantic_session_mode_id_for_permission_profile(config: &Config) -> Option<&'static str> {
-    let permission_profile = config.permissions.permission_profile.get();
+    let permission_profile = config.permissions.permission_profile();
 
     match permission_profile {
         PermissionProfile::Managed { .. } => {
@@ -212,7 +212,7 @@ fn current_session_mode_id(config: &Config) -> Option<SessionModeId> {
 
     if let Some(preset) = APPROVAL_PRESETS.iter().find(|preset| {
         approval_matches_current_config(preset, config)
-            && &preset.permission_profile == config.permissions.permission_profile.get()
+            && &preset.permission_profile == config.permissions.permission_profile()
     }) {
         return Some(SessionModeId::new(preset.id));
     }
@@ -337,6 +337,7 @@ enum ThreadMessage {
     },
     PermissionRequestResolved {
         submission_id: String,
+        interaction_id: u64,
         request_key: String,
         response: Result<RequestPermissionResponse, Error>,
     },
@@ -528,21 +529,27 @@ impl SubmissionState {
     async fn handle_permission_request_resolved(
         &mut self,
         client: &SessionClient,
+        interaction_id: u64,
         request_key: String,
         response: Result<RequestPermissionResponse, Error>,
     ) -> Result<(), Error> {
         match self {
             Self::Prompt(state) => {
                 state
-                    .handle_permission_request_resolved(client, request_key, response)
+                    .handle_permission_request_resolved(
+                        client,
+                        interaction_id,
+                        request_key,
+                        response,
+                    )
                     .await
             }
         }
     }
 
-    fn abort_pending_interactions(&mut self) {
+    fn detach_pending_interactions(&mut self) {
         let Self::Prompt(state) = self;
-        state.abort_pending_interactions();
+        state.detach_pending_interactions();
     }
 
     fn fail(&mut self, err: Error) {
@@ -564,8 +571,8 @@ struct ActiveCommand {
 }
 
 struct PendingPermissionInteraction {
+    id: u64,
     request: PendingPermissionRequest,
-    task: tokio::task::JoinHandle<()>,
 }
 
 enum PendingPermissionRequest {
@@ -875,6 +882,7 @@ struct PromptState {
     thread: Arc<dyn CodexThreadImpl>,
     resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
     pending_permission_interactions: HashMap<String, PendingPermissionInteraction>,
+    next_permission_interaction_id: u64,
     event_count: usize,
     response_tx: Option<oneshot::Sender<Result<StopReason, Error>>>,
     seen_message_deltas: bool,
@@ -1035,6 +1043,8 @@ fn format_thread_goal_update(event: &ThreadGoalUpdatedEvent) -> String {
     let status = match event.goal.status {
         ThreadGoalStatus::Active => "active",
         ThreadGoalStatus::Paused => "paused",
+        ThreadGoalStatus::Blocked => "blocked",
+        ThreadGoalStatus::UsageLimited => "usage limited",
         ThreadGoalStatus::BudgetLimited => "budget limited",
         ThreadGoalStatus::Complete => "complete",
     };
@@ -1128,7 +1138,7 @@ fn format_permission_rule(permissions: &RequestPermissionProfile) -> Option<Stri
             file_system
                 .entries
                 .iter()
-                .filter(|entry| entry.access == FileSystemAccessMode::None),
+                .filter(|entry| entry.access == FileSystemAccessMode::Deny),
         );
         if !denies.is_empty() {
             parts.push(format!("deny {denies}"));
@@ -1437,6 +1447,7 @@ impl PromptState {
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
+            next_permission_interaction_id: 0,
             event_count: 0,
             response_tx: Some(response_tx),
             seen_message_deltas: false,
@@ -1459,6 +1470,7 @@ impl PromptState {
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
+            next_permission_interaction_id: 0,
             event_count: 0,
             response_tx: None,
             seen_message_deltas: false,
@@ -1482,36 +1494,37 @@ impl PromptState {
         tool_call: ToolCallUpdate,
         options: Vec<PermissionOption>,
     ) {
+        let interaction_id = self.next_permission_interaction_id;
+        self.next_permission_interaction_id = self.next_permission_interaction_id.wrapping_add(1);
         let client = client.clone();
         let resolution_tx = self.resolution_tx.clone();
         let submission_id = self.submission_id.clone();
         let resolved_request_key = request_key.clone();
-        let handle = tokio::spawn(async move {
+        drop(tokio::spawn(async move {
             let response = client.request_permission(tool_call, options).await;
             drop(
                 resolution_tx.send(ThreadMessage::PermissionRequestResolved {
                     submission_id,
+                    interaction_id,
                     request_key: resolved_request_key,
                     response,
                 }),
             );
-        });
+        }));
 
-        if let Some(interaction) = self.pending_permission_interactions.insert(
+        self.pending_permission_interactions.insert(
             request_key,
             PendingPermissionInteraction {
+                id: interaction_id,
                 request: pending_request,
-                task: handle,
             },
-        ) {
-            interaction.task.abort();
-        }
+        );
     }
 
-    fn abort_pending_interactions(&mut self) {
-        for (_, interaction) in self.pending_permission_interactions.drain() {
-            interaction.task.abort();
-        }
+    fn detach_pending_interactions(&mut self) {
+        // Keep detached permission request tasks running so ACP can route the
+        // client's required `Cancelled` response after session cancellation.
+        self.pending_permission_interactions.clear();
     }
 
     fn fail(&mut self, err: Error) {
@@ -1523,9 +1536,24 @@ impl PromptState {
     async fn handle_permission_request_resolved(
         &mut self,
         _client: &SessionClient,
+        interaction_id: u64,
         request_key: String,
         response: Result<RequestPermissionResponse, Error>,
     ) -> Result<(), Error> {
+        let Some(pending_interaction_id) = self
+            .pending_permission_interactions
+            .get(&request_key)
+            .map(|interaction| interaction.id)
+        else {
+            warn!("Ignoring permission response for unknown request key: {request_key}");
+            return Ok(());
+        };
+
+        if pending_interaction_id != interaction_id {
+            warn!("Ignoring stale permission response for request key: {request_key}");
+            return Ok(());
+        }
+
         let Some(interaction) = self.pending_permission_interactions.remove(&request_key) else {
             warn!("Ignoring permission response for unknown request key: {request_key}");
             return Ok(());
@@ -1871,6 +1899,7 @@ impl PromptState {
                 images: _,
                 text_elements: _,
                 local_images: _,
+                ..
             }) => {
                 info!("User message: {message:?}");
                 if self.project_user_messages {
@@ -2166,7 +2195,7 @@ impl PromptState {
                 client
                     .send_turn_lifecycle(CODEX_ACP_TURN_COMPLETE_EVENT_TYPE, Some(&turn_id))
                     .await;
-                self.abort_pending_interactions();
+                self.detach_pending_interactions();
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx.send(Ok(StopReason::EndTurn)).ok();
                 }
@@ -2198,7 +2227,7 @@ impl PromptState {
                 codex_error_info,
             }) => {
                 error!("Unhandled error during turn: {message} {codex_error_info:?}");
-                self.abort_pending_interactions();
+                self.detach_pending_interactions();
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx
                         .send(Err(Error::internal_error().data(
@@ -2216,7 +2245,7 @@ impl PromptState {
                 client
                     .send_turn_lifecycle(CODEX_ACP_TURN_ABORTED_EVENT_TYPE, turn_id.as_deref())
                     .await;
-                self.abort_pending_interactions();
+                self.detach_pending_interactions();
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx.send(Ok(StopReason::Cancelled)).ok();
                 }
@@ -2226,7 +2255,7 @@ impl PromptState {
                 client
                     .send_turn_lifecycle(CODEX_ACP_SHUTDOWN_COMPLETE_EVENT_TYPE, None)
                     .await;
-                self.abort_pending_interactions();
+                self.detach_pending_interactions();
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx.send(Ok(StopReason::Cancelled)).ok();
                 }
@@ -2382,7 +2411,7 @@ impl PromptState {
             | EventMsg::ThreadRolledBack(..)
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
-            | EventMsg::SkillsUpdateAvailable
+            | EventMsg::ThreadSettingsApplied(..)
             | EventMsg::RawResponseItem(..)
             | EventMsg::SessionConfigured(..)
             | EventMsg::RealtimeConversationStarted(..)
@@ -2631,6 +2660,7 @@ impl PromptState {
             // grant_root doesn't seem to be set anywhere on the codex side
             grant_root: _,
             turn_id: _,
+            ..
         } = event;
         let (title, locations, content) = extract_tool_call_content_from_changes(changes);
         let request_key = patch_request_key(&call_id);
@@ -3861,15 +3891,21 @@ impl<A: Auth> ThreadActor<A> {
             }
             ThreadMessage::PermissionRequestResolved {
                 submission_id,
+                interaction_id,
                 request_key,
                 response,
             } => {
                 if let Some(submission) = self.submissions.get_mut(&submission_id) {
                     if let Err(err) = submission
-                        .handle_permission_request_resolved(&self.client, request_key, response)
+                        .handle_permission_request_resolved(
+                            &self.client,
+                            interaction_id,
+                            request_key,
+                            response,
+                        )
                         .await
                     {
-                        submission.abort_pending_interactions();
+                        submission.detach_pending_interactions();
                         submission.fail(err);
                     }
                     return;
@@ -3883,10 +3919,15 @@ impl<A: Auth> ThreadActor<A> {
                 };
 
                 if let Err(err) = projection
-                    .handle_permission_request_resolved(&self.client, request_key, response)
+                    .handle_permission_request_resolved(
+                        &self.client,
+                        interaction_id,
+                        request_key,
+                        response,
+                    )
                     .await
                 {
-                    projection.abort_pending_interactions();
+                    projection.detach_pending_interactions();
                     projection.fail(err);
                 }
             }
@@ -3995,7 +4036,7 @@ impl<A: Auth> ThreadActor<A> {
         self.config
             .service_tier
             .as_deref()
-            .and_then(|value| serde_json::from_value(value.into()).ok())
+            .and_then(ServiceTier::from_request_value)
     }
 
     fn fast_mode_available(&self) -> bool {
@@ -4208,19 +4249,12 @@ impl<A: Auth> ThreadActor<A> {
         };
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                permission_profile: None,
-                windows_sandbox_level: None,
-                model: Some(model_to_use.clone()),
-                effort: Some(effort_to_use),
-                summary: None,
-                service_tier: None,
-                collaboration_mode: None,
-                personality: None,
+            .submit(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    model: Some(model_to_use.clone()),
+                    effort: Some(effort_to_use),
+                    ..Default::default()
+                },
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
@@ -4256,19 +4290,11 @@ impl<A: Auth> ThreadActor<A> {
         }
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                permission_profile: None,
-                windows_sandbox_level: None,
-                model: None,
-                effort: Some(Some(effort)),
-                summary: None,
-                service_tier: None,
-                collaboration_mode: None,
-                personality: None,
+            .submit(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    effort: Some(Some(effort)),
+                    ..Default::default()
+                },
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
@@ -4290,24 +4316,16 @@ impl<A: Auth> ThreadActor<A> {
         };
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                permission_profile: None,
-                windows_sandbox_level: None,
-                model: None,
-                effort: None,
-                summary: None,
-                service_tier: Some(service_tier.map(|tier| tier.to_string())),
-                collaboration_mode: None,
-                personality: None,
+            .submit(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    service_tier: Some(service_tier.map(|tier| tier.request_value().to_string())),
+                    ..Default::default()
+                },
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
-        self.config.service_tier = service_tier.map(|tier| tier.to_string());
+        self.config.service_tier = service_tier.map(|tier| tier.request_value().to_string());
 
         Ok(())
     }
@@ -4383,6 +4401,7 @@ impl<A: Auth> ThreadActor<A> {
                         }],
                         final_output_json_schema: None,
                         responsesapi_client_metadata: None,
+                        thread_settings: Default::default(),
                     }
                 }
                 "fast" => {
@@ -4510,6 +4529,7 @@ impl<A: Auth> ThreadActor<A> {
                             }],
                             final_output_json_schema: None,
                             responsesapi_client_metadata: None,
+                            thread_settings: Default::default(),
                         }
                     } else {
                         op = Op::UserInput {
@@ -4517,6 +4537,7 @@ impl<A: Auth> ThreadActor<A> {
                             items,
                             final_output_json_schema: None,
                             responsesapi_client_metadata: None,
+                            thread_settings: Default::default(),
                         }
                     }
                 }
@@ -4527,6 +4548,7 @@ impl<A: Auth> ThreadActor<A> {
                 items,
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                thread_settings: Default::default(),
             }
         }
 
@@ -4558,19 +4580,14 @@ impl<A: Auth> ThreadActor<A> {
             .ok_or_else(Error::invalid_params)?;
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: Some(preset.approval),
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                permission_profile: Some(preset.permission_profile.clone()),
-                windows_sandbox_level: None,
-                model: None,
-                effort: None,
-                summary: None,
-                service_tier: None,
-                collaboration_mode: None,
-                personality: None,
+            .submit(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    approval_policy: Some(preset.approval),
+                    permission_profile: Some(preset.permission_profile.clone()),
+                    active_permission_profile: active_profile_id_for_session_mode(preset.id)
+                        .map(ActivePermissionProfile::new),
+                    ..Default::default()
+                },
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
@@ -4582,10 +4599,12 @@ impl<A: Auth> ThreadActor<A> {
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
         self.config
             .permissions
-            .set_permission_profile_with_active_profile(
+            .set_permission_profile_from_session_snapshot(PermissionProfileSnapshot::active(
                 preset.permission_profile.clone(),
-                active_profile_id_for_session_mode(preset.id).map(ActivePermissionProfile::new),
-            )
+                ActivePermissionProfile::new(
+                    active_profile_id_for_session_mode(preset.id).unwrap_or(preset.id),
+                ),
+            ))
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
 
         if mode_trusts_project(preset.id) {
@@ -4622,19 +4641,12 @@ impl<A: Auth> ThreadActor<A> {
         }
 
         self.thread
-            .submit(Op::OverrideTurnContext {
-                cwd: None,
-                approval_policy: None,
-                approvals_reviewer: None,
-                sandbox_policy: None,
-                permission_profile: None,
-                windows_sandbox_level: None,
-                model: Some(model_to_use.clone()),
-                effort: Some(effort_to_use),
-                summary: None,
-                service_tier: None,
-                collaboration_mode: None,
-                personality: None,
+            .submit(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    model: Some(model_to_use.clone()),
+                    effort: Some(effort_to_use),
+                    ..Default::default()
+                },
             })
             .await
             .map_err(|e| Error::from(anyhow::anyhow!(e)))?;
@@ -4646,7 +4658,7 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     async fn handle_cancel(&mut self) -> Result<(), Error> {
-        self.abort_pending_interactions();
+        self.detach_pending_interactions();
         self.thread
             .submit(Op::Interrupt)
             .await
@@ -4655,7 +4667,7 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     async fn handle_shutdown(&mut self) -> Result<(), Error> {
-        self.abort_pending_interactions();
+        self.detach_pending_interactions();
         self.thread
             .submit(Op::Shutdown)
             .await
@@ -4663,9 +4675,12 @@ impl<A: Auth> ThreadActor<A> {
         Ok(())
     }
 
-    fn abort_pending_interactions(&mut self) {
+    fn detach_pending_interactions(&mut self) {
         for submission in self.submissions.values_mut() {
-            submission.abort_pending_interactions();
+            submission.detach_pending_interactions();
+        }
+        for projection in self.event_projections.values_mut() {
+            projection.detach_pending_interactions();
         }
     }
 
@@ -5121,6 +5136,7 @@ fn build_prompt_items(prompt: Vec<ContentBlock>) -> Vec<UserInput> {
             }),
             ContentBlock::Image(image_block) => Some(UserInput::Image {
                 image_url: format!("data:{};base64,{}", image_block.mime_type, image_block.data),
+                detail: None,
             }),
             ContentBlock::ResourceLink(ResourceLink { name, uri, .. }) => Some(UserInput::Text {
                 text: format_uri_as_link(Some(name), uri),
@@ -6010,10 +6026,12 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert!(matches!(
             &ops[0],
-            Op::OverrideTurnContext {
-                service_tier: Some(Some(tier)),
-                ..
-            } if tier == "fast"
+            Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    service_tier: Some(Some(tier)),
+                    ..
+                },
+            } if tier == ServiceTier::Fast.request_value()
         ));
 
         Ok(())
@@ -6058,10 +6076,12 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert!(matches!(
             &ops[0],
-            Op::OverrideTurnContext {
-                service_tier: Some(Some(tier)),
-                ..
-            } if tier == "fast"
+            Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    service_tier: Some(Some(tier)),
+                    ..
+                },
+            } if tier == ServiceTier::Fast.request_value()
         ));
 
         Ok(())
@@ -6134,16 +6154,20 @@ mod tests {
         assert_eq!(ops.len(), 2);
         assert!(matches!(
             &ops[0],
-            Op::OverrideTurnContext {
-                service_tier: Some(Some(tier)),
-                ..
-            } if tier == "fast"
+            Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    service_tier: Some(Some(tier)),
+                    ..
+                },
+            } if tier == ServiceTier::Fast.request_value()
         ));
         assert!(matches!(
             &ops[1],
-            Op::OverrideTurnContext {
-                service_tier: Some(None),
-                ..
+            Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    service_tier: Some(None),
+                    ..
+                },
             }
         ));
 
@@ -6196,6 +6220,7 @@ mod tests {
                 environments: None,
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                thread_settings: Default::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -6484,6 +6509,7 @@ mod tests {
                 environments: None,
                 final_output_json_schema: None,
                 responsesapi_client_metadata: None,
+                thread_settings: Default::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -7159,10 +7185,10 @@ mod tests {
                 .expect("approval policy should update");
             config
                 .permissions
-                .set_permission_profile_with_active_profile(
+                .set_permission_profile_from_session_snapshot(PermissionProfileSnapshot::active(
                     preset.permission_profile.clone(),
-                    Some(ActivePermissionProfile::new(active_profile_id)),
-                )
+                    ActivePermissionProfile::new(active_profile_id),
+                ))
                 .expect("permission profile should update");
 
             assert_eq!(
@@ -7194,9 +7220,11 @@ mod tests {
         );
         assert!(matches!(
             conversation.ops.lock().unwrap().last(),
-            Some(Op::OverrideTurnContext {
-                permission_profile: Some(_),
-                ..
+            Some(Op::ThreadSettings {
+                thread_settings: ThreadSettingsOverrides {
+                    permission_profile: Some(_),
+                    ..
+                },
             })
         ));
 
@@ -7661,7 +7689,7 @@ mod tests {
                             })
                             .unwrap();
                     }
-                    Op::OverrideTurnContext { .. } => {}
+                    Op::ThreadSettings { .. } => {}
                     _ => {
                         unimplemented!()
                     }

--- a/vendor/codex-acp/vendor/codex-utils-pty/BUILD.bazel
+++ b/vendor/codex-acp/vendor/codex-utils-pty/BUILD.bazel
@@ -1,0 +1,6 @@
+load("//:defs.bzl", "codex_rust_crate")
+
+codex_rust_crate(
+    name = "pty",
+    crate_name = "codex_utils_pty",
+)

--- a/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
+++ b/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+edition = "2024"
+license = "Apache-2.0"
+name = "codex-utils-pty"
+version = "0.133.0"
+
+[dependencies]
+anyhow = "1"
+portable-pty = "0.9.0"
+tokio = { version = "1", features = ["io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+pretty_assertions = "1"
+
+[target.'cfg(windows)'.dependencies]
+filedescriptor = "0.8.3"
+lazy_static = "1"
+log = "0.4"
+shared_library = "0.1.9"
+winapi = { version = "0.3.9", features = [
+    "handleapi",
+    "minwinbase",
+    "processthreadsapi",
+    "synchapi",
+    "winbase",
+    "wincon",
+    "winerror",
+    "winnt",
+] }
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
+[lib]
+doctest = false

--- a/vendor/codex-acp/vendor/codex-utils-pty/README.md
+++ b/vendor/codex-acp/vendor/codex-utils-pty/README.md
@@ -1,0 +1,64 @@
+# codex-utils-pty
+
+Lightweight helpers for spawning interactive processes either under a PTY (pseudo terminal) or regular pipes. The public API is minimal and mirrors both backends so callers can switch based on their needs (e.g., enabling or disabling TTY).
+
+## API surface
+
+- `spawn_pty_process(program, args, cwd, env, arg0, size)` → `SpawnedProcess`
+- `spawn_pipe_process(program, args, cwd, env, arg0)` → `SpawnedProcess`
+- `spawn_pipe_process_no_stdin(program, args, cwd, env, arg0)` → `SpawnedProcess`
+- `combine_output_receivers(stdout_rx, stderr_rx)` → `broadcast::Receiver<Vec<u8>>`
+- `conpty_supported()` → `bool` (Windows only; always true elsewhere)
+- `TerminalSize { rows, cols }` selects PTY dimensions in character cells.
+- `ProcessHandle` exposes:
+  - `writer_sender()` → `mpsc::Sender<Vec<u8>>` (stdin)
+  - `resize(TerminalSize)`
+  - `close_stdin()`
+  - `has_exited()`, `exit_code()`, `terminate()`
+- `SpawnedProcess` bundles `session`, `stdout_rx`, `stderr_rx`, and `exit_rx` (oneshot exit code).
+
+## Usage examples
+
+```rust
+use std::collections::HashMap;
+use std::path::Path;
+use codex_utils_pty::combine_output_receivers;
+use codex_utils_pty::spawn_pty_process;
+use codex_utils_pty::TerminalSize;
+
+# tokio_test::block_on(async {
+let env_map: HashMap<String, String> = std::env::vars().collect();
+let spawned = spawn_pty_process(
+    "bash",
+    &["-lc".into(), "echo hello".into()],
+    Path::new("."),
+    &env_map,
+    &None,
+    TerminalSize::default(),
+).await?;
+
+let writer = spawned.session.writer_sender();
+writer.send(b"exit\n".to_vec()).await?;
+
+// Collect output until the process exits.
+let mut output_rx = combine_output_receivers(spawned.stdout_rx, spawned.stderr_rx);
+let mut collected = Vec::new();
+while let Ok(chunk) = output_rx.try_recv() {
+    collected.extend_from_slice(&chunk);
+}
+let exit_code = spawned.exit_rx.await.unwrap_or(-1);
+# let _ = (collected, exit_code);
+# anyhow::Ok(())
+# });
+```
+
+Swap in `spawn_pipe_process` for a non-TTY subprocess; the rest of the API stays the same.
+Use `spawn_pipe_process_no_stdin` to force stdin closed (commands that read stdin will see EOF immediately).
+
+## Tests
+
+Unit tests live in `src/lib.rs` and cover both backends (PTY Python REPL and pipe-based stdin roundtrip). Run with:
+
+```
+cargo test -p codex-utils-pty -- --nocapture
+```

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/lib.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/lib.rs
@@ -1,0 +1,39 @@
+pub mod pipe;
+mod process;
+pub mod process_group;
+pub mod pty;
+#[cfg(test)]
+mod tests;
+#[cfg(windows)]
+mod win;
+
+pub const DEFAULT_OUTPUT_BYTES_CAP: usize = 1024 * 1024;
+
+/// Spawn a non-interactive process using regular pipes for stdin/stdout/stderr.
+pub use pipe::spawn_process as spawn_pipe_process;
+/// Spawn a non-interactive process using regular pipes, but close stdin immediately.
+pub use pipe::spawn_process_no_stdin as spawn_pipe_process_no_stdin;
+/// Driver-backed process adapter used by integrations with their own process transport.
+pub use process::ProcessDriver;
+/// Handle for interacting with a spawned process (PTY or pipe).
+pub use process::ProcessHandle;
+/// Bundle of process handles plus split output and exit receivers returned by spawn helpers.
+pub use process::SpawnedProcess;
+/// Terminal size in character cells used for PTY spawn and resize operations.
+pub use process::TerminalSize;
+/// Combine stdout/stderr receivers into a single broadcast receiver.
+pub use process::combine_output_receivers;
+/// Adapt an externally-driven process into the standard spawned-process handle.
+pub use process::spawn_from_driver;
+/// Backwards-compatible alias for ProcessHandle.
+pub type ExecCommandSession = ProcessHandle;
+/// Backwards-compatible alias for SpawnedProcess.
+pub type SpawnedPty = SpawnedProcess;
+/// Report whether ConPTY is available on this platform (Windows only).
+pub use pty::conpty_supported;
+/// Spawn a process attached to a PTY for interactive use.
+pub use pty::spawn_process as spawn_pty_process;
+#[cfg(windows)]
+pub use win::PsuedoCon;
+#[cfg(windows)]
+pub use win::conpty::RawConPty;

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
@@ -1,0 +1,290 @@
+use std::collections::HashMap;
+use std::io;
+use std::io::ErrorKind;
+use std::path::Path;
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicBool;
+
+use anyhow::Result;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::process::Command;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::process::ChildTerminator;
+use crate::process::ProcessHandle;
+use crate::process::SpawnedProcess;
+
+#[cfg(target_os = "linux")]
+use libc;
+
+struct PipeChildTerminator {
+    #[cfg(windows)]
+    pid: u32,
+    #[cfg(unix)]
+    process_group_id: u32,
+}
+
+impl ChildTerminator for PipeChildTerminator {
+    fn kill(&mut self) -> io::Result<()> {
+        #[cfg(unix)]
+        {
+            crate::process_group::kill_process_group(self.process_group_id)
+        }
+
+        #[cfg(windows)]
+        {
+            kill_process(self.pid)
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            Ok(())
+        }
+    }
+}
+
+#[cfg(windows)]
+fn kill_process(pid: u32) -> io::Result<()> {
+    unsafe {
+        let handle = winapi::um::processthreadsapi::OpenProcess(
+            winapi::um::winnt::PROCESS_TERMINATE,
+            0,
+            pid,
+        );
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let success = winapi::um::processthreadsapi::TerminateProcess(handle, 1);
+        let err = io::Error::last_os_error();
+        winapi::um::handleapi::CloseHandle(handle);
+        if success == 0 { Err(err) } else { Ok(()) }
+    }
+}
+
+async fn read_output_stream<R>(mut reader: R, output_tx: mpsc::Sender<Vec<u8>>)
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buf = vec![0u8; 8_192];
+    loop {
+        match reader.read(&mut buf).await {
+            Ok(0) => break,
+            Ok(n) => {
+                let _ = output_tx.send(buf[..n].to_vec()).await;
+            }
+            Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+            Err(_) => break,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+enum PipeStdinMode {
+    Piped,
+    Null,
+}
+
+async fn spawn_process_with_stdin_mode(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    stdin_mode: PipeStdinMode,
+    inherited_fds: &[i32],
+) -> Result<SpawnedProcess> {
+    if program.is_empty() {
+        anyhow::bail!("missing program for pipe spawn");
+    }
+
+    #[cfg(not(unix))]
+    let _ = inherited_fds;
+
+    let mut command = Command::new(program);
+    #[cfg(unix)]
+    if let Some(arg0) = arg0 {
+        command.arg0(arg0);
+    }
+    #[cfg(target_os = "linux")]
+    let parent_pid = unsafe { libc::getpid() };
+    #[cfg(unix)]
+    let inherited_fds = inherited_fds.to_vec();
+    #[cfg(unix)]
+    unsafe {
+        command.pre_exec(move || {
+            crate::process_group::detach_from_tty()?;
+            #[cfg(target_os = "linux")]
+            crate::process_group::set_parent_death_signal(parent_pid)?;
+            crate::pty::close_inherited_fds_except(&inherited_fds);
+            Ok(())
+        });
+    }
+    #[cfg(not(unix))]
+    let _ = arg0;
+    command.current_dir(cwd);
+    command.env_clear();
+    for (key, value) in env {
+        command.env(key, value);
+    }
+    for arg in args {
+        command.arg(arg);
+    }
+    match stdin_mode {
+        PipeStdinMode::Piped => {
+            command.stdin(Stdio::piped());
+        }
+        PipeStdinMode::Null => {
+            command.stdin(Stdio::null());
+        }
+    }
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    let mut child = command.spawn()?;
+    let pid = child
+        .id()
+        .ok_or_else(|| io::Error::other("missing child pid"))?;
+    #[cfg(unix)]
+    let process_group_id = pid;
+
+    let stdin = child.stdin.take();
+    let stdout = child.stdout.take();
+    let stderr = child.stderr.take();
+
+    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(128);
+    let writer_handle = if let Some(stdin) = stdin {
+        tokio::spawn(async move {
+            let mut writer = stdin;
+            while let Some(bytes) = writer_rx.recv().await {
+                let _ = writer.write_all(&bytes).await;
+                let _ = writer.flush().await;
+            }
+        })
+    } else {
+        drop(writer_rx);
+        tokio::spawn(async {})
+    };
+
+    let stdout_handle = stdout.map(|stdout| {
+        let stdout_tx = stdout_tx.clone();
+        tokio::spawn(async move {
+            read_output_stream(BufReader::new(stdout), stdout_tx).await;
+        })
+    });
+    let stderr_handle = stderr.map(|stderr| {
+        let stderr_tx = stderr_tx.clone();
+        tokio::spawn(async move {
+            read_output_stream(BufReader::new(stderr), stderr_tx).await;
+        })
+    });
+    let mut reader_abort_handles = Vec::new();
+    if let Some(handle) = stdout_handle.as_ref() {
+        reader_abort_handles.push(handle.abort_handle());
+    }
+    if let Some(handle) = stderr_handle.as_ref() {
+        reader_abort_handles.push(handle.abort_handle());
+    }
+    let reader_handle = tokio::spawn(async move {
+        if let Some(handle) = stdout_handle {
+            let _ = handle.await;
+        }
+        if let Some(handle) = stderr_handle {
+            let _ = handle.await;
+        }
+    });
+
+    let (exit_tx, exit_rx) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle: JoinHandle<()> = tokio::spawn(async move {
+        let code = match child.wait().await {
+            Ok(status) => status.code().unwrap_or(-1),
+            Err(_) => -1,
+        };
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_tx.send(code);
+    });
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(PipeChildTerminator {
+            #[cfg(windows)]
+            pid,
+            #[cfg(unix)]
+            process_group_id,
+        }),
+        reader_handle,
+        reader_abort_handles,
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        /*pty_handles*/ None,
+        /*resizer*/ None,
+    );
+
+    Ok(SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    })
+}
+
+/// Spawn a process using regular pipes (no PTY), returning handles for stdin, split output, and exit.
+pub async fn spawn_process(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+) -> Result<SpawnedProcess> {
+    spawn_process_with_stdin_mode(program, args, cwd, env, arg0, PipeStdinMode::Piped, &[]).await
+}
+
+/// Spawn a process using regular pipes, but close stdin immediately.
+pub async fn spawn_process_no_stdin(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+) -> Result<SpawnedProcess> {
+    spawn_process_no_stdin_with_inherited_fds(program, args, cwd, env, arg0, &[]).await
+}
+
+/// Spawn a process using regular pipes, close stdin immediately, and preserve
+/// selected inherited file descriptors across exec on Unix.
+pub async fn spawn_process_no_stdin_with_inherited_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    inherited_fds: &[i32],
+) -> Result<SpawnedProcess> {
+    spawn_process_with_stdin_mode(
+        program,
+        args,
+        cwd,
+        env,
+        arg0,
+        PipeStdinMode::Null,
+        inherited_fds,
+    )
+    .await
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/process.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/process.rs
@@ -1,0 +1,408 @@
+use core::fmt;
+use std::io;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicBool;
+
+use anyhow::anyhow;
+use portable_pty::MasterPty;
+use portable_pty::PtySize;
+use portable_pty::SlavePty;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::sync::watch;
+use tokio::task::AbortHandle;
+use tokio::task::JoinHandle;
+
+pub(crate) trait ChildTerminator: Send + Sync {
+    fn kill(&mut self) -> io::Result<()>;
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TerminalSize {
+    pub rows: u16,
+    pub cols: u16,
+}
+
+impl Default for TerminalSize {
+    fn default() -> Self {
+        Self { rows: 24, cols: 80 }
+    }
+}
+
+impl From<TerminalSize> for PtySize {
+    fn from(value: TerminalSize) -> Self {
+        Self {
+            rows: value.rows,
+            cols: value.cols,
+            pixel_width: 0,
+            pixel_height: 0,
+        }
+    }
+}
+
+#[cfg(unix)]
+pub(crate) trait PtyHandleKeepAlive: Send {}
+
+#[cfg(unix)]
+impl<T: Send + ?Sized> PtyHandleKeepAlive for T {}
+
+pub(crate) enum PtyMasterHandle {
+    Resizable(Box<dyn MasterPty + Send>),
+    #[cfg(unix)]
+    Opaque {
+        raw_fd: RawFd,
+        _handle: Box<dyn PtyHandleKeepAlive>,
+    },
+}
+
+pub struct PtyHandles {
+    pub _slave: Option<Box<dyn SlavePty + Send>>,
+    pub(crate) _master: PtyMasterHandle,
+}
+
+impl fmt::Debug for PtyHandles {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PtyHandles").finish()
+    }
+}
+
+/// Callback used by driver-backed sessions to resize a PTY-like backend when
+/// there is no local `PtyHandles` instance to resize directly.
+type ResizeFn = Box<dyn FnMut(TerminalSize) -> anyhow::Result<()> + Send>;
+
+/// Handle for driving an interactive process (PTY or pipe).
+pub struct ProcessHandle {
+    writer_tx: StdMutex<Option<mpsc::Sender<Vec<u8>>>>,
+    killer: StdMutex<Option<Box<dyn ChildTerminator>>>,
+    reader_handle: StdMutex<Option<JoinHandle<()>>>,
+    reader_abort_handles: StdMutex<Vec<AbortHandle>>,
+    writer_handle: StdMutex<Option<JoinHandle<()>>>,
+    wait_handle: StdMutex<Option<JoinHandle<()>>>,
+    exit_status: Arc<AtomicBool>,
+    exit_code: Arc<StdMutex<Option<i32>>>,
+    // PtyHandles must be preserved because the process will receive Control+C if the
+    // slave is closed
+    _pty_handles: StdMutex<Option<PtyHandles>>,
+    // Optional resize hook for driver-backed sessions that proxy PTY control to
+    // another backend instead of owning local PTY handles.
+    resizer: StdMutex<Option<ResizeFn>>,
+}
+
+impl fmt::Debug for ProcessHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProcessHandle").finish()
+    }
+}
+
+impl ProcessHandle {
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new(
+        writer_tx: mpsc::Sender<Vec<u8>>,
+        killer: Box<dyn ChildTerminator>,
+        reader_handle: JoinHandle<()>,
+        reader_abort_handles: Vec<AbortHandle>,
+        writer_handle: JoinHandle<()>,
+        wait_handle: JoinHandle<()>,
+        exit_status: Arc<AtomicBool>,
+        exit_code: Arc<StdMutex<Option<i32>>>,
+        pty_handles: Option<PtyHandles>,
+        resizer: Option<ResizeFn>,
+    ) -> Self {
+        Self {
+            writer_tx: StdMutex::new(Some(writer_tx)),
+            killer: StdMutex::new(Some(killer)),
+            reader_handle: StdMutex::new(Some(reader_handle)),
+            reader_abort_handles: StdMutex::new(reader_abort_handles),
+            writer_handle: StdMutex::new(Some(writer_handle)),
+            wait_handle: StdMutex::new(Some(wait_handle)),
+            exit_status,
+            exit_code,
+            _pty_handles: StdMutex::new(pty_handles),
+            resizer: StdMutex::new(resizer),
+        }
+    }
+
+    /// Returns a channel sender for writing raw bytes to the child stdin.
+    pub fn writer_sender(&self) -> mpsc::Sender<Vec<u8>> {
+        if let Ok(writer_tx) = self.writer_tx.lock()
+            && let Some(writer_tx) = writer_tx.as_ref()
+        {
+            return writer_tx.clone();
+        }
+
+        let (writer_tx, writer_rx) = mpsc::channel(1);
+        drop(writer_rx);
+        writer_tx
+    }
+
+    /// True if the child process has exited.
+    pub fn has_exited(&self) -> bool {
+        self.exit_status.load(std::sync::atomic::Ordering::SeqCst)
+    }
+
+    /// Returns the exit code if known.
+    pub fn exit_code(&self) -> Option<i32> {
+        self.exit_code.lock().ok().and_then(|guard| *guard)
+    }
+
+    /// Resize the PTY in character cells.
+    pub fn resize(&self, size: TerminalSize) -> anyhow::Result<()> {
+        {
+            let handles = self
+                ._pty_handles
+                .lock()
+                .map_err(|_| anyhow!("failed to lock PTY handles"))?;
+            if let Some(handles) = handles.as_ref() {
+                return match &handles._master {
+                    PtyMasterHandle::Resizable(master) => master.resize(size.into()),
+                    #[cfg(unix)]
+                    PtyMasterHandle::Opaque { raw_fd, .. } => resize_raw_pty(*raw_fd, size),
+                };
+            }
+        }
+
+        let mut resizer = self
+            .resizer
+            .lock()
+            .map_err(|_| anyhow!("failed to lock PTY resizer"))?;
+        if let Some(resizer) = resizer.as_mut() {
+            resizer(size)
+        } else {
+            Err(anyhow!("process is not attached to a PTY"))
+        }
+    }
+
+    /// Close the child's stdin channel.
+    pub fn close_stdin(&self) {
+        if let Ok(mut writer_tx) = self.writer_tx.lock() {
+            writer_tx.take();
+        }
+    }
+
+    /// Attempts to kill the child while leaving the reader/writer tasks alive
+    /// so callers can still drain output until EOF.
+    pub fn request_terminate(&self) {
+        if let Ok(mut killer_opt) = self.killer.lock()
+            && let Some(mut killer) = killer_opt.take()
+        {
+            let _ = killer.kill();
+        }
+    }
+
+    /// Attempts to kill the child and abort helper tasks.
+    pub fn terminate(&self) {
+        self.request_terminate();
+
+        if let Ok(mut h) = self.reader_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+        if let Ok(mut handles) = self.reader_abort_handles.lock() {
+            for handle in handles.drain(..) {
+                handle.abort();
+            }
+        }
+        if let Ok(mut h) = self.writer_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+        if let Ok(mut h) = self.wait_handle.lock()
+            && let Some(handle) = h.take()
+        {
+            handle.abort();
+        }
+    }
+}
+
+impl Drop for ProcessHandle {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+/// Adapts a closure into a `ChildTerminator` implementation.
+struct ClosureTerminator {
+    inner: Option<Box<dyn FnMut() + Send + Sync>>,
+}
+
+impl ChildTerminator for ClosureTerminator {
+    fn kill(&mut self) -> io::Result<()> {
+        if let Some(inner) = self.inner.as_mut() {
+            (inner)();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(unix)]
+fn resize_raw_pty(raw_fd: RawFd, size: TerminalSize) -> anyhow::Result<()> {
+    let mut winsize = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let result = unsafe { libc::ioctl(raw_fd, libc::TIOCSWINSZ, &mut winsize) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+/// Combine split stdout/stderr receivers into a single broadcast receiver.
+pub fn combine_output_receivers(
+    mut stdout_rx: mpsc::Receiver<Vec<u8>>,
+    mut stderr_rx: mpsc::Receiver<Vec<u8>>,
+) -> broadcast::Receiver<Vec<u8>> {
+    let (combined_tx, combined_rx) = broadcast::channel(256);
+    tokio::spawn(async move {
+        let mut stdout_open = true;
+        let mut stderr_open = true;
+
+        loop {
+            tokio::select! {
+                stdout = stdout_rx.recv(), if stdout_open => match stdout {
+                    Some(chunk) => {
+                        let _ = combined_tx.send(chunk);
+                    }
+                    None => {
+                        stdout_open = false;
+                    }
+                },
+                stderr = stderr_rx.recv(), if stderr_open => match stderr {
+                    Some(chunk) => {
+                        let _ = combined_tx.send(chunk);
+                    }
+                    None => {
+                        stderr_open = false;
+                    }
+                },
+                else => break,
+            }
+        }
+    });
+    combined_rx
+}
+
+/// Return value from PTY or pipe spawn helpers.
+#[derive(Debug)]
+pub struct SpawnedProcess {
+    pub session: ProcessHandle,
+    pub stdout_rx: mpsc::Receiver<Vec<u8>>,
+    pub stderr_rx: mpsc::Receiver<Vec<u8>>,
+    pub exit_rx: oneshot::Receiver<i32>,
+}
+
+/// Driver-backed process handles for non-standard spawn backends.
+pub struct ProcessDriver {
+    pub writer_tx: mpsc::Sender<Vec<u8>>,
+    pub stdout_rx: broadcast::Receiver<Vec<u8>>,
+    pub stderr_rx: Option<broadcast::Receiver<Vec<u8>>>,
+    pub exit_rx: oneshot::Receiver<i32>,
+    pub terminator: Option<Box<dyn FnMut() + Send + Sync>>,
+    pub writer_handle: Option<JoinHandle<()>>,
+    pub resizer: Option<ResizeFn>,
+}
+
+/// Build a `SpawnedProcess` from a driver that supplies stdin/output/exit channels.
+pub fn spawn_from_driver(driver: ProcessDriver) -> SpawnedProcess {
+    let ProcessDriver {
+        writer_tx,
+        stdout_rx: stdout_driver_rx,
+        stderr_rx: mut stderr_driver_rx,
+        exit_rx,
+        terminator,
+        writer_handle,
+        resizer,
+    } = driver;
+
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(256);
+    let (stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(256);
+    let (exit_seen_tx, exit_seen_rx) = watch::channel(false);
+    let spawn_stream_reader =
+        |mut output_rx: broadcast::Receiver<Vec<u8>>,
+         output_tx: mpsc::Sender<Vec<u8>>,
+         mut exit_seen_rx: watch::Receiver<bool>| {
+            tokio::spawn(async move {
+                loop {
+                    let recv_result = if *exit_seen_rx.borrow() {
+                        // Once exit has been observed, we no longer want a timer here. Some
+                        // backends publish the exit code before their final stdout/stderr bytes
+                        // have been forwarded through the broadcast channel, so a fixed grace
+                        // period can still drop the tail of the stream under load.
+                        //
+                        // Instead, keep waiting until the driver closes the broadcast sender.
+                        // That makes the shutdown contract explicit: the backend is responsible
+                        // for dropping its sender when it has truly finished forwarding output.
+                        output_rx.recv().await
+                    } else {
+                        tokio::select! {
+                            _ = exit_seen_rx.changed() => {
+                                continue;
+                            }
+                            result = output_rx.recv() => result,
+                        }
+                    };
+                    match recv_result {
+                        Ok(chunk) => {
+                            if output_tx.send(chunk).await.is_err() {
+                                break;
+                            }
+                        }
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+            })
+        };
+    let reader_handle = spawn_stream_reader(stdout_driver_rx, stdout_tx, exit_seen_rx.clone());
+    let stderr_reader_handle = stderr_driver_rx
+        .take()
+        .map(|rx| spawn_stream_reader(rx, stderr_tx, exit_seen_rx));
+
+    let writer_handle = writer_handle.unwrap_or_else(|| tokio::spawn(async {}));
+
+    let (exit_tx, exit_rx_out) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle = tokio::spawn(async move {
+        let code = exit_rx.await.unwrap_or(-1);
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_seen_tx.send(true);
+        let _ = exit_tx.send(code);
+    });
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(ClosureTerminator { inner: terminator }),
+        reader_handle,
+        stderr_reader_handle
+            .map(|handle| handle.abort_handle())
+            .into_iter()
+            .collect(),
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        /*pty_handles*/ None,
+        resizer,
+    );
+
+    SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx: exit_rx_out,
+    }
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/process_group.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/process_group.rs
@@ -1,0 +1,184 @@
+//! Process-group helpers shared by pipe/pty and shell command execution.
+//!
+//! This module centralizes the OS-specific pieces that ensure a spawned
+//! command can be cleaned up reliably:
+//! - `set_process_group` is called in `pre_exec` so the child starts its own
+//!   process group.
+//! - `detach_from_tty` starts a new session so non-interactive children do not
+//!   inherit the controlling TTY.
+//! - `kill_process_group_by_pid` targets the whole group (children/grandchildren)
+//! - `kill_process_group` targets a known process group ID directly
+//!   instead of a single PID.
+//! - `set_parent_death_signal` (Linux only) arranges for the child to receive a
+//!   `SIGTERM` when the parent exits, and re-checks the parent PID to avoid
+//!   races during fork/exec.
+//!
+//! On non-Unix platforms these helpers are no-ops.
+
+use std::io;
+
+use tokio::process::Child;
+
+#[cfg(target_os = "linux")]
+/// Ensure the child receives SIGTERM when the original parent dies.
+///
+/// This should run in `pre_exec` and uses `parent_pid` captured before spawn to
+/// avoid a race where the parent exits between fork and exec.
+pub fn set_parent_death_signal(parent_pid: libc::pid_t) -> io::Result<()> {
+    if unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) } == -1 {
+        return Err(io::Error::last_os_error());
+    }
+
+    if unsafe { libc::getppid() } != parent_pid {
+        unsafe {
+            libc::raise(libc::SIGTERM);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+/// No-op on non-Linux platforms.
+pub fn set_parent_death_signal(_parent_pid: i32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Detach from the controlling TTY by starting a new session.
+pub fn detach_from_tty() -> io::Result<()> {
+    let result = unsafe { libc::setsid() };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.raw_os_error() == Some(libc::EPERM) {
+            return set_process_group();
+        }
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn detach_from_tty() -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Put the calling process into its own process group.
+///
+/// Intended for use in `pre_exec` so the child becomes the group leader.
+pub fn set_process_group() -> io::Result<()> {
+    let result = unsafe { libc::setpgid(0, 0) };
+    if result == -1 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn set_process_group() -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Kill the process group for the given PID (best-effort).
+///
+/// This resolves the PGID for `pid` and sends SIGKILL to the whole group.
+pub fn kill_process_group_by_pid(pid: u32) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    let pid = pid as libc::pid_t;
+    let pgid = unsafe { libc::getpgid(pid) };
+    if pgid == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+        return Ok(());
+    }
+
+    let result = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn kill_process_group_by_pid(_pid: u32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Send SIGTERM to a specific process group ID (best-effort).
+///
+/// Returns `Ok(true)` when SIGTERM was delivered to an existing group and
+/// `Ok(false)` when the group no longer exists.
+pub fn terminate_process_group(process_group_id: u32) -> io::Result<bool> {
+    use std::io::ErrorKind;
+
+    let pgid = process_group_id as libc::pid_t;
+    let result = unsafe { libc::killpg(pgid, libc::SIGTERM) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() == ErrorKind::NotFound {
+            return Ok(false);
+        }
+        return Err(err);
+    }
+
+    Ok(true)
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn terminate_process_group(_process_group_id: u32) -> io::Result<bool> {
+    Ok(false)
+}
+
+#[cfg(unix)]
+/// Kill a specific process group ID (best-effort).
+pub fn kill_process_group(process_group_id: u32) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    let pgid = process_group_id as libc::pid_t;
+    let result = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn kill_process_group(_process_group_id: u32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
+/// Kill the process group for a tokio child (best-effort).
+pub fn kill_child_process_group(child: &mut Child) -> io::Result<()> {
+    if let Some(pid) = child.id() {
+        return kill_process_group_by_pid(pid);
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn kill_child_process_group(_child: &mut Child) -> io::Result<()> {
+    Ok(())
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/pty.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/pty.rs
@@ -1,0 +1,483 @@
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::fs::File;
+use std::io::ErrorKind;
+#[cfg(unix)]
+use std::os::fd::AsRawFd;
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+#[cfg(unix)]
+use std::os::fd::RawFd;
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
+use std::path::Path;
+#[cfg(unix)]
+use std::process::Command as StdCommand;
+#[cfg(unix)]
+use std::process::Stdio;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::atomic::AtomicBool;
+use std::time::Duration;
+
+use anyhow::Result;
+use portable_pty::CommandBuilder;
+#[cfg(not(windows))]
+use portable_pty::native_pty_system;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use crate::process::ChildTerminator;
+use crate::process::ProcessHandle;
+use crate::process::PtyHandles;
+use crate::process::PtyMasterHandle;
+use crate::process::SpawnedProcess;
+use crate::process::TerminalSize;
+
+/// Returns true when ConPTY support is available (Windows only).
+#[cfg(windows)]
+pub fn conpty_supported() -> bool {
+    crate::win::conpty_supported()
+}
+
+/// Returns true when ConPTY support is available (non-Windows always true).
+#[cfg(not(windows))]
+pub fn conpty_supported() -> bool {
+    true
+}
+
+struct PtyChildTerminator {
+    killer: Box<dyn portable_pty::ChildKiller + Send + Sync>,
+    #[cfg(unix)]
+    process_group_id: Option<u32>,
+}
+
+impl ChildTerminator for PtyChildTerminator {
+    fn kill(&mut self) -> std::io::Result<()> {
+        #[cfg(unix)]
+        if let Some(process_group_id) = self.process_group_id {
+            // Match the pipe backend's hard-kill behavior so descendant
+            // processes from interactive shells/REPLs do not survive shutdown.
+            // Also try the direct child killer in case the cached PGID is stale.
+            let process_group_kill_result =
+                crate::process_group::kill_process_group(process_group_id);
+            let child_kill_result = self.killer.kill();
+            return match child_kill_result {
+                Ok(()) => Ok(()),
+                Err(err) if err.kind() == ErrorKind::NotFound => process_group_kill_result,
+                Err(err) => process_group_kill_result.or(Err(err)),
+            };
+        }
+
+        self.killer.kill()
+    }
+}
+
+#[cfg(unix)]
+struct RawPidTerminator {
+    process_group_id: u32,
+}
+
+#[cfg(unix)]
+impl ChildTerminator for RawPidTerminator {
+    fn kill(&mut self) -> std::io::Result<()> {
+        crate::process_group::kill_process_group(self.process_group_id)
+    }
+}
+
+fn platform_native_pty_system() -> Box<dyn portable_pty::PtySystem + Send> {
+    #[cfg(windows)]
+    {
+        Box::new(crate::win::ConPtySystem::default())
+    }
+
+    #[cfg(not(windows))]
+    {
+        native_pty_system()
+    }
+}
+
+/// Spawn a process attached to a PTY, returning handles for stdin, split output, and exit.
+pub async fn spawn_process(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+) -> Result<SpawnedProcess> {
+    spawn_process_with_inherited_fds(program, args, cwd, env, arg0, size, &[]).await
+}
+
+/// Spawn a process attached to a PTY, preserving any inherited file
+/// descriptors listed in `inherited_fds` across exec on Unix.
+pub async fn spawn_process_with_inherited_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+    inherited_fds: &[i32],
+) -> Result<SpawnedProcess> {
+    if program.is_empty() {
+        anyhow::bail!("missing program for PTY spawn");
+    }
+
+    #[cfg(not(unix))]
+    let _ = inherited_fds;
+
+    #[cfg(unix)]
+    if !inherited_fds.is_empty() {
+        return spawn_process_preserving_fds(program, args, cwd, env, arg0, size, inherited_fds)
+            .await;
+    }
+
+    spawn_process_portable(program, args, cwd, env, arg0, size).await
+}
+
+async fn spawn_process_portable(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+) -> Result<SpawnedProcess> {
+    let pty_system = platform_native_pty_system();
+    let pair = pty_system.openpty(size.into())?;
+
+    let mut command_builder = CommandBuilder::new(arg0.as_ref().unwrap_or(&program.to_string()));
+    command_builder.cwd(cwd);
+    command_builder.env_clear();
+    for arg in args {
+        command_builder.arg(arg);
+    }
+    for (key, value) in env {
+        command_builder.env(key, value);
+    }
+
+    let mut child = pair.slave.spawn_command(command_builder)?;
+    #[cfg(unix)]
+    // portable-pty establishes the spawned PTY child as a new session leader on
+    // Unix, so PID == PGID and we can reuse the pipe backend's process-group
+    // hard-kill semantics for descendants.
+    let process_group_id = child.process_id();
+    let killer = child.clone_killer();
+
+    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (_stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(1);
+    let mut reader = pair.master.try_clone_reader()?;
+    let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; 8_192];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = stdout_tx.blocking_send(buf[..n].to_vec());
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let writer = pair.master.take_writer()?;
+    let writer = Arc::new(tokio::sync::Mutex::new(writer));
+    let writer_handle: JoinHandle<()> = tokio::spawn({
+        let writer = Arc::clone(&writer);
+        async move {
+            while let Some(bytes) = writer_rx.recv().await {
+                let mut guard = writer.lock().await;
+                use std::io::Write;
+                let _ = guard.write_all(&bytes);
+                let _ = guard.flush();
+            }
+        }
+    });
+
+    let (exit_tx, exit_rx) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let code = match child.wait() {
+            Ok(status) => status.exit_code() as i32,
+            Err(_) => -1,
+        };
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_tx.send(code);
+    });
+
+    let handles = PtyHandles {
+        _slave: if cfg!(windows) {
+            Some(pair.slave)
+        } else {
+            None
+        },
+        _master: PtyMasterHandle::Resizable(pair.master),
+    };
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(PtyChildTerminator {
+            killer,
+            #[cfg(unix)]
+            process_group_id,
+        }),
+        reader_handle,
+        Vec::new(),
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        Some(handles),
+        /*resizer*/ None,
+    );
+
+    Ok(SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    })
+}
+
+#[cfg(unix)]
+async fn spawn_process_preserving_fds(
+    program: &str,
+    args: &[String],
+    cwd: &Path,
+    env: &HashMap<String, String>,
+    arg0: &Option<String>,
+    size: TerminalSize,
+    inherited_fds: &[RawFd],
+) -> Result<SpawnedProcess> {
+    let (master, slave) = open_unix_pty(size)?;
+    let mut command = StdCommand::new(program);
+    if let Some(arg0) = arg0 {
+        command.arg0(arg0);
+    }
+    command.current_dir(cwd);
+    command.env_clear();
+    for arg in args {
+        command.arg(arg);
+    }
+    for (key, value) in env {
+        command.env(key, value);
+    }
+
+    // The child should see one terminal on all three stdio streams. Cloning
+    // the slave fd gives us three owned handles to the same PTY slave device
+    // so Command can wire them up independently as stdin/stdout/stderr.
+    let stdin = slave.try_clone()?;
+    let stdout = slave.try_clone()?;
+    let stderr = slave.try_clone()?;
+    let inherited_fds = inherited_fds.to_vec();
+
+    unsafe {
+        command
+            .stdin(Stdio::from(stdin))
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .pre_exec(move || {
+                for signo in &[
+                    libc::SIGCHLD,
+                    libc::SIGHUP,
+                    libc::SIGINT,
+                    libc::SIGQUIT,
+                    libc::SIGTERM,
+                    libc::SIGALRM,
+                ] {
+                    libc::signal(*signo, libc::SIG_DFL);
+                }
+
+                let empty_set: libc::sigset_t = std::mem::zeroed();
+                libc::sigprocmask(libc::SIG_SETMASK, &empty_set, std::ptr::null_mut());
+
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
+                // stdin now refers to the PTY slave, so make that fd the
+                // controlling terminal for the child's new session. stdout and
+                // stderr point at clones of the same slave device.
+                #[allow(clippy::cast_lossless)]
+                if libc::ioctl(0, libc::TIOCSCTTY as _, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
+                close_inherited_fds_except(&inherited_fds);
+                Ok(())
+            });
+    }
+
+    let mut child = command.spawn()?;
+    drop(slave);
+    let process_group_id = child.id();
+
+    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (_stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(1);
+    let mut reader = master.try_clone()?;
+    let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let mut buf = [0u8; 8_192];
+        loop {
+            match std::io::Read::read(&mut reader, &mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    let _ = stdout_tx.blocking_send(buf[..n].to_vec());
+                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                    std::thread::sleep(Duration::from_millis(5));
+                    continue;
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let writer = Arc::new(tokio::sync::Mutex::new(master.try_clone()?));
+    let writer_handle: JoinHandle<()> = tokio::spawn({
+        let writer = Arc::clone(&writer);
+        async move {
+            while let Some(bytes) = writer_rx.recv().await {
+                let mut guard = writer.lock().await;
+                use std::io::Write;
+                let _ = guard.write_all(&bytes);
+                let _ = guard.flush();
+            }
+        }
+    });
+
+    let (exit_tx, exit_rx) = oneshot::channel::<i32>();
+    let exit_status = Arc::new(AtomicBool::new(false));
+    let wait_exit_status = Arc::clone(&exit_status);
+    let exit_code = Arc::new(StdMutex::new(None));
+    let wait_exit_code = Arc::clone(&exit_code);
+    let wait_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+        let code = match child.wait() {
+            Ok(status) => status.code().unwrap_or(-1),
+            Err(_) => -1,
+        };
+        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        if let Ok(mut guard) = wait_exit_code.lock() {
+            *guard = Some(code);
+        }
+        let _ = exit_tx.send(code);
+    });
+
+    let handles = PtyHandles {
+        _slave: None,
+        _master: PtyMasterHandle::Opaque {
+            raw_fd: master.as_raw_fd(),
+            _handle: Box::new(master),
+        },
+    };
+
+    let handle = ProcessHandle::new(
+        writer_tx,
+        Box::new(RawPidTerminator { process_group_id }),
+        reader_handle,
+        Vec::new(),
+        writer_handle,
+        wait_handle,
+        exit_status,
+        exit_code,
+        Some(handles),
+        /*resizer*/ None,
+    );
+
+    Ok(SpawnedProcess {
+        session: handle,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    })
+}
+
+#[cfg(unix)]
+fn open_unix_pty(size: TerminalSize) -> Result<(File, File)> {
+    let mut master: RawFd = -1;
+    let mut slave: RawFd = -1;
+    let mut size = libc::winsize {
+        ws_row: size.rows,
+        ws_col: size.cols,
+        ws_xpixel: 0,
+        ws_ypixel: 0,
+    };
+    let winp = std::ptr::addr_of_mut!(size);
+
+    let result = unsafe {
+        libc::openpty(
+            &mut master,
+            &mut slave,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            winp,
+        )
+    };
+    if result != 0 {
+        anyhow::bail!("failed to openpty: {:?}", std::io::Error::last_os_error());
+    }
+
+    set_cloexec(master)?;
+    set_cloexec(slave)?;
+
+    Ok(unsafe { (File::from_raw_fd(master), File::from_raw_fd(slave)) })
+}
+
+#[cfg(unix)]
+fn set_cloexec(fd: RawFd) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFD) };
+    if flags == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFD, flags | libc::FD_CLOEXEC) };
+    if result == -1 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+pub(crate) fn close_inherited_fds_except(preserved_fds: &[RawFd]) {
+    if let Ok(dir) = std::fs::read_dir("/dev/fd") {
+        let mut fds = Vec::new();
+        for entry in dir {
+            let num = entry
+                .ok()
+                .map(|entry| entry.file_name())
+                .and_then(|name| name.into_string().ok())
+                .and_then(|name| name.parse::<RawFd>().ok());
+            if let Some(num) = num {
+                if num <= 2 || preserved_fds.contains(&num) {
+                    continue;
+                }
+                // Keep CLOEXEC descriptors open so std::process can still use
+                // its internal exec-error pipe to report spawn failures.
+                let flags = unsafe { libc::fcntl(num, libc::F_GETFD) };
+                if flags == -1 || flags & libc::FD_CLOEXEC != 0 {
+                    continue;
+                }
+                fds.push(num);
+            }
+        }
+        for fd in fds {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/tests.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/tests.rs
@@ -1,0 +1,1100 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use pretty_assertions::assert_eq;
+
+use crate::ProcessDriver;
+use crate::SpawnedProcess;
+use crate::TerminalSize;
+use crate::combine_output_receivers;
+#[cfg(unix)]
+use crate::pipe::spawn_process_no_stdin_with_inherited_fds;
+#[cfg(unix)]
+use crate::pty::spawn_process_with_inherited_fds;
+use crate::spawn_from_driver;
+use crate::spawn_pipe_process;
+use crate::spawn_pipe_process_no_stdin;
+use crate::spawn_pty_process;
+
+fn find_python() -> Option<String> {
+    for candidate in ["python3", "python"] {
+        if let Ok(output) = std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            && output.status.success()
+        {
+            return Some(candidate.to_string());
+        }
+    }
+    None
+}
+
+fn setsid_available() -> bool {
+    if cfg!(windows) {
+        return false;
+    }
+    std::process::Command::new("setsid")
+        .arg("true")
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+fn shell_command(program: &str) -> (String, Vec<String>) {
+    if cfg!(windows) {
+        let cmd = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+        (cmd, vec!["/C".to_string(), program.to_string()])
+    } else {
+        (
+            "/bin/sh".to_string(),
+            vec!["-c".to_string(), program.to_string()],
+        )
+    }
+}
+
+fn echo_sleep_command(marker: &str) -> String {
+    if cfg!(windows) {
+        format!("echo {marker} & ping -n 2 127.0.0.1 > NUL")
+    } else {
+        format!("echo {marker}; sleep 0.05")
+    }
+}
+
+fn split_stdout_stderr_command() -> String {
+    if cfg!(windows) {
+        // Keep this in cmd.exe syntax so the test does not depend on a runner-local
+        // PowerShell/Python setup just to produce deterministic split output.
+        "(echo split-out)&(>&2 echo split-err)".to_string()
+    } else {
+        "printf 'split-out\\n'; printf 'split-err\\n' >&2".to_string()
+    }
+}
+
+async fn collect_split_output(mut output_rx: tokio::sync::mpsc::Receiver<Vec<u8>>) -> Vec<u8> {
+    let mut collected = Vec::new();
+    while let Some(chunk) = output_rx.recv().await {
+        collected.extend_from_slice(&chunk);
+    }
+    collected
+}
+
+fn combine_spawned_output(
+    spawned: SpawnedProcess,
+) -> (
+    crate::ProcessHandle,
+    tokio::sync::broadcast::Receiver<Vec<u8>>,
+    tokio::sync::oneshot::Receiver<i32>,
+) {
+    let SpawnedProcess {
+        session,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    } = spawned;
+    (
+        session,
+        combine_output_receivers(stdout_rx, stderr_rx),
+        exit_rx,
+    )
+}
+
+async fn collect_output_until_exit(
+    mut output_rx: tokio::sync::broadcast::Receiver<Vec<u8>>,
+    exit_rx: tokio::sync::oneshot::Receiver<i32>,
+    timeout_ms: u64,
+) -> (Vec<u8>, i32) {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    tokio::pin!(exit_rx);
+
+    loop {
+        tokio::select! {
+            res = output_rx.recv() => {
+                if let Ok(chunk) = res {
+                    collected.extend_from_slice(&chunk);
+                }
+            }
+            res = &mut exit_rx => {
+                let code = res.unwrap_or(-1);
+                // On Windows (ConPTY in particular), it's possible to observe the exit notification
+                // before the final bytes are drained from the PTY reader thread. Drain for a brief
+                // "quiet" window to make output assertions deterministic.
+                let (quiet_ms, max_ms) = if cfg!(windows) { (200, 2_000) } else { (50, 500) };
+                let quiet = tokio::time::Duration::from_millis(quiet_ms);
+                let max_deadline =
+                    tokio::time::Instant::now() + tokio::time::Duration::from_millis(max_ms);
+                while tokio::time::Instant::now() < max_deadline {
+                    match tokio::time::timeout(quiet, output_rx.recv()).await {
+                        Ok(Ok(chunk)) => collected.extend_from_slice(&chunk),
+                        Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                        Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
+                        Err(_) => break,
+                    }
+                }
+                return (collected, code);
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                return (collected, -1);
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_output_contains(
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    needle: &str,
+    timeout_ms: u64,
+) -> anyhow::Result<Vec<u8>> {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+
+    while tokio::time::Instant::now() < deadline {
+        let now = tokio::time::Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        match tokio::time::timeout(remaining, output_rx.recv()).await {
+            Ok(Ok(chunk)) => {
+                collected.extend_from_slice(&chunk);
+                if String::from_utf8_lossy(&collected).contains(needle) {
+                    return Ok(collected);
+                }
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                anyhow::bail!(
+                    "PTY output closed while waiting for {needle:?}: {:?}",
+                    String::from_utf8_lossy(&collected)
+                );
+            }
+            Err(_) => break,
+        }
+    }
+
+    anyhow::bail!(
+        "timed out waiting for {needle:?} in PTY output: {:?}",
+        String::from_utf8_lossy(&collected)
+    );
+}
+
+async fn wait_for_python_repl_ready(
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    timeout_ms: u64,
+    ready_marker: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+
+    while tokio::time::Instant::now() < deadline {
+        let now = tokio::time::Instant::now();
+        let remaining = deadline.saturating_duration_since(now);
+        match tokio::time::timeout(remaining, output_rx.recv()).await {
+            Ok(Ok(chunk)) => {
+                collected.extend_from_slice(&chunk);
+                if String::from_utf8_lossy(&collected).contains(ready_marker) {
+                    return Ok(collected);
+                }
+            }
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+            Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                anyhow::bail!(
+                    "PTY output closed while waiting for Python REPL readiness: {:?}",
+                    String::from_utf8_lossy(&collected)
+                );
+            }
+            Err(_) => break,
+        }
+    }
+
+    anyhow::bail!(
+        "timed out waiting for Python REPL readiness marker {ready_marker:?} in PTY: {:?}",
+        String::from_utf8_lossy(&collected)
+    );
+}
+
+#[cfg(unix)]
+async fn wait_for_python_repl_ready_via_probe(
+    writer: &tokio::sync::mpsc::Sender<Vec<u8>>,
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    timeout_ms: u64,
+    newline: &str,
+) -> anyhow::Result<Vec<u8>> {
+    let mut collected = Vec::new();
+    let marker = "__codex_pty_ready__";
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    let probe_window = tokio::time::Duration::from_millis(if cfg!(windows) { 750 } else { 250 });
+
+    while tokio::time::Instant::now() < deadline {
+        writer
+            .send(format!("print('{marker}'){newline}").into_bytes())
+            .await?;
+
+        let probe_deadline = tokio::time::Instant::now() + probe_window;
+        loop {
+            let now = tokio::time::Instant::now();
+            if now >= deadline || now >= probe_deadline {
+                break;
+            }
+            let remaining = std::cmp::min(
+                deadline.saturating_duration_since(now),
+                probe_deadline.saturating_duration_since(now),
+            );
+            match tokio::time::timeout(remaining, output_rx.recv()).await {
+                Ok(Ok(chunk)) => {
+                    collected.extend_from_slice(&chunk);
+                    if String::from_utf8_lossy(&collected).contains(marker) {
+                        return Ok(collected);
+                    }
+                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => continue,
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                    anyhow::bail!(
+                        "PTY output closed while waiting for Python REPL readiness: {:?}",
+                        String::from_utf8_lossy(&collected)
+                    );
+                }
+                Err(_) => break,
+            }
+        }
+    }
+
+    anyhow::bail!(
+        "timed out waiting for Python REPL readiness in PTY: {:?}",
+        String::from_utf8_lossy(&collected)
+    );
+}
+
+#[cfg(unix)]
+fn process_exists(pid: i32) -> anyhow::Result<bool> {
+    let result = unsafe { libc::kill(pid, 0) };
+    if result == 0 {
+        return Ok(true);
+    }
+
+    let err = std::io::Error::last_os_error();
+    match err.raw_os_error() {
+        Some(libc::ESRCH) => Ok(false),
+        Some(libc::EPERM) => Ok(true),
+        _ => Err(err.into()),
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_marker_pid(
+    output_rx: &mut tokio::sync::broadcast::Receiver<Vec<u8>>,
+    marker: &str,
+    timeout_ms: u64,
+) -> anyhow::Result<i32> {
+    let mut collected = Vec::new();
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    loop {
+        let now = tokio::time::Instant::now();
+        if now >= deadline {
+            anyhow::bail!(
+                "timed out waiting for marker {marker:?} in PTY output: {:?}",
+                String::from_utf8_lossy(&collected)
+            );
+        }
+
+        let remaining = deadline.saturating_duration_since(now);
+        let chunk = tokio::time::timeout(remaining, output_rx.recv())
+            .await
+            .map_err(|_| anyhow::anyhow!("timeout waiting for PTY output"))??;
+        collected.extend_from_slice(&chunk);
+
+        let text = String::from_utf8_lossy(&collected);
+        let mut offset = 0;
+        while let Some(pos) = text[offset..].find(marker) {
+            let marker_start = offset + pos;
+            let suffix = &text[marker_start + marker.len()..];
+            let digits_len = suffix
+                .chars()
+                .take_while(char::is_ascii_digit)
+                .map(char::len_utf8)
+                .sum::<usize>();
+            if digits_len == 0 {
+                offset = marker_start + marker.len();
+                continue;
+            }
+
+            let pid_str = &suffix[..digits_len];
+            let trailing = &suffix[digits_len..];
+            if trailing.is_empty() {
+                break;
+            }
+            return Ok(pid_str.parse()?);
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn wait_for_process_exit(pid: i32, timeout_ms: u64) -> anyhow::Result<bool> {
+    let deadline = tokio::time::Instant::now() + tokio::time::Duration::from_millis(timeout_ms);
+    loop {
+        if !process_exists(pid)? {
+            return Ok(true);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return Ok(false);
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_python_repl_emits_output_and_exits() -> anyhow::Result<()> {
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping pty_python_repl_emits_output_and_exits");
+        return Ok(());
+    };
+
+    let ready_marker = "__codex_pty_ready__";
+    let args = vec![
+        "-i".to_string(),
+        "-q".to_string(),
+        "-c".to_string(),
+        format!("print('{ready_marker}')"),
+    ];
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawned = spawn_pty_process(
+        &python,
+        &args,
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+    )
+    .await?;
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let newline = if cfg!(windows) { "\r\n" } else { "\n" };
+    let startup_timeout_ms = if cfg!(windows) { 10_000 } else { 5_000 };
+    let mut output =
+        wait_for_python_repl_ready(&mut output_rx, startup_timeout_ms, ready_marker).await?;
+    writer
+        .send(format!("print('hello from pty'){newline}").into_bytes())
+        .await?;
+    writer.send(format!("exit(){newline}").into_bytes()).await?;
+
+    let timeout_ms = if cfg!(windows) { 10_000 } else { 5_000 };
+    let (remaining_output, code) = collect_output_until_exit(output_rx, exit_rx, timeout_ms).await;
+    output.extend_from_slice(&remaining_output);
+    let text = String::from_utf8_lossy(&output);
+
+    assert!(
+        text.contains("hello from pty"),
+        "expected python output in PTY: {text:?}"
+    );
+    assert_eq!(code, 0, "expected python to exit cleanly");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_process_round_trips_stdin() -> anyhow::Result<()> {
+    let (program, args) = if cfg!(windows) {
+        let cmd = std::env::var("COMSPEC").unwrap_or_else(|_| "cmd.exe".to_string());
+        (
+            cmd,
+            vec![
+                "/Q".to_string(),
+                "/V:ON".to_string(),
+                "/D".to_string(),
+                "/C".to_string(),
+                "set /p line= & echo(!line!".to_string(),
+            ],
+        )
+    } else {
+        let Some(python) = find_python() else {
+            eprintln!("python not found; skipping pipe_process_round_trips_stdin");
+            return Ok(());
+        };
+        (
+            python,
+            vec![
+                "-u".to_string(),
+                "-c".to_string(),
+                "import sys; print(sys.stdin.readline().strip());".to_string(),
+            ],
+        )
+    };
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawned = spawn_pipe_process(&program, &args, Path::new("."), &env_map, &None).await?;
+    let (session, output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let newline = if cfg!(windows) { "\r\n" } else { "\n" };
+    writer
+        .send(format!("roundtrip{newline}").into_bytes())
+        .await?;
+    drop(writer);
+    session.close_stdin();
+
+    let (output, code) = collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 5_000).await;
+    let text = String::from_utf8_lossy(&output);
+
+    assert!(
+        text.contains("roundtrip"),
+        "expected pipe process to echo stdin: {text:?}"
+    );
+    assert_eq!(code, 0, "expected python -c to exit cleanly");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_process_detaches_from_parent_session() -> anyhow::Result<()> {
+    let parent_sid = unsafe { libc::getsid(0) };
+    if parent_sid == -1 {
+        anyhow::bail!("failed to read parent session id");
+    }
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let script = "echo $$; sleep 0.2";
+    let (program, args) = shell_command(script);
+    let spawned = spawn_pipe_process(&program, &args, Path::new("."), &env_map, &None).await?;
+
+    let (_session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let pid_bytes =
+        tokio::time::timeout(tokio::time::Duration::from_millis(500), output_rx.recv()).await??;
+    let pid_text = String::from_utf8_lossy(&pid_bytes);
+    let child_pid: i32 = pid_text
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("missing child pid output: {pid_text:?}"))?
+        .parse()?;
+
+    let child_sid = unsafe { libc::getsid(child_pid) };
+    if child_sid == -1 {
+        anyhow::bail!("failed to read child session id");
+    }
+
+    assert_eq!(child_sid, child_pid, "expected child to be session leader");
+    assert_ne!(
+        child_sid, parent_sid,
+        "expected child to be detached from parent session"
+    );
+
+    let exit_code = exit_rx.await.unwrap_or(-1);
+    assert_eq!(
+        exit_code, 0,
+        "expected detached pipe process to exit cleanly"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_and_pty_share_interface() -> anyhow::Result<()> {
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+
+    let (pipe_program, pipe_args) = shell_command(&echo_sleep_command("pipe_ok"));
+    let (pty_program, pty_args) = shell_command(&echo_sleep_command("pty_ok"));
+
+    let pipe =
+        spawn_pipe_process(&pipe_program, &pipe_args, Path::new("."), &env_map, &None).await?;
+    let pty = spawn_pty_process(
+        &pty_program,
+        &pty_args,
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+    )
+    .await?;
+    let (_pipe_session, pipe_output_rx, pipe_exit_rx) = combine_spawned_output(pipe);
+    let (_pty_session, pty_output_rx, pty_exit_rx) = combine_spawned_output(pty);
+
+    let timeout_ms = if cfg!(windows) { 10_000 } else { 3_000 };
+    let (pipe_out, pipe_code) =
+        collect_output_until_exit(pipe_output_rx, pipe_exit_rx, timeout_ms).await;
+    let (pty_out, pty_code) =
+        collect_output_until_exit(pty_output_rx, pty_exit_rx, timeout_ms).await;
+
+    assert_eq!(pipe_code, 0);
+    assert_eq!(pty_code, 0);
+    assert!(
+        String::from_utf8_lossy(&pipe_out).contains("pipe_ok"),
+        "pipe output mismatch: {pipe_out:?}"
+    );
+    assert!(
+        String::from_utf8_lossy(&pty_out).contains("pty_ok"),
+        "pty output mismatch: {pty_out:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_drains_stderr_without_stdout_activity() -> anyhow::Result<()> {
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping pipe_drains_stderr_without_stdout_activity");
+        return Ok(());
+    };
+
+    let script = "import sys\nchunk = 'E' * 65536\nfor _ in range(64):\n    sys.stderr.write(chunk)\n    sys.stderr.flush()\n";
+    let args = vec!["-c".to_string(), script.to_string()];
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawned = spawn_pipe_process(&python, &args, Path::new("."), &env_map, &None).await?;
+    let (_session, output_rx, exit_rx) = combine_spawned_output(spawned);
+
+    let (output, code) = collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 10_000).await;
+
+    assert_eq!(code, 0, "expected python to exit cleanly");
+    assert!(!output.is_empty(), "expected stderr output to be drained");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_process_can_expose_split_stdout_and_stderr() -> anyhow::Result<()> {
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let (program, args) = shell_command(&split_stdout_stderr_command());
+    let spawned =
+        spawn_pipe_process_no_stdin(&program, &args, Path::new("."), &env_map, &None).await?;
+    let SpawnedProcess {
+        session: _session,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    } = spawned;
+
+    let timeout_ms = if cfg!(windows) { 10_000 } else { 2_000 };
+    let timeout = tokio::time::Duration::from_millis(timeout_ms);
+    let stdout_task = tokio::spawn(async move { collect_split_output(stdout_rx).await });
+    let stderr_task = tokio::spawn(async move { collect_split_output(stderr_rx).await });
+    let code = tokio::time::timeout(timeout, exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for split process exit"))?
+        .unwrap_or(-1);
+    let stdout = tokio::time::timeout(timeout, stdout_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting to drain split stdout"))??;
+    let stderr = tokio::time::timeout(timeout, stderr_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting to drain split stderr"))??;
+
+    let expected_stdout = if cfg!(windows) {
+        b"split-out\r\n".to_vec()
+    } else {
+        b"split-out\n".to_vec()
+    };
+    let expected_stderr = if cfg!(windows) {
+        b"split-err\r\n".to_vec()
+    } else {
+        b"split-err\n".to_vec()
+    };
+
+    assert_eq!(stdout, expected_stdout);
+    assert_eq!(stderr, expected_stderr);
+    assert_eq!(code, 0);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn driver_backed_process_can_expose_split_stdout_and_stderr() -> anyhow::Result<()> {
+    let (writer_tx, _writer_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
+    let (stdout_tx, stdout_driver_rx) = tokio::sync::broadcast::channel::<Vec<u8>>(8);
+    let (stderr_tx, stderr_driver_rx) = tokio::sync::broadcast::channel::<Vec<u8>>(8);
+    let (exit_tx, exit_rx) = tokio::sync::oneshot::channel::<i32>();
+
+    let spawned = spawn_from_driver(ProcessDriver {
+        writer_tx,
+        stdout_rx: stdout_driver_rx,
+        stderr_rx: Some(stderr_driver_rx),
+        exit_rx,
+        terminator: None,
+        writer_handle: None,
+        resizer: None,
+    });
+
+    let SpawnedProcess {
+        session: _session,
+        stdout_rx,
+        stderr_rx,
+        exit_rx,
+    } = spawned;
+    let stdout_task = tokio::spawn(async move { collect_split_output(stdout_rx).await });
+    let stderr_task = tokio::spawn(async move { collect_split_output(stderr_rx).await });
+
+    stdout_tx.send(b"driver-out".to_vec())?;
+    stderr_tx.send(b"driver-err".to_vec())?;
+    drop(stdout_tx);
+    drop(stderr_tx);
+    exit_tx.send(0).expect("send exit code");
+
+    let timeout = tokio::time::Duration::from_secs(2);
+    let code = tokio::time::timeout(timeout, exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for driver exit"))?
+        .unwrap_or(-1);
+    let stdout = tokio::time::timeout(timeout, stdout_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting to drain driver stdout"))??;
+    let stderr = tokio::time::timeout(timeout, stderr_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting to drain driver stderr"))??;
+
+    assert_eq!(stdout, b"driver-out".to_vec());
+    assert_eq!(stderr, b"driver-err".to_vec());
+    assert_eq!(code, 0);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn driver_backed_process_can_resize_via_resizer_hook() -> anyhow::Result<()> {
+    let (writer_tx, _writer_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
+    let (_stdout_tx, stdout_driver_rx) = tokio::sync::broadcast::channel::<Vec<u8>>(8);
+    let (exit_tx, exit_rx) = tokio::sync::oneshot::channel::<i32>();
+    let (size_tx, size_rx) = tokio::sync::oneshot::channel::<TerminalSize>();
+
+    let size_tx = std::sync::Arc::new(std::sync::Mutex::new(Some(size_tx)));
+    let spawned = spawn_from_driver(ProcessDriver {
+        writer_tx,
+        stdout_rx: stdout_driver_rx,
+        stderr_rx: None,
+        exit_rx,
+        terminator: None,
+        writer_handle: None,
+        resizer: Some(Box::new(move |size| {
+            if let Ok(mut guard) = size_tx.lock()
+                && let Some(size_tx) = guard.take()
+            {
+                let _ = size_tx.send(size);
+            }
+            Ok(())
+        })),
+    });
+
+    spawned.session.resize(TerminalSize {
+        rows: 40,
+        cols: 120,
+    })?;
+    exit_tx.send(0).expect("send exit code");
+
+    let resized = tokio::time::timeout(tokio::time::Duration::from_secs(2), size_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for resize"))?
+        .expect("receive resized terminal size");
+    assert_eq!(
+        resized,
+        TerminalSize {
+            rows: 40,
+            cols: 120
+        }
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn driver_backed_process_drains_output_that_arrives_after_exit_signal() -> anyhow::Result<()>
+{
+    let (writer_tx, _writer_rx) = tokio::sync::mpsc::channel::<Vec<u8>>(1);
+    let (stdout_tx, stdout_driver_rx) = tokio::sync::broadcast::channel::<Vec<u8>>(8);
+    let (exit_tx, exit_rx) = tokio::sync::oneshot::channel::<i32>();
+
+    let spawned = spawn_from_driver(ProcessDriver {
+        writer_tx,
+        stdout_rx: stdout_driver_rx,
+        stderr_rx: None,
+        exit_rx,
+        terminator: None,
+        writer_handle: None,
+        resizer: None,
+    });
+
+    let SpawnedProcess {
+        session: _session,
+        stdout_rx,
+        stderr_rx: _stderr_rx,
+        exit_rx,
+    } = spawned;
+    let stdout_task = tokio::spawn(async move { collect_split_output(stdout_rx).await });
+
+    exit_tx.send(0).expect("send exit code");
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    stdout_tx.send(b"tail".to_vec())?;
+    drop(stdout_tx);
+
+    let timeout = tokio::time::Duration::from_secs(2);
+    let code = tokio::time::timeout(timeout, exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for driver exit"))?
+        .unwrap_or(-1);
+    let stdout = tokio::time::timeout(timeout, stdout_task)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting to drain driver stdout"))??;
+
+    assert_eq!(stdout, b"tail".to_vec());
+    assert_eq!(code, 0);
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_terminate_aborts_detached_readers() -> anyhow::Result<()> {
+    if !setsid_available() {
+        eprintln!("setsid not available; skipping pipe_terminate_aborts_detached_readers");
+        return Ok(());
+    }
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let script =
+        "setsid sh -c 'i=0; while [ $i -lt 200 ]; do echo tick; sleep 0.01; i=$((i+1)); done' &";
+    let (program, args) = shell_command(script);
+    let spawned = spawn_pipe_process(&program, &args, Path::new("."), &env_map, &None).await?;
+    let (session, mut output_rx, _exit_rx) = combine_spawned_output(spawned);
+
+    let _ = tokio::time::timeout(tokio::time::Duration::from_millis(500), output_rx.recv())
+        .await
+        .map_err(|_| anyhow::anyhow!("expected detached output before terminate"))??;
+
+    session.terminate();
+    let mut post_rx = output_rx.resubscribe();
+
+    let post_terminate =
+        tokio::time::timeout(tokio::time::Duration::from_millis(200), post_rx.recv()).await;
+
+    match post_terminate {
+        Err(_) => Ok(()),
+        Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => Ok(()),
+        Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
+            anyhow::bail!("unexpected output after terminate (lagged)")
+        }
+        Ok(Ok(chunk)) => anyhow::bail!(
+            "unexpected output after terminate: {:?}",
+            String::from_utf8_lossy(&chunk)
+        ),
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_terminate_kills_background_children_in_same_process_group() -> anyhow::Result<()> {
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let marker = "__codex_bg_pid:";
+    let script = format!("sleep 1000 & bg=$!; echo {marker}$bg; wait");
+    let (program, args) = shell_command(&script);
+    let spawned = spawn_pty_process(
+        &program,
+        &args,
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+    )
+    .await?;
+    let (session, mut output_rx, _exit_rx) = combine_spawned_output(spawned);
+
+    let bg_pid = match wait_for_marker_pid(&mut output_rx, marker, /*timeout_ms*/ 2_000).await {
+        Ok(pid) => pid,
+        Err(err) => {
+            session.terminate();
+            return Err(err);
+        }
+    };
+    assert!(
+        process_exists(bg_pid)?,
+        "expected background child pid {bg_pid} to exist before terminate"
+    );
+
+    session.terminate();
+
+    let exited = wait_for_process_exit(bg_pid, /*timeout_ms*/ 3_000).await?;
+    if !exited {
+        let _ = unsafe { libc::kill(bg_pid, libc::SIGKILL) };
+    }
+
+    assert!(
+        exited,
+        "background child pid {bg_pid} survived PTY terminate()"
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_can_preserve_inherited_fds() -> anyhow::Result<()> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        write_end.as_raw_fd().to_string(),
+    );
+
+    let script = "printf __preserved__ >\"/dev/fd/$PRESERVED_FD\"";
+    let spawned = spawn_process_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    drop(write_end);
+
+    let (_session, output_rx, exit_rx) = combine_spawned_output(spawned);
+    let (_, code) = collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 2_000).await;
+    assert_eq!(code, 0, "expected preserved-fd PTY child to exit cleanly");
+
+    let mut pipe_output = String::new();
+    read_end.read_to_string(&mut pipe_output)?;
+    assert_eq!(pipe_output, "__preserved__");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_preserving_inherited_fds_keeps_python_repl_running() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let Some(python) = find_python() else {
+        eprintln!(
+            "python not found; skipping pty_preserving_inherited_fds_keeps_python_repl_running"
+        );
+        return Ok(());
+    };
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let preserved_fd = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        preserved_fd.as_raw_fd().to_string(),
+    );
+
+    let spawned = spawn_process_with_inherited_fds(
+        &python,
+        &[],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[preserved_fd.as_raw_fd()],
+    )
+    .await?;
+    drop(read_end);
+    drop(preserved_fd);
+
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let newline = "\n";
+    let mut output = wait_for_python_repl_ready_via_probe(
+        &writer,
+        &mut output_rx,
+        /*timeout_ms*/ 5_000,
+        newline,
+    )
+    .await?;
+    let marker = "__codex_preserved_py_pid:";
+    writer
+        .send(format!("import os; print('{marker}' + str(os.getpid())){newline}").into_bytes())
+        .await?;
+
+    let python_pid = match wait_for_marker_pid(&mut output_rx, marker, /*timeout_ms*/ 2_000).await {
+        Ok(pid) => pid,
+        Err(err) => {
+            session.terminate();
+            return Err(err);
+        }
+    };
+    assert!(
+        process_exists(python_pid)?,
+        "expected python pid {python_pid} to stay alive after prompt output"
+    );
+
+    writer.send(format!("exit(){newline}").into_bytes()).await?;
+    let (remaining_output, code) =
+        collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 5_000).await;
+    output.extend_from_slice(&remaining_output);
+
+    assert_eq!(code, 0, "expected python to exit cleanly");
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_with_inherited_fds_reports_exec_failures() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawn_result = spawn_process_with_inherited_fds(
+        "/definitely/missing/command",
+        &[],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[write_end.as_raw_fd()],
+    )
+    .await;
+
+    drop(read_end);
+    drop(write_end);
+
+    let err = match spawn_result {
+        Ok(spawned) => {
+            spawned.session.terminate();
+            anyhow::bail!("missing executable unexpectedly spawned");
+        }
+        Err(err) => err,
+    };
+    let err_text = err.to_string();
+    assert!(
+        err_text.contains("No such file")
+            || err_text.contains("not found")
+            || err_text.contains("os error 2"),
+        "expected spawn error for missing executable, got: {err_text}",
+    );
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_spawn_with_inherited_fds_supports_resize() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let script = "stty -echo; printf 'start:%s\\n' \"$(stty size)\"; IFS= read _line; printf 'after:%s\\n' \"$(stty size)\"";
+    let spawned = spawn_process_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize {
+            rows: 31,
+            cols: 101,
+        },
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    let writer = session.writer_sender();
+    let mut output = wait_for_output_contains(
+        &mut output_rx,
+        "start:31 101\r\n",
+        /*timeout_ms*/ 5_000,
+    )
+    .await?;
+
+    session.resize(TerminalSize {
+        rows: 45,
+        cols: 132,
+    })?;
+    writer.send(b"go\n".to_vec()).await?;
+    session.close_stdin();
+
+    let (remaining_output, code) =
+        collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 5_000).await;
+    output.extend_from_slice(&remaining_output);
+    let text = String::from_utf8_lossy(&output);
+    let normalized = text.replace("\r\n", "\n");
+
+    assert!(
+        normalized.contains("after:45 132\n"),
+        "expected resized PTY dimensions in output: {text:?}"
+    );
+    assert_eq!(code, 0, "expected shell to exit cleanly after resize");
+
+    drop(read_end);
+    drop(write_end);
+
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_spawn_no_stdin_can_preserve_inherited_fds() -> anyhow::Result<()> {
+    use std::io::Read;
+    use std::os::fd::AsRawFd;
+    use std::os::fd::FromRawFd;
+
+    let mut fds = [0; 2];
+    let result = unsafe { libc::pipe(fds.as_mut_ptr()) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let mut read_end = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+    let write_end = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+
+    let mut env_map: HashMap<String, String> = std::env::vars().collect();
+    env_map.insert(
+        "PRESERVED_FD".to_string(),
+        write_end.as_raw_fd().to_string(),
+    );
+
+    let script = "printf __pipe_preserved__ >\"/dev/fd/$PRESERVED_FD\"";
+    let spawned = spawn_process_no_stdin_with_inherited_fds(
+        "/bin/sh",
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        &[write_end.as_raw_fd()],
+    )
+    .await?;
+
+    drop(write_end);
+
+    let (_session, output_rx, exit_rx) = combine_spawned_output(spawned);
+    let (_, code) = collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 2_000).await;
+    assert_eq!(code, 0, "expected preserved-fd pipe child to exit cleanly");
+
+    let mut pipe_output = String::new();
+    read_end.read_to_string(&mut pipe_output)?;
+    assert_eq!(pipe_output, "__pipe_preserved__");
+
+    Ok(())
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
@@ -1,0 +1,192 @@
+#![allow(clippy::unwrap_used)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use crate::win::psuedocon::PsuedoCon;
+use anyhow::Error;
+use filedescriptor::FileDescriptor;
+use filedescriptor::Pipe;
+use portable_pty::Child;
+use portable_pty::MasterPty;
+use portable_pty::PtyPair;
+use portable_pty::PtySize;
+use portable_pty::PtySystem;
+use portable_pty::SlavePty;
+use portable_pty::cmdbuilder::CommandBuilder;
+use std::mem::ManuallyDrop;
+use std::os::windows::io::RawHandle;
+use std::ptr;
+use std::sync::Arc;
+use std::sync::Mutex;
+use winapi::um::wincon::COORD;
+
+#[derive(Default)]
+pub struct ConPtySystem {}
+
+fn create_conpty_handles(
+    size: PtySize,
+) -> anyhow::Result<(PsuedoCon, FileDescriptor, FileDescriptor)> {
+    let stdin = Pipe::new()?;
+    let stdout = Pipe::new()?;
+
+    let con = PsuedoCon::new(
+        COORD {
+            X: size.cols as i16,
+            Y: size.rows as i16,
+        },
+        stdin.read,
+        stdout.write,
+    )?;
+
+    Ok((con, stdin.write, stdout.read))
+}
+
+pub struct RawConPty {
+    con: PsuedoCon,
+    input_write: FileDescriptor,
+    output_read: FileDescriptor,
+}
+
+impl RawConPty {
+    pub fn new(cols: i16, rows: i16) -> anyhow::Result<Self> {
+        let (con, input_write, output_read) = create_conpty_handles(PtySize {
+            rows: rows as u16,
+            cols: cols as u16,
+            pixel_width: 0,
+            pixel_height: 0,
+        })?;
+        Ok(Self {
+            con,
+            input_write,
+            output_read,
+        })
+    }
+
+    pub fn pseudoconsole_handle(&self) -> RawHandle {
+        self.con.raw_handle() as RawHandle
+    }
+
+    pub fn into_handles(self) -> (PsuedoCon, FileDescriptor, FileDescriptor) {
+        let me = ManuallyDrop::new(self);
+        unsafe {
+            (
+                ptr::read(&me.con),
+                ptr::read(&me.input_write),
+                ptr::read(&me.output_read),
+            )
+        }
+    }
+}
+
+impl PtySystem for ConPtySystem {
+    fn openpty(&self, size: PtySize) -> anyhow::Result<PtyPair> {
+        let (con, writable, readable) = create_conpty_handles(size)?;
+
+        let master = ConPtyMasterPty {
+            inner: Arc::new(Mutex::new(Inner {
+                con,
+                readable,
+                writable: Some(writable),
+                size,
+            })),
+        };
+
+        let slave = ConPtySlavePty {
+            inner: master.inner.clone(),
+        };
+
+        Ok(PtyPair {
+            master: Box::new(master),
+            slave: Box::new(slave),
+        })
+    }
+}
+
+struct Inner {
+    con: PsuedoCon,
+    readable: FileDescriptor,
+    writable: Option<FileDescriptor>,
+    size: PtySize,
+}
+
+impl Inner {
+    pub fn resize(
+        &mut self,
+        num_rows: u16,
+        num_cols: u16,
+        pixel_width: u16,
+        pixel_height: u16,
+    ) -> Result<(), Error> {
+        self.con.resize(COORD {
+            X: num_cols as i16,
+            Y: num_rows as i16,
+        })?;
+        self.size = PtySize {
+            rows: num_rows,
+            cols: num_cols,
+            pixel_width,
+            pixel_height,
+        };
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct ConPtyMasterPty {
+    inner: Arc<Mutex<Inner>>,
+}
+
+pub struct ConPtySlavePty {
+    inner: Arc<Mutex<Inner>>,
+}
+
+impl MasterPty for ConPtyMasterPty {
+    fn resize(&self, size: PtySize) -> anyhow::Result<()> {
+        let mut inner = self.inner.lock().unwrap();
+        inner.resize(size.rows, size.cols, size.pixel_width, size.pixel_height)
+    }
+
+    fn get_size(&self) -> Result<PtySize, Error> {
+        let inner = self.inner.lock().unwrap();
+        Ok(inner.size)
+    }
+
+    fn try_clone_reader(&self) -> anyhow::Result<Box<dyn std::io::Read + Send>> {
+        Ok(Box::new(self.inner.lock().unwrap().readable.try_clone()?))
+    }
+
+    fn take_writer(&self) -> anyhow::Result<Box<dyn std::io::Write + Send>> {
+        Ok(Box::new(
+            self.inner
+                .lock()
+                .unwrap()
+                .writable
+                .take()
+                .ok_or_else(|| anyhow::anyhow!("writer already taken"))?,
+        ))
+    }
+}
+
+impl SlavePty for ConPtySlavePty {
+    fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<Box<dyn Child + Send + Sync>> {
+        let inner = self.inner.lock().unwrap();
+        let child = inner.con.spawn_command(cmd)?;
+        Ok(Box::new(child))
+    }
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/mod.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/mod.rs
@@ -1,0 +1,175 @@
+#![allow(clippy::unwrap_used)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// Local modifications:
+// - Fix Codex bug #13945 in the Windows PTY kill path. The vendored code treated
+//   `TerminateProcess`'s nonzero success return as failure and `0` as success,
+//   which inverts kill outcomes for both `WinChild::do_kill` and
+//   `WinChildKiller::kill`.
+// - This bug still exists in the original WezTerm source as of 2026-03-08, so
+//   this is an intentional divergence from upstream.
+
+use anyhow::Context as _;
+use filedescriptor::OwnedHandle;
+use portable_pty::Child;
+use portable_pty::ChildKiller;
+use portable_pty::ExitStatus;
+use std::io::Error as IoError;
+use std::io::Result as IoResult;
+use std::os::windows::io::AsRawHandle;
+use std::pin::Pin;
+use std::sync::Mutex;
+use std::task::Context;
+use std::task::Poll;
+use winapi::shared::minwindef::DWORD;
+use winapi::um::minwinbase::STILL_ACTIVE;
+use winapi::um::processthreadsapi::*;
+use winapi::um::synchapi::WaitForSingleObject;
+use winapi::um::winbase::INFINITE;
+
+pub(crate) mod conpty;
+mod procthreadattr;
+mod psuedocon;
+
+pub use conpty::ConPtySystem;
+pub use psuedocon::PsuedoCon;
+pub use psuedocon::conpty_supported;
+
+#[derive(Debug)]
+pub struct WinChild {
+    proc: Mutex<OwnedHandle>,
+}
+
+impl WinChild {
+    fn is_complete(&mut self) -> IoResult<Option<ExitStatus>> {
+        let mut status: DWORD = 0;
+        let proc = self.proc.lock().unwrap().try_clone().unwrap();
+        let res = unsafe { GetExitCodeProcess(proc.as_raw_handle() as _, &mut status) };
+        if res != 0 {
+            if status == STILL_ACTIVE {
+                Ok(None)
+            } else {
+                Ok(Some(ExitStatus::with_exit_code(status)))
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn do_kill(&mut self) -> IoResult<()> {
+        let proc = self.proc.lock().unwrap().try_clone().unwrap();
+        let res = unsafe { TerminateProcess(proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
+        if res == 0 {
+            Err(IoError::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl ChildKiller for WinChild {
+    fn kill(&mut self) -> IoResult<()> {
+        self.do_kill().ok();
+        Ok(())
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        let proc = self.proc.lock().unwrap().try_clone().unwrap();
+        Box::new(WinChildKiller { proc })
+    }
+}
+
+#[derive(Debug)]
+pub struct WinChildKiller {
+    proc: OwnedHandle,
+}
+
+impl ChildKiller for WinChildKiller {
+    fn kill(&mut self) -> IoResult<()> {
+        let res = unsafe { TerminateProcess(self.proc.as_raw_handle() as _, 1) };
+        // Codex bug #13945: Win32 returns nonzero on success, so only `0` is an error.
+        if res == 0 {
+            Err(IoError::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+
+    fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+        let proc = self.proc.try_clone().unwrap();
+        Box::new(WinChildKiller { proc })
+    }
+}
+
+impl Child for WinChild {
+    fn try_wait(&mut self) -> IoResult<Option<ExitStatus>> {
+        self.is_complete()
+    }
+
+    fn wait(&mut self) -> IoResult<ExitStatus> {
+        if let Ok(Some(status)) = self.try_wait() {
+            return Ok(status);
+        }
+        let proc = self.proc.lock().unwrap().try_clone().unwrap();
+        unsafe {
+            WaitForSingleObject(proc.as_raw_handle() as _, INFINITE);
+        }
+        let mut status: DWORD = 0;
+        let res = unsafe { GetExitCodeProcess(proc.as_raw_handle() as _, &mut status) };
+        if res != 0 {
+            Ok(ExitStatus::with_exit_code(status))
+        } else {
+            Err(IoError::last_os_error())
+        }
+    }
+
+    fn process_id(&self) -> Option<u32> {
+        let res = unsafe { GetProcessId(self.proc.lock().unwrap().as_raw_handle() as _) };
+        if res == 0 { None } else { Some(res) }
+    }
+
+    fn as_raw_handle(&self) -> Option<std::os::windows::io::RawHandle> {
+        let proc = self.proc.lock().unwrap();
+        Some(proc.as_raw_handle())
+    }
+}
+
+impl std::future::Future for WinChild {
+    type Output = anyhow::Result<ExitStatus>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<anyhow::Result<ExitStatus>> {
+        match self.is_complete() {
+            Ok(Some(status)) => Poll::Ready(Ok(status)),
+            Err(err) => Poll::Ready(Err(err).context("Failed to retrieve process exit status")),
+            Ok(None) => {
+                let proc = self.proc.lock().unwrap().try_clone()?;
+                let waker = cx.waker().clone();
+                std::thread::spawn(move || {
+                    unsafe {
+                        WaitForSingleObject(proc.as_raw_handle() as _, INFINITE);
+                    }
+                    waker.wake();
+                });
+                Poll::Pending
+            }
+        }
+    }
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/procthreadattr.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/procthreadattr.rs
@@ -1,0 +1,91 @@
+#![allow(clippy::uninit_vec)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use super::psuedocon::HPCON;
+use anyhow::Error;
+use anyhow::ensure;
+use std::io::Error as IoError;
+use std::mem;
+use std::ptr;
+use winapi::shared::minwindef::DWORD;
+use winapi::um::processthreadsapi::*;
+
+const PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE: usize = 0x00020016;
+
+pub struct ProcThreadAttributeList {
+    data: Vec<u8>,
+}
+
+impl ProcThreadAttributeList {
+    pub fn with_capacity(num_attributes: DWORD) -> Result<Self, Error> {
+        let mut bytes_required: usize = 0;
+        unsafe {
+            InitializeProcThreadAttributeList(
+                ptr::null_mut(),
+                num_attributes,
+                0,
+                &mut bytes_required,
+            )
+        };
+        let mut data = Vec::with_capacity(bytes_required);
+        unsafe { data.set_len(bytes_required) };
+
+        let attr_ptr = data.as_mut_slice().as_mut_ptr() as *mut _;
+        let res = unsafe {
+            InitializeProcThreadAttributeList(attr_ptr, num_attributes, 0, &mut bytes_required)
+        };
+        ensure!(
+            res != 0,
+            "InitializeProcThreadAttributeList failed: {}",
+            IoError::last_os_error()
+        );
+        Ok(Self { data })
+    }
+
+    pub fn as_mut_ptr(&mut self) -> LPPROC_THREAD_ATTRIBUTE_LIST {
+        self.data.as_mut_slice().as_mut_ptr() as *mut _
+    }
+
+    pub fn set_pty(&mut self, con: HPCON) -> Result<(), Error> {
+        let res = unsafe {
+            UpdateProcThreadAttribute(
+                self.as_mut_ptr(),
+                0,
+                PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE,
+                con,
+                mem::size_of::<HPCON>(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+            )
+        };
+        ensure!(
+            res != 0,
+            "UpdateProcThreadAttribute failed: {}",
+            IoError::last_os_error()
+        );
+        Ok(())
+    }
+}
+
+impl Drop for ProcThreadAttributeList {
+    fn drop(&mut self) {
+        unsafe { DeleteProcThreadAttributeList(self.as_mut_ptr()) };
+    }
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/psuedocon.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/psuedocon.rs
@@ -1,0 +1,377 @@
+#![allow(clippy::expect_used)]
+#![allow(clippy::upper_case_acronyms)]
+
+// This file is copied from https://github.com/wezterm/wezterm (MIT license).
+// Copyright (c) 2018-Present Wez Furlong
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+use super::WinChild;
+use crate::win::procthreadattr::ProcThreadAttributeList;
+use anyhow::Error;
+use anyhow::bail;
+use anyhow::ensure;
+use filedescriptor::FileDescriptor;
+use filedescriptor::OwnedHandle;
+use lazy_static::lazy_static;
+use portable_pty::cmdbuilder::CommandBuilder;
+use shared_library::shared_library;
+use std::env;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::io::Error as IoError;
+use std::mem;
+use std::os::windows::ffi::OsStrExt;
+use std::os::windows::ffi::OsStringExt;
+use std::os::windows::io::AsRawHandle;
+use std::os::windows::io::FromRawHandle;
+use std::path::Path;
+use std::ptr;
+use std::sync::Mutex;
+use winapi::shared::minwindef::DWORD;
+use winapi::shared::ntdef::NTSTATUS;
+use winapi::shared::ntstatus::STATUS_SUCCESS;
+use winapi::shared::winerror::HRESULT;
+use winapi::shared::winerror::S_OK;
+use winapi::um::handleapi::*;
+use winapi::um::processthreadsapi::*;
+use winapi::um::winbase::CREATE_UNICODE_ENVIRONMENT;
+use winapi::um::winbase::EXTENDED_STARTUPINFO_PRESENT;
+use winapi::um::winbase::STARTF_USESTDHANDLES;
+use winapi::um::winbase::STARTUPINFOEXW;
+use winapi::um::wincon::COORD;
+use winapi::um::winnt::HANDLE;
+use winapi::um::winnt::OSVERSIONINFOW;
+
+pub type HPCON = HANDLE;
+
+pub const PSEUDOCONSOLE_RESIZE_QUIRK: DWORD = 0x2;
+#[allow(dead_code)]
+pub const PSEUDOCONSOLE_PASSTHROUGH_MODE: DWORD = 0x8;
+
+// https://learn.microsoft.com/en-gb/windows/console/createpseudoconsole
+// https://learn.microsoft.com/en-gb/windows/release-health/release-information
+const MIN_CONPTY_BUILD: u32 = 17_763;
+
+shared_library!(ConPtyFuncs,
+    pub fn CreatePseudoConsole(
+        size: COORD,
+        hInput: HANDLE,
+        hOutput: HANDLE,
+        flags: DWORD,
+        hpc: *mut HPCON
+    ) -> HRESULT,
+    pub fn ResizePseudoConsole(hpc: HPCON, size: COORD) -> HRESULT,
+    pub fn ClosePseudoConsole(hpc: HPCON),
+);
+
+shared_library!(Ntdll,
+    pub fn RtlGetVersion(
+        version_info: *mut OSVERSIONINFOW
+    ) -> NTSTATUS,
+);
+
+fn load_conpty() -> ConPtyFuncs {
+    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
+        "this system does not support conpty.  Windows 10 October 2018 or newer is required",
+    );
+
+    if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
+        sideloaded
+    } else {
+        kernel
+    }
+}
+
+lazy_static! {
+    static ref CONPTY: ConPtyFuncs = load_conpty();
+}
+
+pub fn conpty_supported() -> bool {
+    windows_build_number().is_some_and(|build| build >= MIN_CONPTY_BUILD)
+}
+
+fn windows_build_number() -> Option<u32> {
+    let ntdll = Ntdll::open(Path::new("ntdll.dll")).ok()?;
+    let mut info: OSVERSIONINFOW = unsafe { mem::zeroed() };
+    info.dwOSVersionInfoSize = mem::size_of::<OSVERSIONINFOW>() as u32;
+    let status = unsafe { (ntdll.RtlGetVersion)(&mut info) };
+    if status == STATUS_SUCCESS {
+        Some(info.dwBuildNumber)
+    } else {
+        None
+    }
+}
+
+pub struct PsuedoCon {
+    con: HPCON,
+    // CreatePseudoConsole borrows these pipe handles for the lifetime of the
+    // pseudoconsole, so we must keep owning them until ClosePseudoConsole.
+    _input: FileDescriptor,
+    _output: FileDescriptor,
+}
+
+unsafe impl Send for PsuedoCon {}
+unsafe impl Sync for PsuedoCon {}
+
+impl Drop for PsuedoCon {
+    fn drop(&mut self) {
+        unsafe { (CONPTY.ClosePseudoConsole)(self.con) };
+    }
+}
+
+impl PsuedoCon {
+    pub fn raw_handle(&self) -> HPCON {
+        self.con
+    }
+
+    pub fn new(size: COORD, input: FileDescriptor, output: FileDescriptor) -> Result<Self, Error> {
+        let mut con: HPCON = INVALID_HANDLE_VALUE;
+        let result = unsafe {
+            (CONPTY.CreatePseudoConsole)(
+                size,
+                input.as_raw_handle() as _,
+                output.as_raw_handle() as _,
+                PSEUDOCONSOLE_RESIZE_QUIRK,
+                &mut con,
+            )
+        };
+        ensure!(
+            result == S_OK,
+            "failed to create psuedo console: HRESULT {result}"
+        );
+        Ok(Self {
+            con,
+            _input: input,
+            _output: output,
+        })
+    }
+
+    pub fn resize(&self, size: COORD) -> Result<(), Error> {
+        let result = unsafe { (CONPTY.ResizePseudoConsole)(self.con, size) };
+        ensure!(
+            result == S_OK,
+            "failed to resize console to {}x{}: HRESULT: {}",
+            size.X,
+            size.Y,
+            result
+        );
+        Ok(())
+    }
+
+    pub fn spawn_command(&self, cmd: CommandBuilder) -> anyhow::Result<WinChild> {
+        let mut si: STARTUPINFOEXW = unsafe { mem::zeroed() };
+        si.StartupInfo.cb = mem::size_of::<STARTUPINFOEXW>() as u32;
+        si.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+        si.StartupInfo.hStdInput = INVALID_HANDLE_VALUE;
+        si.StartupInfo.hStdOutput = INVALID_HANDLE_VALUE;
+        si.StartupInfo.hStdError = INVALID_HANDLE_VALUE;
+
+        let mut attrs = ProcThreadAttributeList::with_capacity(/*num_attributes*/ 1)?;
+        attrs.set_pty(self.con)?;
+        si.lpAttributeList = attrs.as_mut_ptr();
+
+        let mut pi: PROCESS_INFORMATION = unsafe { mem::zeroed() };
+
+        let (mut exe, mut cmdline) = build_cmdline(&cmd)?;
+        let cmd_os = OsString::from_wide(&cmdline);
+
+        let cwd = resolve_current_directory(&cmd);
+        let mut env_block = build_environment_block(&cmd);
+
+        let res = unsafe {
+            CreateProcessW(
+                exe.as_mut_ptr(),
+                cmdline.as_mut_ptr(),
+                ptr::null_mut(),
+                ptr::null_mut(),
+                0,
+                EXTENDED_STARTUPINFO_PRESENT | CREATE_UNICODE_ENVIRONMENT,
+                env_block.as_mut_ptr() as *mut _,
+                cwd.as_ref().map_or(ptr::null(), std::vec::Vec::as_ptr),
+                &mut si.StartupInfo,
+                &mut pi,
+            )
+        };
+        if res == 0 {
+            let err = IoError::last_os_error();
+            let msg = format!(
+                "CreateProcessW `{:?}` in cwd `{:?}` failed: {}",
+                cmd_os,
+                cwd.as_ref().map(|c| OsString::from_wide(c)),
+                err
+            );
+            log::error!("{msg}");
+            bail!("{msg}");
+        }
+
+        let _main_thread = unsafe { OwnedHandle::from_raw_handle(pi.hThread as _) };
+        let proc = unsafe { OwnedHandle::from_raw_handle(pi.hProcess as _) };
+
+        Ok(WinChild {
+            proc: Mutex::new(proc),
+        })
+    }
+}
+
+fn resolve_current_directory(cmd: &CommandBuilder) -> Option<Vec<u16>> {
+    let home = cmd
+        .get_env("USERPROFILE")
+        .and_then(|path| Path::new(path).is_dir().then(|| path.to_owned()));
+    let cwd = cmd
+        .get_cwd()
+        .and_then(|path| Path::new(path).is_dir().then(|| path.to_owned()));
+    let dir = cwd.or(home)?;
+
+    let mut wide = Vec::new();
+    if Path::new(&dir).is_relative() {
+        if let Ok(current_dir) = env::current_dir() {
+            wide.extend(current_dir.join(&dir).as_os_str().encode_wide());
+        } else {
+            wide.extend(dir.encode_wide());
+        }
+    } else {
+        wide.extend(dir.encode_wide());
+    }
+    wide.push(0);
+    Some(wide)
+}
+
+fn build_environment_block(cmd: &CommandBuilder) -> Vec<u16> {
+    let mut block = Vec::new();
+    for (key, value) in cmd.iter_full_env_as_str() {
+        block.extend(OsStr::new(key).encode_wide());
+        block.push(b'=' as u16);
+        block.extend(OsStr::new(value).encode_wide());
+        block.push(0);
+    }
+    block.push(0);
+    block
+}
+
+fn build_cmdline(cmd: &CommandBuilder) -> anyhow::Result<(Vec<u16>, Vec<u16>)> {
+    let exe_os: OsString = if cmd.is_default_prog() {
+        cmd.get_env("ComSpec")
+            .unwrap_or(OsStr::new("cmd.exe"))
+            .to_os_string()
+    } else {
+        let argv = cmd.get_argv();
+        let Some(first) = argv.first() else {
+            anyhow::bail!("missing program name");
+        };
+        search_path(cmd, first)
+    };
+
+    let mut cmdline = Vec::new();
+    append_quoted(&exe_os, &mut cmdline);
+    for arg in cmd.get_argv().iter().skip(1) {
+        cmdline.push(' ' as u16);
+        ensure!(
+            !arg.encode_wide().any(|c| c == 0),
+            "invalid encoding for command line argument {arg:?}"
+        );
+        append_quoted(arg, &mut cmdline);
+    }
+    cmdline.push(0);
+
+    let mut exe: Vec<u16> = exe_os.encode_wide().collect();
+    exe.push(0);
+
+    Ok((exe, cmdline))
+}
+
+fn search_path(cmd: &CommandBuilder, exe: &OsStr) -> OsString {
+    if let Some(path) = cmd.get_env("PATH") {
+        let extensions = cmd.get_env("PATHEXT").unwrap_or(OsStr::new(".EXE"));
+        for path in env::split_paths(path) {
+            let candidate = path.join(exe);
+            if candidate.exists() {
+                return candidate.into_os_string();
+            }
+
+            for ext in env::split_paths(extensions) {
+                let ext = ext.to_str().unwrap_or("");
+                let path = path
+                    .join(exe)
+                    .with_extension(ext.strip_prefix('.').unwrap_or(ext));
+                if path.exists() {
+                    return path.into_os_string();
+                }
+            }
+        }
+    }
+
+    exe.to_os_string()
+}
+
+fn append_quoted(arg: &OsStr, cmdline: &mut Vec<u16>) {
+    if !arg.is_empty()
+        && !arg.encode_wide().any(|c| {
+            c == ' ' as u16
+                || c == '\t' as u16
+                || c == '\n' as u16
+                || c == '\x0b' as u16
+                || c == '\"' as u16
+        })
+    {
+        cmdline.extend(arg.encode_wide());
+        return;
+    }
+    cmdline.push('"' as u16);
+
+    let arg: Vec<_> = arg.encode_wide().collect();
+    let mut i = 0;
+    while i < arg.len() {
+        let mut num_backslashes = 0;
+        while i < arg.len() && arg[i] == '\\' as u16 {
+            i += 1;
+            num_backslashes += 1;
+        }
+
+        if i == arg.len() {
+            for _ in 0..num_backslashes * 2 {
+                cmdline.push('\\' as u16);
+            }
+            break;
+        } else if arg[i] == b'"' as u16 {
+            for _ in 0..num_backslashes * 2 + 1 {
+                cmdline.push('\\' as u16);
+            }
+            cmdline.push(arg[i]);
+        } else {
+            for _ in 0..num_backslashes {
+                cmdline.push('\\' as u16);
+            }
+            cmdline.push(arg[i]);
+        }
+        i += 1;
+    }
+    cmdline.push('"' as u16);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::MIN_CONPTY_BUILD;
+    use super::windows_build_number;
+
+    #[test]
+    fn windows_build_number_returns_value() {
+        // We can't stably check the version of the GH workers, but we can
+        // at least check that this.
+        let version = windows_build_number().unwrap();
+        assert!(version > MIN_CONPTY_BUILD);
+    }
+}


### PR DESCRIPTION
## Summary

Updates the vendored ACP runtime adapter to the 0.15 line and aligns the desktop/backend protocol dependency with `agent-client-protocol` 0.12.1.

This also preserves the NeverWrite-specific runtime delta for review metadata, inline diff reconstruction, permission/session mode handling, Fast mode controls, saved prompt expansion, and subagent projection.

## Details

- Refreshes the vendored runtime package metadata, lockfile, and OpenAI Rust crate tag.
- Adds the required vendored PTY support crate referenced by the runtime patch configuration.
- Migrates session setting updates to the current thread settings API.
- Keeps Fast mode UI IDs stable while sending the current upstream request value to the runtime.
- Updates vendor documentation with the new baseline and local delta notes.

## Validation

- Diff whitespace check passed.
- Vendor ACP crate check and tests passed.
- Native backend check and tests passed.
- AI tool diff tests passed.
- Desktop AI review, edited-files, message list, and merge/diff tests passed.

## Runtime Smoke

Built the release ACP runtime locally, staged it under the Electron native backend resources, rebuilt the native backend sidecar, and confirmed runtime diagnostics resolve the staged binary as bundled for hot-app testing.
