### PR TITLE
Patch rand advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1611,7 +1611,7 @@ dependencies = [
  "md-5",
  "nom",
  "nom_locate",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rangemap",
  "sha2",
  "stringprep",
@@ -2175,7 +2175,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2235,9 +2235,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",


### PR DESCRIPTION
## Summary

Updates the Rust lockfile to use `rand` 0.9.3 instead of 0.9.2, addressing Dependabot alert #4 / GHSA-cq8v-f236-94qc.

## Root cause

`rand` is pulled in transitively through the PDF extraction stack:

```text
pdf-extract -> lopdf -> rand
```

The vulnerable version was present in `Cargo.lock`, so the desktop native backend release artifact could include it even though the app does not call `rand` directly.

## Impact

This should not change visible app behavior. The affected path is indirect PDF handling/indexing, and the patch only moves `rand` to its fixed patch release.

## Validation

- `cargo test`
- `git diff --check`
- `cargo tree -i rand@0.9.3`
