### PR TITLE
Tighten web clipper YAML date matching

### DIFF
--- a/apps/web-clipper/src/lib/clip-markdown.test.ts
+++ b/apps/web-clipper/src/lib/clip-markdown.test.ts
@@ -38,6 +38,10 @@ describe("clip markdown", () => {
         expect(markdown).toContain(
             "\nsource: https://example.com/articles/demo\n",
         );
+        expect(markdown).toContain('\npublished: "2026-03-24"\n');
+        expect(markdown).toContain(
+            '\nclipped_at: "2026-03-24T00:00:00.000Z"\n',
+        );
         expect(markdown).toContain("\n# Custom title\n");
         expect(markdown.match(/^# Custom title$/gm)).toHaveLength(1);
         expect(markdown).toContain("> **Notes:** Keep for later.");
@@ -83,6 +87,27 @@ describe("clip markdown", () => {
 
         expect(markdown).toContain(
             "\n# Video clip\n\nhttps://www.youtube.com/watch?v=dQw4w9WgXcQ\n\nDemo body",
+        );
+    });
+
+    it("quotes ISO-like date values without treating arbitrary suffixes as dates", () => {
+        const markdown = buildClipMarkdown({
+            clipData: {
+                ...clipData,
+                metadata: {
+                    ...clipData.metadata,
+                    published: "2026-03-24T12:34@Z",
+                },
+                extractedAt: "2026-03-24T12:34:56.789+03:00",
+            },
+            title: "Date parsing demo",
+            tags: [],
+            contentMode: "full-page",
+        });
+
+        expect(markdown).toContain("\npublished: 2026-03-24T12:34@Z\n");
+        expect(markdown).toContain(
+            '\nclipped_at: "2026-03-24T12:34:56.789+03:00"\n',
         );
     });
 });

--- a/apps/web-clipper/src/lib/clip-markdown.ts
+++ b/apps/web-clipper/src/lib/clip-markdown.ts
@@ -1,6 +1,9 @@
 import type { ClipData } from "./clipper-contract";
 import type { ClipContentMode } from "./types";
 
+const YAML_IMPLICIT_DATE_PATTERN =
+    /^\d{4}-\d{2}-\d{2}(?:[Tt ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?)?$/;
+
 function quoteYaml(value: string): string {
     if (value.length === 0) {
         return '""';
@@ -9,7 +12,7 @@ function quoteYaml(value: string): string {
     if (
         /^(true|false|null|~)$/i.test(value) ||
         /^-?\d+(\.\d+)?$/.test(value) ||
-        /^\d{4}-\d{2}-\d{2}(?:[Tt ][\d:.+-Zz]+)?$/.test(value)
+        YAML_IMPLICIT_DATE_PATTERN.test(value)
     ) {
         return JSON.stringify(value);
     }


### PR DESCRIPTION
## Summary

Replaces the ambiguous Web Clipper YAML date regex with an explicit ISO-like date/timestamp matcher and adds tests for quoted date frontmatter.

## Root cause

CodeQL flagged the previous character class because `+-Z` was interpreted as a broad character range, allowing arbitrary characters like `@` or uppercase letters to be treated as part of a date-like value.

## Impact

Generated clip frontmatter keeps quoting real YAML-implicit dates and timestamps, while values with arbitrary suffixes are no longer classified as dates by accident.

## Validation

- `pnpm run test:run -- src/lib/clip-markdown.test.ts`
- `pnpm run compile`
- `git diff --check`
- subagent audit: no issues found