### PR TITLE
Fix web clipper tmp advisory

### DIFF
--- a/apps/web-clipper/pnpm-lock.yaml
+++ b/apps/web-clipper/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   node-notifier>uuid: 11.1.1
+  web-ext-run>tmp: 0.2.6
 
 importers:
 
@@ -2030,8 +2031,8 @@ packages:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tmp@0.2.5:
-    resolution: {integrity: sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==}
+  tmp@0.2.6:
+    resolution: {integrity: sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==}
     engines: {node: '>=14.14'}
 
   tough-cookie@5.1.2:
@@ -4078,7 +4079,7 @@ snapshots:
     dependencies:
       tldts-core: 6.1.86
 
-  tmp@0.2.5: {}
+  tmp@0.2.6: {}
 
   tough-cookie@5.1.2:
     dependencies:
@@ -4247,7 +4248,7 @@ snapshots:
       source-map-support: 0.5.21
       strip-bom: 5.0.0
       strip-json-comments: 5.0.2
-      tmp: 0.2.5
+      tmp: 0.2.6
       update-notifier: 7.3.1
       watchpack: 2.4.4
       zip-dir: 2.0.0

--- a/apps/web-clipper/pnpm-workspace.yaml
+++ b/apps/web-clipper/pnpm-workspace.yaml
@@ -3,3 +3,4 @@ packages:
 
 overrides:
     node-notifier>uuid: 11.1.1
+    web-ext-run>tmp: 0.2.6


### PR DESCRIPTION
## Summary

- Add a pnpm override so `web-ext-run` resolves `tmp` to the patched `0.2.6` release.
- Regenerate the web clipper lockfile so Dependabot alert 15 no longer resolves `tmp@0.2.5`.

## Root cause

`wxt@0.20.25` depends on `web-ext-run@0.2.4`, and that package pins `tmp: 0.2.5`. Since `web-ext-run` has no newer release, the cleanest bounded fix is an explicit pnpm override in the web clipper workspace.

## Validation

- `pnpm why tmp` shows `tmp@0.2.6` under `web-ext-run@0.2.4`.
- `rg -n 'tmp@0\.2\.[0-5]|tmp: 0\.2\.[0-5]' apps/web-clipper/pnpm-lock.yaml apps/web-clipper/pnpm-workspace.yaml` returns no matches.
- `pnpm run check` in `apps/web-clipper` passes: TypeScript compile, 7 test files / 25 tests, Chrome build, Firefox build.