### PR TITLE
Prepare 0.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.3.1] - 2026-05-28
+
+### Changed
+
+- Updated the embedded Claude Code runtime to `2.1.154`, including compatibility with the newer thinking-token telemetry event emitted by the Claude SDK.
+- Changed APT repository publishing so Debian `.deb` binaries stay on GitHub Releases while signed APT metadata remains on GitHub Pages, keeping Linux installs pointed at release assets without publishing large package files to the Pages branch.
+- Updated the desktop app's transitive `tmp` dependency to `0.2.6`.
+
+### Fixed
+
+- Fixed HTML preview tabs so iframe previews no longer swallow internal file-tree or agent-sidebar drag events, restoring reliable drag interactions across HTML previews.
+- Fixed APT repository validation for Debian packages published through remote GitHub Release URLs.
+
 ## [0.3.0] - 2026-05-27
 
 ### Added

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.0",
+            "version": "0.3.1",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.0",
+    "version": "0.3.1",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.0",
+    "version": "0.3.1",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary
- bump NeverWrite release metadata to 0.3.1
- add the 0.3.1 changelog entry

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.3.1
- node --test scripts/release-metadata.test.mjs
- node --test scripts/apt-repo.test.mjs
- node --check scripts/build-apt-repository.mjs
- node --check scripts/sign-apt-repository.mjs
- node --check scripts/validate-apt-repository.mjs
- node --test scripts/appcast.test.mjs scripts/platform-validation.test.mjs scripts/release-assets.test.mjs
- node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs