### PR TITLE
Clarify default agent preference

### DIFF
--- a/apps/desktop/src/features/ai/chatPaneMovement.test.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.test.ts
@@ -453,6 +453,60 @@ describe("createNewChatInWorkspace", () => {
         });
     });
 
+    it("uses an explicit default runtime before the focused workspace chat runtime", async () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            defaultRuntimeId: "codex-acp",
+            runtimes: [runtimeDescriptor, claudeRuntimeDescriptor],
+            selectedRuntimeId: "claude-acp",
+            setupStatusByRuntimeId: {
+                "codex-acp": readySetupStatusState,
+                "claude-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "claude-acp",
+                    authMethod: "claude-login",
+                },
+            },
+        }));
+        const claudeSession = createStoredSession(
+            "claude-session-existing",
+            "Claude chat",
+            "claude-acp",
+        );
+        seedChatSessions(claudeSession);
+        useEditorStore.getState().openChat(claudeSession.sessionId, {
+            title: "Claude chat",
+            paneId: "primary",
+        });
+
+        invokeMock.mockImplementation((command, args) => {
+            if (command === "ai_get_setup_status") {
+                expect(
+                    (args as { runtimeId?: string } | undefined)?.runtimeId,
+                ).toBe("codex-acp");
+                return Promise.resolve(setupStatusPayload);
+            }
+            if (command === "ai_create_session") {
+                expect(
+                    (
+                        args as
+                            | { input?: { runtime_id?: string } }
+                            | undefined
+                    )?.input?.runtime_id,
+                ).toBe("codex-acp");
+                return Promise.resolve(createdSessionPayload);
+            }
+            return Promise.reject(new Error(`Unexpected invoke: ${command}`));
+        });
+
+        const pendingSessionId = await createNewChatInWorkspace();
+
+        expect(pendingSessionId).toMatch(/^pending:/);
+        expect(
+            useChatStore.getState().sessionsById[pendingSessionId!]?.runtimeId,
+        ).toBe("codex-acp");
+    });
+
     it("does not create an ACP chat when the selected runtime is Claude Code terminal", async () => {
         useChatStore.setState((state) => ({
             ...state,
@@ -507,6 +561,32 @@ describe("createNewChatInWorkspace", () => {
         expect(newSession).toHaveBeenCalledWith("codex-acp", sessionId);
         expect(upsertSession).toHaveBeenCalled();
         expect(openChat).toHaveBeenCalled();
+    });
+
+    it("does not create an ACP chat when Claude Code is the explicit default runtime", async () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            defaultRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+            runtimes: [runtimeDescriptor, claudeTerminalRuntimeDescriptor],
+            selectedRuntimeId: "codex-acp",
+            setupStatusByRuntimeId: {
+                "codex-acp": readySetupStatusState,
+                [CLAUDE_TERMINAL_RUNTIME_ID]: {
+                    ...readySetupStatusState,
+                    runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                    authMethod: "claude-code",
+                },
+            },
+        }));
+        const newSession = vi.spyOn(useChatStore.getState(), "newSession");
+        const upsertSession = vi.spyOn(useChatStore.getState(), "upsertSession");
+        const openChat = vi.spyOn(useEditorStore.getState(), "openChat");
+
+        await expect(createNewChatInWorkspace()).resolves.toBeNull();
+
+        expect(newSession).not.toHaveBeenCalled();
+        expect(upsertSession).not.toHaveBeenCalled();
+        expect(openChat).not.toHaveBeenCalled();
     });
 
     it("does not create a pending chat when Claude Code terminal is the only ready runtime", async () => {

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -132,9 +132,31 @@ function getSessionRuntimeId(sessionId?: string | null) {
     return useChatStore.getState().sessionsById[sessionId]?.runtimeId ?? null;
 }
 
+function getExplicitDefaultRuntimeId() {
+    const state = useChatStore.getState();
+    const runtimeId = state.defaultRuntimeId;
+    if (!runtimeId) {
+        return null;
+    }
+    const runtime = state.runtimes.find(
+        (descriptor) => descriptor.runtime.id === runtimeId,
+    );
+    if (!runtime) {
+        return null;
+    }
+    return isRuntimeSetupReady(state.setupStatusByRuntimeId[runtimeId])
+        ? runtimeId
+        : null;
+}
+
 function resolveWorkspaceNewChatRuntimeId(runtimeId?: string) {
     if (runtimeId) {
         return runtimeId;
+    }
+
+    const explicitDefaultRuntimeId = getExplicitDefaultRuntimeId();
+    if (explicitDefaultRuntimeId) {
+        return explicitDefaultRuntimeId;
     }
 
     const chatState = useChatStore.getState();

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -999,6 +999,70 @@ describe("chatStore", () => {
         ).toBe("codex-acp");
     });
 
+    it("uses the explicit default runtime when newSession is called without a runtime", async () => {
+        useChatStore.setState({
+            defaultRuntimeId: "codex-acp",
+            selectedRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+            runtimes: [
+                {
+                    runtime: { ...runtimePayload[0].runtime },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+                {
+                    runtime: {
+                        id: CLAUDE_TERMINAL_RUNTIME_ID,
+                        name: "Claude Code",
+                        description: "Claude Code terminal pseudo-runtime",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                "codex-acp": readySetupStatusState,
+                [CLAUDE_TERMINAL_RUNTIME_ID]: {
+                    ...readySetupStatusState,
+                    runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                    authMethod: "claude-code",
+                },
+            },
+        });
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_get_setup_status") {
+                expect(
+                    (args as { runtimeId?: string } | undefined)?.runtimeId,
+                ).toBe("codex-acp");
+                return readySetupStatus;
+            }
+            if (command === "ai_create_session") {
+                expect(
+                    (
+                        args as
+                            | { input?: { runtime_id?: string } }
+                            | undefined
+                    )?.input?.runtime_id,
+                ).toBe("codex-acp");
+                return sessionPayload;
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().newSession();
+
+        expect(invokeMock).toHaveBeenCalledWith(
+            "ai_create_session",
+            expect.objectContaining({
+                input: expect.objectContaining({
+                    runtime_id: "codex-acp",
+                }),
+            }),
+        );
+    });
+
     it("selects the first configured runtime on fresh boot", async () => {
         const claudeRuntimePayload = {
             runtime: {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -877,6 +877,7 @@ describe("chatStore", () => {
             binaryReady: true,
         });
         expect(state.selectedRuntimeId).toBe("codex-acp");
+        expect(state.defaultRuntimeId).toBeNull();
         expect(state.activeSessionId).toBe("codex-session-1");
         expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
         expect(
@@ -905,6 +906,7 @@ describe("chatStore", () => {
             .initialize({ createDefaultSession: false });
 
         const state = useChatStore.getState();
+        expect(state.defaultRuntimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
         expect(state.selectedRuntimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
         expect(state.getDefaultNewChatRuntimeId()).toBe(
             CLAUDE_TERMINAL_RUNTIME_ID,
@@ -924,6 +926,7 @@ describe("chatStore", () => {
         await useChatStore.getState().initialize();
 
         const state = useChatStore.getState();
+        expect(state.defaultRuntimeId).toBeNull();
         expect(state.selectedRuntimeId).toBe("codex-acp");
         expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
         expect(state.sessionsById["codex-session-1"]?.runtimeId).toBe(
@@ -948,8 +951,52 @@ describe("chatStore", () => {
             authReady: false,
             binaryReady: false,
         });
+        expect(state.defaultRuntimeId).toBeNull();
         expect(state.selectedRuntimeId).toBe("codex-acp");
         expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
+    });
+
+    it("keeps current runtime changes separate from the explicit default preference", () => {
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: { ...runtimePayload[0].runtime },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+                {
+                    runtime: {
+                        ...runtimePayload[0].runtime,
+                        id: "claude-acp",
+                        name: "Claude ACP",
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                "codex-acp": readySetupStatusState,
+                "claude-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "claude-acp",
+                },
+            },
+            selectedRuntimeId: "codex-acp",
+        });
+
+        useChatStore.getState().setDefaultRuntime("codex-acp");
+        useChatStore.getState().setSelectedRuntime("claude-acp");
+
+        const state = useChatStore.getState();
+        expect(state.defaultRuntimeId).toBe("codex-acp");
+        expect(state.selectedRuntimeId).toBe("claude-acp");
+        expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
+        expect(
+            JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}")
+                .defaultRuntimeId,
+        ).toBe("codex-acp");
     });
 
     it("selects the first configured runtime on fresh boot", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1155,6 +1155,7 @@ interface ChatStore {
     sessionOrder: string[];
     activeSessionId: string | null;
     lastFocusedSessionId: string | null;
+    defaultRuntimeId: string | null;
     selectedRuntimeId: string | null;
     isInitializing: boolean;
     notePickerOpen: boolean;
@@ -1189,6 +1190,7 @@ interface ChatStore {
     ) => Promise<void>;
     syncAutoContextForVault: (vaultPath: string | null) => void;
     setSelectedRuntime: (runtimeId: string | null) => void;
+    setDefaultRuntime: (runtimeId: string | null) => void;
     getDefaultNewChatRuntimeId: () => string | null;
     refreshSetupStatus: (runtimeId?: string) => Promise<void>;
     saveSetup: (input: {
@@ -6639,6 +6641,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         sessionOrder: [],
         activeSessionId: null,
         lastFocusedSessionId: null,
+        defaultRuntimeId: null,
         selectedRuntimeId: null,
         isInitializing: false,
         notePickerOpen: false,
@@ -6672,6 +6675,13 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
         setSelectedRuntime: (runtimeId) => {
             set({ selectedRuntimeId: runtimeId });
+        },
+
+        setDefaultRuntime: (runtimeId) => {
+            set((state) => ({
+                defaultRuntimeId: runtimeId,
+                selectedRuntimeId: runtimeId ?? state.selectedRuntimeId,
+            }));
             saveAiPreferences({ defaultRuntimeId: runtimeId ?? undefined });
         },
 
@@ -6679,12 +6689,12 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const state = get();
             return (
                 getSelectableDefaultRuntimeId(
-                    state.selectedRuntimeId,
+                    state.defaultRuntimeId,
                     state.runtimes,
                     state.setupStatusByRuntimeId,
                 ) ??
                 getSelectableDefaultRuntimeId(
-                    loadAiPreferences().defaultRuntimeId,
+                    state.selectedRuntimeId,
                     state.runtimes,
                     state.setupStatusByRuntimeId,
                 ) ??
@@ -6757,7 +6767,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         runtimes,
                         setupStatusByRuntimeId,
                     );
-                const defaultRuntimeId =
+                const initialSelectedRuntimeId =
                     persistedRuntimeId ??
                     getImplicitDefaultAcpRuntimeId(
                         runtimes,
@@ -6766,7 +6776,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
                 set({
                     runtimes,
-                    selectedRuntimeId: defaultRuntimeId,
+                    defaultRuntimeId: persistedRuntimeId,
+                    selectedRuntimeId: initialSelectedRuntimeId,
                     setupStatusByRuntimeId,
                     runtimeConnectionByRuntimeId,
                 });
@@ -6960,7 +6971,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 }
 
                 if (!get().activeSessionId && shouldCreateDefaultSession) {
-                    const runtimeId = defaultRuntimeId;
+                    const runtimeId = initialSelectedRuntimeId;
                     const setupStatus = getSetupStatusForRuntime(
                         setupStatusByRuntimeId,
                         runtimeId,
@@ -10944,15 +10955,20 @@ export const useChatStore = create<ChatStore>((set, get) => {
             useChatTabsStore.getState().reset();
             _queueDrainLocks.clear();
             resetChatRowUiStore();
+            const state = get();
+            const defaultRuntimeId =
+                getSelectableDefaultRuntimeId(
+                    state.defaultRuntimeId,
+                    state.runtimes,
+                    state.setupStatusByRuntimeId,
+                ) ??
+                getDefaultRuntimeId(state.runtimes, state.setupStatusByRuntimeId);
             set({
                 sessionsById: {},
                 sessionOrder: [],
                 activeSessionId: null,
                 lastFocusedSessionId: null,
-                selectedRuntimeId: getDefaultRuntimeId(
-                    get().runtimes,
-                    get().setupStatusByRuntimeId,
-                ),
+                selectedRuntimeId: defaultRuntimeId,
                 composerPartsBySessionId: {},
                 queuedMessagesBySessionId: {},
                 queuedMessageEditBySessionId: {},
@@ -11510,6 +11526,7 @@ export function resetChatStore() {
         sessionOrder: [],
         activeSessionId: null,
         lastFocusedSessionId: null,
+        defaultRuntimeId: null,
         selectedRuntimeId: null,
         isInitializing: false,
         notePickerOpen: false,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -10634,6 +10634,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const nextRuntimeId =
                 runtimeId ??
                 getSelectableDefaultRuntimeId(
+                    get().defaultRuntimeId,
+                    runtimes,
+                    get().setupStatusByRuntimeId,
+                ) ??
+                getSelectableDefaultRuntimeId(
                     get().selectedRuntimeId,
                     runtimes,
                     get().setupStatusByRuntimeId,

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -964,8 +964,8 @@ export function AIProvidersSettings({
     searchQuery?: SettingsSearchQuery;
 }) {
     const vaultPath = useVaultStore((s) => s.vaultPath);
-    const selectedRuntimeId = useChatStore((s) => s.selectedRuntimeId);
-    const setSelectedRuntime = useChatStore((s) => s.setSelectedRuntime);
+    const defaultRuntimeId = useChatStore((s) => s.defaultRuntimeId);
+    const setDefaultRuntime = useChatStore((s) => s.setDefaultRuntime);
     const [runtimes, setRuntimes] = useState<AIRuntimeDescriptor[]>([]);
     const [setupStatusMap, setSetupStatusMap] = useState<
         Record<string, AIRuntimeSetupStatus>
@@ -1410,9 +1410,9 @@ export function AIProvidersSettings({
                                 session — no API key required.
                             </p>
                             <select
-                                value={selectedRuntimeId ?? ""}
+                                value={defaultRuntimeId ?? ""}
                                 onChange={(e) =>
-                                    setSelectedRuntime(
+                                    setDefaultRuntime(
                                         e.target.value || null,
                                     )
                                 }
@@ -1430,7 +1430,7 @@ export function AIProvidersSettings({
                                 }}
                             >
                                 <option value="">
-                                    Automatic (first connected provider)
+                                    Automatic (current or last used provider)
                                 </option>
                                 {selectableProviders.map((p) => (
                                     <option key={p.id} value={p.id}>
@@ -1441,7 +1441,7 @@ export function AIProvidersSettings({
                                     </option>
                                 ))}
                             </select>
-                            {selectedRuntimeId === CLAUDE_TERMINAL_RUNTIME_ID && (
+                            {defaultRuntimeId === CLAUDE_TERMINAL_RUNTIME_ID && (
                                 <p
                                     style={{
                                         fontSize: 11,


### PR DESCRIPTION
## Summary

- Separates the explicit default agent preference from the current/last selected runtime.
- Keeps Automatic aligned with the existing contextual behavior: current or last used provider, with fallback handling.
- Makes explicitly selected providers win over focused or last-used chat runtime for new agent creation.
- Updates the settings label to reflect the contextual automatic behavior.

## Validation

- npm run test -- src/features/ai/chatPaneMovement.test.ts src/features/ai/store/chatStore.test.ts src/features/editor/newTabMenuActions.test.ts src/features/settings/AIProvidersSettings.test.tsx
- npm run test -- src/App.webClipper.test.tsx src/features/ai/AIChatDetachedWindowHost.test.tsx src/features/editor/UnifiedBar.test.tsx
- npx tsc -b --pretty false
- git diff --check

## Notes

Opened as draft while follow-up coverage from review is explored locally.