### PR TITLE
Sync native backend lockfile version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "agent-client-protocol",
  "keyring",


### PR DESCRIPTION
## Summary

Updates `Cargo.lock` so `neverwrite-native-backend` matches the `0.3.1` package version declared in `apps/desktop/native-backend/Cargo.toml`.

## Why

The manifest had already been bumped to `0.3.1`, but the lockfile still recorded the workspace package as `0.3.0` on `origin/main`. Keeping these aligned avoids release/versioning confusion for the native backend.

## Validation

- `cargo check -p neverwrite-native-backend`