### PR TITLE
Fix HTML preview drag capture

### DIFF
--- a/apps/desktop/src/features/editor/HtmlTabView.test.tsx
+++ b/apps/desktop/src/features/editor/HtmlTabView.test.tsx
@@ -1,0 +1,146 @@
+import { act, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import type { FileTab } from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import {
+    AGENT_SIDEBAR_DRAG_EVENT,
+    type AgentSidebarDragDetail,
+} from "../ai/agentSidebarDragEvents";
+import {
+    FILE_TREE_NOTE_DRAG_EVENT,
+    type FileTreeNoteDragDetail,
+} from "../ai/dragEvents";
+import { renderComponent } from "../../test/test-utils";
+import { HtmlTabView } from "./HtmlTabView";
+
+const tab: FileTab = {
+    id: "html-tab",
+    kind: "file",
+    relativePath: "docs/preview.html",
+    path: "/vault/docs/preview.html",
+    title: "preview.html",
+    content: "",
+    mimeType: "text/html",
+    viewer: "html",
+    history: [],
+    historyIndex: -1,
+};
+
+function getPreviewFrame() {
+    return screen.getByTitle(tab.title) as HTMLIFrameElement;
+}
+
+function dispatchFileTreeDrag(
+    phase: FileTreeNoteDragDetail["phase"],
+    origin?: FileTreeNoteDragDetail["origin"],
+) {
+    act(() => {
+        window.dispatchEvent(
+            new CustomEvent<FileTreeNoteDragDetail>(
+                FILE_TREE_NOTE_DRAG_EVENT,
+                {
+                    detail: {
+                        phase,
+                        x: 120,
+                        y: 180,
+                        notes: [],
+                        files: [
+                            {
+                                filePath: "/vault/docs/source.md",
+                                fileName: "source.md",
+                                mimeType: "text/markdown",
+                            },
+                        ],
+                        origin,
+                    },
+                },
+            ),
+        );
+    });
+}
+
+function dispatchAgentDrag(phase: AgentSidebarDragDetail["phase"]) {
+    act(() => {
+        window.dispatchEvent(
+            new CustomEvent<AgentSidebarDragDetail>(
+                AGENT_SIDEBAR_DRAG_EVENT,
+                {
+                    detail: {
+                        phase,
+                        x: 140,
+                        y: 200,
+                        sessionId: "session-1",
+                        title: "Draft agent",
+                    },
+                },
+            ),
+        );
+    });
+}
+
+describe("HtmlTabView", () => {
+    beforeEach(() => {
+        useVaultStore.setState((state) => ({
+            ...state,
+            vaultPath: "/vault",
+        }));
+    });
+
+    it("makes the iframe inert during file tree drags", () => {
+        renderComponent(<HtmlTabView tab={tab} />);
+
+        const frame = getPreviewFrame();
+        expect(frame.style.pointerEvents).toBe("auto");
+
+        dispatchFileTreeDrag("start");
+        expect(frame.style.pointerEvents).toBe("none");
+
+        dispatchFileTreeDrag("move");
+        expect(frame.style.pointerEvents).toBe("none");
+
+        dispatchFileTreeDrag("end");
+        expect(frame.style.pointerEvents).toBe("auto");
+    });
+
+    it("makes the iframe inert during agent sidebar drags", () => {
+        renderComponent(<HtmlTabView tab={tab} />);
+
+        const frame = getPreviewFrame();
+        expect(frame.style.pointerEvents).toBe("auto");
+
+        dispatchAgentDrag("start");
+        expect(frame.style.pointerEvents).toBe("none");
+
+        dispatchAgentDrag("move");
+        expect(frame.style.pointerEvents).toBe("none");
+
+        dispatchAgentDrag("cancel");
+        expect(frame.style.pointerEvents).toBe("auto");
+    });
+
+    it("keeps workspace-tab file drags from changing iframe pointer handling", () => {
+        renderComponent(<HtmlTabView tab={tab} />);
+
+        const frame = getPreviewFrame();
+        dispatchFileTreeDrag("start", {
+            kind: "workspace-tab",
+            tabId: "file-tab",
+        });
+
+        expect(frame.style.pointerEvents).toBe("auto");
+    });
+
+    it("releases the iframe shield on global drag cancellation", () => {
+        renderComponent(<HtmlTabView tab={tab} />);
+
+        const frame = getPreviewFrame();
+        dispatchAgentDrag("start");
+        expect(frame.style.pointerEvents).toBe("none");
+
+        act(() => {
+            window.dispatchEvent(new Event("pointercancel"));
+        });
+
+        expect(frame.style.pointerEvents).toBe("auto");
+    });
+});

--- a/apps/desktop/src/features/editor/HtmlTabView.tsx
+++ b/apps/desktop/src/features/editor/HtmlTabView.tsx
@@ -4,9 +4,11 @@ import { useVaultStore } from "../../app/store/vaultStore";
 import { toVaultRelativePath } from "../../app/utils/vaultPaths";
 import { buildVaultAssetUrl } from "../../app/utils/filePreviewUrl";
 import type { FileTab } from "../../app/store/editorStore";
+import { useInternalDragIframeShield } from "./useInternalDragIframeShield";
 
 export function HtmlTabView({ tab }: { tab: FileTab }) {
     const vaultPath = useVaultStore((state) => state.vaultPath);
+    const iframeShieldActive = useInternalDragIframeShield();
 
     const previewUrl = useMemo(() => {
         const relative = toVaultRelativePath(tab.path, vaultPath);
@@ -74,6 +76,9 @@ export function HtmlTabView({ tab }: { tab: FileTab }) {
                             height: "100%",
                             border: "none",
                             backgroundColor: "white",
+                            pointerEvents: iframeShieldActive
+                                ? "none"
+                                : "auto",
                         }}
                     />
                 ) : (

--- a/apps/desktop/src/features/editor/useInternalDragIframeShield.ts
+++ b/apps/desktop/src/features/editor/useInternalDragIframeShield.ts
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import {
+    AGENT_SIDEBAR_DRAG_EVENT,
+    type AgentSidebarDragDetail,
+} from "../ai/agentSidebarDragEvents";
+import {
+    FILE_TREE_NOTE_DRAG_EVENT,
+    type FileTreeNoteDragDetail,
+} from "../ai/dragEvents";
+
+function isActiveDragPhase(phase: FileTreeNoteDragDetail["phase"]) {
+    return phase === "start" || phase === "move";
+}
+
+export function useInternalDragIframeShield() {
+    const [active, setActive] = useState(false);
+
+    useEffect(() => {
+        // HTML previews run in iframes, which can swallow window-level drag
+        // events. Make the frame inert while an internal sidebar drag is active.
+        const setShieldActive = (nextActive: boolean) => {
+            setActive((current) =>
+                current === nextActive ? current : nextActive,
+            );
+        };
+
+        const handleFileTreeDrag = (event: Event) => {
+            const detail = (event as CustomEvent<FileTreeNoteDragDetail>)
+                .detail;
+            if (!detail || detail.origin?.kind === "workspace-tab") {
+                return;
+            }
+
+            setShieldActive(isActiveDragPhase(detail.phase));
+        };
+
+        const handleAgentSidebarDrag = (event: Event) => {
+            const detail = (event as CustomEvent<AgentSidebarDragDetail>)
+                .detail;
+            if (!detail) return;
+
+            setShieldActive(isActiveDragPhase(detail.phase));
+        };
+
+        const releaseShield = () => setShieldActive(false);
+
+        window.addEventListener(FILE_TREE_NOTE_DRAG_EVENT, handleFileTreeDrag);
+        window.addEventListener(
+            AGENT_SIDEBAR_DRAG_EVENT,
+            handleAgentSidebarDrag,
+        );
+        window.addEventListener("mouseup", releaseShield, true);
+        window.addEventListener("pointerup", releaseShield, true);
+        window.addEventListener("pointercancel", releaseShield, true);
+        window.addEventListener("dragend", releaseShield, true);
+        window.addEventListener("blur", releaseShield);
+
+        return () => {
+            window.removeEventListener(
+                FILE_TREE_NOTE_DRAG_EVENT,
+                handleFileTreeDrag,
+            );
+            window.removeEventListener(
+                AGENT_SIDEBAR_DRAG_EVENT,
+                handleAgentSidebarDrag,
+            );
+            window.removeEventListener("mouseup", releaseShield, true);
+            window.removeEventListener("pointerup", releaseShield, true);
+            window.removeEventListener("pointercancel", releaseShield, true);
+            window.removeEventListener("dragend", releaseShield, true);
+            window.removeEventListener("blur", releaseShield);
+        };
+    }, []);
+
+    return active;
+}


### PR DESCRIPTION
## Summary
- Add an internal drag iframe shield for HTML previews.
- Make HTML preview iframes temporarily inert while files or agent sessions are dragged from the sidebar.
- Cover file-tree, agent-sidebar, workspace-tab, and cancellation behavior in HtmlTabView tests.

## Root Cause
HTML previews render inside an iframe. When an internal drag crosses that iframe, the frame can swallow the window-level move/up events that keep sidebar drags and multi-pane drop previews alive. The drag state can then remain stuck and leave the workspace drop system in a broken state.

## Validation
- npm test -- HtmlTabView.test.tsx MultiPaneWorkspace.test.tsx AgentsSidebarPanel.test.tsx
- npx eslint src/features/editor/HtmlTabView.tsx src/features/editor/HtmlTabView.test.tsx src/features/editor/useInternalDragIframeShield.ts
- git diff --check

Fixes #165
