### PR TITLE
Add Debian release packages

### DIFF
--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -311,3 +311,13 @@ jobs:
                     --repo "${{ github.repository }}" \
                     --output-dir "$RUNNER_TEMP/release-assets" \
                     --metadata-out "$RUNNER_TEMP/target-metadata/${{ matrix.target }}.json"
+
+            - name: Validate Linux Debian package
+              shell: bash
+              run: |
+                  VERSION="$(node -p "require('./apps/desktop/package.json').version")"
+                  node apps/desktop/scripts/validate-linux-deb-package.mjs \
+                    --staged-assets-dir "$RUNNER_TEMP/release-assets" \
+                    --target ${{ matrix.target }} \
+                    --version "$VERSION" \
+                    --install

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -363,39 +363,11 @@ jobs:
               if: matrix.platform == 'linux'
               shell: bash
               run: |
-                  set -euo pipefail
-
-                  if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]]; then
-                    DEB_ARCH="amd64"
-                  elif [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
-                    DEB_ARCH="arm64"
-                  else
-                    echo "Unsupported Linux target for Debian validation: ${{ matrix.target }}" >&2
-                    exit 1
-                  fi
-
-                  DEB_PATH="$RUNNER_TEMP/release-assets/NeverWrite-${{ needs.prepare.outputs.version }}-${DEB_ARCH}.deb"
-                  if [[ ! -f "$DEB_PATH" ]]; then
-                    echo "Missing staged Debian package: $DEB_PATH" >&2
-                    exit 1
-                  fi
-
-                  dpkg-deb --info "$DEB_PATH" | tee "$RUNNER_TEMP/deb-info.txt"
-                  dpkg-deb --contents "$DEB_PATH" | tee "$RUNNER_TEMP/deb-contents.txt"
-
-                  grep -Eq '^[[:space:]]*Package: neverwrite$' "$RUNNER_TEMP/deb-info.txt"
-                  grep -Eq "^[[:space:]]*Version: ${{ needs.prepare.outputs.version }}$" "$RUNNER_TEMP/deb-info.txt"
-                  grep -Eq "^[[:space:]]*Architecture: ${DEB_ARCH}$" "$RUNNER_TEMP/deb-info.txt"
-                  grep -Eq '/usr/bin/neverwrite$|/opt/NeverWrite/neverwrite$' "$RUNNER_TEMP/deb-contents.txt"
-                  grep -Eq '/usr/share/applications/.*\.desktop$' "$RUNNER_TEMP/deb-contents.txt"
-                  grep -Eq '/usr/share/icons/|/usr/share/pixmaps/' "$RUNNER_TEMP/deb-contents.txt"
-
-                  if [[ "${DEB_ARCH}" == "amd64" ]]; then
-                    sudo apt-get install -y "$DEB_PATH"
-                    dpkg-query -W -f='${Package} ${Architecture} ${Version}\n' neverwrite | grep -Eq "^neverwrite amd64 ${{ needs.prepare.outputs.version }}$"
-                    command -v neverwrite
-                    sudo apt-get remove -y neverwrite
-                  fi
+                  node apps/desktop/scripts/validate-linux-deb-package.mjs \
+                    --staged-assets-dir "$RUNNER_TEMP/release-assets" \
+                    --target ${{ matrix.target }} \
+                    --version "${{ needs.prepare.outputs.version }}" \
+                    --install
 
             - name: Upload release asset artifact
               uses: actions/upload-artifact@v4

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -359,6 +359,44 @@ jobs:
                     --output-dir "$RUNNER_TEMP/release-assets" \
                     --metadata-out "$RUNNER_TEMP/target-metadata/${{ matrix.target }}.json"
 
+            - name: Validate Linux Debian package
+              if: matrix.platform == 'linux'
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  if [[ "${{ matrix.target }}" == "x86_64-unknown-linux-gnu" ]]; then
+                    DEB_ARCH="amd64"
+                  elif [[ "${{ matrix.target }}" == "aarch64-unknown-linux-gnu" ]]; then
+                    DEB_ARCH="arm64"
+                  else
+                    echo "Unsupported Linux target for Debian validation: ${{ matrix.target }}" >&2
+                    exit 1
+                  fi
+
+                  DEB_PATH="$RUNNER_TEMP/release-assets/NeverWrite-${{ needs.prepare.outputs.version }}-${DEB_ARCH}.deb"
+                  if [[ ! -f "$DEB_PATH" ]]; then
+                    echo "Missing staged Debian package: $DEB_PATH" >&2
+                    exit 1
+                  fi
+
+                  dpkg-deb --info "$DEB_PATH" | tee "$RUNNER_TEMP/deb-info.txt"
+                  dpkg-deb --contents "$DEB_PATH" | tee "$RUNNER_TEMP/deb-contents.txt"
+
+                  grep -Eq '^[[:space:]]*Package: neverwrite$' "$RUNNER_TEMP/deb-info.txt"
+                  grep -Eq "^[[:space:]]*Version: ${{ needs.prepare.outputs.version }}$" "$RUNNER_TEMP/deb-info.txt"
+                  grep -Eq "^[[:space:]]*Architecture: ${DEB_ARCH}$" "$RUNNER_TEMP/deb-info.txt"
+                  grep -Eq '/usr/bin/neverwrite$|/opt/NeverWrite/neverwrite$' "$RUNNER_TEMP/deb-contents.txt"
+                  grep -Eq '/usr/share/applications/.*\.desktop$' "$RUNNER_TEMP/deb-contents.txt"
+                  grep -Eq '/usr/share/icons/|/usr/share/pixmaps/' "$RUNNER_TEMP/deb-contents.txt"
+
+                  if [[ "${DEB_ARCH}" == "amd64" ]]; then
+                    sudo apt-get install -y "$DEB_PATH"
+                    dpkg-query -W -f='${Package} ${Architecture} ${Version}\n' neverwrite | grep -Eq "^neverwrite amd64 ${{ needs.prepare.outputs.version }}$"
+                    command -v neverwrite
+                    sudo apt-get remove -y neverwrite
+                  fi
+
             - name: Upload release asset artifact
               uses: actions/upload-artifact@v4
               with:
@@ -627,16 +665,26 @@ jobs:
                     );
 
                   const toMiB = (bytes) => `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+                  const formatAdditionalManualAssets = (entry) => {
+                    const assets = entry.additionalManualAssets ?? [];
+                    if (assets.length === 0) {
+                      return "None";
+                    }
+                    return assets
+                      .map((asset) => `${asset.assetName}: ${toMiB(asset.sizeBytes)}`)
+                      .join("<br>");
+                  };
+
                   const markdown = [
                     "# Electron Release Asset Sizes",
                     "",
                     `Release: ${{ needs.prepare.outputs.tag }}`,
                     "",
-                    "| Build target | Manual installer | Updater asset | Blockmap |",
-                    "| --- | --- | --- | --- |",
+                    "| Build target | Manual installer | Additional manual assets | Updater asset | Blockmap |",
+                    "| --- | --- | --- | --- | --- |",
                     ...entries.map(
                       (entry) =>
-                        `| \`${entry.buildTarget}\` | ${toMiB(entry.manualAssetSizeBytes)} | ${toMiB(entry.updaterAssetSizeBytes)} | ${toMiB(entry.updaterBlockmapSizeBytes)} |`,
+                        `| \`${entry.buildTarget}\` | ${toMiB(entry.manualAssetSizeBytes)} | ${formatAdditionalManualAssets(entry)} | ${toMiB(entry.updaterAssetSizeBytes)} | ${toMiB(entry.updaterBlockmapSizeBytes)} |`,
                     ),
                     "",
                   ].join("\n");

--- a/.github/workflows/validate-release-metadata.yml
+++ b/.github/workflows/validate-release-metadata.yml
@@ -16,6 +16,7 @@ on:
             - apps/desktop/scripts/stage-electron-release-assets.mjs
             - apps/desktop/scripts/stage-electron-release-assets.test.mjs
             - apps/desktop/scripts/stage-electron-sidecar.mjs
+            - apps/desktop/scripts/validate-linux-deb-package.mjs
             - apps/desktop/scripts/verify-electron-bundle.mjs
             - apps/desktop/src-electron/**
             - apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -71,6 +72,9 @@ jobs:
 
             - name: Run Electron release helper tests
               run: node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs
+
+            - name: Check Debian package validation script
+              run: node --check apps/desktop/scripts/validate-linux-deb-package.mjs
 
             - name: Run platform validation tests
               run: node --test scripts/platform-validation.test.mjs

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -208,12 +208,23 @@ export default {
     },
     linux: {
         icon: path.join("build", "icons", "icon.png"),
-        target: ["AppImage"],
+        target: ["AppImage", "deb"],
         category: "Utility",
         executableName: "neverwrite",
         artifactName: "${productName}-${version}-${arch}.AppImage",
     },
     appImage: {
         artifactName: "${productName}-${version}-${arch}.AppImage",
+    },
+    deb: {
+        packageName: "neverwrite",
+        packageCategory: "utils",
+        priority: "optional",
+        maintainer: "NeverWrite Maintainers <jsgrrchg@users.noreply.github.com>",
+        synopsis: "AI-powered writing workspace",
+        description:
+            "NeverWrite is an AI-powered writing workspace for power users.",
+        artifactName: "${productName}-${version}-${arch}.deb",
+        publish: null,
     },
 };

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,7 @@
     "name": "desktop",
     "private": true,
     "version": "0.2.7",
+    "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",
     "engines": {

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import test from "node:test";
 
 import config from "../electron-builder.config.mjs";
+import packageJson from "../package.json" with { type: "json" };
 
 const require = createRequire(import.meta.url);
 const minimatch = require("minimatch");
@@ -50,8 +51,18 @@ test("desktop app icons are wired for all packaged platforms", () => {
     assert.equal(config.mac.icon, "build/icons/icon.icns");
     assert.equal(config.win.icon, "build/icons/icon.ico");
     assert.equal(config.linux.icon, "build/icons/icon.png");
-    assert.deepEqual(config.linux.target, ["AppImage"]);
+    assert.deepEqual(config.linux.target, ["AppImage", "deb"]);
     assert.equal(config.nsis.installerIcon, "build/icons/icon.ico");
     assert.equal(config.nsis.uninstallerIcon, "build/icons/icon.ico");
     assert.equal(config.nsis.installerHeaderIcon, "build/icons/icon.ico");
+});
+
+test("Debian package metadata is stable for Ubuntu/Debian releases", () => {
+    assert.equal(packageJson.homepage, "https://github.com/jsgrrchg/NeverWrite");
+    assert.equal(config.deb.packageName, "neverwrite");
+    assert.equal(config.deb.packageCategory, "utils");
+    assert.equal(config.deb.priority, "optional");
+    assert.equal(config.deb.artifactName, "${productName}-${version}-${arch}.deb");
+    assert.equal(config.deb.publish, null);
+    assert.equal(config.deb.synopsis, "AI-powered writing workspace");
 });

--- a/apps/desktop/scripts/stage-electron-release-assets.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.mjs
@@ -4,10 +4,12 @@ import path from "node:path";
 import { parseDocument } from "yaml";
 
 import {
+    buildDebianPackageAssetName,
     buildElectronBlockmapAssetName,
     buildElectronUpdaterAssetName,
     buildGitHubReleaseAssetUrl,
     buildPublicReleaseAssetName,
+    debianArchForBuildTarget,
     feedTargetForBuildTarget,
     metadataFileNameForBuildTarget,
 } from "../../../scripts/electron-release-lib.mjs";
@@ -150,7 +152,7 @@ function feedAliasFileNamesForBuildTarget(buildTarget) {
     return [];
 }
 
-function collectArtifacts(distDir, buildTarget) {
+function collectArtifacts(distDir, buildTarget, version) {
     const metadataFileName = metadataFileNameForBuildTarget(buildTarget);
     const findFeedPath = () =>
         findSingleFile(
@@ -178,6 +180,7 @@ function collectArtifacts(distDir, buildTarget) {
                 (filePath) => filePath.endsWith(".zip.blockmap"),
                 "zip blockmap",
             ),
+            additionalManualArtifacts: [],
         };
     }
     if (buildTarget.endsWith("-unknown-linux-gnu")) {
@@ -199,12 +202,27 @@ function collectArtifacts(distDir, buildTarget) {
                       `${metadataFileName} feed`,
                   )
                 : findFeedPath();
+        const expectedDebAssetName = buildDebianPackageAssetName(
+            version,
+            buildTarget,
+        );
+        const debPackagePath = findSingleFile(
+            distDir,
+            (filePath) => path.basename(filePath) === expectedDebAssetName,
+            `${debianArchForBuildTarget(buildTarget)} Debian package named ${expectedDebAssetName}`,
+        );
 
         return {
             feedPath,
             manualAssetPath: appImagePath,
             updaterAssetPath: appImagePath,
             blockmapPath,
+            additionalManualArtifacts: [
+                {
+                    kind: "deb",
+                    sourcePath: debPackagePath,
+                },
+            ],
         };
     }
 
@@ -225,6 +243,7 @@ function collectArtifacts(distDir, buildTarget) {
         manualAssetPath: installerPath,
         updaterAssetPath: installerPath,
         blockmapPath,
+        additionalManualArtifacts: [],
     };
 }
 
@@ -365,12 +384,21 @@ function rewriteFeed({
     document.set("sha512", publishedAssetMetadata.updaterUrl.sha512);
     const files = document.get("files");
     if (files?.items) {
+        const retainedItems = [];
         for (const item of files.items) {
             const resolvedUrl = item?.has?.("url")
                 ? resolvePublishedAssetUrl(item.get("url"), publishedAssetUrls)
                 : item?.has?.("path")
                   ? resolvePublishedAssetUrl(item.get("path"), publishedAssetUrls)
                   : updaterUrl;
+            const originalUrl = item?.has?.("url")
+                ? item.get("url")
+                : item?.has?.("path")
+                  ? item.get("path")
+                  : null;
+            if (!shouldKeepFeedArtifact(originalUrl, buildTarget)) {
+                continue;
+            }
             const metadata =
                 publishedAssetMetadata[
                     metadataKeyForPublishedAssetUrl(
@@ -391,12 +419,20 @@ function rewriteFeed({
             if (item?.has?.("size")) {
                 item.set("size", metadata.size);
             }
+            retainedItems.push(item);
         }
+        files.items = retainedItems;
     }
     const packages = document.get("packages");
     if (packages?.items) {
+        const retainedPackages = [];
         for (const item of packages.items) {
             if (item?.value?.has("path")) {
+                if (
+                    !shouldKeepFeedArtifact(item.value.get("path"), buildTarget)
+                ) {
+                    continue;
+                }
                 item.value.set(
                     "path",
                     resolvePublishedAssetUrl(
@@ -405,8 +441,18 @@ function rewriteFeed({
                     ),
                 );
             }
+            retainedPackages.push(item);
+        }
+        packages.items = retainedPackages;
+        if (retainedPackages.length === 0) {
+            document.delete("packages");
         }
     }
+    ensureFeedHasDownloadableUpdaterFile(
+        document,
+        updaterUrl,
+        publishedAssetMetadata.updaterUrl,
+    );
 
     fs.writeFileSync(destinationFeedPath, document.toString(), "utf8");
     const feedAliasRelativePaths = copyFeedAliases(
@@ -423,6 +469,32 @@ function rewriteFeed({
         updaterUrl,
         feedAliasRelativePaths,
     };
+}
+
+function ensureFeedHasDownloadableUpdaterFile(document, updaterUrl, metadata) {
+    const files = document.get("files");
+    if (files?.items && files.items.length > 0) {
+        return;
+    }
+
+    document.set("files", [
+        {
+            url: updaterUrl,
+            sha512: metadata.sha512,
+            size: metadata.size,
+        },
+    ]);
+}
+
+function shouldKeepFeedArtifact(sourceValue, buildTarget) {
+    if (
+        buildTarget.endsWith("-unknown-linux-gnu") &&
+        typeof sourceValue === "string" &&
+        sourceValue.toLowerCase().endsWith(".deb")
+    ) {
+        return false;
+    }
+    return true;
 }
 
 function metadataKeyForPublishedAssetUrl(resolvedUrl, publishedAssetUrls) {
@@ -451,9 +523,34 @@ function resolvePublishedAssetUrl(sourceValue, publishedAssetUrls) {
     return publishedAssetUrls.updaterUrl;
 }
 
+function stageAdditionalManualAssets({
+    artifacts,
+    version,
+    target,
+    outputDir,
+}) {
+    return artifacts.additionalManualArtifacts.map((artifact) => {
+        if (artifact.kind !== "deb") {
+            throw new Error(
+                `Unsupported additional manual artifact kind "${artifact.kind}".`,
+            );
+        }
+
+        const assetName = buildDebianPackageAssetName(version, target);
+        const destinationPath = path.join(outputDir, assetName);
+        copyIfNeeded(artifact.sourcePath, destinationPath);
+
+        return {
+            kind: artifact.kind,
+            assetName,
+            sizeBytes: fileSizeInBytes(destinationPath),
+        };
+    });
+}
+
 function main() {
     const args = parseArgs(process.argv.slice(2));
-    const artifacts = collectArtifacts(args.distDir, args.target);
+    const artifacts = collectArtifacts(args.distDir, args.target, args.version);
 
     fs.mkdirSync(args.outputDir, { recursive: true });
 
@@ -486,6 +583,12 @@ function main() {
             path.join(args.outputDir, blockmapAssetName),
         );
     }
+    const additionalManualAssets = stageAdditionalManualAssets({
+        artifacts,
+        version: args.version,
+        target: args.target,
+        outputDir: args.outputDir,
+    });
 
     const metadata = {
         tag: args.tag,
@@ -512,6 +615,7 @@ function main() {
                 ? fileSizeInBytes(path.join(args.outputDir, blockmapAssetName))
                 : 0,
         updaterUrl: feed.updaterUrl,
+        additionalManualAssets,
     };
 
     fs.mkdirSync(path.dirname(args.metadataOut), { recursive: true });

--- a/apps/desktop/scripts/stage-electron-release-assets.test.mjs
+++ b/apps/desktop/scripts/stage-electron-release-assets.test.mjs
@@ -275,6 +275,10 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
             "appimage",
         );
         writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-amd64.deb"),
+            "deb package",
+        );
+        writeFile(
             path.join(distDir, "latest-linux.yml"),
             [
                 "version: 0.2.0",
@@ -283,6 +287,11 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
                 "files:",
                 "  - url: NeverWrite-0.2.0-x64.AppImage",
                 "    sha512: original",
+                "  - url: NeverWrite-0.2.0-amd64.deb",
+                "    sha512: deb",
+                "packages:",
+                "  deb:",
+                "    path: NeverWrite-0.2.0-amd64.deb",
                 "",
             ].join("\n"),
         );
@@ -322,10 +331,21 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
         assert.equal(metadata.metadataFileName, "latest-linux.yml");
         assert.equal(metadata.manualAssetName, "NeverWrite-0.2.0-x64.AppImage");
         assert.equal(metadata.updaterAssetName, "NeverWrite-0.2.0-x64.AppImage");
+        assert.deepEqual(metadata.additionalManualAssets, [
+            {
+                kind: "deb",
+                assetName: "NeverWrite-0.2.0-amd64.deb",
+                sizeBytes: 11,
+            },
+        ]);
         assert.equal(metadata.updaterBlockmapAssetName, null);
         assert.equal(metadata.updaterBlockmapSizeBytes, 0);
         assert.equal(metadata.feedRelativePath, "linux-x64/latest-linux.yml");
         assert.deepEqual(metadata.feedAliasRelativePaths, []);
+        assert.equal(
+            fs.existsSync(path.join(outputDir, "NeverWrite-0.2.0-amd64.deb")),
+            true,
+        );
         assert.equal(
             fs.existsSync(
                 path.join(outputDir, "NeverWrite-0.2.0-x64.AppImage.blockmap"),
@@ -336,6 +356,85 @@ test("stage-electron-release-assets stages Linux AppImage feeds", () => {
             rewrittenFeed,
             /https:\/\/github\.com\/jsgrrchg\/NeverWrite\/releases\/download\/v0\.2\.0\/NeverWrite-0\.2\.0-x64\.AppImage/,
         );
+        assert.doesNotMatch(rewrittenFeed, /\.deb/);
+        assert.doesNotMatch(rewrittenFeed, /packages:/);
+    });
+});
+
+test("stage-electron-release-assets restores AppImage files when Linux feeds only list deb packages", () => {
+    withTempDir((tempDir) => {
+        const distDir = path.join(tempDir, "dist");
+        const outputDir = path.join(tempDir, "staged");
+        const metadataOut = path.join(tempDir, "metadata", "linux-x64.json");
+        const appImageContents = "appimage";
+        const appImageSha512 = sha512Base64(appImageContents);
+
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-x86_64.AppImage"),
+            appImageContents,
+        );
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-amd64.deb"),
+            "deb package",
+        );
+        writeFile(
+            path.join(distDir, "latest-linux.yml"),
+            [
+                "version: 0.2.0",
+                "path: NeverWrite-0.2.0-amd64.deb",
+                "sha512: deb",
+                "files:",
+                "  - url: NeverWrite-0.2.0-amd64.deb",
+                "    sha512: deb",
+                "packages:",
+                "  deb:",
+                "    path: NeverWrite-0.2.0-amd64.deb",
+                "",
+            ].join("\n"),
+        );
+
+        execFileSync(
+            process.execPath,
+            [
+                stageScriptPath,
+                "--dist-dir",
+                distDir,
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "--version",
+                "0.2.0",
+                "--tag",
+                "v0.2.0",
+                "--repo",
+                "jsgrrchg/NeverWrite",
+                "--output-dir",
+                outputDir,
+                "--metadata-out",
+                metadataOut,
+            ],
+            {
+                cwd: repoRoot,
+                stdio: "pipe",
+            },
+        );
+
+        const rewrittenFeed = fs.readFileSync(
+            path.join(outputDir, "feeds", "linux-x64", "latest-linux.yml"),
+            "utf8",
+        );
+        const feedDocument = parseDocument(rewrittenFeed);
+        const updaterUrl =
+            "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-x64.AppImage";
+        const files = feedDocument.get("files", true);
+
+        assert.equal(feedDocument.get("path"), updaterUrl);
+        assert.equal(feedDocument.get("sha512"), appImageSha512);
+        assert.equal(files.items.length, 1);
+        assert.equal(files.items[0].get("url"), updaterUrl);
+        assert.equal(files.items[0].get("sha512"), appImageSha512);
+        assert.equal(files.items[0].get("size"), 8);
+        assert.doesNotMatch(rewrittenFeed, /\.deb/);
+        assert.doesNotMatch(rewrittenFeed, /packages:/);
     });
 });
 
@@ -350,6 +449,10 @@ test("stage-electron-release-assets synthesizes missing Linux AppImage feeds", (
         writeFile(
             path.join(distDir, "NeverWrite-0.2.0-arm64.AppImage"),
             appImageContents,
+        );
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-arm64.deb"),
+            "arm64 deb",
         );
 
         execFileSync(
@@ -387,6 +490,13 @@ test("stage-electron-release-assets synthesizes missing Linux AppImage feeds", (
         assert.equal(metadata.metadataFileName, "latest-linux.yml");
         assert.equal(metadata.manualAssetName, "NeverWrite-0.2.0-arm64.AppImage");
         assert.equal(metadata.updaterAssetName, "NeverWrite-0.2.0-arm64.AppImage");
+        assert.deepEqual(metadata.additionalManualAssets, [
+            {
+                kind: "deb",
+                assetName: "NeverWrite-0.2.0-arm64.deb",
+                sizeBytes: 9,
+            },
+        ]);
         assert.equal(metadata.updaterBlockmapAssetName, null);
         assert.equal(metadata.updaterBlockmapSizeBytes, 0);
         assert.equal(metadata.feedRelativePath, "linux-arm64/latest-linux.yml");
@@ -429,6 +539,10 @@ test("stage-electron-release-assets requires generated Linux x64 feeds", () => {
             path.join(distDir, "NeverWrite-0.2.0-x86_64.AppImage"),
             "x64 appimage",
         );
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-amd64.deb"),
+            "x64 deb",
+        );
 
         assert.throws(
             () =>
@@ -457,6 +571,64 @@ test("stage-electron-release-assets requires generated Linux x64 feeds", () => {
                     },
                 ),
             /Expected exactly one latest-linux\.yml feed/,
+        );
+    });
+});
+
+test("stage-electron-release-assets requires Linux Debian packages", () => {
+    withTempDir((tempDir) => {
+        const distDir = path.join(tempDir, "dist");
+        const outputDir = path.join(tempDir, "staged");
+        const metadataOut = path.join(tempDir, "metadata", "linux-x64.json");
+
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-x86_64.AppImage"),
+            "x64 appimage",
+        );
+        writeFile(
+            path.join(distDir, "NeverWrite-0.2.0-arm64.deb"),
+            "wrong arch deb",
+        );
+        writeFile(
+            path.join(distDir, "latest-linux.yml"),
+            [
+                "version: 0.2.0",
+                "path: NeverWrite-0.2.0-x64.AppImage",
+                "sha512: original",
+                "files:",
+                "  - url: NeverWrite-0.2.0-x64.AppImage",
+                "    sha512: original",
+                "",
+            ].join("\n"),
+        );
+
+        assert.throws(
+            () =>
+                execFileSync(
+                    process.execPath,
+                    [
+                        stageScriptPath,
+                        "--dist-dir",
+                        distDir,
+                        "--target",
+                        "x86_64-unknown-linux-gnu",
+                        "--version",
+                        "0.2.0",
+                        "--tag",
+                        "v0.2.0",
+                        "--repo",
+                        "jsgrrchg/NeverWrite",
+                        "--output-dir",
+                        outputDir,
+                        "--metadata-out",
+                        metadataOut,
+                    ],
+                    {
+                        cwd: repoRoot,
+                        stdio: "pipe",
+                    },
+                ),
+            /Expected exactly one amd64 Debian package/,
         );
     });
 });

--- a/apps/desktop/scripts/validate-linux-deb-package.mjs
+++ b/apps/desktop/scripts/validate-linux-deb-package.mjs
@@ -1,0 +1,207 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+
+import {
+    buildDebianPackageAssetName,
+    debianArchForBuildTarget,
+} from "../../../scripts/electron-release-lib.mjs";
+
+function parseArgs(argv) {
+    const args = {
+        stagedAssetsDir: null,
+        target: null,
+        version: null,
+        install: false,
+    };
+
+    for (let index = 0; index < argv.length; index += 1) {
+        const arg = argv[index];
+        const next = argv[index + 1] ?? null;
+
+        if (arg === "--staged-assets-dir") {
+            args.stagedAssetsDir = path.resolve(next);
+            index += 1;
+            continue;
+        }
+        if (arg === "--target") {
+            args.target = next;
+            index += 1;
+            continue;
+        }
+        if (arg === "--version") {
+            args.version = next;
+            index += 1;
+            continue;
+        }
+        if (arg === "--install") {
+            args.install = true;
+            continue;
+        }
+
+        throw new Error(
+            `Unknown argument "${arg}". Supported args: --staged-assets-dir, --target, --version, --install.`,
+        );
+    }
+
+    for (const key of ["stagedAssetsDir", "target", "version"]) {
+        if (!args[key]) {
+            throw new Error(
+                `Missing required argument --${key.replace(/[A-Z]/g, (match) => `-${match.toLowerCase()}`)}.`,
+            );
+        }
+    }
+
+    return args;
+}
+
+function run(command, args, options = {}) {
+    const result = spawnSync(command, args, {
+        encoding: "utf8",
+        stdio: options.capture ? "pipe" : "inherit",
+    });
+
+    if (options.capture) {
+        process.stdout.write(result.stdout ?? "");
+        process.stderr.write(result.stderr ?? "");
+    }
+
+    if (result.error) {
+        throw result.error;
+    }
+    if (result.status !== 0) {
+        throw new Error(`${command} ${args.join(" ")} exited with ${result.status}`);
+    }
+
+    return result.stdout ?? "";
+}
+
+function assertMatches(contents, pattern, description) {
+    if (!pattern.test(contents)) {
+        throw new Error(`Debian package validation failed: ${description}.`);
+    }
+}
+
+function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function validatePackageMetadata({ debPath, debArch, version }) {
+    const info = run("dpkg-deb", ["--info", debPath], { capture: true });
+    const contents = run("dpkg-deb", ["--contents", debPath], { capture: true });
+
+    assertMatches(info, /^[\t ]*Package: neverwrite$/m, "package name is not neverwrite");
+    assertMatches(
+        info,
+        new RegExp(`^[\\t ]*Version: ${escapeRegex(version)}$`, "m"),
+        `package version is not ${version}`,
+    );
+    assertMatches(
+        info,
+        new RegExp(`^[\\t ]*Architecture: ${escapeRegex(debArch)}$`, "m"),
+        `package architecture is not ${debArch}`,
+    );
+    assertMatches(
+        contents,
+        /\/usr\/bin\/neverwrite$|\/opt\/NeverWrite\/neverwrite$/m,
+        "launcher or app binary is missing",
+    );
+    assertMatches(
+        contents,
+        /\/usr\/share\/applications\/.*\.desktop$/m,
+        "desktop entry is missing",
+    );
+    assertMatches(
+        contents,
+        /\/usr\/share\/icons\/|\/usr\/share\/pixmaps\//m,
+        "desktop icon is missing",
+    );
+}
+
+function queryInstalledPackage() {
+    const query = run(
+        "dpkg-query",
+        [
+            "-W",
+            "-f=${binary:Package}\t${Architecture}\t${Version}\n",
+            "neverwrite",
+        ],
+        { capture: true },
+    ).trim();
+    const [packageName, architecture, version] = query.split(/\t/);
+    return { packageName, architecture, version };
+}
+
+function validateInstalledPackage({ debPath, debArch, version }) {
+    const nativeArch = run("dpkg", ["--print-architecture"], { capture: true }).trim();
+    if (nativeArch !== debArch) {
+        console.log(
+            `Skipping install smoke for ${debArch} package on ${nativeArch} runner.`,
+        );
+        return;
+    }
+
+    let installed = false;
+
+    try {
+        run("sudo", ["apt-get", "install", "-y", debPath]);
+        installed = true;
+
+        const installedPackage = queryInstalledPackage();
+        if (
+            installedPackage.packageName !== "neverwrite" &&
+            installedPackage.packageName !== `neverwrite:${debArch}`
+        ) {
+            throw new Error(
+                `Expected package neverwrite:${debArch}, received ${installedPackage.packageName}.`,
+            );
+        }
+        if (installedPackage.architecture !== debArch) {
+            throw new Error(
+                `Expected installed architecture ${debArch}, received ${installedPackage.architecture}.`,
+            );
+        }
+        if (installedPackage.version !== version) {
+            throw new Error(
+                `Expected installed version ${version}, received ${installedPackage.version}.`,
+            );
+        }
+
+        // This verifies packaging registered the launcher without executing
+        // foreign-architecture binaries on amd64 runners.
+        run("sh", ["-lc", "command -v neverwrite"]);
+    } finally {
+        if (installed) {
+            run("sudo", ["apt-get", "remove", "-y", "neverwrite"]);
+        }
+    }
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const debArch = debianArchForBuildTarget(args.target);
+    const debAssetName = buildDebianPackageAssetName(args.version, args.target);
+    const debPath = path.join(args.stagedAssetsDir, debAssetName);
+
+    if (!fs.existsSync(debPath)) {
+        throw new Error(`Missing staged Debian package: ${debPath}`);
+    }
+
+    validatePackageMetadata({
+        debPath,
+        debArch,
+        version: args.version,
+    });
+
+    if (args.install) {
+        validateInstalledPackage({
+            debPath,
+            debArch,
+            version: args.version,
+        });
+    }
+
+    console.log(`Validated Debian package ${debAssetName}.`);
+}
+
+main();

--- a/apps/desktop/src-electron/main/updater.test.ts
+++ b/apps/desktop/src-electron/main/updater.test.ts
@@ -41,6 +41,7 @@ import { ElectronAppUpdater } from "./updater";
 const originalPlatform = Object.getOwnPropertyDescriptor(process, "platform");
 const originalArch = Object.getOwnPropertyDescriptor(process, "arch");
 const updaterEnvKeys = [
+    "APPIMAGE",
     "NEVERWRITE_UPDATER_ENDPOINT",
     "NEVERWRITE_UPDATER_BASE_URL",
     "NEVERWRITE_UPDATER_CHANNEL",
@@ -122,6 +123,7 @@ describe("ElectronAppUpdater configuration", () => {
 
     it("uses the Linux x64 AppImage feed in packaged Linux builds", () => {
         setRuntimePlatform("linux", "x64");
+        process.env.APPIMAGE = "/tmp/NeverWrite.AppImage";
 
         const status = new ElectronAppUpdater().getConfiguration();
 
@@ -135,6 +137,7 @@ describe("ElectronAppUpdater configuration", () => {
 
     it("uses the Linux ARM64 AppImage feed in packaged Linux builds", () => {
         setRuntimePlatform("linux", "arm64");
+        process.env.APPIMAGE = "/tmp/NeverWrite-arm64.AppImage";
 
         const status = new ElectronAppUpdater().getConfiguration();
 
@@ -143,6 +146,34 @@ describe("ElectronAppUpdater configuration", () => {
             endpoint:
                 "https://jsgrrchg.github.io/NeverWrite/stable/linux-arm64/latest-linux-arm64.yml",
             message: null,
+        });
+    });
+
+    it("disables the Linux x64 updater outside AppImage builds", () => {
+        setRuntimePlatform("linux", "x64");
+
+        const status = new ElectronAppUpdater().getConfiguration();
+
+        expect(status).toMatchObject({
+            enabled: false,
+            endpoint: null,
+            message:
+                "Updates for Debian packages are handled outside the app. Download the latest .deb from GitHub Releases.",
+            update: null,
+        });
+    });
+
+    it("disables the Linux ARM64 updater outside AppImage builds", () => {
+        setRuntimePlatform("linux", "arm64");
+
+        const status = new ElectronAppUpdater().getConfiguration();
+
+        expect(status).toMatchObject({
+            enabled: false,
+            endpoint: null,
+            message:
+                "Updates for Debian packages are handled outside the app. Download the latest .deb from GitHub Releases.",
+            update: null,
         });
     });
 });

--- a/apps/desktop/src-electron/main/updater.ts
+++ b/apps/desktop/src-electron/main/updater.ts
@@ -66,6 +66,8 @@ const UPDATER_VERBOSE_LOG_ENV_VARS = [
     "NEVERWRITE_UPDATER_DEBUG",
 ];
 const DEFAULT_UPDATER_BASE_URL = "https://jsgrrchg.github.io/NeverWrite";
+const LINUX_DEBIAN_PACKAGE_UPDATER_MESSAGE =
+    "Updates for Debian packages are handled outside the app. Download the latest .deb from GitHub Releases.";
 
 function readFirstNonEmptyEnv(keys: readonly string[]) {
     for (const key of keys) {
@@ -257,6 +259,14 @@ function currentUpdaterRuntimeMode(): UpdaterRuntimeMode {
     return app.isPackaged ? "production" : "non-production";
 }
 
+function isSupportedLinuxUpdaterArch() {
+    return process.arch === "x64" || process.arch === "arm64";
+}
+
+function isRunningAsLinuxAppImage() {
+    return Boolean(process.env.APPIMAGE?.trim());
+}
+
 function resolveFeedTarget() {
     if (process.platform === "darwin") {
         return "darwin-universal";
@@ -265,7 +275,7 @@ function resolveFeedTarget() {
         return `windows-${process.arch}`;
     }
     if (process.platform === "linux") {
-        if (process.arch === "x64" || process.arch === "arm64") {
+        if (isSupportedLinuxUpdaterArch() && isRunningAsLinuxAppImage()) {
             return `linux-${process.arch}`;
         }
         return null;
@@ -281,12 +291,27 @@ function resolveMetadataFileName() {
         return "latest.yml";
     }
     if (process.platform === "linux") {
+        if (!isSupportedLinuxUpdaterArch() || !isRunningAsLinuxAppImage()) {
+            return null;
+        }
         if (process.arch === "arm64") {
             return "latest-linux-arm64.yml";
         }
         return "latest-linux.yml";
     }
     return null;
+}
+
+function resolveUnsupportedUpdaterMessage() {
+    if (
+        process.platform === "linux" &&
+        isSupportedLinuxUpdaterArch() &&
+        !isRunningAsLinuxAppImage()
+    ) {
+        return LINUX_DEBIAN_PACKAGE_UPDATER_MESSAGE;
+    }
+
+    return "Updater is only supported on macOS, Windows, and Linux AppImage x64/ARM64 builds.";
 }
 
 function buildUpdaterEndpoint(baseUrl: string, channel: string, feedTarget: string) {
@@ -342,8 +367,7 @@ function loadUpdaterRuntimeConfig(): UpdaterRuntimeConfig {
             runtimeMode,
             endpoint: null,
             endpointDisplay,
-            endpointError:
-                "Updater is only supported on macOS, Windows, and Linux AppImage x64/ARM64 builds.",
+            endpointError: resolveUnsupportedUpdaterMessage(),
             feedDirectoryUrl: null,
             feedTarget,
             metadataFileName,

--- a/release/appcast/README.md
+++ b/release/appcast/README.md
@@ -15,6 +15,7 @@ GitHub Pages publishes one feed per channel, platform, and architecture:
 ```text
 <channel>/<feed-target>/latest-mac.yml
 <channel>/<feed-target>/latest.yml
+<channel>/<feed-target>/latest-linux.yml
 ```
 
 Current feed targets:
@@ -24,12 +25,15 @@ Current feed targets:
 | `universal-apple-darwin` | `darwin-universal` | `latest-mac.yml` |
 | `aarch64-pc-windows-msvc` | `windows-arm64` | `latest.yml` |
 | `x86_64-pc-windows-msvc` | `windows-x64` | `latest.yml` |
+| `aarch64-unknown-linux-gnu` | `linux-arm64` | `latest-linux.yml` |
+| `x86_64-unknown-linux-gnu` | `linux-x64` | `latest-linux.yml` |
 
 Example published URLs:
 
 ```text
 https://jsgrrchg.github.io/NeverWrite/stable/darwin-universal/latest-mac.yml
 https://jsgrrchg.github.io/NeverWrite/stable/windows-x64/latest.yml
+https://jsgrrchg.github.io/NeverWrite/stable/linux-x64/latest-linux.yml
 ```
 
 The updater metadata always points back to versioned assets on `GitHub Releases`.
@@ -39,20 +43,29 @@ The updater metadata always points back to versioned assets on `GitHub Releases`
 Each build target uploads:
 
 - one manual installer for humans
+- optional additional manual installers, such as Linux `.deb` packages
 - one updater asset for `electron-updater`
 - one blockmap for differential updates
 
 Public naming remains stable per target:
 
-| Build target | Manual asset | Updater asset |
-| --- | --- | --- |
-| `universal-apple-darwin` | `NeverWrite_<version>_macOS_Universal.dmg` | `NeverWrite_<version>_macOS_Universal.zip` |
-| `aarch64-pc-windows-msvc` | `NeverWrite_<version>_Windows_ARM64_Setup.exe` | `NeverWrite_<version>_Windows_ARM64_Setup.exe` |
-| `x86_64-pc-windows-msvc` | `NeverWrite_<version>_Windows_x64_Setup.exe` | `NeverWrite_<version>_Windows_x64_Setup.exe` |
-| `x86_64-unknown-linux-gnu` | `NeverWrite-<version>-x64.AppImage` | `NeverWrite-<version>-x64.AppImage` |
-| `aarch64-unknown-linux-gnu` | `NeverWrite-<version>-arm64.AppImage` | `NeverWrite-<version>-arm64.AppImage` |
+| Build target | Manual asset | Additional manual asset | Updater asset |
+| --- | --- | --- | --- |
+| `universal-apple-darwin` | `NeverWrite_<version>_macOS_Universal.dmg` | _None_ | `NeverWrite_<version>_macOS_Universal.zip` |
+| `aarch64-pc-windows-msvc` | `NeverWrite_<version>_Windows_ARM64_Setup.exe` | _None_ | `NeverWrite_<version>_Windows_ARM64_Setup.exe` |
+| `x86_64-pc-windows-msvc` | `NeverWrite_<version>_Windows_x64_Setup.exe` | _None_ | `NeverWrite_<version>_Windows_x64_Setup.exe` |
+| `x86_64-unknown-linux-gnu` | `NeverWrite-<version>-x64.AppImage` | `NeverWrite-<version>-amd64.deb` | `NeverWrite-<version>-x64.AppImage` |
+| `aarch64-unknown-linux-gnu` | `NeverWrite-<version>-arm64.AppImage` | `NeverWrite-<version>-arm64.deb` | `NeverWrite-<version>-arm64.AppImage` |
 
 The architecture suffix is mandatory for Windows. macOS publishes a universal package and a single universal updater feed. We do not publish shared Windows `latest.yml` metadata for multiple architectures in the same directory because `electron-builder` would otherwise collide on Windows metadata names.
+
+For Ubuntu/Debian, the recommended manual installer is the `.deb` package:
+
+```bash
+sudo apt install ./NeverWrite-<version>-amd64.deb
+```
+
+The AppImage remains the portable Linux option and the only Linux package family wired to the in-app updater. Debian packages do not auto-update in this phase; users should install a newer `.deb` manually until an APT repository exists.
 
 ## Signing and notarization
 

--- a/scripts/appcast-lib.mjs
+++ b/scripts/appcast-lib.mjs
@@ -125,6 +125,24 @@ export function buildPublicReleaseAssetName(version, buildTarget) {
     }
 }
 
+export function debianArchForBuildTarget(buildTarget) {
+    switch (buildTarget) {
+        case "aarch64-unknown-linux-gnu":
+            return "arm64";
+        case "x86_64-unknown-linux-gnu":
+            return "amd64";
+        default:
+            throw new Error(
+                `Debian packages are only supported for Linux build targets, received "${buildTarget}".`,
+            );
+    }
+}
+
+export function buildDebianPackageAssetName(version, buildTarget) {
+    const normalizedVersion = normalizeReleaseVersion(version);
+    return `${PUBLIC_PRODUCT_NAME}-${normalizedVersion}-${debianArchForBuildTarget(buildTarget)}.deb`;
+}
+
 export function getCanonicalAppBundleName() {
     return `${PUBLIC_PRODUCT_NAME}.app`;
 }

--- a/scripts/appcast.test.mjs
+++ b/scripts/appcast.test.mjs
@@ -4,6 +4,7 @@ import assert from "node:assert/strict";
 import {
     CANONICAL_RELEASE_PAGES_BASE_URL,
     CANONICAL_RELEASE_REPO_SLUG,
+    buildDebianPackageAssetName,
     buildUpdaterReleaseAssetName,
     buildChannelAppcastUrl,
     buildGitHubPagesBaseUrl,
@@ -51,6 +52,21 @@ test("buildPublicReleaseAssetName uses the human-facing naming convention", () =
     assert.equal(
         buildPublicReleaseAssetName("0.2.0", "x86_64-unknown-linux-gnu"),
         "NeverWrite-0.2.0-x64.AppImage",
+    );
+});
+
+test("buildDebianPackageAssetName uses Debian architecture names", () => {
+    assert.equal(
+        buildDebianPackageAssetName("0.2.0", "x86_64-unknown-linux-gnu"),
+        "NeverWrite-0.2.0-amd64.deb",
+    );
+    assert.equal(
+        buildDebianPackageAssetName("0.2.0", "aarch64-unknown-linux-gnu"),
+        "NeverWrite-0.2.0-arm64.deb",
+    );
+    assert.throws(
+        () => buildDebianPackageAssetName("0.2.0", "universal-apple-darwin"),
+        /Debian packages are only supported/i,
     );
 });
 

--- a/scripts/electron-release-lib.mjs
+++ b/scripts/electron-release-lib.mjs
@@ -1,8 +1,10 @@
 import {
     CANONICAL_RELEASE_PAGES_BASE_URL,
     CANONICAL_RELEASE_REPO_SLUG,
+    buildDebianPackageAssetName,
     buildGitHubReleaseAssetUrl,
     buildPublicReleaseAssetName,
+    debianArchForBuildTarget,
     normalizeAppcastChannel,
     normalizeReleaseVersion,
 } from "./appcast-lib.mjs";
@@ -10,8 +12,10 @@ import {
 export {
     CANONICAL_RELEASE_PAGES_BASE_URL,
     CANONICAL_RELEASE_REPO_SLUG,
+    buildDebianPackageAssetName,
     buildGitHubReleaseAssetUrl,
     buildPublicReleaseAssetName,
+    debianArchForBuildTarget,
     normalizeAppcastChannel,
     normalizeReleaseVersion,
 };

--- a/scripts/platform-validation-lib.mjs
+++ b/scripts/platform-validation-lib.mjs
@@ -6,6 +6,7 @@ import {
     CANONICAL_RELEASE_PAGES_BASE_URL,
     ELECTRON_BUILD_TARGETS,
     buildPublishedFeedUrl,
+    buildDebianPackageAssetName,
     describeBuildTarget,
     describeUpdaterArtifactKind,
     feedTargetForBuildTarget,
@@ -98,6 +99,72 @@ function ensureUniquePerField(entries, field) {
     }
 }
 
+function validateAdditionalManualAssets(entry, resolved) {
+    const assets = entry.additionalManualAssets ?? [];
+    if (!Array.isArray(assets)) {
+        throw new Error(
+            `Target metadata for ${resolved.buildTarget} additionalManualAssets must be an array when provided.`,
+        );
+    }
+
+    const names = new Set();
+    for (const asset of assets) {
+        if (!asset || typeof asset !== "object" || Array.isArray(asset)) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} has an invalid additional manual asset entry.`,
+            );
+        }
+        if (typeof asset.kind !== "string" || !asset.kind.trim()) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} additional manual assets must define kind.`,
+            );
+        }
+        if (typeof asset.assetName !== "string" || !asset.assetName.trim()) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} additional manual assets must define assetName.`,
+            );
+        }
+        if (
+            typeof asset.sizeBytes !== "number" ||
+            !Number.isFinite(asset.sizeBytes) ||
+            asset.sizeBytes <= 0
+        ) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} additional manual assets must define a positive sizeBytes.`,
+            );
+        }
+        if (names.has(asset.assetName)) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} duplicates additional manual asset ${asset.assetName}.`,
+            );
+        }
+        names.add(asset.assetName);
+    }
+
+    if (resolved.buildTarget.endsWith("-unknown-linux-gnu")) {
+        if (typeof entry.version !== "string" || !entry.version.trim()) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} must include version to validate Debian packages.`,
+            );
+        }
+        const expectedDebAssetName = buildDebianPackageAssetName(
+            entry.version,
+            resolved.buildTarget,
+        );
+        const hasDebAsset = assets.some(
+            (asset) =>
+                asset.kind === "deb" && asset.assetName === expectedDebAssetName,
+        );
+        if (!hasDebAsset) {
+            throw new Error(
+                `Target metadata for ${resolved.buildTarget} must include Debian package ${expectedDebAssetName} in additionalManualAssets.`,
+            );
+        }
+    }
+
+    return assets;
+}
+
 export function validateTargetMetadataEntries(entries) {
     if (!Array.isArray(entries) || entries.length === 0) {
         throw new Error("Target metadata entries must be a non-empty array.");
@@ -124,6 +191,7 @@ export function validateTargetMetadataEntries(entries) {
                 `Duplicate target metadata for feed target ${resolved.feedTarget}.`,
             );
         }
+        validateAdditionalManualAssets(entry, resolved);
         byBuildTarget.set(resolved.buildTarget, entry);
         byFeedTarget.set(resolved.feedTarget, entry);
     }
@@ -172,6 +240,7 @@ export function buildPlatformValidationMatrix({
             updaterBlockmapAssetName: metadata.updaterBlockmapAssetName,
             updaterUrl: metadata.updaterUrl,
             feedRelativePath: metadata.feedRelativePath,
+            additionalManualAssets: metadata.additionalManualAssets ?? [],
         };
     });
 }
@@ -247,6 +316,11 @@ export function renderPlatformValidationChecklist({
         lines.push(`Published feed: \`${row.feedUrl}\``);
         lines.push(`Feed target: \`${row.feedTarget}\``);
         lines.push(`Manual installer: \`${row.manualAssetName}\``);
+        for (const asset of row.additionalManualAssets ?? []) {
+            lines.push(
+                `Additional manual asset (${asset.kind}): \`${asset.assetName}\``,
+            );
+        }
         lines.push(`Updater asset: \`${row.updaterAssetName}\``);
         lines.push(
             `Invalid-checksum fixture: \`fixtures/${row.feedTarget}/invalid-checksum/${channel}/${row.metadataFileName}\``,

--- a/scripts/platform-validation.test.mjs
+++ b/scripts/platform-validation.test.mjs
@@ -12,6 +12,7 @@ import {
 function buildMetadataEntries() {
     return [
         {
+            version: "0.2.0",
             buildTarget: "universal-apple-darwin",
             feedTarget: "darwin-universal",
             metadataFileName: "latest-mac.yml",
@@ -24,6 +25,7 @@ function buildMetadataEntries() {
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite_0.2.0_macOS_Universal.zip",
         },
         {
+            version: "0.2.0",
             buildTarget: "aarch64-pc-windows-msvc",
             feedTarget: "windows-arm64",
             metadataFileName: "latest.yml",
@@ -36,6 +38,7 @@ function buildMetadataEntries() {
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite_0.2.0_Windows_ARM64_Setup.exe",
         },
         {
+            version: "0.2.0",
             buildTarget: "x86_64-pc-windows-msvc",
             feedTarget: "windows-x64",
             metadataFileName: "latest.yml",
@@ -48,6 +51,7 @@ function buildMetadataEntries() {
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite_0.2.0_Windows_x64_Setup.exe",
         },
         {
+            version: "0.2.0",
             buildTarget: "aarch64-unknown-linux-gnu",
             feedTarget: "linux-arm64",
             metadataFileName: "latest-linux.yml",
@@ -57,8 +61,16 @@ function buildMetadataEntries() {
             updaterBlockmapAssetName: null,
             updaterUrl:
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-arm64.AppImage",
+            additionalManualAssets: [
+                {
+                    kind: "deb",
+                    assetName: "NeverWrite-0.2.0-arm64.deb",
+                    sizeBytes: 456,
+                },
+            ],
         },
         {
+            version: "0.2.0",
             buildTarget: "x86_64-unknown-linux-gnu",
             feedTarget: "linux-x64",
             metadataFileName: "latest-linux.yml",
@@ -68,6 +80,13 @@ function buildMetadataEntries() {
             updaterBlockmapAssetName: null,
             updaterUrl:
                 "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.2.0/NeverWrite-0.2.0-x64.AppImage",
+            additionalManualAssets: [
+                {
+                    kind: "deb",
+                    assetName: "NeverWrite-0.2.0-amd64.deb",
+                    sizeBytes: 123,
+                },
+            ],
         },
     ];
 }
@@ -136,6 +155,13 @@ test("buildPlatformValidationMatrix aligns feed URLs with target metadata", () =
         rows[4].updaterAssetName,
         "NeverWrite-0.2.0-x64.AppImage",
     );
+    assert.deepEqual(rows[4].additionalManualAssets, [
+        {
+            kind: "deb",
+            assetName: "NeverWrite-0.2.0-amd64.deb",
+            sizeBytes: 123,
+        },
+    ]);
 });
 
 test("tamperFeedChecksum only modifies the sha512 line", () => {
@@ -171,5 +197,22 @@ test("renderPlatformValidationChecklist includes invalid-checksum fixtures", () 
     assert.match(
         markdown,
         /The app does not switch to another architecture feed/,
+    );
+    assert.match(
+        markdown,
+        /Additional manual asset \(deb\): `NeverWrite-0\.2\.0-amd64\.deb`/,
+    );
+});
+
+test("validateTargetMetadataEntries requires Debian package metadata for Linux", () => {
+    const entries = buildMetadataEntries();
+    entries[4] = {
+        ...entries[4],
+        additionalManualAssets: [],
+    };
+
+    assert.throws(
+        () => validateTargetMetadataEntries(entries),
+        /must include Debian package NeverWrite-0\.2\.0-amd64\.deb/i,
     );
 });

--- a/scripts/release-assets-lib.mjs
+++ b/scripts/release-assets-lib.mjs
@@ -3,7 +3,9 @@ import path from "node:path";
 
 import {
     BUILD_TARGET_TO_APPCAST_KEY,
+    buildDebianPackageAssetName,
     buildUpdaterReleaseAssetName,
+    debianArchForBuildTarget,
     buildGitHubReleaseAssetUrl,
     buildPublicReleaseAssetName,
     getCanonicalAppBundleName,
@@ -242,23 +244,44 @@ export function buildManualDownloadRows(version) {
     const normalizedVersion = normalizeReleaseVersion(version);
     return PUBLIC_DOWNLOAD_VARIANTS.map((variant) => ({
         ...variant,
-        assetName: buildPublicReleaseAssetName(
-            normalizedVersion,
-            variant.buildTarget,
-        ),
+        ...(targetPlatformFamily(variant.buildTarget) === "linux"
+            ? {
+                  platformLabel: "Linux Ubuntu/Debian",
+                  architectureLabel: debianArchForBuildTarget(
+                      variant.buildTarget,
+                  ),
+                  recommendedAssetName: buildDebianPackageAssetName(
+                      normalizedVersion,
+                      variant.buildTarget,
+                  ),
+                  portableAssetName: buildPublicReleaseAssetName(
+                      normalizedVersion,
+                      variant.buildTarget,
+                  ),
+              }
+            : {
+                  recommendedAssetName: buildPublicReleaseAssetName(
+                      normalizedVersion,
+                      variant.buildTarget,
+                  ),
+                  portableAssetName: null,
+              }),
     }));
 }
 
 export function renderManualDownloadTable(version) {
     const rows = buildManualDownloadRows(version);
     const lines = [
-        "| Platform | Architecture | Manual installer asset |",
-        "| --- | --- | --- |",
+        "| Platform | Architecture | Recommended installer | Portable option |",
+        "| --- | --- | --- | --- |",
     ];
 
     for (const row of rows) {
+        const portableAssetLabel = row.portableAssetName
+            ? `\`${row.portableAssetName}\``
+            : "_Not applicable_";
         lines.push(
-            `| ${row.platformLabel} | ${row.architectureLabel} | \`${row.assetName}\` |`,
+            `| ${row.platformLabel} | ${row.architectureLabel} | \`${row.recommendedAssetName}\` | ${portableAssetLabel} |`,
         );
     }
 
@@ -274,6 +297,9 @@ export function buildReleaseBody(version, releaseNotes) {
         "Choose the installer that matches your machine:",
         "",
         renderManualDownloadTable(version),
+        "",
+        "For Ubuntu/Debian, install the `.deb` package. For other Linux distributions or portable use, download the AppImage.",
+        "Debian packages do not use the in-app updater yet; download a newer `.deb` from GitHub Releases when upgrading manually.",
         "",
         "Updater artifacts are also attached to the release for in-app updates.",
         "Files ending in `.app.tar.gz`, `.nsis.zip`, `.blockmap`, or `.sig` are internal updater assets and are not intended for manual installation.",

--- a/scripts/release-assets.test.mjs
+++ b/scripts/release-assets.test.mjs
@@ -74,31 +74,36 @@ test("buildManualDownloadRows exposes the public installer set for humans", () =
             buildTarget: "universal-apple-darwin",
             platformLabel: "macOS",
             architectureLabel: "Universal",
-            assetName: "NeverWrite_0.2.0_macOS_Universal.dmg",
+            recommendedAssetName: "NeverWrite_0.2.0_macOS_Universal.dmg",
+            portableAssetName: null,
         },
         {
             buildTarget: "aarch64-pc-windows-msvc",
             platformLabel: "Windows",
             architectureLabel: "ARM64",
-            assetName: "NeverWrite_0.2.0_Windows_ARM64_Setup.exe",
+            recommendedAssetName: "NeverWrite_0.2.0_Windows_ARM64_Setup.exe",
+            portableAssetName: null,
         },
         {
             buildTarget: "x86_64-pc-windows-msvc",
             platformLabel: "Windows",
             architectureLabel: "x64",
-            assetName: "NeverWrite_0.2.0_Windows_x64_Setup.exe",
+            recommendedAssetName: "NeverWrite_0.2.0_Windows_x64_Setup.exe",
+            portableAssetName: null,
         },
         {
             buildTarget: "aarch64-unknown-linux-gnu",
-            platformLabel: "Linux",
-            architectureLabel: "ARM64",
-            assetName: "NeverWrite-0.2.0-arm64.AppImage",
+            platformLabel: "Linux Ubuntu/Debian",
+            architectureLabel: "arm64",
+            recommendedAssetName: "NeverWrite-0.2.0-arm64.deb",
+            portableAssetName: "NeverWrite-0.2.0-arm64.AppImage",
         },
         {
             buildTarget: "x86_64-unknown-linux-gnu",
-            platformLabel: "Linux",
-            architectureLabel: "x64",
-            assetName: "NeverWrite-0.2.0-x64.AppImage",
+            platformLabel: "Linux Ubuntu/Debian",
+            architectureLabel: "amd64",
+            recommendedAssetName: "NeverWrite-0.2.0-amd64.deb",
+            portableAssetName: "NeverWrite-0.2.0-x64.AppImage",
         },
     ]);
 });
@@ -111,7 +116,9 @@ test("buildReleaseBody distinguishes manual installers from internal updater ass
     assert.match(body, /## Manual installers/);
     assert.match(body, /NeverWrite_0.2.0_macOS_Universal\.dmg/);
     assert.match(body, /NeverWrite_0.2.0_Windows_x64_Setup\.exe/);
+    assert.match(body, /NeverWrite-0.2.0-amd64\.deb/);
     assert.match(body, /NeverWrite-0.2.0-x64\.AppImage/);
+    assert.match(body, /For Ubuntu\/Debian, install the `\.deb` package/);
     assert.match(body, /internal updater assets/i);
     assert.match(body, /## Browser extensions/);
     assert.match(

--- a/scripts/release-metadata-lib.mjs
+++ b/scripts/release-metadata-lib.mjs
@@ -270,6 +270,37 @@ export function collectElectronBuildIssues(config) {
             'electron-builder.config.mjs linux.target must include "AppImage".',
         );
     }
+    if (!linuxTargets.has("deb")) {
+        issues.push(
+            'electron-builder.config.mjs linux.target must include "deb".',
+        );
+    }
+    if (linuxTargets.has("deb") || config.deb != null) {
+        if (config.deb?.packageName !== "neverwrite") {
+            issues.push(
+                'electron-builder.config.mjs deb.packageName must be "neverwrite".',
+            );
+        }
+        if (
+            typeof config.deb?.artifactName !== "string" ||
+            !config.deb.artifactName.endsWith(".deb") ||
+            !config.deb.artifactName.includes("${arch}")
+        ) {
+            issues.push(
+                'electron-builder.config.mjs deb.artifactName must include "${arch}" and end with ".deb".',
+            );
+        }
+        if (config.deb?.priority !== "optional") {
+            issues.push(
+                'electron-builder.config.mjs deb.priority must be "optional".',
+            );
+        }
+        if (config.deb?.publish !== null) {
+            issues.push(
+                "electron-builder.config.mjs deb.publish must be null because Debian packages are manual-only in this release phase.",
+            );
+        }
+    }
 
     return issues;
 }

--- a/scripts/release-metadata.test.mjs
+++ b/scripts/release-metadata.test.mjs
@@ -121,7 +121,13 @@ test("collectElectronBuildIssues validates the Electron release contract", () =>
                 target: [{ target: "nsis" }],
             },
             linux: {
-                target: [{ target: "AppImage" }],
+                target: [{ target: "AppImage" }, { target: "deb" }],
+            },
+            deb: {
+                packageName: "neverwrite",
+                artifactName: "${productName}-${version}-${arch}.deb",
+                priority: "optional",
+                publish: null,
             },
         }),
         [],
@@ -139,6 +145,9 @@ test("collectElectronBuildIssues validates the Electron release contract", () =>
             win: {
                 target: [],
             },
+            linux: {
+                target: ["AppImage"],
+            },
         }),
         [
             'electron-builder.config.mjs must register the "neverwrite" protocol.',
@@ -148,7 +157,45 @@ test("collectElectronBuildIssues validates the Electron release contract", () =>
             "electron-builder.config.mjs must configure afterPack bundle verification.",
             'electron-builder.config.mjs mac.target must include "zip".',
             'electron-builder.config.mjs win.target must include "nsis".',
-            'electron-builder.config.mjs linux.target must include "AppImage".',
+            'electron-builder.config.mjs linux.target must include "deb".',
+        ],
+    );
+});
+
+test("collectElectronBuildIssues validates Debian package metadata", () => {
+    assert.deepEqual(
+        collectElectronBuildIssues({
+            artifactName: "${productName}-${version}-${os}-${arch}.${ext}",
+            afterPack: "scripts/verify-electron-bundle.mjs",
+            protocols: [{ schemes: ["neverwrite"] }],
+            extraResources: [
+                {
+                    from: "out/native-backend",
+                    to: "native-backend",
+                },
+            ],
+            mac: {
+                minimumSystemVersion: "12.0",
+                target: ["dmg", "zip"],
+            },
+            win: {
+                target: ["nsis"],
+            },
+            linux: {
+                target: ["AppImage", "deb"],
+            },
+            deb: {
+                packageName: "NeverWrite",
+                artifactName: "${productName}-${version}.deb",
+                priority: "required",
+                publish: {},
+            },
+        }),
+        [
+            'electron-builder.config.mjs deb.packageName must be "neverwrite".',
+            'electron-builder.config.mjs deb.artifactName must include "${arch}" and end with ".deb".',
+            'electron-builder.config.mjs deb.priority must be "optional".',
+            "electron-builder.config.mjs deb.publish must be null because Debian packages are manual-only in this release phase.",
         ],
     );
 });


### PR DESCRIPTION
## Summary

Adds Debian package support to the desktop release pipeline while keeping AppImage as the Linux portable package and updater asset.

- Builds and stages `NeverWrite-<version>-amd64.deb` and `NeverWrite-<version>-arm64.deb` as additional manual GitHub Release assets.
- Keeps AppImage feeds and updater metadata intact for Linux AppImage installs.
- Disables the in-app updater for Linux installs that are not running as AppImage.
- Updates release body, validation metadata, CI checks, and appcast docs for the new Ubuntu/Debian path.

## Why

Ubuntu users can hit AppImage sandbox issues on newer releases, and issue #94 tracks adding an Ubuntu/Debian package path. This starts with `.deb` release assets before adding a full APT repository later.

Related: #94, #122

## Validation

- `node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs`
- `node --test scripts/appcast.test.mjs scripts/release-assets.test.mjs scripts/release-metadata.test.mjs scripts/platform-validation.test.mjs`
- `npm --prefix apps/desktop test -- src-electron/main/updater.test.ts`
- `npm exec eslint -- src-electron/main/updater.ts src-electron/main/updater.test.ts`
- `node scripts/validate-release-metadata.mjs --tag v0.2.7`
- `git diff --check`

Draft because the Linux `.deb` build and install smoke still need GitHub Actions / Ubuntu runner validation.
