### PR TITLE
Polish APT repository metadata

### DIFF
--- a/scripts/apt-repo-lib.mjs
+++ b/scripts/apt-repo-lib.mjs
@@ -16,6 +16,7 @@ export const APT_LABEL = PUBLIC_PRODUCT_NAME;
 export const APT_DESCRIPTION =
     "NeverWrite desktop Debian package repository";
 export const APT_DEFAULT_SUITE = "stable";
+export const APT_DEFAULT_CODENAME = "neverwrite-stable";
 export const APT_DEFAULT_COMPONENT = "main";
 export const APT_SUPPORTED_ARCHITECTURES = ["amd64", "arm64"];
 export const APT_DEFAULT_BASE_URL = `${CANONICAL_RELEASE_PAGES_BASE_URL}/apt`;
@@ -27,6 +28,13 @@ export const APT_RELEASE_CHECKSUMS = [
     { fieldName: "SHA1", algorithm: "sha1" },
     { fieldName: "SHA256", algorithm: "sha256" },
 ];
+export const APT_PACKAGE_CHECKSUMS = [
+    { fieldName: "MD5sum", hashKey: "MD5Sum", algorithm: "md5" },
+    { fieldName: "SHA1", hashKey: "SHA1", algorithm: "sha1" },
+    { fieldName: "SHA256", hashKey: "SHA256", algorithm: "sha256" },
+];
+
+const HASH_READ_BUFFER_SIZE_BYTES = 1024 * 1024;
 
 const BUILD_TARGET_BY_DEBIAN_ARCHITECTURE = {
     amd64: "x86_64-unknown-linux-gnu",
@@ -205,7 +213,27 @@ export function renderDebianControlFields(fields) {
 
 export function hashFile(filePath, algorithm) {
     const hash = crypto.createHash(algorithm);
-    hash.update(fs.readFileSync(filePath));
+    const buffer = Buffer.allocUnsafe(HASH_READ_BUFFER_SIZE_BYTES);
+    const fileDescriptor = fs.openSync(filePath, "r");
+
+    try {
+        let bytesRead = 0;
+        do {
+            bytesRead = fs.readSync(
+                fileDescriptor,
+                buffer,
+                0,
+                buffer.length,
+                null,
+            );
+            if (bytesRead > 0) {
+                hash.update(buffer.subarray(0, bytesRead));
+            }
+        } while (bytesRead > 0);
+    } finally {
+        fs.closeSync(fileDescriptor);
+    }
+
     return hash.digest("hex");
 }
 
@@ -253,9 +281,10 @@ export function renderPackagesStanza({
         ),
         { name: "Filename", value: filename },
         { name: "Size", value: String(sizeBytes) },
-        { name: "MD5sum", value: hashes.MD5Sum },
-        { name: "SHA1", value: hashes.SHA1 },
-        { name: "SHA256", value: hashes.SHA256 },
+        ...APT_PACKAGE_CHECKSUMS.map(({ fieldName, hashKey }) => ({
+            name: fieldName,
+            value: hashes[hashKey],
+        })),
     );
 
     return renderDebianControlFields(orderedFields);
@@ -263,6 +292,7 @@ export function renderPackagesStanza({
 
 export function buildAptReleaseContent({
     suite = APT_DEFAULT_SUITE,
+    codename = APT_DEFAULT_CODENAME,
     component = APT_DEFAULT_COMPONENT,
     architectures = APT_SUPPORTED_ARCHITECTURES,
     files,
@@ -280,7 +310,7 @@ export function buildAptReleaseContent({
         `Origin: ${APT_ORIGIN}`,
         `Label: ${APT_LABEL}`,
         `Suite: ${normalizedSuite}`,
-        `Codename: ${normalizedSuite}`,
+        `Codename: ${codename}`,
         `Date: ${generatedAt.toUTCString()}`,
         `Architectures: ${normalizedArchitectures.join(" ")}`,
         `Components: ${normalizedComponent}`,

--- a/scripts/apt-repo.test.mjs
+++ b/scripts/apt-repo.test.mjs
@@ -104,6 +104,7 @@ test("Packages stanzas append repository filename and checksums", () => {
     assert.match(stanza, /^Package: neverwrite/m);
     assert.match(stanza, /^Filename: pool\/main\/n\/neverwrite\/neverwrite_0\.2\.8_amd64\.deb/m);
     assert.match(stanza, /^Size: 1234/m);
+    assert.match(stanza, /^MD5sum: a{32}$/m);
     assert.match(stanza, /^SHA256: c{64}$/m);
 });
 
@@ -125,6 +126,7 @@ test("Release file includes suite, architectures, components, and checksums", ()
 
     assert.match(release, /^Origin: NeverWrite$/m);
     assert.match(release, /^Suite: stable$/m);
+    assert.match(release, /^Codename: neverwrite-stable$/m);
     assert.match(release, /^Architectures: amd64 arm64$/m);
     assert.match(release, /^Components: main$/m);
     assert.match(release, /^SHA256:/m);

--- a/scripts/validate-apt-repository.mjs
+++ b/scripts/validate-apt-repository.mjs
@@ -5,9 +5,11 @@ import path from "node:path";
 import zlib from "node:zlib";
 
 import {
+    APT_DEFAULT_CODENAME,
     APT_DEFAULT_COMPONENT,
     APT_DEFAULT_SUITE,
     APT_PACKAGE_NAME,
+    APT_PACKAGE_CHECKSUMS,
     APT_PUBLIC_KEY_FILE_NAME,
     APT_RELEASE_CHECKSUMS,
     APT_SOURCES_EXAMPLE_FILE_NAME,
@@ -126,7 +128,7 @@ function validateReleaseFile({ aptDir, suite, component }) {
         Origin: "NeverWrite",
         Label: "NeverWrite",
         Suite: suite,
-        Codename: suite,
+        Codename: APT_DEFAULT_CODENAME,
         Architectures: APT_SUPPORTED_ARCHITECTURES.join(" "),
         Components: component,
     };
@@ -218,7 +220,7 @@ function validatePackagesForArchitecture({
         if (fs.statSync(packagePath).size !== size) {
             throw new Error(`${filename} Size does not match package file.`);
         }
-        for (const { fieldName, algorithm } of APT_RELEASE_CHECKSUMS) {
+        for (const { fieldName, algorithm } of APT_PACKAGE_CHECKSUMS) {
             const expectedHash = getDebianControlField(stanza, fieldName);
             if (!expectedHash) {
                 throw new Error(`${filename} is missing ${fieldName}.`);


### PR DESCRIPTION
## Summary

This tightens the APT/deb repository metadata before the repository is published:

- stream file hashing in `hashFile()` so large `.deb` files are not read fully into memory
- split Release and Packages checksum metadata so `MD5Sum` and `MD5sum` use the right Debian field casing in each file
- use a project-specific APT codename (`neverwrite-stable`) while keeping the published suite path as `stable`

## Why

Reviewer feedback called out a few small APT polish items. The root issue was that one checksum definition was doing double duty for both Release metadata and Packages stanzas, and the Release codename mirrored the suite by default. This keeps those invariants explicit before the APT repository ships publicly.

## Validation

- `node --test scripts/apt-repo.test.mjs`
- `git diff --check`
