### PR TITLE
Limit release metadata workflow permissions

### DIFF
--- a/.github/workflows/validate-release-metadata.yml
+++ b/.github/workflows/validate-release-metadata.yml
@@ -53,6 +53,9 @@ on:
             - v*
     workflow_dispatch:
 
+permissions:
+    contents: read
+
 jobs:
     validate:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit `permissions` block to the release metadata validation workflow
- limit the workflow token to read-only repository contents access

## Why
CodeQL reported that the workflow did not limit `GITHUB_TOKEN` permissions. The workflow only checks out the repository and runs validation/tests, so `contents: read` is sufficient and matches the other read-only CI workflows.

## Validation
- parsed `.github/workflows/validate-release-metadata.yml` with Ruby YAML
- `git diff --check`
