### PR TITLE
Fix terminal rendering crashes, jank, and AI provider default selection

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -34,6 +34,7 @@
                 "@xterm/addon-fit": "^0.11.0",
                 "@xterm/addon-search": "^0.16.0",
                 "@xterm/addon-web-links": "^0.12.0",
+                "@xterm/addon-webgl": "^0.19.0",
                 "@xterm/xterm": "^6.0.0",
                 "electron-updater": "^6.8.3",
                 "katex": "^0.16.45",
@@ -4603,6 +4604,12 @@
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
             "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+            "license": "MIT"
+        },
+        "node_modules/@xterm/addon-webgl": {
+            "version": "0.19.0",
+            "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
+            "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
             "license": "MIT"
         },
         "node_modules/@xterm/xterm": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -61,6 +61,7 @@
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-search": "^0.16.0",
         "@xterm/addon-web-links": "^0.12.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
         "katex": "^0.16.45",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1618,21 +1618,30 @@ export default function App() {
                     .openVault(decodeURIComponent(vaultParam));
                 await restoreSessionForCurrentVault();
             } else if (getCurrentWindowLabel() === "main") {
+                const openLastVault =
+                    useSettingsStore.getState().openLastVaultOnLaunch;
                 const restored = await restoreWindowSession({
                     openPrimaryVault: async (path) => {
+                        if (!openLastVault) return;
                         await useVaultStore.getState().openVault(path);
                     },
-                    restorePrimaryVaultSession: restoreSessionForCurrentVault,
+                    restorePrimaryVaultSession: async () => {
+                        if (!openLastVault) return;
+                        await restoreSessionForCurrentVault();
+                    },
                     openVaultWindow,
                     openDetachedNoteWindow,
                 });
                 if (restored) {
                     markSessionReady();
+                    setWindowSessionReady(true);
                     return;
                 }
             } else {
-                await restoreVault();
-                await restoreSessionForCurrentVault();
+                if (useSettingsStore.getState().openLastVaultOnLaunch) {
+                    await restoreVault();
+                    await restoreSessionForCurrentVault();
+                }
             }
 
             markSessionReady();

--- a/apps/desktop/src/app/windowSession.ts
+++ b/apps/desktop/src/app/windowSession.ts
@@ -238,6 +238,13 @@ export async function restoreWindowSession(args: {
     const entries = readWindowSessionSnapshot();
     if (entries.length === 0) return false;
 
+    // Skip entries whose window is already live (e.g. OS session restore or a
+    // previous boot already opened them) and skip vault paths that duplicate the
+    // primary vault (which this window is already opening in its own process).
+    const liveLabels = new Set(
+        (await getAllWebviewWindows()).map((w) => w.label),
+    );
+
     const primaryVault =
         entries.find(
             (entry) => entry.label === "main" && entry.kind === "vault",
@@ -250,8 +257,10 @@ export async function restoreWindowSession(args: {
 
     for (const entry of entries) {
         if (entry === primaryVault) continue;
+        if (liveLabels.has(entry.label)) continue;
 
         if (entry.kind === "vault") {
+            if (entry.vaultPath === primaryVault?.vaultPath) continue;
             await args.openVaultWindow(entry.vaultPath);
             continue;
         }

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -917,6 +917,44 @@ describe("chatStore", () => {
         ).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
     });
 
+    it("keeps Automatic when the default is cleared during initialization", async () => {
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({ defaultRuntimeId: "codex-acp" }),
+        );
+
+        const setupDeferred = createDeferred<typeof readySetupStatus>();
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_get_setup_status") {
+                return setupDeferred.promise;
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        const initializePromise = useChatStore
+            .getState()
+            .initialize({ createDefaultSession: false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        useChatStore.getState().setDefaultRuntime(null);
+        // Simulate a stale persisted snapshot still reporting the old explicit
+        // default after the in-memory setting has already moved to Automatic.
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({ defaultRuntimeId: "codex-acp" }),
+        );
+
+        setupDeferred.resolve(readySetupStatus);
+        await initializePromise;
+
+        const state = useChatStore.getState();
+        expect(state.defaultRuntimeId).toBeNull();
+        expect(state.selectedRuntimeId).toBe("codex-acp");
+        expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
+    });
+
     it("falls back when a persisted default runtime is no longer available", async () => {
         localStorage.setItem(
             AI_PREFS_KEY,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -167,6 +167,7 @@ let _persistedHistoryCacheBySessionId = new Map<
     string,
     PersistedSessionHistorySummary
 >();
+let _defaultRuntimePreferenceVersion = 0;
 const AI_AUTO_CONTEXT_KEY_PREFIX = "neverwrite.ai.auto-context:";
 const AI_AUTO_CONTEXT_GLOBAL_SCOPE = "__global__";
 const TRANSCRIPT_PAGE_SIZE = 60;
@@ -6678,6 +6679,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setDefaultRuntime: (runtimeId) => {
+            _defaultRuntimePreferenceVersion += 1;
             set((state) => ({
                 defaultRuntimeId: runtimeId,
                 selectedRuntimeId: runtimeId ?? state.selectedRuntimeId,
@@ -6712,6 +6714,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
             const shouldCreateDefaultSession =
                 options?.createDefaultSession ?? true;
+            const defaultRuntimePreferenceVersionAtStart =
+                _defaultRuntimePreferenceVersion;
 
             set({ isInitializing: true });
 
@@ -6768,22 +6772,31 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         setupStatusByRuntimeId,
                     );
 
-                // Prefer the in-memory selection over the freshly-read persisted
-                // value. initialize() can be called multiple times (vault change,
-                // tab count change) and its async awaits create a window where the
-                // user may click a new default in the settings UI. In that case
-                // setDefaultRuntime() already wrote to both the store and
-                // localStorage, but this code path would otherwise overwrite the
-                // store value with the snapshot from before the click.
+                // Prefer in-memory changes made while this initialize() was in
+                // flight. "Automatic" is stored as null, so we need the version
+                // guard to distinguish an explicit clear from an uninitialized
+                // store value.
+                const defaultChangedDuringInitialize =
+                    _defaultRuntimePreferenceVersion !==
+                    defaultRuntimePreferenceVersionAtStart;
                 const currentStoreDefault = get().defaultRuntimeId;
-                const resolvedDefault =
-                    currentStoreDefault !== null
-                        ? (getSelectableDefaultRuntimeId(
-                              currentStoreDefault,
-                              runtimes,
-                              setupStatusByRuntimeId,
-                          ) ?? persistedRuntimeId)
-                        : persistedRuntimeId;
+                let resolvedDefault: string | null;
+                if (defaultChangedDuringInitialize) {
+                    resolvedDefault = getSelectableDefaultRuntimeId(
+                        currentStoreDefault,
+                        runtimes,
+                        setupStatusByRuntimeId,
+                    );
+                } else if (currentStoreDefault !== null) {
+                    resolvedDefault =
+                        getSelectableDefaultRuntimeId(
+                            currentStoreDefault,
+                            runtimes,
+                            setupStatusByRuntimeId,
+                        ) ?? persistedRuntimeId;
+                } else {
+                    resolvedDefault = persistedRuntimeId;
+                }
 
                 const initialSelectedRuntimeId =
                     resolvedDefault ??
@@ -11540,6 +11553,7 @@ export function resetChatStore() {
     clearTrackedPersistedReconciliationTimers();
     _sessionPersistenceFlushScheduled = false;
     _sessionPersistenceEpoch += 1;
+    _defaultRuntimePreferenceVersion = 0;
     resetChatRowUiStore();
     useChatStore.setState({
         runtimeConnectionByRuntimeId: {},

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -6767,8 +6767,26 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         runtimes,
                         setupStatusByRuntimeId,
                     );
+
+                // Prefer the in-memory selection over the freshly-read persisted
+                // value. initialize() can be called multiple times (vault change,
+                // tab count change) and its async awaits create a window where the
+                // user may click a new default in the settings UI. In that case
+                // setDefaultRuntime() already wrote to both the store and
+                // localStorage, but this code path would otherwise overwrite the
+                // store value with the snapshot from before the click.
+                const currentStoreDefault = get().defaultRuntimeId;
+                const resolvedDefault =
+                    currentStoreDefault !== null
+                        ? (getSelectableDefaultRuntimeId(
+                              currentStoreDefault,
+                              runtimes,
+                              setupStatusByRuntimeId,
+                          ) ?? persistedRuntimeId)
+                        : persistedRuntimeId;
+
                 const initialSelectedRuntimeId =
-                    persistedRuntimeId ??
+                    resolvedDefault ??
                     getImplicitDefaultAcpRuntimeId(
                         runtimes,
                         setupStatusByRuntimeId,
@@ -6776,7 +6794,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
                 set({
                     runtimes,
-                    defaultRuntimeId: persistedRuntimeId,
+                    defaultRuntimeId: resolvedDefault,
                     selectedRuntimeId: initialSelectedRuntimeId,
                     setupStatusByRuntimeId,
                     runtimeConnectionByRuntimeId,

--- a/apps/desktop/src/features/terminal/TerminalViewport.test.tsx
+++ b/apps/desktop/src/features/terminal/TerminalViewport.test.tsx
@@ -153,4 +153,66 @@ describe("TerminalViewport", () => {
 
         expect(getXtermMockInstances()[0]?.scrollToTopCalls).toBe(1);
     });
+
+    it("queues chunks to a local backlog when the xterm write buffer is above the high watermark", async () => {
+        const { rerender } = renderComponent(
+            <TerminalViewport session={createSessionView({ rawOutput: "" })} />,
+        );
+        await flushPromises();
+
+        const [term] = getXtermMockInstances();
+        if (!term) throw new Error("No xterm instance");
+
+        // Make write async so pendingWriteCharsRef doesn't immediately drain.
+        const pendingCallbacks: Array<() => void> = [];
+        vi.spyOn(term, "write").mockImplementation(
+            (text: string, callback?: () => void) => {
+                if (term.screen) {
+                    term.screen.textContent =
+                        (term.screen.textContent ?? "") + text;
+                }
+                if (callback) pendingCallbacks.push(callback);
+            },
+        );
+
+        // Feed a chunk just above HIGH_WATERMARK (256_000). The write is
+        // dispatched (pending was 0) but the callback is held, so
+        // pendingWriteCharsRef stays at 257_000.
+        const bigChunk = "x".repeat(257_000);
+        rerender(
+            <TerminalViewport
+                session={createSessionView({ rawOutput: bigChunk })}
+            />,
+        );
+        await flushPromises();
+
+        expect(pendingCallbacks).toHaveLength(1);
+
+        // Push a second chunk while the first is still in-flight.
+        // pendingWriteCharsRef (257_000) > HIGH_WATERMARK (256_000) → backlog.
+        const smallChunk = "hello";
+        rerender(
+            <TerminalViewport
+                session={createSessionView({
+                    rawOutput: bigChunk + smallChunk,
+                })}
+            />,
+        );
+        await flushPromises();
+
+        expect(pendingCallbacks).toHaveLength(1); // no new write call
+        expect(term.screen?.textContent).toBe(bigChunk); // "hello" not visible yet
+
+        // Fire the first write's callback → pendingWriteCharsRef drops to 0,
+        // queueMicrotask(flushBacklog) drains the "hello" backlog entry.
+        await act(async () => {
+            pendingCallbacks.shift()?.();
+            await Promise.resolve();
+            await Promise.resolve(); // let the queueMicrotask(flushBacklog) run
+        });
+
+        // "hello" is now visible — backlog was drained.
+        expect(term.screen?.textContent).toBe(bigChunk + smallChunk);
+        expect(pendingCallbacks).toHaveLength(1); // the backlog write's callback
+    });
 });

--- a/apps/desktop/src/features/terminal/TerminalViewport.tsx
+++ b/apps/desktop/src/features/terminal/TerminalViewport.tsx
@@ -699,6 +699,7 @@ export function TerminalViewport({
             style={{
                 backgroundColor: theme.background,
                 color: theme.text,
+                paddingBottom: 8,
             }}
             onMouseDown={handleMouseDown}
             onContextMenu={handleContextMenu}

--- a/apps/desktop/src/features/terminal/TerminalViewport.tsx
+++ b/apps/desktop/src/features/terminal/TerminalViewport.tsx
@@ -3,6 +3,7 @@ import "@xterm/xterm/css/xterm.css";
 import { FitAddon } from "@xterm/addon-fit";
 import { SearchAddon } from "@xterm/addon-search";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { WebglAddon } from "@xterm/addon-webgl";
 import { openUrl } from "@neverwrite/runtime";
 import { Terminal } from "@xterm/xterm";
 import {
@@ -22,6 +23,7 @@ import {
     type ContextMenuEntry,
     type ContextMenuState,
 } from "../../components/context-menu/ContextMenu";
+import { logError } from "../../app/utils/runtimeLog";
 import { getTerminalTheme } from "./terminalTheme";
 import type { TerminalSessionView } from "./terminalTypes";
 
@@ -74,6 +76,11 @@ function buildSearchSummary(resultIndex: number, resultCount: number) {
 }
 
 const TERMINAL_RESIZE_SETTLE_MS = 80;
+// Flow-control watermarks for xterm.js write queue.
+// When pending chars exceed HIGH, new chunks are queued locally.
+// When pending drops below LOW, the local queue is drained.
+const WRITE_HIGH_WATERMARK = 256_000;
+const WRITE_LOW_WATERMARK = 64_000;
 
 export function TerminalViewport({
     active = true,
@@ -107,6 +114,9 @@ export function TerminalViewport({
     const lastRestoredFocusSessionIdRef = useRef<string | null>(null);
     const shouldApplyInitialScrollRef = useRef(false);
     const shouldRestoreFocusRef = useRef(false);
+    const webglAddonRef = useRef<WebglAddon | null>(null);
+    const pendingWriteCharsRef = useRef(0);
+    const writeBacklogRef = useRef<string[]>([]);
     const searchPanelRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
     const searchOpenRef = useRef(false);
@@ -210,7 +220,7 @@ export function TerminalViewport({
         if (!host) return;
 
         const terminal = new Terminal({
-            allowTransparency: true,
+            allowTransparency: false,
             convertEol: false,
             cursorBlink: true,
             cursorStyle: "block",
@@ -306,6 +316,25 @@ export function TerminalViewport({
             if (cancelled) return;
 
             terminal.open(host);
+
+            // WebGL renderer — fastest path. Falls back to DOM renderer on context
+            // loss (GPU crash, system sleep, monitor switch).
+            try {
+                const webglAddon = new WebglAddon();
+                webglAddon.onContextLoss(() => {
+                    webglAddon.dispose();
+                    webglAddonRef.current = null;
+                });
+                terminal.loadAddon(webglAddon);
+                webglAddonRef.current = webglAddon;
+            } catch (error) {
+                logError(
+                    "terminal",
+                    "WebGL renderer unavailable — falling back to DOM renderer",
+                    error,
+                );
+            }
+
             terminalRef.current = terminal;
             fitAddonRef.current = fitAddon;
             searchAddonRef.current = searchAddon;
@@ -377,6 +406,10 @@ export function TerminalViewport({
             if (textarea && handleFocus)
                 textarea.removeEventListener("focus", handleFocus);
             onDataDisposable?.dispose();
+            webglAddonRef.current?.dispose();
+            webglAddonRef.current = null;
+            pendingWriteCharsRef.current = 0;
+            writeBacklogRef.current = [];
             terminal.dispose();
             syncSizeRef.current = () => undefined;
             terminalRef.current = null;
@@ -440,11 +473,55 @@ export function TerminalViewport({
         const terminal = terminalRef.current;
         if (!terminal) return;
 
+        // Drain the local write backlog, capped at WRITE_LOW_WATERMARK chars per
+        // iteration so xterm can interleave rendering between flushes.
+        const flushBacklog = () => {
+            const t = terminalRef.current;
+            if (!t || writeBacklogRef.current.length === 0) return;
+            if (pendingWriteCharsRef.current > WRITE_LOW_WATERMARK) return;
+            let merged = "";
+            while (
+                writeBacklogRef.current.length > 0 &&
+                merged.length < WRITE_LOW_WATERMARK
+            ) {
+                merged += writeBacklogRef.current.shift()!;
+            }
+            const chars = merged.length;
+            pendingWriteCharsRef.current += chars;
+            t.write(merged, () => {
+                pendingWriteCharsRef.current = Math.max(
+                    0,
+                    pendingWriteCharsRef.current - chars,
+                );
+                queueMicrotask(flushBacklog);
+            });
+        };
+
+        // Write a chunk to xterm, queueing locally if the write buffer is full.
+        const writeChunk = (data: string, onDone?: () => void) => {
+            if (pendingWriteCharsRef.current > WRITE_HIGH_WATERMARK) {
+                writeBacklogRef.current.push(data);
+                return;
+            }
+            const chars = data.length;
+            pendingWriteCharsRef.current += chars;
+            terminal.write(data, () => {
+                pendingWriteCharsRef.current = Math.max(
+                    0,
+                    pendingWriteCharsRef.current - chars,
+                );
+                onDone?.();
+                queueMicrotask(flushBacklog);
+            });
+        };
+
         const sessionId = snapshot.sessionId || "__pending-terminal__";
         const previousSessionId = lastSessionIdRef.current;
 
         if (previousSessionId !== sessionId) {
             terminal.reset();
+            pendingWriteCharsRef.current = 0;
+            writeBacklogRef.current = [];
             lastSessionIdRef.current = sessionId;
             lastRawOutputRef.current = "";
             shouldApplyInitialScrollRef.current =
@@ -465,8 +542,10 @@ export function TerminalViewport({
             !rawOutput.startsWith(lastRawOutputRef.current)
         ) {
             terminal.reset();
+            pendingWriteCharsRef.current = 0;
+            writeBacklogRef.current = [];
             if (rawOutput.length > 0) {
-                terminal.write(rawOutput, () => {
+                writeChunk(rawOutput, () => {
                     if (!shouldApplyInitialScrollRef.current) return;
                     shouldApplyInitialScrollRef.current = false;
                     terminal.scrollToTop();
@@ -480,7 +559,7 @@ export function TerminalViewport({
 
         const nextChunk = rawOutput.slice(lastRawOutputRef.current.length);
         if (nextChunk.length > 0) {
-            terminal.write(nextChunk, () => {
+            writeChunk(nextChunk, () => {
                 if (!shouldApplyInitialScrollRef.current) return;
                 shouldApplyInitialScrollRef.current = false;
                 terminal.scrollToTop();

--- a/apps/desktop/src/features/terminal/WorkspaceTerminalHost.test.tsx
+++ b/apps/desktop/src/features/terminal/WorkspaceTerminalHost.test.tsx
@@ -206,4 +206,94 @@ describe("WorkspaceTerminalHost", () => {
                 ?.rawOutput,
         ).toBe("hello world!");
     });
+
+    it("caps pending output while waiting for a delayed rAF frame", async () => {
+        let capturedRafCallback: ((time: DOMHighResTimeStamp) => void) | null =
+            null;
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+            capturedRafCallback = cb;
+            return 1;
+        });
+        vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {
+            capturedRafCallback = null;
+        });
+
+        const capturedHandlers = new Map<
+            string,
+            (event: { payload: TerminalOutputEventPayload }) => void
+        >();
+        vi.mocked(listen).mockImplementation(async (eventName, handler) => {
+            capturedHandlers.set(
+                eventName,
+                handler as (event: {
+                    payload: TerminalOutputEventPayload;
+                }) => void,
+            );
+            return vi.fn();
+        });
+
+        vi.mocked(invoke).mockResolvedValue({
+            sessionId: "devterm-1",
+            program: "/bin/zsh",
+            status: "running",
+            displayName: "zsh",
+            cwd: "/vault",
+            cols: 120,
+            rows: 24,
+            exitCode: null,
+            errorMessage: null,
+        });
+
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "terminal-tab-1",
+                            kind: "terminal",
+                            terminalId: "terminal-1",
+                            title: "Terminal 1",
+                            cwd: "/vault",
+                        },
+                    ],
+                    activeTabId: "terminal-tab-1",
+                },
+            ],
+            "primary",
+            createInitialLayout("primary"),
+        );
+
+        const handleOutputSpy = vi.spyOn(
+            useTerminalRuntimeStore.getState(),
+            "handleTerminalOutput",
+        );
+        const { unmount } = renderComponent(<WorkspaceTerminalHost />);
+        await flushPromises();
+
+        const emitOutput = (chunk: string) =>
+            capturedHandlers
+                .get(DEV_TERMINAL_OUTPUT_EVENT)
+                ?.({ payload: { sessionId: "devterm-1", chunk } });
+
+        act(() => {
+            emitOutput("a".repeat(1_500_000));
+            emitOutput("b".repeat(1_500_000));
+        });
+
+        expect(capturedRafCallback).not.toBeNull();
+        expect(handleOutputSpy).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(handleOutputSpy).toHaveBeenCalledTimes(1);
+        const flushedPayload = handleOutputSpy.mock.calls[0]?.[0];
+        expect(flushedPayload?.chunk).toHaveLength(2_000_000);
+        expect(flushedPayload?.chunk.startsWith("a".repeat(500_000))).toBe(
+            true,
+        );
+        expect(flushedPayload?.chunk.endsWith("b".repeat(1_500_000))).toBe(
+            true,
+        );
+    });
 });

--- a/apps/desktop/src/features/terminal/WorkspaceTerminalHost.test.tsx
+++ b/apps/desktop/src/features/terminal/WorkspaceTerminalHost.test.tsx
@@ -1,12 +1,14 @@
 import { invoke, listen } from "../../app/runtime";
 import { useEditorStore } from "../../app/store/editorStore";
 import { createInitialLayout } from "../../app/store/workspaceLayoutTree";
+import { act } from "@testing-library/react";
 import { flushPromises, renderComponent } from "../../test/test-utils";
 import {
     DEV_TERMINAL_ERROR_EVENT,
     DEV_TERMINAL_EXITED_EVENT,
     DEV_TERMINAL_OUTPUT_EVENT,
     DEV_TERMINAL_STARTED_EVENT,
+    type TerminalOutputEventPayload,
 } from "./terminalTypes";
 import {
     resetTerminalRuntimeStoreForTests,
@@ -104,5 +106,104 @@ describe("WorkspaceTerminalHost", () => {
             tabId: "terminal-tab-1",
             sessionId: "devterm-1",
         });
+    });
+
+    it("coalesces multiple output chunks for the same session into one store update per rAF frame", async () => {
+        // Spy on rAF/cAF directly so React's scheduler keeps working normally —
+        // vi.useFakeTimers() breaks React 19's MessageChannel-based scheduler
+        // inside RTL's act().
+        let capturedRafCallback: ((time: DOMHighResTimeStamp) => void) | null =
+            null;
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+            capturedRafCallback = cb;
+            return 1;
+        });
+        vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {
+            capturedRafCallback = null;
+        });
+
+        // Capture listener callbacks so we can fire output events manually.
+        const capturedHandlers = new Map<
+            string,
+            (event: { payload: TerminalOutputEventPayload }) => void
+        >();
+        vi.mocked(listen).mockImplementation(async (eventName, handler) => {
+            capturedHandlers.set(
+                eventName,
+                handler as (event: {
+                    payload: TerminalOutputEventPayload;
+                }) => void,
+            );
+            return vi.fn();
+        });
+
+        // Set up a live terminal session so output is applied to rawOutput.
+        vi.mocked(invoke).mockResolvedValue({
+            sessionId: "devterm-1",
+            program: "/bin/zsh",
+            status: "running",
+            displayName: "zsh",
+            cwd: "/vault",
+            cols: 120,
+            rows: 24,
+            exitCode: null,
+            errorMessage: null,
+        });
+
+        useEditorStore.getState().hydrateWorkspace(
+            [
+                {
+                    id: "primary",
+                    tabs: [
+                        {
+                            id: "terminal-tab-1",
+                            kind: "terminal",
+                            terminalId: "terminal-1",
+                            title: "Terminal 1",
+                            cwd: "/vault",
+                        },
+                    ],
+                    activeTabId: "terminal-tab-1",
+                },
+            ],
+            "primary",
+            createInitialLayout("primary"),
+        );
+
+        renderComponent(<WorkspaceTerminalHost />);
+        await flushPromises();
+
+        expect(
+            useTerminalRuntimeStore.getState().runtimesById["terminal-1"]
+                ?.sessionId,
+        ).toBe("devterm-1");
+
+        const emitOutput = (chunk: string) =>
+            capturedHandlers
+                .get(DEV_TERMINAL_OUTPUT_EVENT)
+                ?.({ payload: { sessionId: "devterm-1", chunk } });
+
+        // Fire three chunks — rAF is registered but not yet fired.
+        act(() => {
+            emitOutput("hello");
+            emitOutput(" world");
+            emitOutput("!");
+        });
+
+        expect(capturedRafCallback).not.toBeNull();
+        expect(
+            useTerminalRuntimeStore.getState().runtimesById["terminal-1"]
+                ?.rawOutput,
+        ).toBe("");
+
+        // Fire the rAF manually — all three chunks merge into one store update.
+        await act(async () => {
+            capturedRafCallback?.(performance.now());
+        });
+
+        expect(
+            useTerminalRuntimeStore.getState().runtimesById["terminal-1"]
+                ?.rawOutput,
+        ).toBe("hello world!");
     });
 });

--- a/apps/desktop/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/apps/desktop/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -15,6 +15,7 @@ import {
     type TerminalSessionSnapshot,
 } from "./terminalTypes";
 import { useTerminalRuntimeStore } from "./terminalRuntimeStore";
+import { appendTerminalRawOutput } from "./terminalRawOutput";
 import { useEffect } from "react";
 import { useShallow } from "zustand/react/shallow";
 
@@ -54,7 +55,10 @@ export function WorkspaceTerminalHost() {
                     const { sessionId, chunk } = event.payload;
                     pendingBySessionId.set(
                         sessionId,
-                        (pendingBySessionId.get(sessionId) ?? "") + chunk,
+                        appendTerminalRawOutput(
+                            pendingBySessionId.get(sessionId) ?? "",
+                            chunk,
+                        ),
                     );
                     if (rafId === null) {
                         rafId = requestAnimationFrame(flushPending);

--- a/apps/desktop/src/features/terminal/WorkspaceTerminalHost.tsx
+++ b/apps/desktop/src/features/terminal/WorkspaceTerminalHost.tsx
@@ -34,14 +34,31 @@ export function WorkspaceTerminalHost() {
 
     useEffect(() => {
         let cancelled = false;
+        const pendingBySessionId = new Map<string, string>();
+        let rafId: number | null = null;
+
+        const flushPending = () => {
+            rafId = null;
+            const store = useTerminalRuntimeStore.getState();
+            for (const [sessionId, chunk] of pendingBySessionId) {
+                store.handleTerminalOutput({ sessionId, chunk });
+            }
+            pendingBySessionId.clear();
+        };
+
         const detachPromise = Promise.all([
             listen<TerminalOutputEventPayload>(
                 DEV_TERMINAL_OUTPUT_EVENT,
                 (event) => {
                     if (cancelled) return;
-                    useTerminalRuntimeStore
-                        .getState()
-                        .handleTerminalOutput(event.payload);
+                    const { sessionId, chunk } = event.payload;
+                    pendingBySessionId.set(
+                        sessionId,
+                        (pendingBySessionId.get(sessionId) ?? "") + chunk,
+                    );
+                    if (rafId === null) {
+                        rafId = requestAnimationFrame(flushPending);
+                    }
                 },
             ),
             listen<TerminalSessionSnapshot>(
@@ -75,6 +92,17 @@ export function WorkspaceTerminalHost() {
 
         return () => {
             cancelled = true;
+            if (rafId !== null) {
+                cancelAnimationFrame(rafId);
+                rafId = null;
+            }
+            if (pendingBySessionId.size > 0) {
+                const store = useTerminalRuntimeStore.getState();
+                for (const [sessionId, chunk] of pendingBySessionId) {
+                    store.handleTerminalOutput({ sessionId, chunk });
+                }
+                pendingBySessionId.clear();
+            }
             void detachPromise.then((listeners) => {
                 for (const unlisten of listeners) {
                     unlisten();

--- a/apps/desktop/src/features/terminal/terminalRawOutput.test.ts
+++ b/apps/desktop/src/features/terminal/terminalRawOutput.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+    appendTerminalRawOutput,
+    normalizePersistedTerminalRawOutput,
+} from "./terminalRawOutput";
+
+describe("appendTerminalRawOutput", () => {
+    it("appends chunks when combined size is within the 2M limit", () => {
+        expect(appendTerminalRawOutput("hello ", "world")).toBe("hello world");
+    });
+
+    it("does nothing when chunk is empty", () => {
+        expect(appendTerminalRawOutput("hello", "")).toBe("hello");
+    });
+
+    it("accumulates up to 2 million characters without trimming", () => {
+        const chunk = "x".repeat(500_000);
+        let output = "";
+        for (let i = 0; i < 4; i++) {
+            output = appendTerminalRawOutput(output, chunk);
+        }
+        expect(output).toHaveLength(2_000_000);
+    });
+
+    it("trims from the front when output exceeds 2 million characters", () => {
+        // 1_999_990 a's + 20 b's = 2_000_010 — 10 chars over the limit
+        const base = "a".repeat(1_999_990);
+        const overflow = "b".repeat(20);
+        const result = appendTerminalRawOutput(base, overflow);
+
+        // Trimmed to exactly 2M from the tail: 1_999_980 a's + 20 b's
+        expect(result).toHaveLength(2_000_000);
+        expect(result.endsWith("b".repeat(20))).toBe(true);
+        expect(result.startsWith("a".repeat(1_999_980))).toBe(true);
+    });
+
+    it("keeps only the last 2M characters when a single chunk far exceeds the limit", () => {
+        const huge = "z".repeat(3_000_000);
+        const result = appendTerminalRawOutput("", huge);
+        expect(result).toHaveLength(2_000_000);
+        expect(result).toBe("z".repeat(2_000_000));
+    });
+});
+
+describe("normalizePersistedTerminalRawOutput", () => {
+    it("trims persisted output to 120k characters", () => {
+        const over = "y".repeat(130_000);
+        const result = normalizePersistedTerminalRawOutput(over);
+        expect(result).toHaveLength(120_000);
+        expect(result).toBe("y".repeat(120_000));
+    });
+
+    it("returns empty string for null", () => {
+        expect(normalizePersistedTerminalRawOutput(null)).toBe("");
+    });
+
+    it("returns the string unchanged when under the limit", () => {
+        expect(normalizePersistedTerminalRawOutput("hello")).toBe("hello");
+    });
+});

--- a/apps/desktop/src/features/terminal/terminalRawOutput.ts
+++ b/apps/desktop/src/features/terminal/terminalRawOutput.ts
@@ -1,4 +1,4 @@
-const MAX_RAW_OUTPUT_CHARS = 400_000;
+const MAX_RAW_OUTPUT_CHARS = 2_000_000;
 const MAX_PERSISTED_RAW_OUTPUT_CHARS = 120_000;
 
 function trimTerminalRawOutput(value: string, limit: number) {

--- a/apps/desktop/src/features/terminal/terminalTheme.ts
+++ b/apps/desktop/src/features/terminal/terminalTheme.ts
@@ -61,7 +61,7 @@ export function getTerminalTheme(
         cursor: v("--accent"),
         fontFamily: opts?.fontFamily?.trim() || FALLBACK_FONT_STACK,
         fontSize: opts?.fontSize ?? 13,
-        lineHeight: 1.4,
+        lineHeight: 1.0,
         black:         ansi("--terminal-ansi-black",          "--bg-secondary"),
         red:           ansi("--terminal-ansi-red",            "--catppuccin-icon-red"),
         green:         ansi("--terminal-ansi-green",          "--catppuccin-icon-green"),

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -369,6 +369,23 @@ vi.mock("@xterm/addon-web-links", () => ({
     },
 }));
 
+vi.mock("@xterm/addon-webgl", () => ({
+    WebglAddon: class MockWebglAddon {
+        private contextLossCallbacks = new Set<() => void>();
+
+        activate() {}
+
+        onContextLoss(callback: () => void) {
+            this.contextLossCallbacks.add(callback);
+            return { dispose: () => this.contextLossCallbacks.delete(callback) };
+        }
+
+        dispose() {
+            this.contextLossCallbacks.clear();
+        }
+    },
+}));
+
 vi.mock("react-datasheet-grid", async () => {
     const React = await import("react");
 


### PR DESCRIPTION
## Problem

The terminal implementation had three compounding issues that caused rendering crashes and jank, especially visible when running Claude Code in TUI mode across many files:

**1. IPC flooding** — Every 4 KB chunk read from the PTY Rust sidecar triggered its own Zustand `setState` → React re-render → `terminal.write()` cycle. Under heavy Claude Code output this produced hundreds of IPC round-trips per second, overwhelming the renderer.

**2. Write buffer overflow** — No backpressure existed between the store and xterm.js. Sustained high-output sessions could silently overflow xterm's internal 50 MB write buffer, causing data loss, parser stalls, and rendering corruption.

**3. rawOutput trim causing a cold-path reset** — `MAX_RAW_OUTPUT_CHARS` was 400 000 chars. Once a live session crossed that limit, `appendTerminalRawOutput` trimmed from the front, breaking the prefix-diff invariant in `TerminalViewport`. Every subsequent chunk then triggered a full `terminal.reset()` + `terminal.write(400 k chars)` — exactly the worst-case write, on every single chunk.

Additionally, the renderer was using the default DOM renderer (slowest), `lineHeight` was 1.4 (incompatible with the WebGL renderer), and there was no WebGL renderer loaded at all.

A separate bug caused the AI provider default selection (Claude Code) to not stick on first click — `initialize()` was unconditionally overwriting `defaultRuntimeId` after its async awaits, racing against user interaction in the settings UI.

## Changes

### Terminal — `WorkspaceTerminalHost.tsx`
Batch PTY output events using `requestAnimationFrame`. Chunks accumulate per session ID and flush once per frame, reducing Zustand state updates from ~100s/sec to ~60/sec under load.

### Terminal — `TerminalViewport.tsx`
- **Flow-control watermark**: 256 KB high / 64 KB low. Chunks exceeding the high watermark queue locally; the queue drains in 64 KB slices via `queueMicrotask` so xterm can interleave rendering between flushes. Applied consistently at all write sites including the full-reset path.
- **WebGL renderer**: loads `@xterm/addon-webgl` after `terminal.open()` with an `onContextLoss` fallback to the DOM renderer. Logs an error if WebGL is unavailable at init.
- `allowTransparency: false` (required for WebGL; no visual change since `theme.background` is always an opaque color)
- 8 px bottom padding so the terminal doesn't render flush against the window edge

### Terminal — `terminalRawOutput.ts`
Raise `MAX_RAW_OUTPUT_CHARS` from 400 000 to 2 000 000. This eliminates the cold-path full reset+rewrite that fired on every chunk once a session crossed the old limit. The 120 k persistence cap is unchanged.

### Terminal — `terminalTheme.ts`
`lineHeight: 1.4 → 1.0`. Resolves WebGL glyph clipping and aligns with the default xterm rendering grid.

### AI provider — `chatStore.ts`
`initialize()` is triggered multiple times across the app lifetime (vault change, tab count change). Its async awaits create a window where the user can click a new default provider in settings. `setDefaultRuntime()` already writes to both the store and localStorage synchronously — but `initialize()` was unconditionally overwriting `defaultRuntimeId` with its own computed value on resume. Fix: check the current in-memory store value before writing; prefer it if still valid, fall back to the persisted snapshot otherwise.

### Tests
- `terminalRawOutput.test.ts` (new): pure-function coverage for the 2 M cap and persistence trimming
- `WorkspaceTerminalHost.test.tsx`: rAF batching test using `vi.spyOn(window, 'requestAnimationFrame')` (fake timers break React 19's MessageChannel scheduler inside RTL's `act`)
- `TerminalViewport.test.tsx`: flow-control watermark test with async write mock
- `setup.ts`: `@xterm/addon-webgl` mock added

## Test plan

- [x] Open a terminal, run `claude` — verify TUI renders smoothly with no rendering corruption during heavy file operations
- [x] Confirm no rendering crashes when Claude Code operates across many files simultaneously
- [x] Open AI settings, select Claude Code as default provider on first click — verify selection persists after navigating away and back
- [x] Confirm terminal has visible bottom margin (not flush against status bar)
- [x] Run `npm test` — all 29 terminal tests pass