### PR TITLE
Publish updater feeds before APT validation

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -777,6 +777,44 @@ jobs:
                   }
                   EOF
 
+            - name: Publish updater feeds to gh-pages
+              shell: bash
+              env:
+                  CHANNEL: ${{ needs.prepare.outputs.channel }}
+                  PAGES_DIR: ${{ runner.temp }}/gh-pages
+              run: |
+                  (
+                    cd "$PAGES_DIR"
+                    git config user.name "github-actions[bot]"
+                    git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+                    git add "${CHANNEL}" .nojekyll
+                    if git diff --cached --quiet; then
+                      echo "No updater feed changes to publish."
+                    else
+                      git commit -m "Publish updater feeds for ${{ needs.prepare.outputs.tag }}"
+                      git push origin HEAD:gh-pages
+                    fi
+                  )
+
+            - name: Print published feed URLs
+              shell: bash
+              run: |
+                  node --input-type=module <<'EOF'
+                  import fs from "node:fs";
+                  import path from "node:path";
+
+                  const baseUrl = "${{ needs.prepare.outputs.pages_base_url }}".replace(/\/+$/, "");
+                  const channel = "${{ needs.prepare.outputs.channel }}";
+                  const metadataDir = path.resolve(".artifacts/release-targets");
+
+                  for (const fileName of fs.readdirSync(metadataDir).filter((file) => file.endsWith(".json")).sort()) {
+                    const metadata = JSON.parse(
+                      fs.readFileSync(path.join(metadataDir, fileName), "utf8"),
+                    );
+                    console.log(`${baseUrl}/${channel}/${metadata.feedRelativePath}`);
+                  }
+                  EOF
+
             - name: Install APT repository tools
               run: sudo apt-get update && sudo apt-get install -y dpkg gnupg gzip
 
@@ -860,40 +898,20 @@ jobs:
                       apt-get install -y --download-only "neverwrite=$VERSION"
                     '
 
-            - name: Publish pages artifacts to gh-pages
+            - name: Publish APT repository to gh-pages
               shell: bash
               env:
-                  CHANNEL: ${{ needs.prepare.outputs.channel }}
                   PAGES_DIR: ${{ runner.temp }}/gh-pages
               run: |
                   (
                     cd "$PAGES_DIR"
                     git config user.name "github-actions[bot]"
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-                    git add "${CHANNEL}" apt .nojekyll
+                    git add apt .nojekyll
                     if git diff --cached --quiet; then
-                      echo "No pages artifact changes to publish."
+                      echo "No APT repository changes to publish."
                     else
-                      git commit -m "Publish release pages artifacts for ${{ needs.prepare.outputs.tag }}"
+                      git commit -m "Publish APT repository for ${{ needs.prepare.outputs.tag }}"
                       git push origin HEAD:gh-pages
                     fi
                   )
-
-            - name: Print published feed URLs
-              shell: bash
-              run: |
-                  node --input-type=module <<'EOF'
-                  import fs from "node:fs";
-                  import path from "node:path";
-
-                  const baseUrl = "${{ needs.prepare.outputs.pages_base_url }}".replace(/\/+$/, "");
-                  const channel = "${{ needs.prepare.outputs.channel }}";
-                  const metadataDir = path.resolve(".artifacts/release-targets");
-
-                  for (const fileName of fs.readdirSync(metadataDir).filter((file) => file.endsWith(".json")).sort()) {
-                    const metadata = JSON.parse(
-                      fs.readFileSync(path.join(metadataDir, fileName), "utf8"),
-                    );
-                    console.log(`${baseUrl}/${channel}/${metadata.feedRelativePath}`);
-                  }
-                  EOF


### PR DESCRIPTION
## Summary

- Publish Electron updater feeds to gh-pages immediately after staging them.
- Keep APT repository generation, validation, and publication as a separate later publish step.
- Move feed URL printing next to the updater feed publish step so release logs show the desktop update endpoints even if APT fails later.

## Root cause

The v0.3.1 release built and uploaded GitHub Release assets successfully, but the Pages publish job failed during the APT validation step. Because updater feeds and APT metadata were committed together at the end, the public Electron feeds stayed on v0.3.0 even though v0.3.1 assets existed.

## Impact

Future APT validation failures can still fail the release workflow, but they will no longer block desktop update discovery once the updater feeds have been generated.

## Validation

- node scripts/validate-release-metadata.mjs --tag v0.3.1
- node --test scripts/apt-repo.test.mjs
- Parsed .github/workflows/release-desktop.yml with the YAML parser from the desktop dependencies
