### PR TITLE
Add security reporting policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+NeverWrite is a desktop application for power users, and we take security reports seriously. If you believe you have found a vulnerability, please report it privately so we can investigate and coordinate a fix before details become public.
+
+## Reporting a Vulnerability
+
+Please use GitHub's private vulnerability reporting flow:
+
+1. Open the **Security** tab for this repository.
+2. Click **Report a vulnerability**.
+3. Include a clear description of the issue and its potential impact.
+4. Include reproduction steps, proof-of-concept details, affected versions, logs, or screenshots when they help explain the issue.
+
+Please do not report suspected vulnerabilities through public issues, discussions, pull requests, or social channels until we have reviewed the report and agreed on a disclosure path.
+
+## What to Include
+
+Helpful reports usually include:
+
+- The affected platform and app version.
+- Clear steps to reproduce the behavior.
+- The expected and actual security impact.
+- Any relevant files, configuration, sample payloads, or logs.
+- Whether the issue is already public or known elsewhere.
+
+## Scope
+
+This policy applies to the code, packaging, release artifacts, and project-maintained integrations in this repository.
+
+For vulnerabilities in third-party dependencies, please report the issue to the upstream project first unless NeverWrite's use of that dependency introduces a separate vulnerability.
+
+## Response Expectations
+
+We will review private vulnerability reports as promptly as we can, ask follow-up questions when needed, and coordinate remediation and disclosure through GitHub Security Advisories when appropriate.
+
+Thank you for helping keep NeverWrite and its users safe.


### PR DESCRIPTION
## Summary

Adds a repository-level security policy so GitHub can render the Security page guidance for responsible disclosure.

## Details

- Adds `.github/SECURITY.md` with private vulnerability reporting instructions.
- Documents what information to include in a report.
- Defines the policy scope and response expectations.

## Validation

- Verified GitHub private vulnerability reporting is enabled via the repository API: `{"enabled": true}`.
- Reviewed the staged diff before committing.

No automated tests were run because this is a documentation/configuration-only change.
