### PR TITLE
Render startup errors as text

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -144,7 +144,9 @@ function renderFatalStartupError(error: unknown) {
         error instanceof Error ? error.stack || error.message : String(error);
 
     if (!root) {
-        document.body.innerHTML = `<pre>${stack}</pre>`;
+        const pre = document.createElement("pre");
+        pre.textContent = stack;
+        document.body.replaceChildren(pre);
         return;
     }
 


### PR DESCRIPTION
## Summary
- render fatal startup fallback errors as text instead of assigning stack traces through `innerHTML`
- preserve the same fallback `<pre>` display when the app root is unavailable

## Why
CodeQL reported `Exception text reinterpreted as HTML` in the startup error fallback. The normal React error UI already escapes text, but the no-root fallback used `innerHTML`, which could reinterpret an error stack as HTML.

## Validation
- `npx tsc -p tsconfig.app.json --noEmit`
- `git diff --check`
