### PR TITLE
Add native OpenCode ACP provider

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1628,7 +1628,9 @@ impl NativeAi {
         pending.auth_method = Some(method_id.to_string());
         pending.auth_ready = false;
         pending.suppress_persisted_auth = false;
-        pending.auth_invalidated_at_ms = None;
+        if runtime_id != OPENCODE_RUNTIME_ID {
+            pending.auth_invalidated_at_ms = None;
+        }
         pending.message = None;
         self.setup_store.save(&pending_setup)?;
 
@@ -1826,6 +1828,7 @@ impl NativeAi {
             Arc::clone(&handle.snapshot),
             Arc::clone(&handle.closed),
             Arc::clone(&self.inner),
+            self.setup_store.clone(),
             launch_config.runtime_id.clone(),
             launch_config.method_id.clone(),
             self.event_tx.clone(),
@@ -1838,6 +1841,7 @@ impl NativeAi {
             Arc::clone(&handle.snapshot),
             Arc::clone(&handle.closed),
             Arc::clone(&self.inner),
+            self.setup_store.clone(),
             launch_config.runtime_id.clone(),
             launch_config.method_id.clone(),
             self.event_tx.clone(),
@@ -6158,6 +6162,7 @@ fn spawn_auth_terminal_output_reader(
     snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
     closed: Arc<AtomicBool>,
     session_state: Arc<Mutex<NativeAiInner>>,
+    setup_store: RuntimeSetupStore,
     runtime_id: String,
     method_id: String,
     event_tx: Sender<RpcOutput>,
@@ -6185,7 +6190,12 @@ fn spawn_auth_terminal_output_reader(
                                     &snapshot.buffer,
                                 )
                             {
-                                mark_runtime_auth_verified(&session_state, &runtime_id, &method_id);
+                                mark_runtime_auth_verified(
+                                    &session_state,
+                                    Some(&setup_store),
+                                    &runtime_id,
+                                    &method_id,
+                                );
                                 verified_auth = true;
                             }
                             snapshot.session_id.clone()
@@ -6274,6 +6284,7 @@ fn spawn_auth_terminal_exit_monitor(
     snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
     closed: Arc<AtomicBool>,
     session_state: Arc<Mutex<NativeAiInner>>,
+    setup_store: RuntimeSetupStore,
     runtime_id: String,
     method_id: String,
     event_tx: Sender<RpcOutput>,
@@ -6323,7 +6334,12 @@ fn spawn_auth_terminal_exit_monitor(
         if let Some(exit_status) = exit_status {
             let exit_code = i32::try_from(exit_status.exit_code()).ok();
             if exit_code == Some(0) {
-                mark_runtime_auth_verified(&session_state, &runtime_id, &method_id);
+                mark_runtime_auth_verified(
+                    &session_state,
+                    Some(&setup_store),
+                    &runtime_id,
+                    &method_id,
+                );
             }
             let snapshot = {
                 let mut snapshot_guard = match snapshot.lock() {
@@ -6376,16 +6392,22 @@ fn mark_runtime_auth_pending(
 
 fn mark_runtime_auth_verified(
     session_state: &Arc<Mutex<NativeAiInner>>,
+    setup_store: Option<&RuntimeSetupStore>,
     runtime_id: &str,
     method_id: &str,
 ) {
-    if let Ok(mut state) = session_state.lock() {
+    let setup_to_save = session_state.lock().ok().map(|mut state| {
         let setup = state.setup.entry(runtime_id.to_string()).or_default();
         setup.auth_method = Some(method_id.to_string());
         setup.auth_ready = true;
         setup.suppress_persisted_auth = false;
         setup.auth_invalidated_at_ms = None;
         setup.message = None;
+        state.setup.clone()
+    });
+
+    if let (Some(setup_store), Some(setup)) = (setup_store, setup_to_save) {
+        let _ = setup_store.save(&setup);
     }
 }
 
@@ -7858,7 +7880,7 @@ mod tests {
     fn verified_terminal_auth_marks_runtime_ready() {
         let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
 
-        mark_runtime_auth_verified(&session_state, KILO_RUNTIME_ID, "kilo-login");
+        mark_runtime_auth_verified(&session_state, None, KILO_RUNTIME_ID, "kilo-login");
 
         let state = session_state.lock().unwrap();
         let setup = state.setup.get(KILO_RUNTIME_ID).expect("runtime setup");
@@ -9654,6 +9676,57 @@ mod tests {
             .expect("OpenCode setup should reload");
         assert_eq!(opencode.auth_method.as_deref(), Some("opencode-login"));
         assert_eq!(opencode.auth_invalidated_at_ms, Some(123));
+    }
+
+    #[test]
+    fn opencode_pending_terminal_auth_preserves_disconnect_invalidation_until_verified() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_secret_store(
+            store_path.clone(),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+
+        native_ai
+            .persist_auth_terminal_pending_setup(
+                OPENCODE_RUNTIME_ID,
+                "opencode-login",
+                RuntimeSetupState {
+                    auth_invalidated_at_ms: Some(123),
+                    suppress_persisted_auth: true,
+                    ..RuntimeSetupState::default()
+                },
+            )
+            .unwrap();
+
+        let opencode = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(OPENCODE_RUNTIME_ID)
+            .cloned()
+            .expect("OpenCode setup should be pending");
+        assert_eq!(opencode.auth_method.as_deref(), Some("opencode-login"));
+        assert!(!opencode.auth_ready);
+        assert_eq!(opencode.auth_invalidated_at_ms, Some(123));
+
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("auth_invalidated_at_ms"));
+
+        mark_runtime_auth_verified(
+            &native_ai.inner,
+            Some(&native_ai.setup_store),
+            OPENCODE_RUNTIME_ID,
+            "opencode-login",
+        );
+
+        let loaded = native_ai.setup_store.load().unwrap();
+        let verified = loaded
+            .get(OPENCODE_RUNTIME_ID)
+            .expect("OpenCode setup should persist verified method");
+        assert_eq!(verified.auth_method.as_deref(), Some("opencode-login"));
+        assert_eq!(verified.auth_invalidated_at_ms, None);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -37,7 +37,7 @@ use neverwrite_ai::{
     AI_SESSION_ERROR_EVENT, AI_SESSION_UPDATED_EVENT, AI_STATUS_EVENT, AI_THINKING_COMPLETED_EVENT,
     AI_THINKING_DELTA_EVENT, AI_THINKING_STARTED_EVENT, AI_TOKEN_USAGE_EVENT,
     AI_TOOL_ACTIVITY_EVENT, CLAUDE_RUNTIME_ID, CODEX_RUNTIME_ID, GEMINI_RUNTIME_ID,
-    KILO_RUNTIME_ID,
+    KILO_RUNTIME_ID, OPENCODE_RUNTIME_ID,
 };
 use portable_pty::{
     native_pty_system, Child as PtyChild, ChildKiller, CommandBuilder, MasterPty, PtySize,
@@ -92,6 +92,70 @@ const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
 const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
 const RUNTIME_SECRET_STORE_MODE_ENV: &str = "NEVERWRITE_AI_SECRET_STORE";
 const RUNTIME_SETUP_LOAD_ERROR_MESSAGE: &str = "Secure credential storage is unavailable. Reconnect this AI provider or configure an environment variable before starting a session.";
+const OPENCODE_AUTH_UNVERIFIED_MESSAGE: &str = "OpenCode auth is managed by the OpenCode CLI. NeverWrite could not verify local OpenCode credentials, but OpenCode may still use /connect, environment variables, or a project .env.";
+
+#[derive(Debug, Clone, Copy)]
+struct RuntimeDefinition {
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    default_executable: &'static str,
+    bin_env_var: &'static str,
+    acp_args: &'static [&'static str],
+    supports_native_resume: bool,
+}
+
+const NO_ACP_ARGS: &[&str] = &[];
+const GEMINI_ACP_ARGS: &[&str] = &["--acp"];
+const SHELL_ACP_ARGS: &[&str] = &["acp"];
+
+const RUNTIME_DEFINITIONS: &[RuntimeDefinition] = &[
+    RuntimeDefinition {
+        id: CODEX_RUNTIME_ID,
+        name: "Codex",
+        description: "OpenAI Codex-compatible agent runtime.",
+        default_executable: "codex",
+        bin_env_var: "NEVERWRITE_CODEX_ACP_BIN",
+        acp_args: NO_ACP_ARGS,
+        supports_native_resume: true,
+    },
+    RuntimeDefinition {
+        id: CLAUDE_RUNTIME_ID,
+        name: "Claude",
+        description: "Claude ACP-compatible agent runtime.",
+        default_executable: "claude",
+        bin_env_var: "NEVERWRITE_CLAUDE_ACP_BIN",
+        acp_args: NO_ACP_ARGS,
+        supports_native_resume: false,
+    },
+    RuntimeDefinition {
+        id: GEMINI_RUNTIME_ID,
+        name: "Gemini",
+        description: "Gemini ACP-compatible agent runtime.",
+        default_executable: "gemini",
+        bin_env_var: "NEVERWRITE_GEMINI_ACP_BIN",
+        acp_args: GEMINI_ACP_ARGS,
+        supports_native_resume: false,
+    },
+    RuntimeDefinition {
+        id: KILO_RUNTIME_ID,
+        name: "Kilo",
+        description: "Kilo ACP-compatible agent runtime.",
+        default_executable: "kilo",
+        bin_env_var: "NEVERWRITE_KILO_ACP_BIN",
+        acp_args: SHELL_ACP_ARGS,
+        supports_native_resume: false,
+    },
+    RuntimeDefinition {
+        id: OPENCODE_RUNTIME_ID,
+        name: "OpenCode",
+        description: "OpenCode ACP-compatible agent runtime.",
+        default_executable: "opencode",
+        bin_env_var: "NEVERWRITE_OPENCODE_ACP_BIN",
+        acp_args: SHELL_ACP_ARGS,
+        supports_native_resume: false,
+    },
+];
 
 #[derive(Debug, Clone)]
 struct TerminalExitMeta {
@@ -243,6 +307,7 @@ struct RuntimeSetupState {
     auth_ready: bool,
     auth_method: Option<String>,
     suppress_persisted_auth: bool,
+    auth_invalidated_at_ms: Option<u64>,
     has_gateway_config: bool,
     has_gateway_url: bool,
     message: Option<String>,
@@ -259,6 +324,8 @@ struct PersistedRuntimeSetupFile {
 struct PersistedRuntimeSetupState {
     custom_binary_path: Option<String>,
     auth_method: Option<String>,
+    #[serde(default)]
+    auth_invalidated_at_ms: Option<u64>,
     #[serde(default)]
     env: HashMap<String, String>,
     #[serde(default)]
@@ -451,15 +518,14 @@ impl RuntimeSetupStore {
                 auth_method: persisted_setup
                     .auth_method
                     .and_then(normalize_optional_string),
+                auth_invalidated_at_ms: persisted_setup.auth_invalidated_at_ms,
                 env,
                 ..RuntimeSetupState::default()
             };
             refresh_runtime_setup_flags(&runtime_id, &mut runtime_setup);
-            if !runtime_setup
-                .auth_method
-                .as_deref()
-                .is_some_and(|method| auth_method_has_local_config(&runtime_setup, method))
-            {
+            if !runtime_setup.auth_method.as_deref().is_some_and(|method| {
+                should_persist_auth_method(&runtime_id, &runtime_setup, method)
+            }) {
                 runtime_setup.auth_method =
                     local_auth_method_for_runtime(&runtime_id, &runtime_setup);
             }
@@ -583,10 +649,12 @@ impl PersistedRuntimeSetupState {
             .auth_method
             .clone()
             .and_then(normalize_optional_string)
-            .filter(|method| auth_method_has_local_config(setup, method));
+            .filter(|method| should_persist_auth_method(runtime_id, setup, method));
+        let auth_invalidated_at_ms = setup.auth_invalidated_at_ms;
 
         if custom_binary_path.is_none()
             && auth_method.is_none()
+            && auth_invalidated_at_ms.is_none()
             && env.is_empty()
             && secret_env_keys.is_empty()
         {
@@ -596,6 +664,7 @@ impl PersistedRuntimeSetupState {
         Ok(Some(Self {
             custom_binary_path,
             auth_method,
+            auth_invalidated_at_ms,
             env,
             secret_env_keys,
         }))
@@ -616,6 +685,7 @@ fn is_secret_runtime_env_key(key: &str) -> bool {
             | "ANTHROPIC_CUSTOM_HEADERS"
             | "GEMINI_API_KEY"
             | "GOOGLE_API_KEY"
+            | "OPENCODE_API_KEY"
             | "KILO_API_KEY"
     )
 }
@@ -935,9 +1005,12 @@ impl NativeAi {
                     "setup_status": setup_status,
                     "setup_error": setup_error,
                     "launch_program": default_executable_name(&runtime_id),
-                    "launch_args": [],
+                    "launch_args": runtime_definition(&runtime_id)
+                        .map(|definition| definition.acp_args.to_vec())
+                        .unwrap_or_default(),
                     "resolution_display": find_program_on_path(default_executable_name(&runtime_id))
                         .map(|path| path.display().to_string()),
+                    "auth": runtime_auth_diagnostics(&runtime_id),
                 })
             })
             .collect::<Vec<_>>();
@@ -1076,7 +1149,7 @@ impl NativeAi {
         }
 
         let setup = pending_setup.entry(runtime_id.clone()).or_default();
-        clear_runtime_auth_state(setup);
+        clear_runtime_auth_state(&runtime_id, setup);
         let status = setup_status_for(&runtime_id, setup.clone())?;
         self.setup_store.save(&pending_setup)?;
 
@@ -1523,7 +1596,7 @@ impl NativeAi {
         let cwd = resolve_auth_terminal_cwd(input.vault_path.as_deref())?;
         let launch_config =
             auth_terminal_launch_config(&input.runtime_id, &method_id, &setup, cwd)?;
-        mark_runtime_auth_pending(&self.inner, &input.runtime_id, &method_id);
+        self.persist_auth_terminal_pending_setup(&input.runtime_id, &method_id, setup)?;
         let snapshot = self.spawn_auth_terminal_session(
             session_id,
             launch_config,
@@ -1531,6 +1604,41 @@ impl NativeAi {
             input.rows.unwrap_or(AUTH_TERMINAL_DEFAULT_ROWS),
         )?;
         Ok(json!(snapshot))
+    }
+
+    fn persist_auth_terminal_pending_setup(
+        &self,
+        runtime_id: &str,
+        method_id: &str,
+        setup: RuntimeSetupState,
+    ) -> Result<(), String> {
+        let (mut pending_setup, setup_load_error) = {
+            let state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            (state.setup.clone(), state.setup_load_error.clone())
+        };
+        if setup_load_error.is_some() {
+            pending_setup = self.setup_store.load().map_err(runtime_setup_load_error)?;
+        }
+
+        let pending = pending_setup.entry(runtime_id.to_string()).or_default();
+        *pending = setup;
+        pending.auth_method = Some(method_id.to_string());
+        pending.auth_ready = false;
+        pending.suppress_persisted_auth = false;
+        pending.auth_invalidated_at_ms = None;
+        pending.message = None;
+        self.setup_store.save(&pending_setup)?;
+
+        let mut state = self
+            .inner
+            .lock()
+            .map_err(|error| format!("Internal AI state error: {error}"))?;
+        state.setup = pending_setup;
+        state.setup_load_error = None;
+        Ok(())
     }
 
     pub(crate) fn write_auth_terminal_session(&self, args: &Value) -> Result<Value, String> {
@@ -4055,63 +4163,47 @@ fn reasoning_effort_label(effort: &str) -> String {
     }
 }
 
+fn runtime_definition(runtime_id: &str) -> Option<&'static RuntimeDefinition> {
+    RUNTIME_DEFINITIONS
+        .iter()
+        .find(|definition| definition.id == runtime_id)
+}
+
 fn runtime_descriptors() -> Vec<AiRuntimeDescriptor> {
-    [
-        (
-            CODEX_RUNTIME_ID,
-            "Codex",
-            "OpenAI Codex-compatible agent runtime.",
-            auth_method_ids(CODEX_RUNTIME_ID),
-        ),
-        (
-            CLAUDE_RUNTIME_ID,
-            "Claude",
-            "Claude ACP-compatible agent runtime.",
-            auth_method_ids(CLAUDE_RUNTIME_ID),
-        ),
-        (
-            GEMINI_RUNTIME_ID,
-            "Gemini",
-            "Gemini ACP-compatible agent runtime.",
-            auth_method_ids(GEMINI_RUNTIME_ID),
-        ),
-        (
-            KILO_RUNTIME_ID,
-            "Kilo",
-            "Kilo ACP-compatible agent runtime.",
-            auth_method_ids(KILO_RUNTIME_ID),
-        ),
-    ]
-    .into_iter()
-    .map(|(runtime_id, name, description, auth_methods)| {
-        let models = default_models(runtime_id);
-        let modes = default_modes(runtime_id);
-        let mut capabilities = vec![
-            "create_session".to_string(),
-            "prompt_queueing".to_string(),
-            "user_input".to_string(),
-        ];
-        if runtime_supports_native_resume(runtime_id) {
-            capabilities.push("resume_session".to_string());
-        }
-        AiRuntimeDescriptor {
-            runtime: AiRuntimeOption {
-                id: runtime_id.to_string(),
-                name: name.to_string(),
-                description: description.to_string(),
-                capabilities,
-            },
-            config_options: default_config_options(runtime_id, &models, &modes),
-            models,
-            modes,
-        }
-        .with_auth_capabilities(auth_methods)
-    })
-    .collect()
+    RUNTIME_DEFINITIONS
+        .iter()
+        .map(|definition| {
+            let runtime_id = definition.id;
+            let models = default_models(runtime_id);
+            let modes = default_modes(runtime_id);
+            let mut capabilities = vec![
+                "create_session".to_string(),
+                "prompt_queueing".to_string(),
+                "user_input".to_string(),
+            ];
+            if definition.supports_native_resume {
+                capabilities.push("resume_session".to_string());
+            }
+            AiRuntimeDescriptor {
+                runtime: AiRuntimeOption {
+                    id: runtime_id.to_string(),
+                    name: definition.name.to_string(),
+                    description: definition.description.to_string(),
+                    capabilities,
+                },
+                config_options: default_config_options(runtime_id, &models, &modes),
+                models,
+                modes,
+            }
+            .with_auth_capabilities(auth_method_ids(runtime_id))
+        })
+        .collect()
 }
 
 fn runtime_supports_native_resume(runtime_id: &str) -> bool {
-    matches!(runtime_id, CODEX_RUNTIME_ID)
+    runtime_definition(runtime_id)
+        .map(|definition| definition.supports_native_resume)
+        .unwrap_or(false)
 }
 
 trait RuntimeDescriptorAuthTags {
@@ -4246,7 +4338,7 @@ fn setup_status_for(
     runtime_id: &str,
     setup: RuntimeSetupState,
 ) -> Result<AiRuntimeSetupStatus, String> {
-    let inherited_auth_method = inherited_auth_method(runtime_id, !setup.suppress_persisted_auth);
+    let inherited_auth_method = inherited_auth_method_for_setup(runtime_id, &setup);
     setup_status_for_with_inherited_auth(runtime_id, setup, inherited_auth_method)
 }
 
@@ -4276,6 +4368,9 @@ fn setup_status_for_with_inherited_auth(
         setup.message
     } else if auth_ready {
         None
+    } else if runtime_id == OPENCODE_RUNTIME_ID && auth_method.as_deref() == Some("opencode-login")
+    {
+        Some(OPENCODE_AUTH_UNVERIFIED_MESSAGE.to_string())
     } else {
         setup.message
     };
@@ -4333,6 +4428,35 @@ fn setup_load_error_status_for(
     status.onboarding_required = true;
     status.message = Some(visible_message);
     Ok(status)
+}
+
+fn runtime_auth_diagnostics(runtime_id: &str) -> Value {
+    if runtime_id != OPENCODE_RUNTIME_ID {
+        return Value::Null;
+    }
+
+    let env = opencode_env_auth_keys()
+        .iter()
+        .map(|key| ((*key).to_string(), json!(env_secret_present(key))))
+        .collect::<serde_json::Map<_, _>>();
+    let auth_store = home_dir()
+        .map(|home| {
+            opencode_auth_file_candidates(&home)
+                .into_iter()
+                .map(|path| {
+                    json!({
+                        "path": path.display().to_string(),
+                        "status": opencode_auth_file_status(&path),
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    json!({
+        "environment": env,
+        "auth_store": auth_store,
+    })
 }
 
 fn acp_process_spec(
@@ -4445,6 +4569,15 @@ fn resolve_base_acp_command(runtime_id: &str, setup: &RuntimeSetupState) -> Reso
         };
     }
 
+    if let Some(path) = resolve_macos_homebrew_runtime_fallback(runtime_id) {
+        return ResolvedAcpCommand {
+            display: Some(path.display().to_string()),
+            program: Some(path),
+            args: Vec::new(),
+            source: AiRuntimeBinarySource::Env,
+        };
+    }
+
     ResolvedAcpCommand {
         program: None,
         args: Vec::new(),
@@ -4518,11 +4651,28 @@ fn runtime_binary_name(base: &str) -> String {
     }
 }
 
+#[cfg(target_os = "macos")]
+fn resolve_macos_homebrew_runtime_fallback(runtime_id: &str) -> Option<PathBuf> {
+    if runtime_id != OPENCODE_RUNTIME_ID {
+        return None;
+    }
+    ["/opt/homebrew/bin", "/usr/local/bin"]
+        .into_iter()
+        .map(|entry| PathBuf::from(entry).join(default_executable_name(runtime_id)))
+        .find(|candidate| is_executable_file(candidate))
+}
+
+#[cfg(not(target_os = "macos"))]
+fn resolve_macos_homebrew_runtime_fallback(_runtime_id: &str) -> Option<PathBuf> {
+    None
+}
+
 fn default_terminal_auth_method(runtime_id: &str) -> &'static str {
     match runtime_id {
         CLAUDE_RUNTIME_ID => default_claude_terminal_auth_method(),
         GEMINI_RUNTIME_ID => "login_with_google",
         KILO_RUNTIME_ID => "kilo-login",
+        OPENCODE_RUNTIME_ID => "opencode-login",
         _ => "terminal-login",
     }
 }
@@ -4584,6 +4734,10 @@ fn auth_terminal_launch_config(
         (KILO_RUNTIME_ID, "kilo-login") => {
             args.extend(["auth".to_string(), "login".to_string()]);
             "Kilo Login".to_string()
+        }
+        (OPENCODE_RUNTIME_ID, "opencode-login") => {
+            args.extend(["auth".to_string(), "login".to_string()]);
+            "OpenCode Login".to_string()
         }
         _ => {
             return Err(format!(
@@ -4732,34 +4886,46 @@ fn with_runtime_args(runtime_id: &str, mut resolved: ResolvedAcpCommand) -> Reso
     if resolved.program.is_none() {
         return resolved;
     }
-    match runtime_id {
-        GEMINI_RUNTIME_ID if !resolved.args.iter().any(|arg| arg == "--acp") => {
-            resolved.args.push("--acp".to_string());
+    if let Some(definition) = runtime_definition(runtime_id) {
+        for arg in definition.acp_args {
+            if !resolved.args.iter().any(|existing| existing == arg) {
+                resolved.args.push((*arg).to_string());
+            }
         }
-        KILO_RUNTIME_ID if !resolved.args.iter().any(|arg| arg == "acp") => {
-            resolved.args.push("acp".to_string());
-        }
-        _ => {}
     }
     resolved
 }
 
 fn runtime_bin_env_var(runtime_id: &str) -> &'static str {
-    match runtime_id {
-        CODEX_RUNTIME_ID => "NEVERWRITE_CODEX_ACP_BIN",
-        CLAUDE_RUNTIME_ID => "NEVERWRITE_CLAUDE_ACP_BIN",
-        GEMINI_RUNTIME_ID => "NEVERWRITE_GEMINI_ACP_BIN",
-        KILO_RUNTIME_ID => "NEVERWRITE_KILO_ACP_BIN",
-        _ => "NEVERWRITE_AI_ACP_BIN",
-    }
+    runtime_definition(runtime_id)
+        .map(|definition| definition.bin_env_var)
+        .unwrap_or("NEVERWRITE_AI_ACP_BIN")
 }
 
-fn inherited_auth_method(runtime_id: &str, include_persisted: bool) -> Option<String> {
+fn inherited_auth_method_for_setup(runtime_id: &str, setup: &RuntimeSetupState) -> Option<String> {
+    inherited_auth_method(
+        runtime_id,
+        !setup.suppress_persisted_auth,
+        setup.auth_invalidated_at_ms,
+    )
+}
+
+fn inherited_auth_method(
+    runtime_id: &str,
+    include_persisted: bool,
+    auth_invalidated_at_ms: Option<u64>,
+) -> Option<String> {
     match runtime_id {
         CODEX_RUNTIME_ID => env_secret_present("CODEX_API_KEY")
             .then(|| "codex-api-key".to_string())
             .or_else(|| env_secret_present("OPENAI_API_KEY").then(|| "openai-api-key".to_string()))
-            .or_else(|| inherited_persisted_auth_method(runtime_id, include_persisted)),
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
         CLAUDE_RUNTIME_ID => env_secret_present("ANTHROPIC_AUTH_TOKEN")
             .then(|| "console-login".to_string())
             .or_else(|| {
@@ -4770,33 +4936,82 @@ fn inherited_auth_method(runtime_id: &str, include_persisted: bool) -> Option<St
                     .then(|| "gateway-bedrock".to_string())
             })
             .or_else(|| env_secret_present("ANTHROPIC_BASE_URL").then(|| "gateway".to_string()))
-            .or_else(|| inherited_persisted_auth_method(runtime_id, include_persisted)),
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
         GEMINI_RUNTIME_ID => env_secret_present("GEMINI_API_KEY")
             .then(|| "use_gemini".to_string())
             .or_else(|| env_secret_present("GOOGLE_API_KEY").then(|| "use_gemini".to_string()))
-            .or_else(|| inherited_persisted_auth_method(runtime_id, include_persisted)),
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
         KILO_RUNTIME_ID => env_secret_present("KILO_API_KEY")
             .then(|| "kilo-api-key".to_string())
-            .or_else(|| inherited_persisted_auth_method(runtime_id, include_persisted)),
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
+        OPENCODE_RUNTIME_ID => opencode_env_auth_present()
+            .then(|| "opencode-login".to_string())
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
         _ => None,
     }
 }
 
-fn inherited_persisted_auth_method(runtime_id: &str, include_persisted: bool) -> Option<String> {
+fn inherited_persisted_auth_method(
+    runtime_id: &str,
+    include_persisted: bool,
+    auth_invalidated_at_ms: Option<u64>,
+) -> Option<String> {
     include_persisted
-        .then(|| persisted_cli_auth_method(runtime_id))
+        .then(|| persisted_cli_auth_method_with_invalidated_at(runtime_id, auth_invalidated_at_ms))
         .flatten()
 }
 
-fn persisted_cli_auth_method(runtime_id: &str) -> Option<String> {
+fn persisted_cli_auth_method_with_invalidated_at(
+    runtime_id: &str,
+    auth_invalidated_at_ms: Option<u64>,
+) -> Option<String> {
     let home = home_dir()?;
-    persisted_cli_auth_method_for_home(runtime_id, &home, is_claude_remote_environment())
+    persisted_cli_auth_method_for_home_with_invalidated_at(
+        runtime_id,
+        &home,
+        is_claude_remote_environment(),
+        auth_invalidated_at_ms,
+    )
 }
 
+#[cfg(test)]
 fn persisted_cli_auth_method_for_home(
     runtime_id: &str,
     home: &Path,
     is_claude_remote: bool,
+) -> Option<String> {
+    persisted_cli_auth_method_for_home_with_invalidated_at(runtime_id, home, is_claude_remote, None)
+}
+
+fn persisted_cli_auth_method_for_home_with_invalidated_at(
+    runtime_id: &str,
+    home: &Path,
+    is_claude_remote: bool,
+    auth_invalidated_at_ms: Option<u64>,
 ) -> Option<String> {
     match runtime_id {
         CODEX_RUNTIME_ID if non_empty_file_exists(&home.join(".codex").join("auth.json")) => {
@@ -4814,6 +5029,9 @@ fn persisted_cli_auth_method_for_home(
             .then(|| "login_with_google".to_string()),
         KILO_RUNTIME_ID if non_empty_file_exists_any(kilo_auth_file_candidates(home)) => {
             Some("kilo-login".to_string())
+        }
+        OPENCODE_RUNTIME_ID if active_opencode_auth_file_exists(home, auth_invalidated_at_ms) => {
+            Some("opencode-login".to_string())
         }
         _ => None,
     }
@@ -4847,6 +5065,102 @@ fn kilo_auth_file_candidates(home: &Path) -> Vec<PathBuf> {
     }
 
     candidates
+}
+
+fn opencode_env_auth_keys() -> &'static [&'static str] {
+    &[
+        "OPENCODE_API_KEY",
+        "OPENAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "GEMINI_API_KEY",
+        "GOOGLE_API_KEY",
+        "CODEX_API_KEY",
+    ]
+}
+
+fn opencode_env_auth_present() -> bool {
+    opencode_env_auth_keys()
+        .iter()
+        .any(|key| env_secret_present(key))
+}
+
+fn opencode_auth_file_candidates(home: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
+        candidates.push(
+            PathBuf::from(xdg_data_home)
+                .join("opencode")
+                .join("auth.json"),
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        candidates.push(
+            std::env::var_os("LOCALAPPDATA")
+                .map(PathBuf::from)
+                .unwrap_or_else(|| home.join("AppData").join("Local"))
+                .join("opencode")
+                .join("auth.json"),
+        );
+    }
+
+    candidates.push(
+        home.join(".local")
+            .join("share")
+            .join("opencode")
+            .join("auth.json"),
+    );
+    candidates
+}
+
+fn active_opencode_auth_file_exists(home: &Path, auth_invalidated_at_ms: Option<u64>) -> bool {
+    opencode_auth_file_candidates(home)
+        .into_iter()
+        .any(|path| opencode_auth_file_is_active(&path, auth_invalidated_at_ms))
+}
+
+fn opencode_auth_file_status(path: &Path) -> &'static str {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() => metadata,
+        _ => return "missing",
+    };
+    if metadata.len() == 0 {
+        return "empty";
+    }
+    match std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+    {
+        Some(Value::Object(object)) if !object.is_empty() => "active",
+        Some(Value::Array(array)) if !array.is_empty() => "active",
+        Some(_) => "inactive",
+        None => "invalid",
+    }
+}
+
+fn opencode_auth_file_is_active(path: &Path, auth_invalidated_at_ms: Option<u64>) -> bool {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() && metadata.len() > 0 => metadata,
+        _ => return false,
+    };
+    if let Some(invalidated_at_ms) = auth_invalidated_at_ms {
+        let Some(modified_at_ms) = metadata.modified().ok().and_then(system_time_epoch_ms) else {
+            return false;
+        };
+        if modified_at_ms <= invalidated_at_ms {
+            return false;
+        }
+    }
+
+    match std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Value>(&raw).ok())
+    {
+        Some(Value::Object(object)) => !object.is_empty(),
+        Some(Value::Array(array)) => !array.is_empty(),
+        _ => false,
+    }
 }
 
 fn non_empty_file_exists_any(paths: impl IntoIterator<Item = PathBuf>) -> bool {
@@ -4901,6 +5215,22 @@ fn auth_method_has_local_config(setup: &RuntimeSetupState, method_id: &str) -> b
             .is_some_and(|value| !value.is_empty()),
         _ => false,
     }
+}
+
+fn should_persist_auth_method(
+    runtime_id: &str,
+    setup: &RuntimeSetupState,
+    method_id: &str,
+) -> bool {
+    auth_method_has_local_config(setup, method_id)
+        || is_persistable_external_auth_method(runtime_id, method_id)
+}
+
+fn is_persistable_external_auth_method(runtime_id: &str, method_id: &str) -> bool {
+    matches!(
+        (runtime_id, method_id),
+        (OPENCODE_RUNTIME_ID, "opencode-login")
+    )
 }
 
 fn is_local_auth_method(method_id: &str) -> bool {
@@ -4982,10 +5312,11 @@ fn refresh_runtime_setup_flags(runtime_id: &str, setup: &mut RuntimeSetupState) 
                 .is_some_and(|value| !value.is_empty()));
 }
 
-fn clear_runtime_auth_state(setup: &mut RuntimeSetupState) {
+fn clear_runtime_auth_state(runtime_id: &str, setup: &mut RuntimeSetupState) {
     setup.auth_ready = false;
     setup.auth_method = None;
     setup.suppress_persisted_auth = true;
+    setup.auth_invalidated_at_ms = (runtime_id == OPENCODE_RUNTIME_ID).then(current_epoch_ms);
     setup.has_gateway_config = false;
     setup.has_gateway_url = false;
     setup.message = None;
@@ -5001,6 +5332,7 @@ fn clear_runtime_auth_state(setup: &mut RuntimeSetupState) {
         "AWS_BEARER_TOKEN_BEDROCK",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
+        "OPENCODE_API_KEY",
         "KILO_API_KEY",
         "GOOGLE_CLOUD_PROJECT",
         "GOOGLE_CLOUD_LOCATION",
@@ -5015,14 +5347,20 @@ fn env_secret_present(key: &str) -> bool {
         .unwrap_or(false)
 }
 
+fn current_epoch_ms() -> u64 {
+    system_time_epoch_ms(SystemTime::now()).unwrap_or_default()
+}
+
+fn system_time_epoch_ms(time: SystemTime) -> Option<u64> {
+    time.duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|duration| duration.as_millis().min(u128::from(u64::MAX)) as u64)
+}
+
 fn runtime_name(runtime_id: &str) -> &'static str {
-    match runtime_id {
-        CODEX_RUNTIME_ID => "Codex",
-        CLAUDE_RUNTIME_ID => "Claude",
-        GEMINI_RUNTIME_ID => "Gemini",
-        KILO_RUNTIME_ID => "Kilo",
-        _ => "AI",
-    }
+    runtime_definition(runtime_id)
+        .map(|definition| definition.name)
+        .unwrap_or("AI")
 }
 
 fn codex_vendor_binary_path() -> PathBuf {
@@ -5087,6 +5425,12 @@ fn auth_methods(runtime_id: &str) -> Vec<AiAuthMethod> {
                 description: "Use a Kilo API key stored locally.".to_string(),
             },
         ],
+        OPENCODE_RUNTIME_ID => vec![AiAuthMethod {
+            id: "opencode-login".to_string(),
+            name: "OpenCode login".to_string(),
+            description: "Open the OpenCode CLI sign-in flow in an integrated terminal."
+                .to_string(),
+        }],
         _ => vec![],
     }
 }
@@ -5097,6 +5441,7 @@ fn auth_method_ids(runtime_id: &str) -> Vec<&'static str> {
         CLAUDE_RUNTIME_ID => claude_auth_method_ids_for_environment(is_claude_remote_environment()),
         GEMINI_RUNTIME_ID => vec!["login_with_google", "use_gemini"],
         KILO_RUNTIME_ID => vec!["kilo-login", "kilo-api-key"],
+        OPENCODE_RUNTIME_ID => vec!["opencode-login"],
         _ => vec![],
     }
 }
@@ -5381,6 +5726,7 @@ fn update_auth_state(
             setup.auth_method = local_auth_method_for_runtime(runtime_id, setup);
         }
         setup.suppress_persisted_auth = false;
+        setup.auth_invalidated_at_ms = None;
         setup.message = None;
     }
     Ok(())
@@ -5647,9 +5993,10 @@ fn required_string(args: &Value, names: &[&str]) -> Result<String, String> {
 }
 
 fn validate_runtime_id(runtime_id: &str) -> Result<(), String> {
-    match runtime_id {
-        CODEX_RUNTIME_ID | CLAUDE_RUNTIME_ID | GEMINI_RUNTIME_ID | KILO_RUNTIME_ID => Ok(()),
-        other => Err(format!("Unsupported AI runtime: {other}")),
+    if runtime_definition(runtime_id).is_some() {
+        Ok(())
+    } else {
+        Err(format!("Unsupported AI runtime: {runtime_id}"))
     }
 }
 
@@ -5663,17 +6010,16 @@ fn normalize_optional_string(value: String) -> Option<String> {
 }
 
 fn default_executable_name(runtime_id: &str) -> &'static str {
-    match runtime_id {
-        CODEX_RUNTIME_ID => "codex",
-        CLAUDE_RUNTIME_ID => "claude",
-        GEMINI_RUNTIME_ID => "gemini",
-        KILO_RUNTIME_ID => "kilo",
-        _ => "unknown",
-    }
+    runtime_definition(runtime_id)
+        .map(|definition| definition.default_executable)
+        .unwrap_or("unknown")
 }
 
 fn diagnostic_executable_names() -> Vec<&'static str> {
-    vec!["codex", "claude", "gemini", "kilo"]
+    RUNTIME_DEFINITIONS
+        .iter()
+        .map(|definition| definition.default_executable)
+        .collect()
 }
 
 fn find_program_on_path(name: &str) -> Option<PathBuf> {
@@ -5877,6 +6223,13 @@ fn auth_terminal_output_indicates_success(runtime_id: &str, buffer: &str) -> boo
             buffer.contains("Authentication succeeded")
                 || buffer.contains("successfully signed in with Google")
         }
+        OPENCODE_RUNTIME_ID => {
+            let lower = buffer.to_ascii_lowercase();
+            lower.contains("authentication successful")
+                || lower.contains("login successful")
+                || lower.contains("successfully authenticated")
+                || lower.contains("successfully logged in")
+        }
         _ => false,
     }
 }
@@ -6005,6 +6358,7 @@ fn append_auth_terminal_buffer(buffer: &mut String, chunk: &str) {
     buffer.drain(..trim_to);
 }
 
+#[cfg(test)]
 fn mark_runtime_auth_pending(
     session_state: &Arc<Mutex<NativeAiInner>>,
     runtime_id: &str,
@@ -6015,6 +6369,7 @@ fn mark_runtime_auth_pending(
         setup.auth_method = Some(method_id.to_string());
         setup.auth_ready = false;
         setup.suppress_persisted_auth = false;
+        setup.auth_invalidated_at_ms = None;
         setup.message = None;
     }
 }
@@ -6029,6 +6384,7 @@ fn mark_runtime_auth_verified(
         setup.auth_method = Some(method_id.to_string());
         setup.auth_ready = true;
         setup.suppress_persisted_auth = false;
+        setup.auth_invalidated_at_ms = None;
         setup.message = None;
     }
 }
@@ -6628,6 +6984,7 @@ mod tests {
         assert!(!runtime_supports_native_resume(CLAUDE_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(GEMINI_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(KILO_RUNTIME_ID));
+        assert!(!runtime_supports_native_resume(OPENCODE_RUNTIME_ID));
     }
 
     #[test]
@@ -8958,6 +9315,82 @@ mod tests {
     }
 
     #[test]
+    fn detects_active_persisted_opencode_credentials() {
+        let temp = tempfile::tempdir().unwrap();
+        let opencode_dir = temp.path().join(".local").join("share").join("opencode");
+        fs::create_dir_all(&opencode_dir).unwrap();
+        fs::write(
+            opencode_dir.join("auth.json"),
+            r#"{"openai":{"token":"redacted"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            persisted_cli_auth_method_for_home(OPENCODE_RUNTIME_ID, temp.path(), false),
+            Some("opencode-login".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_inactive_or_invalid_opencode_credentials() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp
+            .path()
+            .join(".local")
+            .join("share")
+            .join("opencode")
+            .join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+
+        for raw in ["", "{}", "[]", "not-json"] {
+            fs::write(&auth_file, raw).unwrap();
+            assert_eq!(
+                persisted_cli_auth_method_for_home(OPENCODE_RUNTIME_ID, temp.path(), false),
+                None,
+                "{raw:?} should not count as active OpenCode auth"
+            );
+        }
+    }
+
+    #[test]
+    fn opencode_auth_invalidation_blocks_stale_auth_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp
+            .path()
+            .join(".local")
+            .join("share")
+            .join("opencode")
+            .join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(&auth_file, r#"[{"provider":"openai"}]"#).unwrap();
+        let modified_at_ms = fs::metadata(&auth_file)
+            .unwrap()
+            .modified()
+            .ok()
+            .and_then(system_time_epoch_ms)
+            .unwrap();
+
+        assert_eq!(
+            persisted_cli_auth_method_for_home_with_invalidated_at(
+                OPENCODE_RUNTIME_ID,
+                temp.path(),
+                false,
+                Some(modified_at_ms),
+            ),
+            None
+        );
+        assert_eq!(
+            persisted_cli_auth_method_for_home_with_invalidated_at(
+                OPENCODE_RUNTIME_ID,
+                temp.path(),
+                false,
+                Some(modified_at_ms.saturating_sub(1)),
+            ),
+            Some("opencode-login".to_string())
+        );
+    }
+
+    #[test]
     fn inherited_kilo_login_does_not_satisfy_selected_kilo_api_key() {
         let current_exe = std::env::current_exe().unwrap();
         let setup = RuntimeSetupState {
@@ -9020,6 +9453,26 @@ mod tests {
     }
 
     #[test]
+    fn auth_terminal_launch_config_uses_opencode_login_command() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let config = auth_terminal_launch_config(
+            OPENCODE_RUNTIME_ID,
+            "opencode-login",
+            &setup,
+            std::env::current_dir().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(config.args, vec!["auth".to_string(), "login".to_string()]);
+        assert_eq!(config.display_name, "OpenCode Login");
+    }
+
+    #[test]
     fn auth_terminal_launch_config_forces_gemini_google_login_method() {
         let current_exe = std::env::current_exe().unwrap();
         let setup = RuntimeSetupState {
@@ -9055,6 +9508,18 @@ mod tests {
         assert!(!auth_terminal_output_indicates_success(
             CLAUDE_RUNTIME_ID,
             "Authentication succeeded"
+        ));
+    }
+
+    #[test]
+    fn opencode_auth_terminal_success_output_is_detected_before_exit() {
+        assert!(auth_terminal_output_indicates_success(
+            OPENCODE_RUNTIME_ID,
+            "OpenCode login successful"
+        ));
+        assert!(!auth_terminal_output_indicates_success(
+            OPENCODE_RUNTIME_ID,
+            "OpenCode login required"
         ));
     }
 
@@ -9158,6 +9623,37 @@ mod tests {
             Some("kilo-api-key")
         );
         assert!(!status.to_string().contains("kilo-test-secret"));
+    }
+
+    #[test]
+    fn opencode_login_selection_persists_without_local_secret() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let store = RuntimeSetupStore::with_secret_store(
+            store_path.clone(),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let mut setup = HashMap::new();
+        setup.insert(
+            OPENCODE_RUNTIME_ID.to_string(),
+            RuntimeSetupState {
+                auth_method: Some("opencode-login".to_string()),
+                auth_invalidated_at_ms: Some(123),
+                ..RuntimeSetupState::default()
+            },
+        );
+
+        store.save(&setup).unwrap();
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("opencode-login"));
+        assert!(encoded.contains("auth_invalidated_at_ms"));
+
+        let loaded = store.load().unwrap();
+        let opencode = loaded
+            .get(OPENCODE_RUNTIME_ID)
+            .expect("OpenCode setup should reload");
+        assert_eq!(opencode.auth_method.as_deref(), Some("opencode-login"));
+        assert_eq!(opencode.auth_invalidated_at_ms, Some(123));
     }
 
     #[test]
@@ -9606,5 +10102,25 @@ mod tests {
             spec.env.get("KILO_API_KEY").map(String::as_str),
             Some("kilo-test-secret")
         );
+    }
+
+    #[test]
+    fn acp_process_spec_launches_opencode_with_acp_arg() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("opencode-login".to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(
+            OPENCODE_RUNTIME_ID,
+            &setup,
+            std::env::current_dir().unwrap(),
+        )
+        .expect("OpenCode ACP process spec should resolve");
+
+        assert_eq!(spec.args, vec!["acp".to_string()]);
+        assert_eq!(spec.runtime_id, OPENCODE_RUNTIME_ID);
     }
 }

--- a/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
+++ b/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
@@ -344,6 +344,7 @@ async function main() {
       "claude-acp",
       "gemini-acp",
       "kilo-acp",
+      "opencode-acp",
     ]) {
       assert(
         runtimes.some((runtime) => runtime.runtime.id === runtimeId),

--- a/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
@@ -120,6 +120,48 @@ describe("AIAuthTerminalModal", () => {
         });
     });
 
+    it("recognizes OpenCode terminal auth success output", async () => {
+        const snapshot = {
+            sessionId: "authterm-opencode",
+            runtimeId: "opencode-acp",
+            program: "opencode",
+            displayName: "OpenCode sign-in",
+            cwd: "/vault",
+            cols: 100,
+            rows: 28,
+            buffer: "OpenCode login successful",
+            status: "exited",
+            exitCode: 0,
+            errorMessage: null,
+        };
+        apiMocks.aiStartAuthTerminalSession.mockResolvedValue(snapshot);
+        apiMocks.aiResizeAuthTerminalSession.mockResolvedValue(
+            snapshot as never,
+        );
+
+        renderComponent(
+            <AIAuthTerminalModal
+                open
+                runtimeId="opencode-acp"
+                runtimeName="OpenCode"
+                vaultPath="/vault"
+                onClose={vi.fn()}
+                onRefreshSetup={vi.fn(async () => undefined)}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(
+                screen.getByText("OpenCode sign-in succeeded"),
+            ).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    /Sign-in completed\. You can close this dialog/,
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
     it("cleans up listeners that resolve after the modal unmounts", async () => {
         const startedDeferred = createDeferred<Mock>();
         const outputDeferred = createDeferred<Mock>();

--- a/apps/desktop/src/features/ai/components/AIAuthTerminalModal.tsx
+++ b/apps/desktop/src/features/ai/components/AIAuthTerminalModal.tsx
@@ -60,6 +60,27 @@ function getRunningStatusLabel(runtimeName: string) {
     return `Waiting for ${runtimeName} sign-in`;
 }
 
+function authTerminalOutputIndicatesSuccess(runtimeId: string, output: string) {
+    if (runtimeId === "gemini-acp") {
+        return (
+            output.includes("Authentication succeeded") ||
+            output.includes("successfully signed in with Google")
+        );
+    }
+
+    if (runtimeId === "opencode-acp") {
+        const normalized = output.toLowerCase();
+        return (
+            normalized.includes("authentication successful") ||
+            normalized.includes("login successful") ||
+            normalized.includes("successfully authenticated") ||
+            normalized.includes("successfully logged in")
+        );
+    }
+
+    return false;
+}
+
 export function AIAuthTerminalModal({
     open,
     runtimeId,
@@ -292,10 +313,10 @@ export function AIAuthTerminalModal({
 
     const terminalExited =
         snapshot.status === "exited" || snapshot.status === "error";
-    const authSucceeded =
-        runtimeId === "gemini-acp" &&
-        (rawOutput.includes("Authentication succeeded") ||
-            rawOutput.includes("successfully signed in with Google"));
+    const authSucceeded = authTerminalOutputIndicatesSuccess(
+        runtimeId,
+        rawOutput,
+    );
 
     return (
         <>
@@ -424,11 +445,11 @@ export function AIAuthTerminalModal({
                             className="text-xs"
                             style={{ color: "var(--text-secondary)" }}
                         >
-                            {terminalExited
-                                ? `If sign-in completed, ${APP_BRAND_NAME} will detect it after refreshing setup.`
-                                : authSucceeded
-                                  ? `Sign-in completed. You can close this dialog; ${APP_BRAND_NAME} will refresh setup.`
-                                : "Complete the sign-in flow in the terminal, then close this dialog or wait for it to exit."}
+                            {authSucceeded
+                                ? `Sign-in completed. You can close this dialog; ${APP_BRAND_NAME} will refresh setup.`
+                                : terminalExited
+                                  ? `If sign-in completed, ${APP_BRAND_NAME} will detect it after refreshing setup.`
+                                  : "Complete the sign-in flow in the terminal, then close this dialog or wait for it to exit."}
                         </div>
                         <div className="flex items-center gap-2">
                             <button

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -182,7 +182,7 @@ describe("AIChatAgentControls", () => {
         );
     });
 
-    it("shows a model search field only for Kilo and filters results", () => {
+    it("shows a model search field for Kilo and filters results", () => {
         const onConfigOptionChange = vi.fn();
 
         renderComponent(
@@ -255,7 +255,85 @@ describe("AIChatAgentControls", () => {
         ).not.toBeInTheDocument();
     });
 
-    it("does not show the model search field for non-Kilo runtimes", () => {
+    it("shows a model search field for OpenCode and filters Zen models", () => {
+        const onConfigOptionChange = vi.fn();
+
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="opencode-acp"
+                modelId="opencode/zen/qwen3.5-plus"
+                modeId="default"
+                effortsByModel={{}}
+                models={[]}
+                modes={[
+                    {
+                        id: "default",
+                        runtimeId: "opencode-acp",
+                        name: "Auto",
+                        description: "",
+                        disabled: false,
+                    },
+                ]}
+                configOptions={[
+                    {
+                        id: "model",
+                        runtimeId: "opencode-acp",
+                        category: "model",
+                        label: "Model",
+                        type: "select",
+                        value: "opencode/zen/qwen3.5-plus",
+                        options: [
+                            {
+                                value: "opencode/zen/qwen3.5-plus",
+                                label: "OpenCode Zen/Qwen3.5 Plus",
+                            },
+                            {
+                                value: "opencode/zen/gemini-3-flash",
+                                label: "OpenCode Zen/Gemini 3 Flash",
+                            },
+                            {
+                                value: "opencode/zen/claude-opus-4.7",
+                                label: "OpenCode Zen/Claude Opus 4.7",
+                            },
+                        ],
+                    },
+                ]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={onConfigOptionChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByTitle("Model"));
+
+        const search = screen.getByLabelText("Model search");
+        expect(search).toBeInTheDocument();
+        expect(
+            screen.getByText("OpenCode Zen/Gemini 3 Flash"),
+        ).toBeInTheDocument();
+
+        fireEvent.change(search, { target: { value: "opus" } });
+
+        expect(
+            screen.getByText("OpenCode Zen/Claude Opus 4.7"),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("OpenCode Zen/Gemini 3 Flash"),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: "OpenCode Zen/Claude Opus 4.7",
+            }),
+        );
+
+        expect(onConfigOptionChange).toHaveBeenCalledWith(
+            "model",
+            "opencode/zen/claude-opus-4.7",
+        );
+    });
+
+    it("does not show the model search field for non-searchable runtimes", () => {
         renderComponent(
             <AIChatAgentControls
                 runtimeId="codex-acp"

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -33,6 +33,14 @@ interface DropdownFieldProps {
     onChange: (value: string) => void;
 }
 
+const SEARCHABLE_MODEL_RUNTIME_IDS = new Set(["kilo-acp", "opencode-acp"]);
+
+function shouldUseSearchableModelMenu(runtimeId?: string) {
+    return (
+        runtimeId !== undefined && SEARCHABLE_MODEL_RUNTIME_IDS.has(runtimeId)
+    );
+}
+
 function formatFallbackLabel(value: string) {
     if (value.trim().includes(" ")) {
         return value;
@@ -387,9 +395,9 @@ export function AIChatAgentControls({
                 disabled={disabled}
                 label="Model"
                 value={selectedModelId}
-                searchable={runtimeId === "kilo-acp"}
-                searchPlaceholder="Select a model..."
-                emptySearchMessage="No Kilo models match that search."
+                searchable={shouldUseSearchableModelMenu(runtimeId)}
+                searchPlaceholder="Search models..."
+                emptySearchMessage="No models match that search."
                 options={
                     modelConfig
                         ? mapConfigOption(modelConfig)

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -213,14 +213,15 @@ function DropdownField({
                                 }}
                                 placeholder={searchPlaceholder}
                                 aria-label={`${label} search`}
-                                className="mt-0.5 w-full rounded-md px-1.5 py-0.5 text-[8px]"
+                                className="mt-0.5 w-full rounded px-1 py-0 text-[7px]"
                                 style={{
                                     color: "var(--text-primary)",
                                     backgroundColor: "var(--bg-primary)",
                                     border: "1px solid var(--border)",
+                                    height: 16,
                                     outline: "none",
-                                    minHeight: 22,
-                                    lineHeight: 1.1,
+                                    minHeight: 16,
+                                    lineHeight: "12px",
                                 }}
                             />
                         </div>

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1922,6 +1922,62 @@ describe("chatStore", () => {
         });
     });
 
+    it("does not treat a generic non-OpenCode 401 as an authentication error", () => {
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: { ...runtimePayload[0].runtime },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                "codex-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "codex-acp",
+                    authReady: true,
+                    onboardingRequired: false,
+                },
+            },
+            sessionsById: {
+                "codex-session-1": {
+                    sessionId: "codex-session-1",
+                    historySessionId: "codex-session-1",
+                    runtimeId: "codex-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    status: "streaming",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                    runtimeState: "live",
+                },
+            },
+            selectedRuntimeId: "codex-acp",
+        });
+
+        useChatStore.getState().applySessionError({
+            session_id: "codex-session-1",
+            message: "401 from a downstream document fetch",
+        });
+
+        expect(
+            useChatStore.getState().setupStatusByRuntimeId["codex-acp"],
+        ).toMatchObject({
+            authReady: true,
+            onboardingRequired: false,
+        });
+        expect(
+            useChatStore.getState().runtimeConnectionByRuntimeId["codex-acp"],
+        ).toMatchObject({
+            status: "error",
+            message: "401 from a downstream document fetch",
+        });
+    });
+
     it("shows provider quota errors as provider limits", () => {
         useChatStore.setState({
             runtimes: [

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1859,6 +1859,69 @@ describe("chatStore", () => {
         });
     });
 
+    it("treats OpenCode auth guidance as an authentication error", () => {
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: {
+                        ...runtimePayload[0].runtime,
+                        id: "opencode-acp",
+                        name: "OpenCode ACP",
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                "opencode-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "opencode-acp",
+                    authMethod: "opencode-login",
+                    authMethods: [
+                        {
+                            id: "opencode-login",
+                            name: "OpenCode login",
+                            description:
+                                "Open the OpenCode CLI sign-in flow in an integrated terminal.",
+                        },
+                    ],
+                },
+            },
+            sessionsById: {
+                "opencode-session-1": {
+                    sessionId: "opencode-session-1",
+                    historySessionId: "opencode-session-1",
+                    runtimeId: "opencode-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    status: "streaming",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                    runtimeState: "live",
+                },
+            },
+            selectedRuntimeId: "opencode-acp",
+        });
+
+        useChatStore.getState().applySessionError({
+            session_id: "opencode-session-1",
+            message: "Missing API key. Run `opencode auth login` or use /connect.",
+        });
+
+        expect(
+            useChatStore.getState().setupStatusByRuntimeId["opencode-acp"],
+        ).toMatchObject({
+            authReady: false,
+            authMethod: undefined,
+            onboardingRequired: true,
+            message: "You were signed out. Reconnect OpenCode to continue.",
+        });
+    });
+
     it("shows provider quota errors as provider limits", () => {
         useChatStore.setState({
             runtimes: [

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1454,18 +1454,26 @@ function applyRuntimeSetupStatusPatch(
     };
 }
 
-function isAuthenticationErrorMessage(message: string) {
+function isAuthenticationErrorMessage(
+    message: string,
+    runtimeId?: string | null,
+) {
     const normalized = message.trim().toLowerCase();
+    const isOpenCodeRuntime = runtimeId === "opencode-acp";
+    const isOpenCodeAuthGuidance =
+        normalized.includes("run opencode auth login") ||
+        normalized.includes("use /connect") ||
+        (isOpenCodeRuntime &&
+            (normalized.includes("missing api key") ||
+                normalized.includes("no provider configured") ||
+                normalized.includes("unauthorized") ||
+                normalized.includes("401")));
+
     return (
         normalized.includes("auth_required") ||
         normalized.includes("authentication required") ||
         normalized.includes("auth required") ||
-        normalized.includes("missing api key") ||
-        normalized.includes("no provider configured") ||
-        normalized.includes("run opencode auth login") ||
-        normalized.includes("use /connect") ||
-        normalized.includes("unauthorized") ||
-        normalized.includes("401") ||
+        isOpenCodeAuthGuidance ||
         normalized.includes("you were signed out") ||
         normalized.includes("reconnect in ai setup") ||
         normalized.includes("reconnect codex") ||
@@ -1506,7 +1514,7 @@ function isRuntimeSessionDisconnectedErrorMessage(message: string) {
     return normalized.includes("runtime session is not connected");
 }
 
-function normalizeAiErrorMessage(message: string) {
+function normalizeAiErrorMessage(message: string, runtimeId?: string | null) {
     if (message.includes("No hay vault abierto")) {
         return "Open a vault before starting a chat.";
     }
@@ -1519,7 +1527,7 @@ function normalizeAiErrorMessage(message: string) {
         return "Provider quota reached. Check your plan or wait until it resets.";
     }
 
-    if (isAuthenticationErrorMessage(message)) {
+    if (isAuthenticationErrorMessage(message, runtimeId)) {
         return "You were signed out. Reconnect in AI setup to continue chatting.";
     }
 
@@ -6578,7 +6586,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 session_id: activeSessionId,
                 message,
             });
-            if (isAuthenticationErrorMessage(message)) {
+            if (isAuthenticationErrorMessage(message, session.runtimeId)) {
                 await get().refreshSetupStatus(session.runtimeId);
             }
         }
@@ -7716,7 +7724,6 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         applySessionError: ({ session_id, message: rawMessage }) => {
-            const message = normalizeAiErrorMessage(rawMessage);
             if (session_id) clearStaleStreamingCheck(session_id);
             set((state) => {
                 const sessionRuntimeId = session_id
@@ -7724,12 +7731,17 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     : null;
                 const effectiveRuntimeId =
                     sessionRuntimeId ?? getEffectiveRuntimeId(state);
+                const message = normalizeAiErrorMessage(
+                    rawMessage,
+                    effectiveRuntimeId,
+                );
                 const runtimeSetupStatus = getSetupStatusForRuntime(
                     state.setupStatusByRuntimeId,
                     effectiveRuntimeId,
                 );
                 const nextSetupStatusByRuntimeId =
-                    runtimeSetupStatus && isAuthenticationErrorMessage(message)
+                    runtimeSetupStatus &&
+                    isAuthenticationErrorMessage(message, effectiveRuntimeId)
                         ? {
                               ...state.setupStatusByRuntimeId,
                               [runtimeSetupStatus.runtimeId]: {
@@ -8938,7 +8950,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     session_id: sessionId,
                     message: SAVED_CHAT_RECONNECT_FAILED_MESSAGE,
                 });
-                if (isAuthenticationErrorMessage(message)) {
+                if (isAuthenticationErrorMessage(message, failedSession.runtimeId)) {
                     await get().refreshSetupStatus(
                         get().sessionsById[sessionId]?.runtimeId,
                     );
@@ -10781,7 +10793,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         message,
                     });
                 }
-                if (isAuthenticationErrorMessage(message)) {
+                if (isAuthenticationErrorMessage(message, nextRuntimeId)) {
                     await get().refreshSetupStatus(nextRuntimeId);
                 }
                 return provisionalSessionId ?? null;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1459,6 +1459,13 @@ function isAuthenticationErrorMessage(message: string) {
     return (
         normalized.includes("auth_required") ||
         normalized.includes("authentication required") ||
+        normalized.includes("auth required") ||
+        normalized.includes("missing api key") ||
+        normalized.includes("no provider configured") ||
+        normalized.includes("run opencode auth login") ||
+        normalized.includes("use /connect") ||
+        normalized.includes("unauthorized") ||
+        normalized.includes("401") ||
         normalized.includes("you were signed out") ||
         normalized.includes("reconnect in ai setup") ||
         normalized.includes("reconnect codex") ||

--- a/apps/desktop/src/features/ai/utils/authMethods.test.ts
+++ b/apps/desktop/src/features/ai/utils/authMethods.test.ts
@@ -18,6 +18,9 @@ describe("authMethods", () => {
         expect(isIntegratedTerminalAuthMethod("kilo-acp", "kilo-login")).toBe(
             true,
         );
+        expect(
+            isIntegratedTerminalAuthMethod("opencode-acp", "opencode-login"),
+        ).toBe(true);
     });
 
     it("rejects terminal auth methods for the wrong runtime", () => {
@@ -30,6 +33,9 @@ describe("authMethods", () => {
         expect(
             isIntegratedTerminalAuthMethod("codex-acp", "kilo-login"),
         ).toBe(false);
+        expect(
+            isIntegratedTerminalAuthMethod("kilo-acp", "opencode-login"),
+        ).toBe(false);
     });
 
     it("recognizes supported terminal auth method ids", () => {
@@ -38,6 +44,7 @@ describe("authMethods", () => {
             true,
         );
         expect(isIntegratedTerminalAuthMethodId("kilo-login")).toBe(true);
+        expect(isIntegratedTerminalAuthMethodId("opencode-login")).toBe(true);
         expect(isIntegratedTerminalAuthMethodId("openai-api-key")).toBe(false);
     });
 });

--- a/apps/desktop/src/features/ai/utils/authMethods.ts
+++ b/apps/desktop/src/features/ai/utils/authMethods.ts
@@ -28,6 +28,10 @@ export function isIntegratedTerminalAuthMethod(
         return methodId === "kilo-login";
     }
 
+    if (runtimeId === "opencode-acp") {
+        return methodId === "opencode-login";
+    }
+
     return false;
 }
 
@@ -35,6 +39,7 @@ export function isIntegratedTerminalAuthMethodId(methodId?: string) {
     return (
         isClaudeTerminalAuthMethodId(methodId) ||
         methodId === "login_with_google" ||
-        methodId === "kilo-login"
+        methodId === "kilo-login" ||
+        methodId === "opencode-login"
     );
 }

--- a/apps/desktop/src/features/ai/utils/runtimeMetadata.test.ts
+++ b/apps/desktop/src/features/ai/utils/runtimeMetadata.test.ts
@@ -6,13 +6,18 @@ import {
 } from "./runtimeMetadata";
 
 describe("runtimeMetadata", () => {
-    it("includes Kilo in the provider catalog", () => {
+    it("includes native ACP runtimes in the provider catalog", () => {
         expect(PROVIDER_CATALOG).toEqual(
             expect.arrayContaining([
                 expect.objectContaining({
                     id: "kilo-acp",
                     name: "Kilo",
                     company: "Kilo Code",
+                }),
+                expect.objectContaining({
+                    id: "opencode-acp",
+                    name: "OpenCode",
+                    company: "OpenCode",
                 }),
             ]),
         );
@@ -26,6 +31,14 @@ describe("runtimeMetadata", () => {
                     runtime: expect.objectContaining({
                         id: "kilo-acp",
                         name: "Kilo ACP",
+                    }),
+                }),
+                expect.objectContaining({
+                    runtime: expect.objectContaining({
+                        id: "opencode-acp",
+                        name: "OpenCode ACP",
+                        description:
+                            "OpenCode CLI running as a native ACP agent.",
                     }),
                 }),
             ]),
@@ -46,6 +59,7 @@ describe("runtimeMetadata", () => {
     it("normalizes runtime display names for the UI", () => {
         expect(getRuntimeDisplayName("kilo-acp", "Kilo ACP")).toBe("Kilo");
         expect(getRuntimeDisplayName("kilo-acp")).toBe("Kilo");
+        expect(getRuntimeDisplayName("opencode-acp")).toBe("OpenCode");
         expect(getRuntimeDisplayName(undefined, undefined)).toBe("Assistant");
     });
 });

--- a/apps/desktop/src/features/ai/utils/runtimeMetadata.ts
+++ b/apps/desktop/src/features/ai/utils/runtimeMetadata.ts
@@ -71,6 +71,21 @@ const RUNTIME_METADATA: RuntimeMetadata[] = [
             "list_sessions",
         ],
     },
+    {
+        id: "opencode-acp",
+        name: "OpenCode",
+        company: "OpenCode",
+        description: "OpenCode CLI running as a native ACP agent.",
+        capabilities: [
+            "attachments",
+            "permissions",
+            "plans",
+            "terminal_output",
+            "create_session",
+            "prompt_queueing",
+            "user_input",
+        ],
+    },
 ];
 
 export const PROVIDER_CATALOG = [

--- a/apps/desktop/src/features/editor/editorTabIcons.test.tsx
+++ b/apps/desktop/src/features/editor/editorTabIcons.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import type { Tab } from "../../app/store/editorStore";
+import { renderComponent } from "../../test/test-utils";
+import { renderEditorTabLeadingIcon } from "./editorTabIcons";
+
+describe("renderEditorTabLeadingIcon", () => {
+    it("uses the official OpenCode logo shape for OpenCode chat tabs", () => {
+        const tab: Tab = {
+            id: "chat-opencode",
+            kind: "ai-chat",
+            sessionId: "session-opencode",
+            title: "OpenCode",
+        };
+
+        const { container } = renderComponent(
+            <>
+                {renderEditorTabLeadingIcon(tab, {
+                    "session-opencode": { runtimeId: "opencode-acp" },
+                })}
+            </>,
+        );
+
+        const svg = container.querySelector("svg");
+        const pathData = Array.from(svg?.querySelectorAll("path") ?? []).map(
+            (path) => path.getAttribute("d"),
+        );
+
+        expect(svg?.getAttribute("viewBox")).toBe("0 0 300 300");
+        expect(pathData).toContain("M210 240H90V120H210V240Z");
+        expect(pathData).toContain(
+            "M210 60H90V240H210V60ZM270 300H30V0H270V300Z",
+        );
+        expect(svg?.querySelector("line")).toBeNull();
+    });
+});

--- a/apps/desktop/src/features/editor/editorTabIcons.tsx
+++ b/apps/desktop/src/features/editor/editorTabIcons.tsx
@@ -88,6 +88,28 @@ function ChatProviderIcon({ runtimeId }: { readonly runtimeId: string }) {
         );
     }
 
+    if (runtimeId.includes("opencode")) {
+        return (
+            <svg
+                className="shrink-0 opacity-55"
+                fill="none"
+                height={12}
+                viewBox="0 0 300 300"
+                width={12}
+            >
+                <path
+                    d="M210 240H90V120H210V240Z"
+                    fill="currentColor"
+                    opacity="0.38"
+                />
+                <path
+                    d="M210 60H90V240H210V60ZM270 300H30V0H270V300Z"
+                    fill="currentColor"
+                />
+            </svg>
+        );
+    }
+
     return (
         <svg
             className="shrink-0 opacity-55"

--- a/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
@@ -143,6 +143,28 @@ function createDefaultProviders() {
     return { descriptors, statuses };
 }
 
+function addOpenCodeProvider(
+    providers: ReturnType<typeof createDefaultProviders>,
+    statusOverrides: Partial<AIRuntimeSetupStatus> = {},
+) {
+    providers.descriptors.push(
+        createRuntimeDescriptor("opencode-acp", "OpenCode ACP"),
+    );
+    providers.statuses["opencode-acp"] = createSetupStatus({
+        runtimeId: "opencode-acp",
+        binarySource: "env",
+        authMethods: [
+            {
+                id: "opencode-login",
+                name: "OpenCode auth",
+                description:
+                    "Use providers and credentials configured by the OpenCode CLI.",
+            },
+        ],
+        ...statusOverrides,
+    });
+}
+
 function mockProviders({
     descriptors,
     statuses,
@@ -221,7 +243,7 @@ function createDeferred<T>() {
 }
 
 async function openProvider(providerName: string) {
-    await screen.findByText(providerName);
+    await screen.findAllByText(providerName);
     const providerButton = screen
         .getAllByRole("button")
         .find((candidate) => candidate.textContent?.includes(providerName));
@@ -579,6 +601,113 @@ describe("AIProvidersSettings", () => {
                 methodId: "kilo-login",
                 vaultPath: null,
                 customBinaryPath: undefined,
+            });
+        });
+    });
+
+    it("lists OpenCode in the provider catalog before it is installed", async () => {
+        renderComponent(<AIProvidersSettings />);
+
+        expect((await screen.findAllByText("OpenCode")).length).toBeGreaterThan(
+            0,
+        );
+    });
+
+    it("opens integrated terminal auth for OpenCode without treating it as an API key", async () => {
+        const providers = createDefaultProviders();
+        addOpenCodeProvider(providers);
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("OpenCode");
+
+        expect(screen.getByText("OpenCode auth")).toBeInTheDocument();
+        expect(
+            screen.getByText(
+                "Use providers and credentials configured by the OpenCode CLI.",
+            ),
+        ).toBeInTheDocument();
+        expect(screen.queryByPlaceholderText("API key")).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open sign-in terminal" }),
+        );
+
+        await waitFor(() => {
+            expect(apiMocks.aiStartAuthTerminalSession).toHaveBeenCalledWith({
+                runtimeId: "opencode-acp",
+                methodId: "opencode-login",
+                vaultPath: null,
+                customBinaryPath: undefined,
+            });
+        });
+        expect(apiMocks.aiStartAuth).not.toHaveBeenCalledWith(
+            { methodId: "opencode-login", runtimeId: "opencode-acp" },
+            null,
+        );
+    });
+
+    it("preflights an OpenCode custom binary path before opening terminal auth", async () => {
+        const providers = createDefaultProviders();
+        addOpenCodeProvider(providers);
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("OpenCode");
+        fireEvent.change(screen.getByLabelText("Runtime binary"), {
+            target: { value: "/usr/local/bin/opencode" },
+        });
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open sign-in terminal" }),
+        );
+
+        await waitFor(() => {
+            expect(apiMocks.aiUpdateSetup).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    runtimeId: "opencode-acp",
+                    customBinaryPath: "/usr/local/bin/opencode",
+                    codexApiKey: { action: "unchanged" },
+                    openaiApiKey: { action: "unchanged" },
+                    geminiApiKey: { action: "unchanged" },
+                    kiloApiKey: { action: "unchanged" },
+                    anthropicApiKey: { action: "unchanged" },
+                }),
+            );
+            expect(apiMocks.aiStartAuthTerminalSession).toHaveBeenCalledWith({
+                runtimeId: "opencode-acp",
+                methodId: "opencode-login",
+                vaultPath: null,
+                customBinaryPath: "/usr/local/bin/opencode",
+            });
+        });
+
+        expect(
+            apiMocks.aiUpdateSetup.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            apiMocks.aiStartAuthTerminalSession.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("labels connected OpenCode auth as a local disconnect action", async () => {
+        const providers = createDefaultProviders();
+        addOpenCodeProvider(providers, {
+            authReady: true,
+            authMethod: "opencode-login",
+            onboardingRequired: false,
+        });
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("OpenCode");
+        fireEvent.click(screen.getByRole("button", { name: "Disconnect" }));
+
+        await waitFor(() => {
+            expect(apiMocks.aiLogout).toHaveBeenCalledWith({
+                runtimeId: "opencode-acp",
+                vaultPath: null,
             });
         });
     });

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -42,6 +42,9 @@ import type {
 
 /* ── Helpers ────────────────────────────────────────────────────── */
 
+const OPENCODE_RUNTIME_ID = "opencode-acp";
+const OPENCODE_AUTH_METHOD_ID = "opencode-login";
+
 function getErrorMessage(error: unknown, fallback: string): string {
     if (error instanceof Error && error.message.trim()) return error.message;
     if (typeof error === "string" && error.trim()) return error;
@@ -83,6 +86,7 @@ function getShortMethodDesc(id: string): string {
         case "console-login":
         case "claude-login":
         case "kilo-login":
+        case OPENCODE_AUTH_METHOD_ID:
             return "Terminal sign-in";
         case "openai-api-key":
             return "OpenAI API key";
@@ -117,6 +121,8 @@ function getAuthHelpText(id: string): string {
             return "Opens a sign-in terminal inside the app.";
         case "kilo-login":
             return "Opens a Kilo sign-in terminal inside the app.";
+        case OPENCODE_AUTH_METHOD_ID:
+            return "Use providers and credentials configured by the OpenCode CLI.";
         case "openai-api-key":
             return `Store an OpenAI API key locally for ${APP_BRAND_NAME} only.`;
         case "codex-api-key":
@@ -156,6 +162,7 @@ function getActionLabel(
     if (isClaudeTerminalAuthMethodId(methodId)) return "Open sign-in terminal";
     if (methodId === "login_with_google") return "Open sign-in terminal";
     if (methodId === "kilo-login") return "Open sign-in terminal";
+    if (methodId === OPENCODE_AUTH_METHOD_ID) return "Open sign-in terminal";
     if (isApiKeyMethod(methodId)) {
         return status.authReady && status.authMethod === methodId
             ? "Replace key"
@@ -163,6 +170,16 @@ function getActionLabel(
     }
     if (isGatewayMethod(methodId)) return "Save gateway";
     return "Connect";
+}
+
+function getSecondaryAuthActionLabel(status: AIRuntimeSetupStatus): string {
+    return status.runtimeId === OPENCODE_RUNTIME_ID ? "Disconnect" : "Log Out";
+}
+
+function getLogoutErrorFallback(runtimeId: string): string {
+    return runtimeId === OPENCODE_RUNTIME_ID
+        ? "Failed to disconnect."
+        : "Failed to log out.";
 }
 
 function getDefaultMethodId(status: AIRuntimeSetupStatus): string {
@@ -193,11 +210,75 @@ const inputStyle: React.CSSProperties = {
 const unchangedSecretPatch: AISecretPatch = { action: "unchanged" };
 const clearSecretPatch: AISecretPatch = { action: "clear" };
 
+interface ProviderAuthInput {
+    runtimeId: string;
+    methodId: string;
+    customBinaryPath?: string;
+    codexApiKey: AISecretPatch;
+    openaiApiKey: AISecretPatch;
+    geminiApiKey: AISecretPatch;
+    kiloApiKey: AISecretPatch;
+    anthropicBaseUrl?: string;
+    anthropicBedrockBaseUrl?: string;
+    anthropicCustomHeaders: AISecretPatch;
+    anthropicAuthToken: AISecretPatch;
+    anthropicApiKey: AISecretPatch;
+}
+
 function setSecretPatch(value: string): AISecretPatch {
     return {
         action: "set",
         value,
     };
+}
+
+function supportsRuntimeBinaryOverride(runtimeId: string): boolean {
+    return runtimeId === OPENCODE_RUNTIME_ID;
+}
+
+function getRuntimeBinaryPlaceholder(runtimeId: string): string {
+    if (runtimeId === OPENCODE_RUNTIME_ID) {
+        return "Custom OpenCode runtime path, for example opencode";
+    }
+    return "Custom runtime path";
+}
+
+function getRuntimeBinaryHelpText(runtimeId: string): string {
+    if (runtimeId === OPENCODE_RUNTIME_ID) {
+        return "Leave empty to use opencode from PATH.";
+    }
+    return "Leave empty to use the bundled runtime or PATH.";
+}
+
+function getInitialCustomBinaryPath(status: AIRuntimeSetupStatus): string {
+    return status.hasCustomBinaryPath ? (status.binaryPath ?? "") : "";
+}
+
+function getPendingCustomBinaryPath(
+    status: AIRuntimeSetupStatus,
+    customBinaryPath: string,
+): string | undefined {
+    const initialPath = getInitialCustomBinaryPath(status).trim();
+    const nextPath = customBinaryPath.trim();
+    if (nextPath !== initialPath) {
+        return nextPath;
+    }
+    return undefined;
+}
+
+function hasPendingSetupUpdate(input: ProviderAuthInput): boolean {
+    return (
+        input.customBinaryPath !== undefined ||
+        input.codexApiKey.action !== "unchanged" ||
+        input.openaiApiKey.action !== "unchanged" ||
+        input.geminiApiKey.action !== "unchanged" ||
+        input.kiloApiKey.action !== "unchanged" ||
+        input.anthropicApiKey.action !== "unchanged" ||
+        input.anthropicBaseUrl !== undefined ||
+        input.anthropicBedrockBaseUrl !== undefined ||
+        input.anthropicCustomHeaders.action !== "unchanged" ||
+        input.anthropicAuthToken.action !== "unchanged"
+    );
 }
 
 function EmptyProviderSearchResult() {
@@ -232,6 +313,16 @@ function getProviderSearchValues(
         setupStatus?.binaryReady ? "Binary ready" : "Binary missing",
         setupStatus?.hasGatewayConfig ? "Custom gateway" : undefined,
         setupStatus?.hasGatewayUrl ? "Gateway URL" : undefined,
+        supportsRuntimeBinaryOverride(provider.id)
+            ? "Runtime binary"
+            : undefined,
+        supportsRuntimeBinaryOverride(provider.id)
+            ? getRuntimeBinaryPlaceholder(provider.id)
+            : undefined,
+        supportsRuntimeBinaryOverride(provider.id)
+            ? getRuntimeBinaryHelpText(provider.id)
+            : undefined,
+        provider.id === OPENCODE_RUNTIME_ID ? "opencode acp" : undefined,
         getMethodDisplayName(setupStatus),
         error,
         ...(setupStatus?.authMethods.flatMap((method) => [
@@ -427,19 +518,7 @@ function ProviderExpandedPanel({
     setupStatus: AIRuntimeSetupStatus;
     error: string | null;
     saving: boolean;
-    onAuth: (input: {
-        runtimeId: string;
-        methodId: string;
-        codexApiKey: AISecretPatch;
-        openaiApiKey: AISecretPatch;
-        geminiApiKey: AISecretPatch;
-        kiloApiKey: AISecretPatch;
-        anthropicBaseUrl?: string;
-        anthropicBedrockBaseUrl?: string;
-        anthropicCustomHeaders: AISecretPatch;
-        anthropicAuthToken: AISecretPatch;
-        anthropicApiKey: AISecretPatch;
-    }) => void;
+    onAuth: (input: ProviderAuthInput) => void;
     onClearGateway: () => void;
     onLogout: () => void;
 }) {
@@ -450,9 +529,18 @@ function ProviderExpandedPanel({
     const [gatewayUrl, setGatewayUrl] = useState("");
     const [gatewayHeaders, setGatewayHeaders] = useState("");
     const [gatewayToken, setGatewayToken] = useState("");
+    const [customBinaryPath, setCustomBinaryPath] = useState(() =>
+        getInitialCustomBinaryPath(setupStatus),
+    );
 
     const selectedMethod =
         setupStatus.authMethods.find((m) => m.id === selectedMethodId) ?? null;
+    const runtimeBinaryOverrideSupported = supportsRuntimeBinaryOverride(
+        setupStatus.runtimeId,
+    );
+    const pendingCustomBinaryPath = runtimeBinaryOverrideSupported
+        ? getPendingCustomBinaryPath(setupStatus, customBinaryPath)
+        : undefined;
     const apiKeySelected = isApiKeyMethod(selectedMethodId);
     const gatewaySelected = isGatewayMethod(selectedMethodId);
     const bedrockGatewaySelected = isBedrockGatewayMethod(selectedMethodId);
@@ -476,6 +564,7 @@ function ProviderExpandedPanel({
         onAuth({
             runtimeId: setupStatus.runtimeId,
             methodId: selectedMethodId,
+            customBinaryPath: pendingCustomBinaryPath,
             openaiApiKey: isOpenAi
                 ? setSecretPatch(apiKey)
                 : unchangedSecretPatch,
@@ -562,6 +651,46 @@ function ProviderExpandedPanel({
                             </button>
                         );
                     })}
+                </div>
+            )}
+
+            {/* Runtime binary override */}
+            {runtimeBinaryOverrideSupported && (
+                <div
+                    style={{
+                        display: "flex",
+                        flexDirection: "column",
+                        gap: 6,
+                    }}
+                >
+                    <label
+                        htmlFor={`${setupStatus.runtimeId}-runtime-binary`}
+                        style={{
+                            fontSize: 11,
+                            fontWeight: 600,
+                            color: "var(--text-primary)",
+                        }}
+                    >
+                        Runtime binary
+                    </label>
+                    <input
+                        id={`${setupStatus.runtimeId}-runtime-binary`}
+                        type="text"
+                        value={customBinaryPath}
+                        onChange={(e) => setCustomBinaryPath(e.target.value)}
+                        placeholder={getRuntimeBinaryPlaceholder(
+                            setupStatus.runtimeId,
+                        )}
+                        style={inputStyle}
+                    />
+                    <div
+                        style={{
+                            fontSize: 11,
+                            color: "var(--text-secondary)",
+                        }}
+                    >
+                        {getRuntimeBinaryHelpText(setupStatus.runtimeId)}
+                    </div>
                 </div>
             )}
 
@@ -738,7 +867,7 @@ function ProviderExpandedPanel({
                             opacity: saving ? 0.5 : 1,
                         }}
                     >
-                        Log Out
+                        {getSecondaryAuthActionLabel(setupStatus)}
                     </button>
                 ) : (
                     <div />
@@ -960,27 +1089,17 @@ export function AIProvidersSettings({
     /* ── Handlers ── */
 
     const handleAuth = useCallback(
-        async (input: {
-            runtimeId: string;
-            methodId: string;
-            customBinaryPath?: string;
-            codexApiKey: AISecretPatch;
-            openaiApiKey: AISecretPatch;
-            geminiApiKey: AISecretPatch;
-            kiloApiKey: AISecretPatch;
-            anthropicBaseUrl?: string;
-            anthropicBedrockBaseUrl?: string;
-            anthropicCustomHeaders: AISecretPatch;
-            anthropicAuthToken: AISecretPatch;
-            anthropicApiKey: AISecretPatch;
-        }) => {
+        async (input: ProviderAuthInput) => {
             const runtime = runtimes.find(
                 (r) => r.runtime.id === input.runtimeId,
             );
+            const terminalAuth = isIntegratedTerminalAuthMethod(
+                input.runtimeId,
+                input.methodId,
+            );
+            const needsPreflight = hasPendingSetupUpdate(input);
 
-            if (
-                isIntegratedTerminalAuthMethod(input.runtimeId, input.methodId)
-            ) {
+            if (terminalAuth && !needsPreflight) {
                 setAuthTerminalRequest({
                     runtimeId: input.runtimeId,
                     methodId: input.methodId,
@@ -995,18 +1114,7 @@ export function AIProvidersSettings({
 
             setSavingId(input.runtimeId);
             try {
-                if (
-                    input.customBinaryPath !== undefined ||
-                    input.codexApiKey.action !== "unchanged" ||
-                    input.openaiApiKey.action !== "unchanged" ||
-                    input.geminiApiKey.action !== "unchanged" ||
-                    input.kiloApiKey.action !== "unchanged" ||
-                    input.anthropicApiKey.action !== "unchanged" ||
-                    input.anthropicBaseUrl !== undefined ||
-                    input.anthropicBedrockBaseUrl !== undefined ||
-                    input.anthropicCustomHeaders.action !== "unchanged" ||
-                    input.anthropicAuthToken.action !== "unchanged"
-                ) {
+                if (needsPreflight) {
                     const preflight = await aiUpdateSetup({
                         runtimeId: input.runtimeId,
                         customBinaryPath: input.customBinaryPath,
@@ -1029,6 +1137,24 @@ export function AIProvidersSettings({
                         ...prev,
                         [input.runtimeId]: preflight,
                     }));
+                }
+
+                if (terminalAuth) {
+                    setAuthTerminalRequest({
+                        runtimeId: input.runtimeId,
+                        methodId: input.methodId,
+                        runtimeName: getRuntimeDisplayName(
+                            input.runtimeId,
+                            runtime?.runtime.name,
+                        ),
+                        customBinaryPath: input.customBinaryPath,
+                    });
+                    setErrorMap((prev) => {
+                        const next = { ...prev };
+                        delete next[input.runtimeId];
+                        return next;
+                    });
+                    return;
                 }
 
                 const status = await aiStartAuth(
@@ -1076,7 +1202,10 @@ export function AIProvidersSettings({
             } catch (error) {
                 setErrorMap((prev) => ({
                     ...prev,
-                    [runtimeId]: getErrorMessage(error, "Failed to log out."),
+                    [runtimeId]: getErrorMessage(
+                        error,
+                        getLogoutErrorFallback(runtimeId),
+                    ),
                 }));
             } finally {
                 setSavingId(null);

--- a/crates/ai/src/domain.rs
+++ b/crates/ai/src/domain.rs
@@ -6,6 +6,7 @@ pub const CODEX_RUNTIME_ID: &str = "codex-acp";
 pub const CLAUDE_RUNTIME_ID: &str = "claude-acp";
 pub const GEMINI_RUNTIME_ID: &str = "gemini-acp";
 pub const KILO_RUNTIME_ID: &str = "kilo-acp";
+pub const OPENCODE_RUNTIME_ID: &str = "opencode-acp";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -22,7 +22,8 @@ and terminal-auth routing helpers are in
 | `codex-acp` | `codex-acp` | Yes. Staged as a sidecar binary. | ChatGPT account, OpenAI API key, Codex API key |
 | `claude-acp` | Claude ACP adapter | Yes. Staged as vendored JS plus embedded Node. | Claude subscription terminal login, Anthropic Console terminal login, Anthropic API key, custom Anthropic-compatible gateway |
 | `gemini-acp` | `gemini --acp` | No. Must be available from PATH or a configured binary override. | Google terminal login, Gemini API key |
-| `kilo-acp` | `kilo-acp acp` | No. Must be available from PATH or a configured binary override. | Kilo terminal login |
+| `kilo-acp` | `kilo acp` | No. Must be available from PATH or a configured binary override. | Kilo terminal login |
+| `opencode-acp` | `opencode acp` | No. Must be available from PATH or a configured binary override. | OpenCode terminal login |
 
 Runtime descriptors returned by the backend currently use default `auto` model
 selection and `default` / `review` modes for every provider. The frontend falls
@@ -46,10 +47,11 @@ The provider-specific runtime binary overrides are:
 | `NEVERWRITE_CLAUDE_ACP_BIN` | Claude |
 | `NEVERWRITE_GEMINI_ACP_BIN` | Gemini |
 | `NEVERWRITE_KILO_ACP_BIN` | Kilo |
+| `NEVERWRITE_OPENCODE_ACP_BIN` | OpenCode |
 
 The values may be absolute paths or command names resolvable on `PATH`. For
-Gemini and Kilo, NeverWrite appends the ACP arguments automatically:
-`gemini --acp` and `kilo-acp acp`.
+Gemini, Kilo, and OpenCode, NeverWrite appends the ACP arguments automatically:
+`gemini --acp`, `kilo acp`, and `opencode acp`.
 
 Packaged builds use `NEVERWRITE_ELECTRON_ACP_RESOURCE_DIR` internally to point
 the native backend at staged Electron resources. In normal app usage this is set
@@ -72,12 +74,13 @@ The backend also detects existing CLI auth files and environment secrets:
 | Claude | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_BEDROCK_BASE_URL`, or non-empty `~/.claude.json` |
 | Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or non-empty `~/.gemini/oauth_creds.json` |
 | Kilo | Non-empty Kilo auth file, including `~/.local/share/kilo/auth.json` on Unix-like systems |
+| OpenCode | `OPENCODE_API_KEY`, provider keys inherited by OpenCode, or active `opencode/auth.json` in the platform data directory |
 
 Codex ChatGPT auth is implemented through the ACP `authenticate` request and
 requires a resolved Codex runtime binary before NeverWrite marks it connected.
 Codex does not use the integrated auth terminal.
 
-Claude, Gemini, and Kilo expose integrated terminal auth methods. NeverWrite
+Claude, Gemini, Kilo, and OpenCode expose integrated terminal auth methods. NeverWrite
 starts the provider CLI in a PTY and marks auth pending before launch. A zero
 exit code marks the provider verified; Gemini can also be marked verified when
 the terminal output contains the success strings recognized by the backend.
@@ -144,10 +147,21 @@ fields for them.
 
 ### Kilo
 
-Use Kilo terminal login from the setup UI or pre-existing Kilo CLI auth. Kilo
-does not currently have a NeverWrite API-key setup path. Because Kilo is not
-bundled by default, install the CLI separately or configure
-`NEVERWRITE_KILO_ACP_BIN`.
+Use Kilo terminal login from the setup UI, a Kilo API key saved in the setup UI,
+or pre-existing Kilo CLI auth. Because Kilo is not bundled by default, install
+the CLI separately or configure `NEVERWRITE_KILO_ACP_BIN`.
+
+### OpenCode
+
+Use OpenCode terminal login from the setup UI, pre-existing OpenCode CLI auth, a
+provider key inherited by the OpenCode CLI, or `/connect` inside OpenCode.
+NeverWrite does not store OpenCode provider secrets in V1; auth remains owned by
+the OpenCode CLI. Disconnecting OpenCode clears NeverWrite's local selection and
+persists an invalidation marker, but it does not delete `opencode/auth.json`.
+
+Because OpenCode is not bundled by default, install the CLI separately or
+configure `NEVERWRITE_OPENCODE_ACP_BIN`. NeverWrite launches sessions as
+`opencode acp` and opens auth as `opencode auth login`.
 
 ## Environment Overrides
 
@@ -159,6 +173,7 @@ These `NEVERWRITE_*` variables are relevant to AI runtime setup and packaging:
 | `NEVERWRITE_CLAUDE_ACP_BIN` | Runtime launch override for Claude in dev or local troubleshooting. |
 | `NEVERWRITE_GEMINI_ACP_BIN` | Runtime launch override for Gemini in dev or local troubleshooting. |
 | `NEVERWRITE_KILO_ACP_BIN` | Runtime launch override for Kilo in dev or local troubleshooting. |
+| `NEVERWRITE_OPENCODE_ACP_BIN` | Runtime launch override for OpenCode in dev or local troubleshooting. |
 | `NEVERWRITE_APP_DATA_DIR` | Overrides app data storage, including `ai/runtime-setup.json`; Electron sets this for the sidecar. |
 | `NEVERWRITE_AI_SECRET_STORE=memory` | Test/smoke-only opt-in for in-memory secrets when no OS keyring is available. Do not use for production persistence. |
 | `NEVERWRITE_NATIVE_BACKEND_PATH` | Forces Electron to use a specific native backend sidecar. Useful when testing a local sidecar build. |
@@ -255,7 +270,7 @@ Common fixes:
 - Set the provider-specific `NEVERWRITE_*_ACP_BIN` variable before launching the app.
 - Supply a custom binary path through `ai_update_setup` if you are exercising
   the backend API directly or a caller that exposes this field.
-- For Gemini or Kilo, install the CLI separately; they are not bundled in releases.
+- For Gemini, Kilo, or OpenCode, install the CLI separately; they are not bundled in releases.
 - For packaged Codex or Claude, check that `native-backend/binaries/` and
   `native-backend/embedded/` exist inside the packaged app resources.
 
@@ -272,12 +287,14 @@ reconnected or configured through environment variables.
 
 ### Provider Terminal Auth
 
-Integrated terminal auth is supported for Claude, Gemini, and Kilo. If terminal
+Integrated terminal auth is supported for Claude, Gemini, Kilo, and OpenCode. If terminal
 auth opens but the provider remains unready:
 
 - Confirm the terminal process exited successfully.
 - For Gemini, look for provider success output such as authentication succeeded
   or successful Google sign-in.
+- For OpenCode, confirm `opencode auth login` completed or use `/connect` in
+  OpenCode itself.
 - Reopen diagnostics and confirm the runtime launch command points to the CLI
   you expected.
 - Remember that Codex ChatGPT auth does not use the integrated auth terminal.


### PR DESCRIPTION
## Summary
- Add OpenCode as a native ACP provider with runtime id `opencode-acp`, `opencode acp` launch args, and `NEVERWRITE_OPENCODE_ACP_BIN` override support.
- Add OpenCode CLI auth via `opencode-login`, integrated terminal launch, external auth detection, persisted disconnect invalidation, and diagnostics without storing OpenCode secrets in NeverWrite.
- Wire OpenCode into the provider catalog/settings UI, auth-method routing, auth error handling, docs, and runtime smoke coverage.

## Validation
- `git diff --check`
- `cargo test -p neverwrite-native-backend`
- `cargo test -p neverwrite-native-backend opencode -- --nocapture`
- `cd apps/desktop && npm run test -- src/features/ai/utils/runtimeMetadata.test.ts src/features/ai/utils/authMethods.test.ts src/features/settings/AIProvidersSettings.test.tsx src/features/ai/store/chatStore.test.ts`
- `cd apps/desktop && npm run test -- src/features/settings/SettingsPanel.test.tsx src/features/ai/chatPaneMovement.test.ts src/features/ai/sessionPresentation.test.ts src/features/ai/AgentsSidebarPanel.test.tsx`
- `cd apps/desktop && npm run test -- src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/AIReviewView.test.tsx src/features/ai/components/EditedFilesBufferPanel.test.tsx`
- `cd apps/desktop && npm run build`
- `cd apps/desktop && npm run electron:sidecar:build && npm run electron:ai-runtime:smoke`

## Notes
- OpenCode auth remains owned by the OpenCode CLI. NeverWrite only stores local selection/invalidation state and does not persist OpenCode provider keys.
- Review/change-control tests were run because the ACP runtime path should stay generic and not branch for OpenCode.
