### PR TITLE
Keep historical chat diffs inspectable

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -29,7 +29,6 @@ function renderMessage(
     options: {
         sessionId?: string | null;
         visibleWorkCycleId?: string | null;
-        recentDiffWorkCycleIds?: string[];
         onDismissMessage?: (messageId: string) => void;
     } = {},
 ) {
@@ -39,7 +38,6 @@ function renderMessage(
             sessionId={options.sessionId}
             pillMetrics={pillMetrics}
             visibleWorkCycleId={options.visibleWorkCycleId}
-            recentDiffWorkCycleIds={options.recentDiffWorkCycleIds}
             onDismissMessage={options.onDismissMessage}
         />,
     );
@@ -390,7 +388,7 @@ describe("AIChatMessageItem tool diffs", () => {
         ).toBeInTheDocument();
     });
 
-    it("hides diff review panels for non-visible work cycles", () => {
+    it("keeps historical work cycle diffs on the rich diff card", () => {
         renderMessage(
             {
                 id: "tool:hidden",
@@ -414,20 +412,16 @@ describe("AIChatMessageItem tool diffs", () => {
                     target: "/vault/src/watcher.rs",
                 },
             },
-            { visibleWorkCycleId: "cycle-new", recentDiffWorkCycleIds: [] },
+            { visibleWorkCycleId: "cycle-new" },
         );
 
-        expect(screen.queryByText("Edit 1 file")).not.toBeInTheDocument();
-        expect(screen.getByTestId("historical-diff-summary")).toHaveTextContent(
-            "Earlier change",
-        );
-        expect(screen.getByText(/watcher\.rs/)).toBeInTheDocument();
-        expect(
-            screen.queryByRole("button", { name: "Open" }),
-        ).not.toBeInTheDocument();
+        expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
+        expect(screen.queryByText("Earlier change")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
+        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
     });
 
-    it("keeps recent non-visible work cycles on the rich diff card in read-only mode", () => {
+    it("keeps non-visible work cycles on the rich diff card without a recency badge", () => {
         renderMessage(
             {
                 id: "tool:recent",
@@ -453,18 +447,16 @@ describe("AIChatMessageItem tool diffs", () => {
             },
             {
                 visibleWorkCycleId: "cycle-current",
-                recentDiffWorkCycleIds: ["cycle-recent"],
             },
         );
 
         expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
-        expect(screen.getByTestId("recent-diff-badge")).toHaveTextContent(
-            "Recent change",
-        );
+        expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
+        expect(screen.queryByText("Recent change")).not.toBeInTheDocument();
         expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
     });
 
-    it("keeps recent permission diffs inspectable without rendering decision actions", () => {
+    it("keeps historical permission diffs inspectable without rendering decision actions", () => {
         renderMessage(
             {
                 id: "permission:recent",
@@ -503,13 +495,12 @@ describe("AIChatMessageItem tool diffs", () => {
             },
             {
                 visibleWorkCycleId: "cycle-current",
-                recentDiffWorkCycleIds: ["cycle-recent"],
             },
         );
 
-        expect(screen.getByTestId("recent-diff-badge")).toHaveTextContent(
-            "Recent change",
-        );
+        expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
+        expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
+        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "Allow once" })).toBeNull();
         expect(screen.queryByRole("button", { name: "Reject" })).toBeNull();
         expect(

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -336,7 +336,6 @@ interface AIChatMessageItemProps {
     pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
     visibleWorkCycleId?: string | null;
-    recentDiffWorkCycleIds?: string[];
     onPermissionResponse?: (requestId: string, optionId?: string) => void;
     onUserInputResponse?: (
         requestId: string,
@@ -494,12 +493,11 @@ function useStoredRowExpanded(
     return [expanded, setExpanded] as const;
 }
 
-type DiffPresentationMode = "active" | "recent" | "historical" | "none";
+type DiffPresentationMode = "active" | "historical" | "none";
 
 function getDiffPresentationMode(
     message: AIChatMessage,
     visibleWorkCycleId?: string | null,
-    recentDiffWorkCycleIds: string[] = [],
 ) {
     if (!message.diffs?.length) {
         return "none";
@@ -511,10 +509,6 @@ function getDiffPresentationMode(
 
     if (message.workCycleId === visibleWorkCycleId) {
         return "active";
-    }
-
-    if (recentDiffWorkCycleIds.includes(message.workCycleId)) {
-        return "recent";
     }
 
     return "historical";
@@ -929,20 +923,12 @@ function ToolMessage({
     const label = shortTarget ?? title;
     const status = String(message.meta?.status ?? "");
     const isCompleted = status === "completed";
-    if (shouldRenderHistoricalDiffSummary(message, diffPresentationMode)) {
-        return <HistoricalDiffSummaryMessage message={message} />;
-    }
-
-    if (
-        diffPresentationMode !== "historical" &&
-        message.diffs &&
-        message.diffs.length > 0
-    ) {
+    if (diffPresentationMode !== "none" && message.diffs?.length) {
         return (
             <ChangeReviewPanel
                 message={message}
                 sessionId={sessionId}
-                readOnly={diffPresentationMode === "recent"}
+                readOnly={diffPresentationMode === "historical"}
             />
         );
     }
@@ -2035,101 +2021,6 @@ function getDiffPanelToolLabel(toolKind: string) {
     }
 }
 
-function shouldRenderHistoricalDiffSummary(
-    message: AIChatMessage,
-    diffPresentationMode: DiffPresentationMode,
-) {
-    if (diffPresentationMode !== "historical" || !message.diffs?.length) {
-        return false;
-    }
-
-    const status = String(message.meta?.status ?? "");
-    if (message.kind === "tool") {
-        return status === "completed";
-    }
-
-    if (message.kind === "permission") {
-        return status === "resolved";
-    }
-
-    return false;
-}
-
-function HistoricalDiffSummaryMessage({ message }: { message: AIChatMessage }) {
-    const diffs = message.diffs ?? [];
-    const stats = computeDiffStats(diffs);
-    const toolKind = String(message.meta?.tool ?? "");
-    const isToolMessage = message.kind === "tool";
-    const accent = isToolMessage
-        ? toolKind === "delete"
-            ? "#ef4444"
-            : "#6b7280"
-        : "#d97706";
-    const singleDiff = diffs.length === 1 ? diffs[0] : null;
-    const actionLabel = isToolMessage
-        ? getDiffPanelToolLabel(toolKind)
-        : "Change";
-    const summaryTitle = singleDiff
-        ? isToolMessage
-            ? `${actionLabel}${actionLabel.endsWith("e") ? "d" : "ed"} ${getFileNameFromPath(singleDiff.path)}`
-            : getFileNameFromPath(singleDiff.path)
-        : `${actionLabel} ${diffs.length} ${diffs.length === 1 ? "file" : "files"}`;
-
-    return (
-        <div
-            className="min-w-0 max-w-full overflow-hidden rounded-lg px-3 py-2"
-            style={{
-                border: `1px solid color-mix(in srgb, ${accent} 18%, var(--border))`,
-                backgroundColor: `color-mix(in srgb, ${accent} 3%, var(--bg-secondary))`,
-                opacity: 0.72,
-            }}
-            data-testid="historical-diff-summary"
-        >
-            <div className="flex min-w-0 items-center gap-2">
-                <span
-                    className="min-w-0 flex-1 truncate"
-                    style={{
-                        color: "var(--text-primary)",
-                        fontSize: "0.81em",
-                        fontWeight: 500,
-                    }}
-                >
-                    {summaryTitle}
-                </span>
-                <span
-                    className="shrink-0 whitespace-nowrap"
-                    style={{
-                        color: "var(--text-secondary)",
-                        fontSize: "0.72em",
-                        opacity: 0.7,
-                    }}
-                >
-                    Earlier change
-                </span>
-            </div>
-            {(stats.additions > 0 || stats.deletions > 0) && (
-                <div
-                    className="mt-1 flex items-center gap-2"
-                    style={{ fontSize: "0.75em" }}
-                >
-                    {stats.additions > 0 && (
-                        <span style={{ color: "#16a34a", fontWeight: 500 }}>
-                            +
-                            {formatDiffStat(stats.additions, stats.approximate)}
-                        </span>
-                    )}
-                    {stats.deletions > 0 && (
-                        <span style={{ color: "#dc2626", fontWeight: 500 }}>
-                            -
-                            {formatDiffStat(stats.deletions, stats.approximate)}
-                        </span>
-                    )}
-                </div>
-            )}
-        </div>
-    );
-}
-
 function PermissionDecisionButton({
     option,
     accent,
@@ -2581,21 +2472,6 @@ function ChangeReviewPanel({
                         zoom={editDiffZoom}
                         onZoomChange={setEditDiffZoom}
                     />
-                    {readOnly ? (
-                        <span
-                            className="ml-1 rounded-full px-2 py-0.5 whitespace-nowrap"
-                            data-testid="recent-diff-badge"
-                            style={{
-                                fontSize: "0.68em",
-                                fontWeight: 500,
-                                letterSpacing: "0.02em",
-                                color: accent,
-                                backgroundColor: `color-mix(in srgb, ${accent} 10%, transparent)`,
-                            }}
-                        >
-                            Recent change
-                        </span>
-                    ) : null}
                     {canOpenFile && openFilePath ? (
                         <DiffOpenButton
                             accent={accent}
@@ -2831,21 +2707,13 @@ function PermissionMessage({
         !canExpand,
     );
 
-    if (shouldRenderHistoricalDiffSummary(message, diffPresentationMode)) {
-        return <HistoricalDiffSummaryMessage message={message} />;
-    }
-
-    if (
-        diffPresentationMode !== "historical" &&
-        message.diffs &&
-        message.diffs.length > 0
-    ) {
+    if (diffPresentationMode !== "none" && message.diffs?.length) {
         return (
             <ChangeReviewPanel
                 message={message}
                 sessionId={sessionId}
                 onPermissionResponse={onPermissionResponse}
-                readOnly={diffPresentationMode === "recent"}
+                readOnly={diffPresentationMode === "historical"}
             />
         );
     }
@@ -3370,18 +3238,15 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
     pillMetrics,
     chatFontSize = 14,
     visibleWorkCycleId = null,
-    recentDiffWorkCycleIds = [],
     onPermissionResponse,
     onUserInputResponse,
     onDismissMessage,
 }: AIChatMessageItemProps) {
     const diffPresentationMode = readOnly
-        ? ("recent" as DiffPresentationMode)
-        : getDiffPresentationMode(
-              message,
-              visibleWorkCycleId,
-              recentDiffWorkCycleIds,
-          );
+        ? message.diffs?.length
+            ? "historical"
+            : "none"
+        : getDiffPresentationMode(message, visibleWorkCycleId);
 
     // User text — full width, subtle box (Zed style)
     if (message.kind === "text" && message.role === "user") {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -418,7 +418,7 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(secondScrollContainer.scrollTop).toBe(4_320);
     });
 
-    it("keeps only the two most recent non-visible diff work cycles as rich cards", () => {
+    it("keeps non-visible diff work cycles as rich cards", () => {
         const messages: AIChatMessage[] = [
             {
                 id: "tool:oldest",
@@ -519,12 +519,13 @@ describe("AIChatMessageList streaming run indicator", () => {
             />,
         );
 
-        expect(screen.getAllByTestId("recent-diff-badge")).toHaveLength(2);
+        expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
+        expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
+        expect(screen.queryByText("Earlier change")).not.toBeInTheDocument();
+        expect(screen.getByText("Edited oldest.ts")).toBeInTheDocument();
         expect(screen.getByText("Edited older.ts")).toBeInTheDocument();
         expect(screen.getByText("Edited recent.ts")).toBeInTheDocument();
-        expect(screen.getByTestId("historical-diff-summary")).toHaveTextContent(
-            "Edited oldest.ts",
-        );
+        expect(screen.getByText("Edited current.ts")).toBeInTheDocument();
     });
 
     it("lets the user dismiss the pinned plan banner and keeps the plan in the timeline", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -67,7 +67,6 @@ type TimelineRow =
 const NEAR_BOTTOM_THRESHOLD = 80;
 const LOAD_OLDER_THRESHOLD = 120;
 const DETACHED_TIMELINE_SCOPE = "__detached_timeline__";
-const RECENT_HISTORICAL_DIFF_WORK_CYCLE_LIMIT = 2;
 
 function isNearBottom(el: HTMLElement) {
     return (
@@ -97,36 +96,6 @@ function scopeTimelineRowKey(
     rowKey: string,
 ) {
     return `${sessionId ?? DETACHED_TIMELINE_SCOPE}:${rowKey}`;
-}
-
-function deriveRecentHistoricalDiffWorkCycleIds(
-    messages: AIChatMessage[],
-    visibleWorkCycleId: string | null | undefined,
-) {
-    if (!visibleWorkCycleId) {
-        return [];
-    }
-
-    const recentWorkCycleIds: string[] = [];
-    const seen = new Set<string>([visibleWorkCycleId]);
-
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-        const message = messages[i];
-        const workCycleId = message.workCycleId;
-        if (!workCycleId || !message.diffs?.length || seen.has(workCycleId)) {
-            continue;
-        }
-
-        seen.add(workCycleId);
-        recentWorkCycleIds.push(workCycleId);
-        if (
-            recentWorkCycleIds.length >= RECENT_HISTORICAL_DIFF_WORK_CYCLE_LIMIT
-        ) {
-            break;
-        }
-    }
-
-    return recentWorkCycleIds;
 }
 
 function StreamingRunIndicator({
@@ -270,7 +239,6 @@ function renderTimelineRow(
         pillMetrics: ReturnType<typeof getChatPillMetrics>;
         chatFontSize: number;
         visibleWorkCycleId?: string | null;
-        recentDiffWorkCycleIds?: string[];
         onPermissionResponse?: (requestId: string, optionId?: string) => void;
         onUserInputResponse?: (
             requestId: string,
@@ -297,7 +265,6 @@ function renderTimelineRow(
             pillMetrics={options.pillMetrics}
             chatFontSize={options.chatFontSize}
             visibleWorkCycleId={options.visibleWorkCycleId}
-            recentDiffWorkCycleIds={options.recentDiffWorkCycleIds}
             onPermissionResponse={
                 options.readOnly ? undefined : options.onPermissionResponse
             }
@@ -436,14 +403,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     );
     const dismissPinnedPlan = useChatRowUiStore((state) => state.patchRow);
     const visiblePinnedPlan = pinnedPlanDismissed ? null : pinnedPlan;
-    const recentDiffWorkCycleIds = useMemo(
-        () =>
-            deriveRecentHistoricalDiffWorkCycleIds(
-                messages,
-                visibleWorkCycleId,
-            ),
-        [messages, visibleWorkCycleId],
-    );
     const timelineRows = useMemo(() => {
         const rows: TimelineRow[] = [];
 
@@ -491,7 +450,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             pillMetrics,
             chatFontSize,
             visibleWorkCycleId,
-            recentDiffWorkCycleIds,
             onPermissionResponse,
             onUserInputResponse,
             onDismissMessage: handleDismissMessage,
@@ -503,7 +461,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             onUserInputResponse,
             pillMetrics,
             readOnly,
-            recentDiffWorkCycleIds,
             sessionId,
             visibleWorkCycleId,
         ],


### PR DESCRIPTION
## Summary

- Keep historical chat diffs rendered as the same inspectable diff cards instead of compacting them into `Earlier change` summaries.
- Remove the `Recent change` presentation path and the two-cycle recency cutoff from the chat timeline.
- Update chat message/list tests to cover the new presentation invariant.

## Why

The old split between recent and earlier diff cards was purely presentational. It made older changes harder to inspect even though the chat diff cards are not the review/accept/reject surface. This keeps the timeline consistent while leaving the review, hunks, accept/reject, and buffer flows untouched.

## Validation

- `npm --prefix apps/desktop test -- src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/components/AIChatMessageList.test.tsx`