### PR TITLE
Fix Debian APT repository publication

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -829,10 +829,7 @@ jobs:
                     --pages-dir "$PAGES_DIR" \
                     --base-url "${{ needs.prepare.outputs.pages_base_url }}/apt" \
                     --suite stable \
-                    --component main \
-                    --remote-packages \
-                    --repo-slug "${{ needs.prepare.outputs.repo_slug }}" \
-                    --tag "${{ needs.prepare.outputs.tag }}"
+                    --component main
 
             - name: Sign APT repository
               shell: bash

--- a/release/apt/README.md
+++ b/release/apt/README.md
@@ -49,6 +49,12 @@ The release workflow publishes these files to `gh-pages`:
 apt/
   neverwrite-archive-keyring.asc
   neverwrite.sources.example
+  pool/
+    main/
+      n/
+        neverwrite/
+          neverwrite_0.3.0_amd64.deb
+          neverwrite_0.3.0_arm64.deb
   dists/
     stable/
       InRelease
@@ -63,14 +69,14 @@ apt/
           Packages.gz
 ```
 
-The `.deb` binary packages are NOT stored on `gh-pages`. Instead, the
-`Filename` field in each `Packages` index points to the GitHub Release
-download URL (e.g., `https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-amd64.deb`).
-APT downloads the `.deb` directly from the GitHub Release when installing.
+The `.deb` binary packages are stored inside the APT repository pool. The
+`Filename` field in each `Packages` index must be a relative pool path, for
+example `pool/main/n/neverwrite/neverwrite_0.3.0_amd64.deb`. APT then resolves
+the package relative to the configured repository URL.
 
 The workflow reads the `.deb` metadata from the staged release assets,
-generates `Packages` and `Release` with URL-based Filenames, signs the
-repository, validates checksums and signatures, then publishes the result
+copies the packages into `apt/pool/`, generates `Packages` and `Release`, signs
+the repository, validates checksums and signatures, then publishes the result
 with the existing Electron feeds.
 
 ## Required GitHub Secrets

--- a/scripts/apt-repo-lib.mjs
+++ b/scripts/apt-repo-lib.mjs
@@ -6,7 +6,6 @@ import {
     CANONICAL_RELEASE_PAGES_BASE_URL,
     PUBLIC_PRODUCT_NAME,
     buildDebianPackageAssetName,
-    buildGitHubReleaseAssetUrl,
     normalizeReleaseVersion,
 } from "./appcast-lib.mjs";
 
@@ -112,19 +111,6 @@ export function buildAptPoolPackagePath(version, debianArchitecture) {
         APT_PACKAGE_NAME,
         buildAptPoolPackageName(version, debianArchitecture),
     );
-}
-
-export function buildGitHubReleaseDebUrl(repoSlug, tag, version, debianArchitecture) {
-    const normalizedTag = tag.startsWith("v") ? tag : `v${normalizeReleaseVersion(tag)}`;
-    const assetName = buildDebianReleaseAssetName(version, debianArchitecture);
-    return buildGitHubReleaseAssetUrl(repoSlug, normalizedTag, assetName);
-}
-
-export function isUrlFilename(filename) {
-    if (typeof filename !== "string") {
-        return false;
-    }
-    return /^https?:\/\//i.test(filename);
 }
 
 export function getAptBinaryPackagesPath(debianArchitecture) {

--- a/scripts/apt-repo.test.mjs
+++ b/scripts/apt-repo.test.mjs
@@ -1,18 +1,26 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import childProcess from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import zlib from "node:zlib";
 
 import {
     APT_DEFAULT_BASE_URL,
+    APT_PUBLIC_KEY_FILE_NAME,
+    APT_SOURCES_EXAMPLE_FILE_NAME,
+    APT_SUPPORTED_ARCHITECTURES,
     buildAptPoolPackageName,
     buildAptPoolPackagePath,
     buildAptReleaseContent,
     buildDebianReleaseAssetName,
-    buildGitHubReleaseDebUrl,
     buildNeverWriteSourcesExample,
     compareReleaseVersionsDescending,
     getAptBinaryPackagesGzipPath,
     getAptBinaryPackagesPath,
-    isUrlFilename,
+    getFileHashes,
     normalizeAptComponent,
     normalizeAptSuite,
     normalizeDebianArchitecture,
@@ -20,6 +28,105 @@ import {
     parseDebianControlStanza,
     renderPackagesStanza,
 } from "./apt-repo-lib.mjs";
+
+const SCRIPTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const VALIDATE_APT_REPOSITORY_SCRIPT = path.join(
+    SCRIPTS_DIR,
+    "validate-apt-repository.mjs",
+);
+
+function writeFixtureAptRepository({ filenamesByArchitecture = {} } = {}) {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "neverwrite-apt-test-"));
+    const aptDir = path.join(rootDir, "apt");
+    const suiteDir = path.join(aptDir, "dists", "stable");
+    const releaseFiles = [];
+
+    fs.mkdirSync(aptDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(aptDir, APT_PUBLIC_KEY_FILE_NAME),
+        "fixture public key\n",
+        "utf8",
+    );
+    fs.writeFileSync(
+        path.join(aptDir, APT_SOURCES_EXAMPLE_FILE_NAME),
+        buildNeverWriteSourcesExample("file:///tmp/neverwrite-apt"),
+        "utf8",
+    );
+
+    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
+        const packageRelativePath = buildAptPoolPackagePath("0.3.0", architecture);
+        const packagePath = path.join(aptDir, packageRelativePath);
+        const packageBytes = Buffer.from(`fixture package ${architecture}\n`);
+        fs.mkdirSync(path.dirname(packagePath), { recursive: true });
+        fs.writeFileSync(packagePath, packageBytes);
+
+        const packagesRelativePath = getAptBinaryPackagesPath(architecture);
+        const packagesPath = path.join(aptDir, packagesRelativePath);
+        const packagesContent = renderPackagesStanza({
+            controlFields: parseDebianControlStanza([
+                "Package: neverwrite",
+                "Version: 0.3.0",
+                `Architecture: ${architecture}`,
+                "Description: NeverWrite desktop",
+                "",
+            ].join("\n")),
+            filename: filenamesByArchitecture[architecture] ?? packageRelativePath,
+            sizeBytes: packageBytes.length,
+            hashes: getFileHashes(packagePath),
+        });
+
+        fs.mkdirSync(path.dirname(packagesPath), { recursive: true });
+        fs.writeFileSync(packagesPath, packagesContent, "utf8");
+        fs.writeFileSync(
+            path.join(aptDir, getAptBinaryPackagesGzipPath(architecture)),
+            zlib.gzipSync(Buffer.from(packagesContent, "utf8")),
+        );
+    }
+
+    for (const relativePath of [
+        ...APT_SUPPORTED_ARCHITECTURES.map((architecture) =>
+            getAptBinaryPackagesPath(architecture),
+        ),
+        ...APT_SUPPORTED_ARCHITECTURES.map((architecture) =>
+            getAptBinaryPackagesGzipPath(architecture),
+        ),
+    ]) {
+        const absolutePath = path.join(aptDir, relativePath);
+        releaseFiles.push({
+            relativePath: relativePath.replace("dists/stable/", ""),
+            sizeBytes: fs.statSync(absolutePath).size,
+            hashes: getFileHashes(absolutePath),
+        });
+    }
+
+    fs.mkdirSync(suiteDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(suiteDir, "Release"),
+        buildAptReleaseContent({ files: releaseFiles }),
+        "utf8",
+    );
+    fs.writeFileSync(path.join(suiteDir, "InRelease"), "fixture inrelease\n", "utf8");
+    fs.writeFileSync(path.join(suiteDir, "Release.gpg"), "fixture signature\n", "utf8");
+
+    return { rootDir, aptDir };
+}
+
+function validateFixtureAptRepository(aptDir) {
+    return childProcess.spawnSync(
+        process.execPath,
+        [
+            VALIDATE_APT_REPOSITORY_SCRIPT,
+            "--apt-dir",
+            aptDir,
+            "--version",
+            "0.3.0",
+            "--skip-signature-check",
+        ],
+        {
+            encoding: "utf8",
+        },
+    );
+}
 
 test("APT package paths use Debian pool conventions", () => {
     assert.equal(
@@ -147,46 +254,27 @@ test("APT pool file parser and version sorter support retention", () => {
     );
 });
 
-test("buildGitHubReleaseDebUrl builds correct GitHub Release download URL", () => {
-    const url = buildGitHubReleaseDebUrl(
-        "jsgrrchg/NeverWrite",
-        "v0.3.0",
-        "0.3.0",
-        "amd64",
-    );
-    assert.equal(
-        url,
-        "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-amd64.deb",
-    );
+test("APT repository validator accepts local pool package filenames", (t) => {
+    const { rootDir, aptDir } = writeFixtureAptRepository();
+    t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+
+    const result = validateFixtureAptRepository(aptDir);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /APT repository is valid for version 0\.3\.0/);
 });
 
-test("buildGitHubReleaseDebUrl handles version-only tag input", () => {
-    const url = buildGitHubReleaseDebUrl(
-        "jsgrrchg/NeverWrite",
-        "0.3.0",
-        "0.3.0",
-        "arm64",
-    );
-    assert.equal(
-        url,
-        "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-arm64.deb",
-    );
-});
+test("APT repository validator rejects package Filename URLs", (t) => {
+    const { rootDir, aptDir } = writeFixtureAptRepository({
+        filenamesByArchitecture: {
+            amd64: "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-amd64.deb",
+        },
+    });
+    t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
 
-test("isUrlFilename detects http and https filenames", () => {
-    assert.equal(
-        isUrlFilename("https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-amd64.deb"),
-        true,
-    );
-    assert.equal(
-        isUrlFilename("http://example.com/pkg.deb"),
-        true,
-    );
-    assert.equal(
-        isUrlFilename("pool/main/n/neverwrite/neverwrite_0.3.0_amd64.deb"),
-        false,
-    );
-    assert.equal(isUrlFilename(null), false);
-    assert.equal(isUrlFilename(undefined), false);
-    assert.equal(isUrlFilename(""), false);
+    const result = validateFixtureAptRepository(aptDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /invalid Filename/);
+    assert.match(result.stderr, /Expected a normalized relative path under "pool\/main\/n\/neverwrite\/"/);
 });

--- a/scripts/build-apt-repository.mjs
+++ b/scripts/build-apt-repository.mjs
@@ -11,7 +11,6 @@ import {
     buildAptPoolPackagePath,
     buildAptReleaseContent,
     buildDebianReleaseAssetName,
-    buildGitHubReleaseDebUrl,
     buildNeverWriteSourcesExample,
     compareReleaseVersionsDescending,
     getAptBinaryPackagesGzipPath,
@@ -27,7 +26,6 @@ import {
     parseDebianControlStanza,
     renderPackagesStanza,
 } from "./apt-repo-lib.mjs";
-import { parseGitHubRepoSlug } from "./appcast-lib.mjs";
 import { normalizeReleaseVersion } from "./appcast-lib.mjs";
 
 function parseArgs(argv) {
@@ -39,9 +37,6 @@ function parseArgs(argv) {
         suite: APT_DEFAULT_SUITE,
         component: APT_DEFAULT_COMPONENT,
         retainVersions: 3,
-        remotePackages: false,
-        repoSlug: null,
-        tag: null,
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -83,23 +78,8 @@ function parseArgs(argv) {
             index += 1;
             continue;
         }
-        if (arg === "--remote-packages") {
-            args.remotePackages = true;
-            continue;
-        }
-        if (arg === "--repo-slug") {
-            args.repoSlug = next;
-            index += 1;
-            continue;
-        }
-        if (arg === "--tag") {
-            args.tag = next;
-            index += 1;
-            continue;
-        }
-
         throw new Error(
-            `Unknown argument "${arg}". Supported args: --version, --release-assets-dir, --pages-dir, --base-url, --suite, --component, --retain-versions, --remote-packages, --repo-slug, --tag.`,
+            `Unknown argument "${arg}". Supported args: --version, --release-assets-dir, --pages-dir, --base-url, --suite, --component, --retain-versions.`,
         );
     }
 
@@ -119,18 +99,6 @@ function parseArgs(argv) {
     }
     if (!Number.isInteger(args.retainVersions) || args.retainVersions < 1) {
         throw new Error("--retain-versions must be a positive integer.");
-    }
-
-    if (args.remotePackages) {
-        if (!args.repoSlug) {
-            throw new Error(
-                "--remote-packages requires --repo-slug <owner/repo>.",
-            );
-        }
-        if (!args.tag) {
-            throw new Error("--remote-packages requires --tag <vX.Y.Z>.");
-        }
-        parseGitHubRepoSlug(args.repoSlug);
     }
 
     return {
@@ -304,40 +272,6 @@ function collectPoolPackages({ aptDir }) {
     return packages;
 }
 
-function collectRemotePackages({ version, releaseAssetsDir, repoSlug, tag }) {
-    const packages = [];
-
-    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
-        const assetName = buildDebianReleaseAssetName(version, architecture);
-        const source = findSingleReleaseAsset(releaseAssetsDir, assetName);
-        const urlFilename = buildGitHubReleaseDebUrl(
-            repoSlug,
-            tag,
-            version,
-            architecture,
-        );
-        const fields = readDebianControlFields(source);
-        validateDebianPackageFields({
-            packagePath: source,
-            relativePath: urlFilename,
-            fields,
-            architecture,
-        });
-        packages.push({
-            version,
-            architecture,
-            content: renderPackagesStanza({
-                controlFields: fields,
-                filename: urlFilename,
-                sizeBytes: fs.statSync(source).size,
-                hashes: getFileHashes(source),
-            }),
-        });
-    }
-
-    return packages;
-}
-
 function renderPackagesFileForArchitecture({ packages, architecture }) {
     const stanzas = packages
         .filter((pkg) => pkg.architecture === architecture)
@@ -422,43 +356,27 @@ function main() {
     const aptDir = getAptRepositoryRoot(args.pagesDir);
     fs.mkdirSync(aptDir, { recursive: true });
 
-    let packages;
+    const copied = copyCurrentReleaseDebs({
+        version: args.version,
+        releaseAssetsDir: args.releaseAssetsDir,
+        aptDir,
+    });
+    const retention = pruneOldPoolPackages({
+        aptDir,
+        retainVersions: args.retainVersions,
+        currentVersion: args.version,
+    });
 
-    if (args.remotePackages) {
-        const poolDir = path.join(aptDir, "pool");
-        if (fs.existsSync(poolDir)) {
-            fs.rmSync(poolDir, { recursive: true, force: true });
-        }
+    const packages = collectPoolPackages({ aptDir });
 
-        packages = collectRemotePackages({
-            version: args.version,
-            releaseAssetsDir: args.releaseAssetsDir,
-            repoSlug: args.repoSlug,
-            tag: args.tag,
-        });
-    } else {
-        const copied = copyCurrentReleaseDebs({
-            version: args.version,
-            releaseAssetsDir: args.releaseAssetsDir,
-            aptDir,
-        });
-        const retention = pruneOldPoolPackages({
-            aptDir,
-            retainVersions: args.retainVersions,
-            currentVersion: args.version,
-        });
-
-        packages = collectPoolPackages({ aptDir });
-
-        console.log(
-            `Copied Debian packages: ${copied.map((entry) => entry.relativePath).join(", ")}`,
-        );
-        console.log(
-            `Retained APT package versions: ${retention.retainedVersions.join(", ")}`,
-        );
-        if (retention.removed.length > 0) {
-            console.log(`Pruned old Debian packages: ${retention.removed.length}`);
-        }
+    console.log(
+        `Copied Debian packages: ${copied.map((entry) => entry.relativePath).join(", ")}`,
+    );
+    console.log(
+        `Retained APT package versions: ${retention.retainedVersions.join(", ")}`,
+    );
+    if (retention.removed.length > 0) {
+        console.log(`Pruned old Debian packages: ${retention.removed.length}`);
     }
 
     // Rebuild metadata from collected packages so stale indexes never leak

--- a/scripts/validate-apt-repository.mjs
+++ b/scripts/validate-apt-repository.mjs
@@ -18,13 +18,14 @@ import {
     getAptBinaryPackagesPath,
     getDebianControlField,
     hashFile,
-    isUrlFilename,
     normalizeAptComponent,
     normalizeAptSuite,
     normalizeDebianArchitecture,
     parseDebianControlStanza,
 } from "./apt-repo-lib.mjs";
 import { normalizeReleaseVersion } from "./appcast-lib.mjs";
+
+const APT_PACKAGE_FILENAME_PREFIX = "pool/main/n/neverwrite/";
 
 function parseArgs(argv) {
     const args = {
@@ -163,6 +164,34 @@ function validateReleaseFile({ aptDir, suite, component }) {
     }
 }
 
+function resolvePackageFilename({ aptDir, arch, filename }) {
+    const normalizedFilename = path.posix.normalize(filename);
+    if (
+        filename !== normalizedFilename ||
+        filename.includes("\\") ||
+        path.posix.isAbsolute(normalizedFilename) ||
+        !normalizedFilename.startsWith(APT_PACKAGE_FILENAME_PREFIX)
+    ) {
+        throw new Error(
+            `${arch} Packages contains invalid Filename "${filename}". Expected a normalized relative path under "${APT_PACKAGE_FILENAME_PREFIX}".`,
+        );
+    }
+
+    const packagePath = path.resolve(aptDir, normalizedFilename);
+    const relativeFromAptRoot = path
+        .relative(aptDir, packagePath)
+        .split(path.sep)
+        .join(path.posix.sep);
+
+    if (relativeFromAptRoot !== normalizedFilename) {
+        throw new Error(
+            `${arch} Packages contains invalid Filename "${filename}". Expected a path inside the APT repository root.`,
+        );
+    }
+
+    return packagePath;
+}
+
 function validatePackagesForArchitecture({
     aptDir,
     architecture,
@@ -215,46 +244,20 @@ function validatePackagesForArchitecture({
             );
         }
 
-        if (isUrlFilename(filename)) {
-            try {
-                const url = new URL(filename);
-                if (url.protocol !== "https:") {
-                    throw new Error(
-                        `URL protocol must be https, got "${url.protocol}"`,
-                    );
-                }
-                if (!url.hostname.endsWith("github.com") && !url.hostname.endsWith("githubusercontent.com")) {
-                    throw new Error(
-                        `URL host must be a GitHub domain, got "${url.hostname}"`,
-                    );
-                }
-            } catch (error) {
-                throw new Error(
-                    `${arch} Packages contains invalid Filename URL "${filename}": ${error.message}`,
-                );
-            }
-        } else {
-            if (!filename.startsWith("pool/main/n/neverwrite/")) {
-                throw new Error(
-                    `${arch} Packages contains invalid Filename "${filename}". Expected "pool/main/n/neverwrite/..." or an absolute URL.`,
-                );
-            }
+        const packagePath = resolvePackageFilename({ aptDir, arch, filename });
+        assertFileExists(packagePath, `${arch} package file`);
 
-            const packagePath = path.join(aptDir, filename);
-            assertFileExists(packagePath, `${arch} package file`);
-
-            if (fs.statSync(packagePath).size !== size) {
-                throw new Error(`${filename} Size does not match package file.`);
+        if (fs.statSync(packagePath).size !== size) {
+            throw new Error(`${filename} Size does not match package file.`);
+        }
+        for (const { fieldName, algorithm } of APT_PACKAGE_CHECKSUMS) {
+            const expectedHash = getDebianControlField(stanza, fieldName);
+            if (!expectedHash) {
+                throw new Error(`${filename} is missing ${fieldName}.`);
             }
-            for (const { fieldName, algorithm } of APT_PACKAGE_CHECKSUMS) {
-                const expectedHash = getDebianControlField(stanza, fieldName);
-                if (!expectedHash) {
-                    throw new Error(`${filename} is missing ${fieldName}.`);
-                }
-                const actualHash = hashFile(packagePath, algorithm);
-                if (expectedHash !== actualHash) {
-                    throw new Error(`${filename} ${fieldName} does not match.`);
-                }
+            const actualHash = hashFile(packagePath, algorithm);
+            if (expectedHash !== actualHash) {
+                throw new Error(`${filename} ${fieldName} does not match.`);
             }
         }
 


### PR DESCRIPTION
## Summary

- Publish Debian packages inside the APT repository pool instead of emitting remote GitHub Release URLs in `Packages` metadata.
- Remove the `--remote-packages` release workflow path so generated `Filename` entries resolve under the configured APT repository URL.
- Harden APT repository validation by rejecting URL `Filename` entries and requiring normalized relative paths under `pool/main/n/neverwrite/`.
- Update APT tests and docs for the local pool publication model.

## Root cause

APT resolves package `Filename` entries relative to the configured repository `URIs`. The previous remote-package model generated `Filename: https://github.com/...`, which fails under the workflow's `file:///repo` validation path and is not the expected APT repository shape for production users.

That URL support also required host suffix checks in the validator. Removing URL `Filename` support closes the CodeQL incomplete URL substring sanitization findings instead of keeping a fragile host allowlist.

Resolves #170.

## Validation

- `node --check scripts/build-apt-repository.mjs`
- `node --check scripts/validate-apt-repository.mjs`
- `node --check scripts/apt-repo-lib.mjs`
- `node --test scripts/apt-repo.test.mjs` 11/11 tests passed
- `git diff --check`
- `rg` audit found no remaining APT workflow/script references to `--remote-packages`, `url.hostname.endsWith`, `isUrlFilename`, `buildGitHubReleaseDebUrl`, or `Filename: https://`