### PR TITLE
List Claude Code terminals in the Agents sidebar with live topic

### DIFF
--- a/apps/desktop/native-backend/src/devtools.rs
+++ b/apps/desktop/native-backend/src/devtools.rs
@@ -867,8 +867,8 @@ fn required_string(args: &Value, keys: &[&str]) -> Result<String, String> {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct ReadClaudeTranscriptInput {
-    /// Claude session UUID (the file is `<session_id>.jsonl`). When absent we
-    /// fall back to the most recently modified transcript in the project dir.
+    /// Claude session UUID (the file is `<session_id>.jsonl`). When absent, we
+    /// skip transcript reading rather than guessing from another terminal.
     #[serde(default)]
     session_id: Option<String>,
     /// The directory Claude Code is running in; used to locate the project dir.
@@ -911,24 +911,6 @@ fn system_time_to_ms(time: std::time::SystemTime) -> Option<u64> {
     time.duration_since(std::time::UNIX_EPOCH)
         .ok()
         .map(|d| d.as_millis() as u64)
-}
-
-fn newest_jsonl(dir: &Path) -> Option<PathBuf> {
-    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
-    for entry in std::fs::read_dir(dir).ok()?.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
-            continue;
-        }
-        let Some(modified) = entry.metadata().ok().and_then(|m| m.modified().ok()) else {
-            continue;
-        };
-        match &newest {
-            Some((best, _)) if *best >= modified => {}
-            _ => newest = Some((modified, path)),
-        }
-    }
-    newest.map(|(_, path)| path)
 }
 
 /// Collapse whitespace to single spaces and cap length, so a multi-line message
@@ -1012,13 +994,15 @@ fn read_claude_transcript(input: ReadClaudeTranscriptInput) -> ClaudeTranscriptR
         .join(".claude")
         .join("projects")
         .join(encode_project_path(&input.cwd));
-    let path = match input.session_id.as_deref() {
-        Some(id) if !id.is_empty() => dir.join(format!("{id}.jsonl")),
-        _ => match newest_jsonl(&dir) {
-            Some(path) => path,
-            None => return ClaudeTranscriptResult::default(),
-        },
+    let Some(id) = input
+        .session_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|id| !id.is_empty())
+    else {
+        return ClaudeTranscriptResult::default();
     };
+    let path = dir.join(format!("{id}.jsonl"));
 
     let Ok(metadata) = std::fs::metadata(&path) else {
         return ClaudeTranscriptResult::default();

--- a/apps/desktop/native-backend/src/devtools.rs
+++ b/apps/desktop/native-backend/src/devtools.rs
@@ -158,6 +158,10 @@ impl DevTerminalManager {
                 let session_id = required_string(&args, &["sessionId", "session_id"])?;
                 Ok(json!(self.snapshot(&session_id)?))
             }
+            "devtools_read_claude_transcript" => {
+                let input = parse_input::<ReadClaudeTranscriptInput>(&args)?;
+                Ok(json!(read_claude_transcript(input)))
+            }
             "devtools_check_binary" => {
                 let name = required_string(&args, &["name"])?;
                 // Reject anything that isn't a plain binary name to prevent
@@ -860,6 +864,193 @@ fn required_string(args: &Value, keys: &[&str]) -> Result<String, String> {
     Err(format!("Missing argument: {}", keys[0]))
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReadClaudeTranscriptInput {
+    /// Claude session UUID (the file is `<session_id>.jsonl`). When absent we
+    /// fall back to the most recently modified transcript in the project dir.
+    #[serde(default)]
+    session_id: Option<String>,
+    /// The directory Claude Code is running in; used to locate the project dir.
+    cwd: String,
+    /// If set, skip reading when the file hasn't changed since this mtime.
+    #[serde(default)]
+    since_mtime_ms: Option<u64>,
+}
+
+#[derive(Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+struct ClaudeTranscriptResult {
+    found: bool,
+    changed: bool,
+    mtime_ms: Option<u64>,
+    title: Option<String>,
+    preview: Option<String>,
+}
+
+fn claude_home_dir() -> Option<PathBuf> {
+    #[cfg(windows)]
+    {
+        env::var_os("USERPROFILE").map(PathBuf::from)
+    }
+    #[cfg(not(windows))]
+    {
+        env::var_os("HOME").map(PathBuf::from)
+    }
+}
+
+/// Claude Code encodes a project directory by replacing every non-alphanumeric
+/// character with '-'. e.g. "/Users/x/My Vault" -> "-Users-x-My-Vault".
+fn encode_project_path(cwd: &str) -> String {
+    cwd.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect()
+}
+
+fn system_time_to_ms(time: std::time::SystemTime) -> Option<u64> {
+    time.duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_millis() as u64)
+}
+
+fn newest_jsonl(dir: &Path) -> Option<PathBuf> {
+    let mut newest: Option<(std::time::SystemTime, PathBuf)> = None;
+    for entry in std::fs::read_dir(dir).ok()?.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Some(modified) = entry.metadata().ok().and_then(|m| m.modified().ok()) else {
+            continue;
+        };
+        match &newest {
+            Some((best, _)) if *best >= modified => {}
+            _ => newest = Some((modified, path)),
+        }
+    }
+    newest.map(|(_, path)| path)
+}
+
+/// Collapse whitespace to single spaces and cap length, so a multi-line message
+/// renders cleanly on one sidebar row.
+fn clean_one_line(text: &str, max_chars: usize) -> String {
+    let collapsed = text.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.chars().count() > max_chars {
+        collapsed.chars().take(max_chars).collect()
+    } else {
+        collapsed
+    }
+}
+
+/// Pull the plain text out of a transcript entry's `message.content`, which may
+/// be a bare string or an array of typed blocks. Only `text` blocks count;
+/// tool calls, tool results, thinking, and images are ignored.
+fn extract_message_text(entry: &Value) -> Option<String> {
+    let content = entry.get("message")?.get("content")?;
+    if let Some(text) = content.as_str() {
+        let trimmed = text.trim();
+        return (!trimmed.is_empty()).then(|| trimmed.to_string());
+    }
+    let blocks = content.as_array()?;
+    let mut buffer = String::new();
+    for block in blocks {
+        if block.get("type").and_then(Value::as_str) == Some("text") {
+            if let Some(text) = block.get("text").and_then(Value::as_str) {
+                if !buffer.is_empty() {
+                    buffer.push(' ');
+                }
+                buffer.push_str(text);
+            }
+        }
+    }
+    let trimmed = buffer.trim();
+    (!trimmed.is_empty()).then(|| trimmed.to_string())
+}
+
+/// Scan a JSONL transcript for the first user prompt (title) and the most
+/// recent assistant answer (preview). Parsing is defensive: unparseable lines,
+/// sidechain/meta entries, and non-text content are skipped.
+fn extract_title_preview(content: &str) -> (Option<String>, Option<String>) {
+    let mut first_user: Option<String> = None;
+    let mut last_assistant: Option<String> = None;
+    for line in content.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if value.get("isSidechain").and_then(Value::as_bool) == Some(true)
+            || value.get("isMeta").and_then(Value::as_bool) == Some(true)
+        {
+            continue;
+        }
+        match value.get("type").and_then(Value::as_str) {
+            Some("user") if first_user.is_none() => {
+                first_user = extract_message_text(&value);
+            }
+            Some("assistant") => {
+                if let Some(text) = extract_message_text(&value) {
+                    last_assistant = Some(text);
+                }
+            }
+            _ => {}
+        }
+    }
+    (
+        first_user.map(|text| clean_one_line(&text, 500)),
+        last_assistant.map(|text| clean_one_line(&text, 500)),
+    )
+}
+
+fn read_claude_transcript(input: ReadClaudeTranscriptInput) -> ClaudeTranscriptResult {
+    let Some(home) = claude_home_dir() else {
+        return ClaudeTranscriptResult::default();
+    };
+    let dir = home
+        .join(".claude")
+        .join("projects")
+        .join(encode_project_path(&input.cwd));
+    let path = match input.session_id.as_deref() {
+        Some(id) if !id.is_empty() => dir.join(format!("{id}.jsonl")),
+        _ => match newest_jsonl(&dir) {
+            Some(path) => path,
+            None => return ClaudeTranscriptResult::default(),
+        },
+    };
+
+    let Ok(metadata) = std::fs::metadata(&path) else {
+        return ClaudeTranscriptResult::default();
+    };
+    let mtime_ms = metadata.modified().ok().and_then(system_time_to_ms);
+
+    // Unchanged since the caller last read it — skip the (potentially large) read.
+    if let (Some(previous), Some(current)) = (input.since_mtime_ms, mtime_ms) {
+        if current <= previous {
+            return ClaudeTranscriptResult {
+                found: true,
+                changed: false,
+                mtime_ms,
+                title: None,
+                preview: None,
+            };
+        }
+    }
+
+    let Ok(content) = std::fs::read_to_string(&path) else {
+        return ClaudeTranscriptResult::default();
+    };
+    let (title, preview) = extract_title_preview(&content);
+    ClaudeTranscriptResult {
+        found: true,
+        changed: true,
+        mtime_ms,
+        title,
+        preview,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -885,6 +1076,50 @@ mod tests {
         assert_eq!(decode_utf8_with_carry(&mut carry, &[0x86]), "");
         assert_eq!(decode_utf8_with_carry(&mut carry, &[0x92]), "\u{2192}");
         assert!(carry.is_empty());
+    }
+
+    #[test]
+    fn encodes_project_path_like_claude_code() {
+        assert_eq!(
+            encode_project_path("/Users/simonpamies/Documents/Code/NeverWrite"),
+            "-Users-simonpamies-Documents-Code-NeverWrite"
+        );
+        // Spaces, dots, and underscores all collapse to '-'.
+        assert_eq!(encode_project_path("/a b/c.d_e"), "-a-b-c-d-e");
+    }
+
+    #[test]
+    fn extracts_first_prompt_and_latest_answer_from_transcript() {
+        let jsonl = [
+            r#"{"type":"system","subtype":"init"}"#,
+            r#"{"type":"user","message":{"content":[{"type":"text","text":"  How do I add a route?  "}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"},{"type":"text","text":"First answer"}]}}"#,
+            r#"{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"x","content":"ok"}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"y","name":"Edit","input":{}}]}}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Latest\nanswer here"}]}}"#,
+            r#"{"type":"assistant","isSidechain":true,"message":{"content":[{"type":"text","text":"subagent noise"}]}}"#,
+        ]
+        .join("\n");
+
+        let (title, preview) = extract_title_preview(&jsonl);
+        assert_eq!(title.as_deref(), Some("How do I add a route?"));
+        // Latest text answer wins; tool_use/sidechain entries are ignored and
+        // newlines collapse to a single line.
+        assert_eq!(preview.as_deref(), Some("Latest answer here"));
+    }
+
+    #[test]
+    fn extract_title_preview_tolerates_garbage_lines() {
+        let jsonl = [
+            "not json at all",
+            r#"{"type":"user","message":{"content":"plain string prompt"}}"#,
+            "",
+            r#"{"broken json"#,
+        ]
+        .join("\n");
+        let (title, preview) = extract_title_preview(&jsonl);
+        assert_eq!(title.as_deref(), Some("plain string prompt"));
+        assert_eq!(preview, None);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/devtools.rs
+++ b/apps/desktop/native-backend/src/devtools.rs
@@ -913,6 +913,21 @@ fn system_time_to_ms(time: std::time::SystemTime) -> Option<u64> {
         .map(|d| d.as_millis() as u64)
 }
 
+fn is_valid_claude_session_id(id: &str) -> bool {
+    const UUID_LEN: usize = 36;
+    const HYPHEN_POSITIONS: [usize; 4] = [8, 13, 18, 23];
+
+    let bytes = id.as_bytes();
+    bytes.len() == UUID_LEN
+        && bytes.iter().enumerate().all(|(index, byte)| {
+            if HYPHEN_POSITIONS.contains(&index) {
+                *byte == b'-'
+            } else {
+                byte.is_ascii_hexdigit()
+            }
+        })
+}
+
 /// Collapse whitespace to single spaces and cap length, so a multi-line message
 /// renders cleanly on one sidebar row.
 fn clean_one_line(text: &str, max_chars: usize) -> String {
@@ -1002,6 +1017,9 @@ fn read_claude_transcript(input: ReadClaudeTranscriptInput) -> ClaudeTranscriptR
     else {
         return ClaudeTranscriptResult::default();
     };
+    if !is_valid_claude_session_id(id) {
+        return ClaudeTranscriptResult::default();
+    }
     let path = dir.join(format!("{id}.jsonl"));
 
     let Ok(metadata) = std::fs::metadata(&path) else {
@@ -1070,6 +1088,27 @@ mod tests {
         );
         // Spaces, dots, and underscores all collapse to '-'.
         assert_eq!(encode_project_path("/a b/c.d_e"), "-a-b-c-d-e");
+    }
+
+    #[test]
+    fn validates_claude_session_id_as_uuid_basename() {
+        assert!(is_valid_claude_session_id(
+            "2198181b-9c2d-4c4b-b646-0c219657a6ff"
+        ));
+        assert!(is_valid_claude_session_id(
+            "2198181B-9C2D-4C4B-B646-0C219657A6FF"
+        ));
+
+        assert!(!is_valid_claude_session_id("../outside"));
+        assert!(!is_valid_claude_session_id(
+            "2198181b/9c2d-4c4b-b646-0c219657a6ff"
+        ));
+        assert!(!is_valid_claude_session_id(
+            "2198181b-9c2d-4c4b-b646-0c219657a6ff.jsonl"
+        ));
+        assert!(!is_valid_claude_session_id(
+            "2198181b-9c2d-4c4b-b646-0c219657a6fg"
+        ));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -895,7 +895,8 @@ impl NativeBackend {
             | "devtools_restart_terminal_session"
             | "devtools_close_terminal_session"
             | "devtools_get_terminal_session_snapshot"
-            | "devtools_check_binary" => self.devtools.invoke(command, args),
+            | "devtools_check_binary"
+            | "devtools_read_claude_transcript" => self.devtools.invoke(command, args),
             "spellcheck_list_languages"
             | "spellcheck_list_catalog"
             | "spellcheck_check_text"

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -97,6 +97,7 @@ const SUPPORTED_COMMANDS = new Set([
     "devtools_close_terminal_session",
     "devtools_get_terminal_session_snapshot",
     "devtools_check_binary",
+    "devtools_read_claude_transcript",
     "spellcheck_list_languages",
     "spellcheck_list_catalog",
     "spellcheck_check_text",

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -5,6 +5,12 @@ import { useEditorStore } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { renderComponent } from "../../test/test-utils";
 import { AgentsSidebarPanel } from "./AgentsSidebarPanel";
+import {
+    resetTerminalRuntimeStoreForTests,
+    useTerminalRuntimeStore,
+    type WorkspaceTerminalRuntime,
+} from "../terminal/terminalRuntimeStore";
+import { EMPTY_TERMINAL_SNAPSHOT } from "../terminal/terminalTypes";
 import { usePinnedChatsStore } from "./store/pinnedChatsStore";
 import { resetChatStore, useChatStore } from "./store/chatStore";
 import type { AIChatSession, AIChatSessionStatus } from "./types";
@@ -86,6 +92,7 @@ function firePointer(
 describe("AgentsSidebarPanel", () => {
     beforeEach(() => {
         resetChatStore();
+        resetTerminalRuntimeStoreForTests();
         vi.clearAllMocks();
         useVaultStore.setState({
             vaultPath: "/vault",
@@ -681,6 +688,82 @@ describe("AgentsSidebarPanel", () => {
         await waitFor(() => {
             expect(confirm).toHaveBeenCalledTimes(1);
         });
+        expect(deleteSession).not.toHaveBeenCalled();
+    });
+
+    it("closes a Claude Code terminal agent instead of deleting it", async () => {
+        const session = createSession(
+            "claude-terminal:term-1",
+            "Claude Code 1",
+            "idle",
+            10,
+            {
+                runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                terminalId: "term-1",
+                persistedTitle: "Claude Code 1",
+                messages: [],
+            },
+        );
+        const deleteSession = vi.fn().mockResolvedValue(undefined);
+
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+            sessionOrder: [session.sessionId],
+            deleteSession,
+        }));
+        useEditorStore.getState().hydrateTabs(
+            [
+                {
+                    id: "term-tab-1",
+                    kind: "terminal",
+                    terminalId: "term-1",
+                    title: "Claude Code 1",
+                    cwd: "/vault",
+                },
+            ],
+            "term-tab-1",
+        );
+        useTerminalRuntimeStore.setState({
+            runtimesById: {
+                "term-1": {
+                    terminalId: "term-1",
+                    tabId: "term-tab-1",
+                    sessionId: null,
+                    snapshot: {
+                        ...EMPTY_TERMINAL_SNAPSHOT,
+                        status: "running",
+                    },
+                    hasOutput: false,
+                    busy: false,
+                    launchError: null,
+                } satisfies WorkspaceTerminalRuntime,
+            },
+        });
+
+        renderComponent(<AgentsSidebarPanel />);
+
+        fireEvent.contextMenu(screen.getByRole("option"));
+        expect(
+            await screen.findByRole("button", { name: "Close Terminal" }),
+        ).toBeInTheDocument();
+        expect(screen.queryByRole("button", { name: "Delete" })).toBeNull();
+        fireEvent.click(screen.getByRole("button", { name: "Close Terminal" }));
+
+        await waitFor(() => {
+            expect(confirm).toHaveBeenCalledWith(
+                expect.stringContaining("Close terminal \"Claude Code 1\"?"),
+                expect.objectContaining({ title: "Close terminal?" }),
+            );
+        });
+        await waitFor(() => {
+            expect(
+                useTerminalRuntimeStore.getState().runtimesById["term-1"],
+            ).toBeUndefined();
+        });
+        expect(useEditorStore.getState().tabs).toHaveLength(0);
         expect(deleteSession).not.toHaveBeenCalled();
     });
 });

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -46,6 +46,7 @@ import {
     countAiSessionChildren,
     type AiSessionHierarchyGroup,
 } from "./sessionHierarchy";
+import { focusClaudeTerminalAgentSession } from "./claudeTerminalAgentSession";
 import { useChatStore } from "./store/chatStore";
 import { usePinnedChatsStore } from "./store/pinnedChatsStore";
 import type { AIChatSession } from "./types";
@@ -611,6 +612,10 @@ export function AgentsSidebarPanel() {
                 onRenameCancel={cancelEditing}
                 renameInputRef={inputRef}
                 onOpen={() => {
+                    if (session.runtimeId === CLAUDE_TERMINAL_RUNTIME_ID) {
+                        focusClaudeTerminalAgentSession(session);
+                        return;
+                    }
                     void openChatSessionInWorkspace(session.sessionId);
                 }}
                 onStartRename={() => {

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -49,7 +49,9 @@ import {
 } from "./sessionHierarchy";
 import {
     claudeTerminalAgentSessionId,
+    closeClaudeTerminalAgentSession,
     focusClaudeTerminalAgentSession,
+    isClaudeTerminalAgentSession,
 } from "./claudeTerminalAgentSession";
 import { useChatStore } from "./store/chatStore";
 import { usePinnedChatsStore } from "./store/pinnedChatsStore";
@@ -494,6 +496,23 @@ export function AgentsSidebarPanel() {
         [deleteSession, sessions, unpinChat],
     );
 
+    const handleCloseClaudeTerminal = useCallback(
+        async (session: AIChatSession) => {
+            const title = getSessionTitleText(session);
+            const approved = await confirm(
+                `Close terminal "${title}"?\n\nThis closes the Claude Code terminal backing this Agents entry. The entry will disappear from the sidebar when the terminal closes.`,
+                {
+                    title: "Close terminal?",
+                    kind: "warning",
+                },
+            );
+            if (!approved) return;
+
+            await closeClaudeTerminalAgentSession(session);
+        },
+        [],
+    );
+
     // --- Context menu ------------------------------------------------------
     const [contextMenu, setContextMenu] = useState<
         ContextMenuState<AIChatSession> | null
@@ -885,13 +904,23 @@ export function AgentsSidebarPanel() {
                                 handleStartRename(contextMenu.payload),
                         },
                         { type: "separator" },
-                        {
-                            label: "Delete",
-                            danger: true,
-                            action: () => {
-                                void handleDelete(contextMenu.payload);
-                            },
-                        },
+                        isClaudeTerminalAgentSession(contextMenu.payload)
+                            ? {
+                                  label: "Close Terminal",
+                                  danger: true,
+                                  action: () => {
+                                      void handleCloseClaudeTerminal(
+                                          contextMenu.payload,
+                                      );
+                                  },
+                              }
+                            : {
+                                  label: "Delete",
+                                  danger: true,
+                                  action: () => {
+                                      void handleDelete(contextMenu.payload);
+                                  },
+                              },
                     ]}
                 />
             )}

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { SidebarFilterInput } from "../../components/layout/SidebarFilterInput";
 import {
     isChatTab,
+    isTerminalTab,
     selectEditorWorkspaceTabs,
     selectFocusedEditorTab,
     useEditorStore,
@@ -46,7 +47,10 @@ import {
     countAiSessionChildren,
     type AiSessionHierarchyGroup,
 } from "./sessionHierarchy";
-import { focusClaudeTerminalAgentSession } from "./claudeTerminalAgentSession";
+import {
+    claudeTerminalAgentSessionId,
+    focusClaudeTerminalAgentSession,
+} from "./claudeTerminalAgentSession";
 import { useChatStore } from "./store/chatStore";
 import { usePinnedChatsStore } from "./store/pinnedChatsStore";
 import type { AIChatSession } from "./types";
@@ -285,7 +289,13 @@ export function AgentsSidebarPanel() {
         useShallow((state) => {
             const ids = new Set<string>();
             for (const tab of selectEditorWorkspaceTabs(state)) {
-                if (isChatTab(tab)) ids.add(tab.sessionId);
+                if (isChatTab(tab)) {
+                    ids.add(tab.sessionId);
+                } else if (isTerminalTab(tab)) {
+                    // A Claude Code terminal tab being open means its agent
+                    // entry belongs in the "Open" section.
+                    ids.add(claudeTerminalAgentSessionId(tab.terminalId));
+                }
             }
             return ids;
         }),
@@ -295,6 +305,17 @@ export function AgentsSidebarPanel() {
         useShallow((state) => {
             const focused = selectFocusedEditorTab(state);
             return focused && isChatTab(focused) ? focused.sessionId : null;
+        }),
+    );
+
+    // When a Claude Code terminal tab is focused, mark its agent entry as
+    // selected (the entry has no chat tab of its own).
+    const focusedTerminalAgentSessionId = useEditorStore(
+        useShallow((state) => {
+            const focused = selectFocusedEditorTab(state);
+            return focused && isTerminalTab(focused)
+                ? claudeTerminalAgentSessionId(focused.terminalId)
+                : null;
         }),
     );
 
@@ -521,7 +542,13 @@ export function AgentsSidebarPanel() {
         [],
     );
 
-    const activeSidebarId = focusedWorkspaceChatSessionId ?? activeSessionId;
+    const activeSidebarId =
+        focusedWorkspaceChatSessionId ??
+        (focusedTerminalAgentSessionId &&
+        sessionsById[focusedTerminalAgentSessionId]
+            ? focusedTerminalAgentSessionId
+            : null) ??
+        activeSessionId;
     const metrics = useMemo(
         () => buildAgentsSidebarMetrics(agentsSidebarScale),
         [agentsSidebarScale],

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -5,6 +5,10 @@ import {
 } from "../../app/store/editorStore";
 import { createChatTab } from "../../app/store/editorTabs";
 import type { WorkspaceDropTarget } from "../../app/store/workspaceContracts";
+import {
+    focusClaudeTerminalAgentSession,
+    isClaudeTerminalAgentSession,
+} from "./claudeTerminalAgentSession";
 import { getSessionTitle } from "./sessionPresentation";
 import { useChatStore } from "./store/chatStore";
 import { useChatTabsStore } from "./store/chatTabsStore";
@@ -276,6 +280,13 @@ export function openChatSessionInWorkspace(
     sessionId: string,
     options?: OpenChatInWorkspaceOptions,
 ) {
+    // A claude-code-terminal agent has no ACP session — opening it as a chat
+    // would resume a nonexistent backend session. Focus its terminal instead.
+    const session = useChatStore.getState().sessionsById[sessionId];
+    if (session && isClaudeTerminalAgentSession(session)) {
+        focusClaudeTerminalAgentSession(session);
+        return sessionId;
+    }
     const { title, historySessionId } = prepareChatSessionForWorkspace(sessionId);
     useEditorStore.getState().openChat(sessionId, {
         title,
@@ -296,6 +307,17 @@ export function openOrMoveChatSessionAtDropTarget(
     sessionId: string,
     target: ChatWorkspaceDropTarget,
 ) {
+    // Dragging a claude-code-terminal agent into the workspace focuses its
+    // terminal tab rather than opening a (nonexistent) ACP chat session.
+    const terminalAgentSession =
+        useChatStore.getState().sessionsById[sessionId];
+    if (
+        terminalAgentSession &&
+        isClaudeTerminalAgentSession(terminalAgentSession)
+    ) {
+        focusClaudeTerminalAgentSession(terminalAgentSession);
+        return sessionId;
+    }
     const { title, historySessionId } = prepareChatSessionForWorkspace(sessionId);
     const existing = findWorkspaceChatTab(sessionId, historySessionId);
     const editor = useEditorStore.getState();

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -1,9 +1,13 @@
 import { invoke } from "@neverwrite/runtime";
 import { waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useEditorStore } from "../../app/store/editorStore";
+import {
+    selectEditorWorkspaceTabs,
+    useEditorStore,
+} from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { setEditorTabs } from "../../test/test-utils";
+import { openChatSessionInWorkspace } from "./chatPaneMovement";
 import {
     resetTerminalRuntimeStoreForTests,
     useTerminalRuntimeStore,
@@ -180,6 +184,34 @@ describe("claudeTerminalAgentSession", () => {
         expect(
             focusClaudeTerminalAgentSession({ terminalId: "missing" }),
         ).toBe(false);
+    });
+
+    it("opening the entry in the workspace focuses the terminal, not an ACP chat", () => {
+        const tabs = [
+            { id: "note-1", kind: "note", noteId: "notes/a", title: "Note A" },
+            {
+                id: "term-tab-1",
+                kind: "terminal",
+                terminalId: "term-1",
+                title: "Claude Code 1",
+                cwd: "/vault",
+            },
+        ] as Parameters<typeof setEditorTabs>[0];
+        setEditorTabs(tabs, "note-1");
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+        });
+
+        openChatSessionInWorkspace(SESSION_ID);
+
+        // Focused the terminal tab; no ai-chat tab was opened for it (which would
+        // have resumed a nonexistent ACP session).
+        expect(useEditorStore.getState().activeTabId).toBe("term-tab-1");
+        const chatTabs = selectEditorWorkspaceTabs(
+            useEditorStore.getState(),
+        ).filter((tab) => "sessionId" in tab && tab.kind === "ai-chat");
+        expect(chatTabs).toHaveLength(0);
     });
 
     it("prunes agent entries whose terminal is gone, keeping live ones", async () => {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -1,0 +1,138 @@
+import { waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useEditorStore } from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import { setEditorTabs } from "../../test/test-utils";
+import {
+    resetTerminalRuntimeStoreForTests,
+    useTerminalRuntimeStore,
+    type WorkspaceTerminalRuntime,
+} from "../terminal/terminalRuntimeStore";
+import { EMPTY_TERMINAL_SNAPSHOT } from "../terminal/terminalTypes";
+import {
+    focusClaudeTerminalAgentSession,
+    pruneClaudeTerminalAgentSessions,
+    registerClaudeTerminalAgentSession,
+} from "./claudeTerminalAgentSession";
+import { resetChatStore, useChatStore } from "./store/chatStore";
+import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
+
+function seedTerminalRuntime(terminalId: string) {
+    useTerminalRuntimeStore.setState((state) => ({
+        runtimesById: {
+            ...state.runtimesById,
+            [terminalId]: {
+                terminalId,
+                tabId: `${terminalId}-tab`,
+                sessionId: `session-${terminalId}`,
+                snapshot: { ...EMPTY_TERMINAL_SNAPSHOT, status: "running" },
+                hasOutput: false,
+                busy: false,
+                launchError: null,
+            } satisfies WorkspaceTerminalRuntime,
+        },
+    }));
+}
+
+const SESSION_ID = "claude-terminal:term-1";
+
+describe("claudeTerminalAgentSession", () => {
+    beforeEach(() => {
+        resetChatStore();
+        resetTerminalRuntimeStoreForTests();
+        useVaultStore.setState({ vaultPath: "/vault" });
+        setEditorTabs([]);
+    });
+
+    afterEach(() => {
+        resetChatStore();
+        resetTerminalRuntimeStoreForTests();
+    });
+
+    it("registers a listed, non-active agent entry for a Claude Code terminal", () => {
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+        });
+
+        const state = useChatStore.getState();
+        const session = state.sessionsById[SESSION_ID];
+        expect(session).toBeDefined();
+        expect(session?.runtimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
+        expect(session?.terminalId).toBe("term-1");
+        expect(session?.customTitle).toBe("Claude Code 1");
+        expect(session?.messages).toEqual([]);
+        expect(state.sessionOrder).toContain(SESSION_ID);
+        // A terminal agent is never a real chat target, so it must not steal the
+        // active session (even when none was active before).
+        expect(state.activeSessionId).not.toBe(SESSION_ID);
+    });
+
+    it("is idempotent — re-registering the same terminal updates one entry", () => {
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+        });
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1 (renamed)",
+        });
+
+        const state = useChatStore.getState();
+        expect(
+            state.sessionOrder.filter((id) => id === SESSION_ID),
+        ).toHaveLength(1);
+        expect(state.sessionsById[SESSION_ID]?.customTitle).toBe(
+            "Claude Code 1 (renamed)",
+        );
+    });
+
+    it("focuses the terminal tab when the agent entry is opened", () => {
+        const tabs = [
+            { id: "note-1", kind: "note", noteId: "notes/a", title: "Note A" },
+            {
+                id: "term-tab-1",
+                kind: "terminal",
+                terminalId: "term-1",
+                title: "Claude Code 1",
+                cwd: "/vault",
+            },
+        ] as Parameters<typeof setEditorTabs>[0];
+        setEditorTabs(tabs, "note-1");
+
+        const focused = focusClaudeTerminalAgentSession({ terminalId: "term-1" });
+
+        expect(focused).toBe(true);
+        expect(useEditorStore.getState().activeTabId).toBe("term-tab-1");
+    });
+
+    it("returns false when no terminal tab backs the entry", () => {
+        setEditorTabs([]);
+        expect(
+            focusClaudeTerminalAgentSession({ terminalId: "missing" }),
+        ).toBe(false);
+    });
+
+    it("prunes agent entries whose terminal is gone, keeping live ones", async () => {
+        seedTerminalRuntime("term-live");
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-live",
+            title: "Live",
+        });
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-dead",
+            title: "Dead",
+        });
+
+        pruneClaudeTerminalAgentSessions();
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().sessionsById["claude-terminal:term-dead"],
+            ).toBeUndefined();
+        });
+        expect(
+            useChatStore.getState().sessionsById["claude-terminal:term-live"],
+        ).toBeDefined();
+    });
+});

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -15,6 +15,7 @@ import {
 } from "../terminal/terminalRuntimeStore";
 import { EMPTY_TERMINAL_SNAPSHOT } from "../terminal/terminalTypes";
 import {
+    closeClaudeTerminalAgentSession,
     focusClaudeTerminalAgentSession,
     pruneClaudeTerminalAgentSessions,
     refreshClaudeTerminalAgentTranscripts,
@@ -187,6 +188,30 @@ describe("claudeTerminalAgentSession", () => {
         expect(
             focusClaudeTerminalAgentSession({ terminalId: "missing" }),
         ).toBe(false);
+    });
+
+    it("closes the terminal tab and runtime backing the agent entry", async () => {
+        const tabs = [
+            { id: "note-1", kind: "note", noteId: "notes/a", title: "Note A" },
+            {
+                id: "term-tab-1",
+                kind: "terminal",
+                terminalId: "term-1",
+                title: "Claude Code 1",
+                cwd: "/vault",
+            },
+        ] as Parameters<typeof setEditorTabs>[0];
+        setEditorTabs(tabs, "term-tab-1");
+
+        await expect(
+            closeClaudeTerminalAgentSession({ terminalId: "term-1" }),
+        ).resolves.toBe(true);
+
+        expect(useEditorStore.getState().tabs).toHaveLength(1);
+        expect(useEditorStore.getState().tabs[0]?.id).toBe("note-1");
+        expect(
+            useTerminalRuntimeStore.getState().runtimesById["term-1"],
+        ).toBeUndefined();
     });
 
     it("opening the entry in the workspace focuses the terminal, not an ACP chat", () => {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -164,6 +164,25 @@ describe("claudeTerminalAgentSession", () => {
         expect(session?.persistedPreview).toBeFalsy();
     });
 
+    it("does not read a transcript without an exact Claude session id", async () => {
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+            transcriptSessionId: null,
+            cwd: "/vault",
+        });
+
+        await refreshClaudeTerminalAgentTranscripts();
+
+        expect(vi.mocked(invoke)).not.toHaveBeenCalledWith(
+            "devtools_read_claude_transcript",
+            expect.anything(),
+        );
+        const session = useChatStore.getState().sessionsById[SESSION_ID];
+        expect(session?.persistedTitle).toBe("Claude Code 1");
+        expect(session?.persistedPreview).toBeFalsy();
+    });
+
     it("focuses the terminal tab when the agent entry is opened", () => {
         const tabs = [
             { id: "note-1", kind: "note", noteId: "notes/a", title: "Note A" },

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -51,6 +51,9 @@ describe("claudeTerminalAgentSession", () => {
         vi.mocked(invoke).mockReset();
         useVaultStore.setState({ vaultPath: "/vault" });
         setEditorTabs([]);
+        // The entry is self-healing: it only survives while its terminal is
+        // live, so seed the runtime the default-case tests register against.
+        seedTerminalRuntime("term-1");
     });
 
     afterEach(() => {
@@ -212,6 +215,31 @@ describe("claudeTerminalAgentSession", () => {
             useEditorStore.getState(),
         ).filter((tab) => "sessionId" in tab && tab.kind === "ai-chat");
         expect(chatTabs).toHaveLength(0);
+    });
+
+    it("re-asserts the entry if a store rebuild drops it while the terminal is live", () => {
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+        });
+        expect(useChatStore.getState().sessionsById[SESSION_ID]).toBeDefined();
+
+        // Simulate a backend reconcile rebuilding sessionsById without our
+        // client-only entry (what happens when opening another agent).
+        useChatStore.setState((state) => {
+            const sessionsById = { ...state.sessionsById };
+            delete sessionsById[SESSION_ID];
+            return {
+                sessionsById,
+                sessionOrder: state.sessionOrder.filter(
+                    (id) => id !== SESSION_ID,
+                ),
+            };
+        });
+
+        // The chatStore subscription re-adds it because the terminal is alive.
+        expect(useChatStore.getState().sessionsById[SESSION_ID]).toBeDefined();
+        expect(useChatStore.getState().sessionOrder).toContain(SESSION_ID);
     });
 
     it("prunes agent entries whose terminal is gone, keeping live ones", async () => {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -1,5 +1,6 @@
+import { invoke } from "@neverwrite/runtime";
 import { waitFor } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { setEditorTabs } from "../../test/test-utils";
@@ -12,7 +13,9 @@ import { EMPTY_TERMINAL_SNAPSHOT } from "../terminal/terminalTypes";
 import {
     focusClaudeTerminalAgentSession,
     pruneClaudeTerminalAgentSessions,
+    refreshClaudeTerminalAgentTranscripts,
     registerClaudeTerminalAgentSession,
+    resetClaudeTerminalAgentSessionsForTests,
 } from "./claudeTerminalAgentSession";
 import { resetChatStore, useChatStore } from "./store/chatStore";
 import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
@@ -38,13 +41,16 @@ const SESSION_ID = "claude-terminal:term-1";
 
 describe("claudeTerminalAgentSession", () => {
     beforeEach(() => {
+        resetClaudeTerminalAgentSessionsForTests();
         resetChatStore();
         resetTerminalRuntimeStoreForTests();
+        vi.mocked(invoke).mockReset();
         useVaultStore.setState({ vaultPath: "/vault" });
         setEditorTabs([]);
     });
 
     afterEach(() => {
+        resetClaudeTerminalAgentSessionsForTests();
         resetChatStore();
         resetTerminalRuntimeStoreForTests();
     });
@@ -60,7 +66,11 @@ describe("claudeTerminalAgentSession", () => {
         expect(session).toBeDefined();
         expect(session?.runtimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
         expect(session?.terminalId).toBe("term-1");
-        expect(session?.customTitle).toBe("Claude Code 1");
+        // Default label lives in persistedTitle, so a manual rename (customTitle)
+        // and the transcript-derived title can both override it.
+        expect(session?.persistedTitle).toBe("Claude Code 1");
+        // No manual rename, so the title falls back to persistedTitle.
+        expect(session?.customTitle).toBeFalsy();
         expect(session?.messages).toEqual([]);
         expect(state.sessionOrder).toContain(SESSION_ID);
         // A terminal agent is never a real chat target, so it must not steal the
@@ -82,9 +92,68 @@ describe("claudeTerminalAgentSession", () => {
         expect(
             state.sessionOrder.filter((id) => id === SESSION_ID),
         ).toHaveLength(1);
-        expect(state.sessionsById[SESSION_ID]?.customTitle).toBe(
+        expect(state.sessionsById[SESSION_ID]?.persistedTitle).toBe(
             "Claude Code 1 (renamed)",
         );
+    });
+
+    it("fills title and preview from the Claude Code transcript", async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            found: true,
+            changed: true,
+            mtimeMs: 1000,
+            title: "How do I add a route?",
+            preview: "First, open the router file and add an entry.",
+        });
+
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+            transcriptSessionId: "uuid-1",
+            cwd: "/vault",
+        });
+
+        await refreshClaudeTerminalAgentTranscripts();
+
+        const session = useChatStore.getState().sessionsById[SESSION_ID];
+        expect(session?.persistedTitle).toBe("How do I add a route?");
+        expect(session?.persistedPreview).toBe(
+            "First, open the router file and add an entry.",
+        );
+        // It read the transcript via the backend with the pinned session id.
+        expect(vi.mocked(invoke)).toHaveBeenCalledWith(
+            "devtools_read_claude_transcript",
+            {
+                input: {
+                    sessionId: "uuid-1",
+                    cwd: "/vault",
+                    sinceMtimeMs: null,
+                },
+            },
+        );
+    });
+
+    it("leaves the default title when the transcript has not been written yet", async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            found: false,
+            changed: false,
+            mtimeMs: null,
+            title: null,
+            preview: null,
+        });
+
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+            transcriptSessionId: "uuid-1",
+            cwd: "/vault",
+        });
+
+        await refreshClaudeTerminalAgentTranscripts();
+
+        const session = useChatStore.getState().sessionsById[SESSION_ID];
+        expect(session?.persistedTitle).toBe("Claude Code 1");
+        expect(session?.persistedPreview).toBeFalsy();
     });
 
     it("focuses the terminal tab when the agent entry is opened", () => {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.test.ts
@@ -113,6 +113,18 @@ describe("claudeTerminalAgentSession", () => {
             title: "How do I add a route?",
             preview: "First, open the router file and add an entry.",
         });
+        setEditorTabs(
+            [
+                {
+                    id: "term-tab-1",
+                    kind: "terminal",
+                    terminalId: "term-1",
+                    title: "Claude Code 1",
+                    cwd: "/vault",
+                },
+            ],
+            "term-tab-1",
+        );
 
         registerClaudeTerminalAgentSession({
             terminalId: "term-1",
@@ -128,6 +140,9 @@ describe("claudeTerminalAgentSession", () => {
         expect(session?.persistedPreview).toBe(
             "First, open the router file and add an entry.",
         );
+        expect(useEditorStore.getState().tabs[0]?.title).toBe(
+            "How do I add a route?",
+        );
         // It read the transcript via the backend with the pinned session id.
         expect(vi.mocked(invoke)).toHaveBeenCalledWith(
             "devtools_read_claude_transcript",
@@ -139,6 +154,70 @@ describe("claudeTerminalAgentSession", () => {
                 },
             },
         );
+    });
+
+    it("does not replace a manually renamed terminal tab with the transcript title", async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            found: true,
+            changed: true,
+            mtimeMs: 1000,
+            title: "How do I add a route?",
+            preview: "First, open the router file and add an entry.",
+        });
+        setEditorTabs(
+            [
+                {
+                    id: "term-tab-1",
+                    kind: "terminal",
+                    terminalId: "term-1",
+                    title: "Pinned Claude Scratchpad",
+                    cwd: "/vault",
+                },
+            ],
+            "term-tab-1",
+        );
+
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+            transcriptSessionId: "uuid-1",
+            cwd: "/vault",
+        });
+
+        await refreshClaudeTerminalAgentTranscripts();
+
+        expect(useChatStore.getState().sessionsById[SESSION_ID]?.persistedTitle).toBe(
+            "How do I add a route?",
+        );
+        expect(useEditorStore.getState().tabs[0]?.title).toBe(
+            "Pinned Claude Scratchpad",
+        );
+    });
+
+    it("syncs sidebar renames to the backing terminal tab", async () => {
+        setEditorTabs(
+            [
+                {
+                    id: "term-tab-1",
+                    kind: "terminal",
+                    terminalId: "term-1",
+                    title: "Claude Code 1",
+                    cwd: "/vault",
+                },
+            ],
+            "term-tab-1",
+        );
+        registerClaudeTerminalAgentSession({
+            terminalId: "term-1",
+            title: "Claude Code 1",
+        });
+
+        useChatStore.getState().renameSession(SESSION_ID, "Renamed task");
+
+        expect(
+            useChatStore.getState().sessionsById[SESSION_ID]?.customTitle,
+        ).toBe("Renamed task");
+        expect(useEditorStore.getState().tabs[0]?.title).toBe("Renamed task");
     });
 
     it("leaves the default title when the transcript has not been written yet", async () => {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -13,33 +13,36 @@ import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
 // Claude Code launched in a terminal has no ACP backend session, so it never
 // appears in the Agents sidebar on its own. We register a lightweight,
 // non-persisted chat session entry for it, linked to the terminal via
-// `terminalId`, and keep its title/preview in sync with Claude Code's own
-// on-disk session transcript. The entry is removed when its terminal closes.
+// `terminalId`, with title/preview sourced from Claude Code's transcript.
+//
+// chatStore is the source of truth for the sidebar, but it is rebuilt from the
+// backend on several events (vault init, runtime reconnect, …) which would drop
+// a client-only session. So we keep our own registry of live terminal agents
+// and re-assert any entry that goes missing while its terminal is still alive —
+// and remove entries whose terminal has closed.
 
 const SESSION_ID_PREFIX = "claude-terminal:";
 const TRANSCRIPT_POLL_INTERVAL_MS = 4_000;
 
-interface TranscriptInfo {
-    cwd: string;
-    // Claude session UUID when we pinned it at launch (--session-id); null means
-    // fall back to the most recently modified transcript in the project dir.
+interface TerminalAgentEntry {
+    terminalId: string;
+    defaultTitle: string;
     transcriptSessionId: string | null;
+    cwd: string | null;
+    createdAt: number;
+    // Latest transcript-derived values, re-applied if the session is rebuilt.
+    title: string | null;
+    preview: string | null;
+    updatedAt: number;
     lastMtimeMs: number | null;
 }
 
-interface ClaudeTranscriptResult {
-    found: boolean;
-    changed: boolean;
-    mtimeMs: number | null;
-    title: string | null;
-    preview: string | null;
-}
-
-const transcriptInfoByTerminalId = new Map<string, TranscriptInfo>();
+const agentsByTerminalId = new Map<string, TerminalAgentEntry>();
 let pollTimer: ReturnType<typeof setInterval> | null = null;
-let pruneUnsubscribe: (() => void) | null = null;
+let terminalUnsubscribe: (() => void) | null = null;
+let chatUnsubscribe: (() => void) | null = null;
 
-function sessionIdForTerminal(terminalId: string) {
+export function claudeTerminalAgentSessionId(terminalId: string) {
     return `${SESSION_ID_PREFIX}${terminalId}`;
 }
 
@@ -49,118 +52,12 @@ export function isClaudeTerminalAgentSession(
     return session.runtimeId === CLAUDE_TERMINAL_RUNTIME_ID;
 }
 
-function installPruneSubscription() {
-    if (pruneUnsubscribe) return;
-    // Terminal lifecycle drives the agent entry: when a terminal runtime is gone
-    // (tab closed), drop its agent session. Firing on every terminal store
-    // change is cheap — prune only touches the handful of claude-terminal
-    // sessions.
-    pruneUnsubscribe = useTerminalRuntimeStore.subscribe(() => {
-        pruneClaudeTerminalAgentSessions();
-    });
-}
-
-// Remove agent entries whose backing terminal runtime no longer exists.
-export function pruneClaudeTerminalAgentSessions() {
-    const liveTerminalIds = new Set(
-        Object.keys(useTerminalRuntimeStore.getState().runtimesById),
-    );
-    const chat = useChatStore.getState();
-    for (const session of Object.values(chat.sessionsById)) {
-        if (
-            isClaudeTerminalAgentSession(session) &&
-            session.terminalId &&
-            !liveTerminalIds.has(session.terminalId)
-        ) {
-            transcriptInfoByTerminalId.delete(session.terminalId);
-            void chat.deleteSession(session.sessionId);
-        }
-    }
-    stopTranscriptPollingIfIdle();
-}
-
-function ensureTranscriptPolling() {
-    if (pollTimer || transcriptInfoByTerminalId.size === 0) return;
-    pollTimer = setInterval(() => {
-        void refreshClaudeTerminalAgentTranscripts();
-    }, TRANSCRIPT_POLL_INTERVAL_MS);
-}
-
-function stopTranscriptPollingIfIdle() {
-    if (pollTimer && transcriptInfoByTerminalId.size === 0) {
-        clearInterval(pollTimer);
-        pollTimer = null;
-    }
-}
-
-// Poll Claude Code's transcript for each tracked terminal and refresh the agent
-// entry's title (first prompt) and preview (latest answer). Reads are skipped at
-// the backend when the file hasn't changed since the last read.
-export async function refreshClaudeTerminalAgentTranscripts() {
-    const chat = useChatStore.getState();
-    for (const [terminalId, info] of [...transcriptInfoByTerminalId]) {
-        const sessionId = sessionIdForTerminal(terminalId);
-        if (!chat.sessionsById[sessionId]) {
-            transcriptInfoByTerminalId.delete(terminalId);
-            continue;
-        }
-
-        let result: ClaudeTranscriptResult;
-        try {
-            result = await invoke<ClaudeTranscriptResult>(
-                "devtools_read_claude_transcript",
-                {
-                    input: {
-                        sessionId: info.transcriptSessionId,
-                        cwd: info.cwd,
-                        sinceMtimeMs: info.lastMtimeMs,
-                    },
-                },
-            );
-        } catch {
-            continue;
-        }
-
-        if (!result?.changed) continue;
-        if (result.mtimeMs != null) info.lastMtimeMs = result.mtimeMs;
-        if (!result.title && !result.preview) continue;
-
-        useChatStore.setState((state) => {
-            const session = state.sessionsById[sessionId];
-            if (!session) return state;
-            return {
-                sessionsById: {
-                    ...state.sessionsById,
-                    [sessionId]: {
-                        ...session,
-                        persistedTitle: result.title ?? session.persistedTitle,
-                        persistedPreview:
-                            result.preview ?? session.persistedPreview,
-                    },
-                },
-            };
-        });
-    }
-    stopTranscriptPollingIfIdle();
-}
-
-// Register (or update) the Agents-sidebar entry for a Claude Code terminal.
-// Idempotent: the session id is derived from the terminal id. Pass the cwd (and
-// the pinned session id, if any) to enable transcript-driven title/preview.
-export function registerClaudeTerminalAgentSession(args: {
-    terminalId: string;
-    title: string;
-    transcriptSessionId?: string | null;
-    cwd?: string | null;
-}) {
-    installPruneSubscription();
-
-    const sessionId = sessionIdForTerminal(args.terminalId);
-    const session: AIChatSession = {
-        sessionId,
-        historySessionId: sessionId,
+function buildSession(entry: TerminalAgentEntry): AIChatSession {
+    return {
+        sessionId: claudeTerminalAgentSessionId(entry.terminalId),
+        historySessionId: claudeTerminalAgentSessionId(entry.terminalId),
         runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
-        terminalId: args.terminalId,
+        terminalId: entry.terminalId,
         vaultPath: useVaultStore.getState().vaultPath ?? null,
         status: "idle",
         modelId: "",
@@ -170,33 +67,175 @@ export function registerClaudeTerminalAgentSession(args: {
         configOptions: [],
         messages: [],
         attachments: [],
-        // Default label until the transcript yields the first prompt. Use
         // persistedTitle (not customTitle) so a manual rename still wins and the
-        // transcript-derived title can fill in over it.
-        persistedTitle: args.title,
+        // transcript-derived title can fill in over the default label.
+        persistedTitle: entry.title ?? entry.defaultTitle,
+        persistedPreview: entry.preview,
+        persistedCreatedAt: entry.createdAt,
+        persistedUpdatedAt: entry.updatedAt,
     };
+}
 
-    // activate:false so launching a terminal doesn't hijack the active chat;
-    // allowUnknownSession so this brand-new entry is admitted to the list.
+function upsertAgentSession(entry: TerminalAgentEntry) {
+    const sessionId = claudeTerminalAgentSessionId(entry.terminalId);
     const previousActiveSessionId = useChatStore.getState().activeSessionId;
-    useChatStore.getState().upsertSession(session, false, {
-        allowUnknownSession: true,
-    });
-    // upsertSession makes a session active when none was — but a terminal agent
-    // is never a real chat target, so keep the prior active session.
+    // activate:false so it doesn't hijack the active chat; allowUnknownSession
+    // so this client-only entry is admitted to the list.
+    useChatStore
+        .getState()
+        .upsertSession(buildSession(entry), false, { allowUnknownSession: true });
+    // upsertSession makes a session active when none was — a terminal agent is
+    // never a real chat target, so keep the prior active session.
     if (
         previousActiveSessionId !== sessionId &&
         useChatStore.getState().activeSessionId === sessionId
     ) {
         useChatStore.setState({ activeSessionId: previousActiveSessionId });
     }
+}
 
-    if (args.cwd) {
-        transcriptInfoByTerminalId.set(args.terminalId, {
-            cwd: args.cwd,
-            transcriptSessionId: args.transcriptSessionId ?? null,
-            lastMtimeMs: null,
+// Keep chatStore in sync with live terminal agents: re-add any that a store
+// rebuild dropped, and remove any whose terminal has closed.
+function reconcileAgentSessions() {
+    const liveTerminalIds = new Set(
+        Object.keys(useTerminalRuntimeStore.getState().runtimesById),
+    );
+    const chat = useChatStore.getState();
+
+    for (const entry of [...agentsByTerminalId.values()]) {
+        const sessionId = claudeTerminalAgentSessionId(entry.terminalId);
+        if (!liveTerminalIds.has(entry.terminalId)) {
+            agentsByTerminalId.delete(entry.terminalId);
+            if (chat.sessionsById[sessionId]) {
+                void chat.deleteSession(sessionId);
+            }
+            continue;
+        }
+        if (!chat.sessionsById[sessionId]) {
+            upsertAgentSession(entry);
+        }
+    }
+    stopTranscriptPollingIfIdle();
+}
+
+// Back-compat name used elsewhere (and tests): prune == reconcile.
+export function pruneClaudeTerminalAgentSessions() {
+    reconcileAgentSessions();
+}
+
+function installSubscriptions() {
+    if (!terminalUnsubscribe) {
+        terminalUnsubscribe = useTerminalRuntimeStore.subscribe(() => {
+            reconcileAgentSessions();
         });
+    }
+    if (!chatUnsubscribe) {
+        // A store rebuild can drop our client-only entries; re-assert them.
+        chatUnsubscribe = useChatStore.subscribe(() => {
+            reconcileAgentSessions();
+        });
+    }
+}
+
+function ensureTranscriptPolling() {
+    if (pollTimer || agentsByTerminalId.size === 0) return;
+    pollTimer = setInterval(() => {
+        void refreshClaudeTerminalAgentTranscripts();
+    }, TRANSCRIPT_POLL_INTERVAL_MS);
+}
+
+function stopTranscriptPollingIfIdle() {
+    if (pollTimer && agentsByTerminalId.size === 0) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+// Poll Claude Code's transcript for each tracked terminal and refresh the agent
+// entry's title (first prompt) and preview (latest answer).
+export async function refreshClaudeTerminalAgentTranscripts() {
+    for (const entry of [...agentsByTerminalId.values()]) {
+        if (!entry.cwd) continue;
+
+        let result:
+            | {
+                  found: boolean;
+                  changed: boolean;
+                  mtimeMs: number | null;
+                  title: string | null;
+                  preview: string | null;
+              }
+            | undefined;
+        try {
+            result = await invoke("devtools_read_claude_transcript", {
+                input: {
+                    sessionId: entry.transcriptSessionId,
+                    cwd: entry.cwd,
+                    sinceMtimeMs: entry.lastMtimeMs,
+                },
+            });
+        } catch {
+            continue;
+        }
+
+        if (!result?.changed) continue;
+        if (result.mtimeMs != null) entry.lastMtimeMs = result.mtimeMs;
+        if (!result.title && !result.preview) continue;
+
+        if (result.title) entry.title = result.title;
+        if (result.preview) entry.preview = result.preview;
+        entry.updatedAt = Date.now();
+
+        const sessionId = claudeTerminalAgentSessionId(entry.terminalId);
+        const session = useChatStore.getState().sessionsById[sessionId];
+        if (!session) continue;
+        useChatStore.setState((state) => {
+            const current = state.sessionsById[sessionId];
+            if (!current) return state;
+            return {
+                sessionsById: {
+                    ...state.sessionsById,
+                    [sessionId]: {
+                        ...current,
+                        persistedTitle: entry.title ?? current.persistedTitle,
+                        persistedPreview:
+                            entry.preview ?? current.persistedPreview,
+                        persistedUpdatedAt: entry.updatedAt,
+                    },
+                },
+            };
+        });
+    }
+    stopTranscriptPollingIfIdle();
+}
+
+// Register (or update) the Agents-sidebar entry for a Claude Code terminal.
+export function registerClaudeTerminalAgentSession(args: {
+    terminalId: string;
+    title: string;
+    transcriptSessionId?: string | null;
+    cwd?: string | null;
+}) {
+    installSubscriptions();
+
+    const now = Date.now();
+    const existing = agentsByTerminalId.get(args.terminalId);
+    const entry: TerminalAgentEntry = {
+        terminalId: args.terminalId,
+        defaultTitle: args.title,
+        transcriptSessionId: args.transcriptSessionId ?? null,
+        cwd: args.cwd ?? null,
+        createdAt: existing?.createdAt ?? now,
+        title: existing?.title ?? null,
+        preview: existing?.preview ?? null,
+        updatedAt: existing?.updatedAt ?? now,
+        lastMtimeMs: existing?.lastMtimeMs ?? null,
+    };
+    agentsByTerminalId.set(args.terminalId, entry);
+
+    upsertAgentSession(entry);
+
+    if (entry.cwd) {
         ensureTranscriptPolling();
         void refreshClaudeTerminalAgentTranscripts();
     }
@@ -219,11 +258,13 @@ export function focusClaudeTerminalAgentSession(
 }
 
 export function resetClaudeTerminalAgentSessionsForTests() {
-    transcriptInfoByTerminalId.clear();
+    agentsByTerminalId.clear();
     if (pollTimer) {
         clearInterval(pollTimer);
         pollTimer = null;
     }
-    pruneUnsubscribe?.();
-    pruneUnsubscribe = null;
+    terminalUnsubscribe?.();
+    terminalUnsubscribe = null;
+    chatUnsubscribe?.();
+    chatUnsubscribe = null;
 }

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -257,6 +257,30 @@ export function focusClaudeTerminalAgentSession(
     return true;
 }
 
+// Close the workspace terminal backing this lightweight Agents entry. The
+// terminal runtime store tears down the PTY; the regular reconciliation path
+// then removes the pseudo-session from the sidebar.
+export async function closeClaudeTerminalAgentSession(
+    session: Pick<AIChatSession, "terminalId">,
+): Promise<boolean> {
+    const terminalId = session.terminalId;
+    if (!terminalId) return false;
+
+    const tab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (candidate) =>
+            isTerminalTab(candidate) && candidate.terminalId === terminalId,
+    );
+    const hadRuntime = Boolean(
+        useTerminalRuntimeStore.getState().runtimesById[terminalId],
+    );
+
+    if (tab) {
+        useEditorStore.getState().closeTab(tab.id);
+    }
+    await useTerminalRuntimeStore.getState().closeTerminal(terminalId);
+    return Boolean(tab || hadRuntime);
+}
+
 export function resetClaudeTerminalAgentSessionsForTests() {
     agentsByTerminalId.clear();
     if (pollTimer) {

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -155,7 +155,7 @@ function stopTranscriptPollingIfIdle() {
 // entry's title (first prompt) and preview (latest answer).
 export async function refreshClaudeTerminalAgentTranscripts() {
     for (const entry of [...agentsByTerminalId.values()]) {
-        if (!entry.cwd) continue;
+        if (!entry.cwd || !entry.transcriptSessionId) continue;
 
         let result:
             | {
@@ -235,7 +235,7 @@ export function registerClaudeTerminalAgentSession(args: {
 
     upsertAgentSession(entry);
 
-    if (entry.cwd) {
+    if (entry.cwd && entry.transcriptSessionId) {
         ensureTranscriptPolling();
         void refreshClaudeTerminalAgentTranscripts();
     }

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -1,0 +1,116 @@
+import {
+    selectEditorWorkspaceTabs,
+    useEditorStore,
+} from "../../app/store/editorStore";
+import { isTerminalTab } from "../../app/store/editorTabs";
+import { useVaultStore } from "../../app/store/vaultStore";
+import { useTerminalRuntimeStore } from "../terminal/terminalRuntimeStore";
+import { useChatStore } from "./store/chatStore";
+import type { AIChatSession } from "./types";
+import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
+
+// Claude Code launched in a terminal has no ACP backend session, so it never
+// appears in the Agents sidebar on its own. We register a lightweight,
+// non-persisted chat session entry for it, linked to the terminal via
+// `terminalId`. The entry is removed when its terminal goes away.
+
+const SESSION_ID_PREFIX = "claude-terminal:";
+
+function sessionIdForTerminal(terminalId: string) {
+    return `${SESSION_ID_PREFIX}${terminalId}`;
+}
+
+export function isClaudeTerminalAgentSession(
+    session: Pick<AIChatSession, "runtimeId">,
+) {
+    return session.runtimeId === CLAUDE_TERMINAL_RUNTIME_ID;
+}
+
+let pruneSubscriptionInstalled = false;
+
+function installPruneSubscription() {
+    if (pruneSubscriptionInstalled) return;
+    pruneSubscriptionInstalled = true;
+    // Terminal lifecycle drives the agent entry: when a terminal runtime is
+    // gone (tab closed), drop its agent session. Firing on every terminal
+    // store change is cheap — prune only touches the handful of claude-terminal
+    // sessions.
+    useTerminalRuntimeStore.subscribe(() => {
+        pruneClaudeTerminalAgentSessions();
+    });
+}
+
+// Remove agent entries whose backing terminal runtime no longer exists.
+export function pruneClaudeTerminalAgentSessions() {
+    const liveTerminalIds = new Set(
+        Object.keys(useTerminalRuntimeStore.getState().runtimesById),
+    );
+    const chat = useChatStore.getState();
+    for (const session of Object.values(chat.sessionsById)) {
+        if (
+            isClaudeTerminalAgentSession(session) &&
+            session.terminalId &&
+            !liveTerminalIds.has(session.terminalId)
+        ) {
+            void chat.deleteSession(session.sessionId);
+        }
+    }
+}
+
+// Register (or update) the Agents-sidebar entry for a Claude Code terminal.
+// Idempotent: the session id is derived from the terminal id.
+export function registerClaudeTerminalAgentSession(args: {
+    terminalId: string;
+    title: string;
+}) {
+    installPruneSubscription();
+
+    const sessionId = sessionIdForTerminal(args.terminalId);
+    const session: AIChatSession = {
+        sessionId,
+        historySessionId: sessionId,
+        runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+        terminalId: args.terminalId,
+        vaultPath: useVaultStore.getState().vaultPath ?? null,
+        status: "idle",
+        modelId: "",
+        modeId: "",
+        models: [],
+        modes: [],
+        configOptions: [],
+        messages: [],
+        attachments: [],
+        customTitle: args.title,
+    };
+
+    // activate:false so launching a terminal doesn't hijack the active chat;
+    // allowUnknownSession so this brand-new entry is admitted to the list.
+    const previousActiveSessionId = useChatStore.getState().activeSessionId;
+    useChatStore.getState().upsertSession(session, false, {
+        allowUnknownSession: true,
+    });
+    // upsertSession makes a session active when none was — but a terminal agent
+    // is never a real chat target, so keep the prior active session.
+    if (
+        previousActiveSessionId !== sessionId &&
+        useChatStore.getState().activeSessionId === sessionId
+    ) {
+        useChatStore.setState({ activeSessionId: previousActiveSessionId });
+    }
+}
+
+// Focus the terminal tab backing a Claude Code agent entry. Returns false if no
+// matching terminal tab exists (e.g. it was closed between render and click).
+export function focusClaudeTerminalAgentSession(
+    session: Pick<AIChatSession, "terminalId">,
+): boolean {
+    if (!session.terminalId) return false;
+    const tab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (candidate) =>
+            isTerminalTab(candidate) &&
+            candidate.terminalId === session.terminalId,
+    );
+    if (!tab) return false;
+    useEditorStore.getState().switchTab(tab.id);
+    return true;
+}

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -33,6 +33,7 @@ interface TerminalAgentEntry {
     // Latest transcript-derived values, re-applied if the session is rebuilt.
     title: string | null;
     preview: string | null;
+    customTitle: string | null;
     updatedAt: number;
     lastMtimeMs: number | null;
 }
@@ -67,9 +68,10 @@ function buildSession(entry: TerminalAgentEntry): AIChatSession {
         configOptions: [],
         messages: [],
         attachments: [],
-        // persistedTitle (not customTitle) so a manual rename still wins and the
-        // transcript-derived title can fill in over the default label.
+        // persistedTitle carries the transcript/default title; customTitle
+        // mirrors sidebar renames so re-asserted entries keep the user's label.
         persistedTitle: entry.title ?? entry.defaultTitle,
+        customTitle: entry.customTitle,
         persistedPreview: entry.preview,
         persistedCreatedAt: entry.createdAt,
         persistedUpdatedAt: entry.updatedAt,
@@ -113,7 +115,9 @@ function reconcileAgentSessions() {
         }
         if (!chat.sessionsById[sessionId]) {
             upsertAgentSession(entry);
+            continue;
         }
+        syncTerminalAgentCustomTitle(entry, chat.sessionsById[sessionId]);
     }
     stopTranscriptPollingIfIdle();
 }
@@ -151,8 +155,62 @@ function stopTranscriptPollingIfIdle() {
     }
 }
 
+function updateTerminalTabTitle(terminalId: string, nextTitle: string) {
+    const tab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (candidate) =>
+            isTerminalTab(candidate) && candidate.terminalId === terminalId,
+    );
+    if (!tab || tab.title === nextTitle) return;
+
+    useEditorStore.getState().updateTabTitle(tab.id, nextTitle);
+}
+
+function syncTerminalTabTitleFromTranscript(
+    entry: TerminalAgentEntry,
+    nextTitle: string,
+    previousTitle: string | null,
+) {
+    const tab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (candidate) =>
+            isTerminalTab(candidate) && candidate.terminalId === entry.terminalId,
+    );
+    if (!tab || tab.title === nextTitle) return;
+
+    const titleIsStillAutomatic =
+        tab.title === entry.defaultTitle ||
+        (previousTitle != null && tab.title === previousTitle);
+    if (!titleIsStillAutomatic) return;
+
+    useEditorStore.getState().updateTabTitle(tab.id, nextTitle);
+}
+
+function syncTerminalAgentCustomTitle(
+    entry: TerminalAgentEntry,
+    session: AIChatSession | undefined,
+) {
+    const nextCustomTitle = session?.customTitle?.trim() || null;
+    if (entry.customTitle === nextCustomTitle) return;
+
+    const previousCustomTitle = entry.customTitle;
+    entry.customTitle = nextCustomTitle;
+
+    const nextTabTitle = nextCustomTitle ?? entry.title ?? entry.defaultTitle;
+    if (nextCustomTitle) {
+        updateTerminalTabTitle(entry.terminalId, nextTabTitle);
+        return;
+    }
+
+    const tab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (candidate) =>
+            isTerminalTab(candidate) && candidate.terminalId === entry.terminalId,
+    );
+    if (previousCustomTitle && tab?.title === previousCustomTitle) {
+        useEditorStore.getState().updateTabTitle(tab.id, nextTabTitle);
+    }
+}
+
 // Poll Claude Code's transcript for each tracked terminal and refresh the agent
-// entry's title (first prompt) and preview (latest answer).
+// entry's title (first prompt), preview (latest answer), and terminal tab title.
 export async function refreshClaudeTerminalAgentTranscripts() {
     for (const entry of [...agentsByTerminalId.values()]) {
         if (!entry.cwd || !entry.transcriptSessionId) continue;
@@ -182,7 +240,11 @@ export async function refreshClaudeTerminalAgentTranscripts() {
         if (result.mtimeMs != null) entry.lastMtimeMs = result.mtimeMs;
         if (!result.title && !result.preview) continue;
 
-        if (result.title) entry.title = result.title;
+        if (result.title) {
+            const previousTitle = entry.title;
+            entry.title = result.title;
+            syncTerminalTabTitleFromTranscript(entry, result.title, previousTitle);
+        }
         if (result.preview) entry.preview = result.preview;
         entry.updatedAt = Date.now();
 
@@ -228,6 +290,7 @@ export function registerClaudeTerminalAgentSession(args: {
         createdAt: existing?.createdAt ?? now,
         title: existing?.title ?? null,
         preview: existing?.preview ?? null,
+        customTitle: existing?.customTitle ?? null,
         updatedAt: existing?.updatedAt ?? now,
         lastMtimeMs: existing?.lastMtimeMs ?? null,
     };

--- a/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
+++ b/apps/desktop/src/features/ai/claudeTerminalAgentSession.ts
@@ -1,3 +1,4 @@
+import { invoke } from "@neverwrite/runtime";
 import {
     selectEditorWorkspaceTabs,
     useEditorStore,
@@ -12,9 +13,31 @@ import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
 // Claude Code launched in a terminal has no ACP backend session, so it never
 // appears in the Agents sidebar on its own. We register a lightweight,
 // non-persisted chat session entry for it, linked to the terminal via
-// `terminalId`. The entry is removed when its terminal goes away.
+// `terminalId`, and keep its title/preview in sync with Claude Code's own
+// on-disk session transcript. The entry is removed when its terminal closes.
 
 const SESSION_ID_PREFIX = "claude-terminal:";
+const TRANSCRIPT_POLL_INTERVAL_MS = 4_000;
+
+interface TranscriptInfo {
+    cwd: string;
+    // Claude session UUID when we pinned it at launch (--session-id); null means
+    // fall back to the most recently modified transcript in the project dir.
+    transcriptSessionId: string | null;
+    lastMtimeMs: number | null;
+}
+
+interface ClaudeTranscriptResult {
+    found: boolean;
+    changed: boolean;
+    mtimeMs: number | null;
+    title: string | null;
+    preview: string | null;
+}
+
+const transcriptInfoByTerminalId = new Map<string, TranscriptInfo>();
+let pollTimer: ReturnType<typeof setInterval> | null = null;
+let pruneUnsubscribe: (() => void) | null = null;
 
 function sessionIdForTerminal(terminalId: string) {
     return `${SESSION_ID_PREFIX}${terminalId}`;
@@ -26,16 +49,13 @@ export function isClaudeTerminalAgentSession(
     return session.runtimeId === CLAUDE_TERMINAL_RUNTIME_ID;
 }
 
-let pruneSubscriptionInstalled = false;
-
 function installPruneSubscription() {
-    if (pruneSubscriptionInstalled) return;
-    pruneSubscriptionInstalled = true;
-    // Terminal lifecycle drives the agent entry: when a terminal runtime is
-    // gone (tab closed), drop its agent session. Firing on every terminal
-    // store change is cheap — prune only touches the handful of claude-terminal
+    if (pruneUnsubscribe) return;
+    // Terminal lifecycle drives the agent entry: when a terminal runtime is gone
+    // (tab closed), drop its agent session. Firing on every terminal store
+    // change is cheap — prune only touches the handful of claude-terminal
     // sessions.
-    useTerminalRuntimeStore.subscribe(() => {
+    pruneUnsubscribe = useTerminalRuntimeStore.subscribe(() => {
         pruneClaudeTerminalAgentSessions();
     });
 }
@@ -52,16 +72,86 @@ export function pruneClaudeTerminalAgentSessions() {
             session.terminalId &&
             !liveTerminalIds.has(session.terminalId)
         ) {
+            transcriptInfoByTerminalId.delete(session.terminalId);
             void chat.deleteSession(session.sessionId);
         }
     }
+    stopTranscriptPollingIfIdle();
+}
+
+function ensureTranscriptPolling() {
+    if (pollTimer || transcriptInfoByTerminalId.size === 0) return;
+    pollTimer = setInterval(() => {
+        void refreshClaudeTerminalAgentTranscripts();
+    }, TRANSCRIPT_POLL_INTERVAL_MS);
+}
+
+function stopTranscriptPollingIfIdle() {
+    if (pollTimer && transcriptInfoByTerminalId.size === 0) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+}
+
+// Poll Claude Code's transcript for each tracked terminal and refresh the agent
+// entry's title (first prompt) and preview (latest answer). Reads are skipped at
+// the backend when the file hasn't changed since the last read.
+export async function refreshClaudeTerminalAgentTranscripts() {
+    const chat = useChatStore.getState();
+    for (const [terminalId, info] of [...transcriptInfoByTerminalId]) {
+        const sessionId = sessionIdForTerminal(terminalId);
+        if (!chat.sessionsById[sessionId]) {
+            transcriptInfoByTerminalId.delete(terminalId);
+            continue;
+        }
+
+        let result: ClaudeTranscriptResult;
+        try {
+            result = await invoke<ClaudeTranscriptResult>(
+                "devtools_read_claude_transcript",
+                {
+                    input: {
+                        sessionId: info.transcriptSessionId,
+                        cwd: info.cwd,
+                        sinceMtimeMs: info.lastMtimeMs,
+                    },
+                },
+            );
+        } catch {
+            continue;
+        }
+
+        if (!result?.changed) continue;
+        if (result.mtimeMs != null) info.lastMtimeMs = result.mtimeMs;
+        if (!result.title && !result.preview) continue;
+
+        useChatStore.setState((state) => {
+            const session = state.sessionsById[sessionId];
+            if (!session) return state;
+            return {
+                sessionsById: {
+                    ...state.sessionsById,
+                    [sessionId]: {
+                        ...session,
+                        persistedTitle: result.title ?? session.persistedTitle,
+                        persistedPreview:
+                            result.preview ?? session.persistedPreview,
+                    },
+                },
+            };
+        });
+    }
+    stopTranscriptPollingIfIdle();
 }
 
 // Register (or update) the Agents-sidebar entry for a Claude Code terminal.
-// Idempotent: the session id is derived from the terminal id.
+// Idempotent: the session id is derived from the terminal id. Pass the cwd (and
+// the pinned session id, if any) to enable transcript-driven title/preview.
 export function registerClaudeTerminalAgentSession(args: {
     terminalId: string;
     title: string;
+    transcriptSessionId?: string | null;
+    cwd?: string | null;
 }) {
     installPruneSubscription();
 
@@ -80,7 +170,10 @@ export function registerClaudeTerminalAgentSession(args: {
         configOptions: [],
         messages: [],
         attachments: [],
-        customTitle: args.title,
+        // Default label until the transcript yields the first prompt. Use
+        // persistedTitle (not customTitle) so a manual rename still wins and the
+        // transcript-derived title can fill in over it.
+        persistedTitle: args.title,
     };
 
     // activate:false so launching a terminal doesn't hijack the active chat;
@@ -96,6 +189,16 @@ export function registerClaudeTerminalAgentSession(args: {
         useChatStore.getState().activeSessionId === sessionId
     ) {
         useChatStore.setState({ activeSessionId: previousActiveSessionId });
+    }
+
+    if (args.cwd) {
+        transcriptInfoByTerminalId.set(args.terminalId, {
+            cwd: args.cwd,
+            transcriptSessionId: args.transcriptSessionId ?? null,
+            lastMtimeMs: null,
+        });
+        ensureTranscriptPolling();
+        void refreshClaudeTerminalAgentTranscripts();
     }
 }
 
@@ -113,4 +216,14 @@ export function focusClaudeTerminalAgentSession(
     if (!tab) return false;
     useEditorStore.getState().switchTab(tab.id);
     return true;
+}
+
+export function resetClaudeTerminalAgentSessionsForTests() {
+    transcriptInfoByTerminalId.clear();
+    if (pollTimer) {
+        clearInterval(pollTimer);
+        pollTimer = null;
+    }
+    pruneUnsubscribe?.();
+    pruneUnsubscribe = null;
 }

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -12111,6 +12111,65 @@ describe("chatStore", () => {
         );
     });
 
+    it("does not create a replacement ACP session when deleting the last Claude terminal entry", async () => {
+        const terminalSession: AIChatSession = {
+            sessionId: "claude-terminal:term-1",
+            historySessionId: "claude-terminal:term-1",
+            runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+            terminalId: "term-1",
+            modelId: "",
+            modeId: "",
+            status: "idle",
+            models: [],
+            modes: [],
+            configOptions: [],
+            messages: [],
+            attachments: [],
+        };
+
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: {
+                        id: CLAUDE_TERMINAL_RUNTIME_ID,
+                        name: "Claude Code",
+                        description: "Claude Code terminal pseudo-runtime",
+                        capabilities: ["attachments"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                [CLAUDE_TERMINAL_RUNTIME_ID]: {
+                    ...readySetupStatusState,
+                    runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                },
+            },
+            sessionsById: {
+                [terminalSession.sessionId]: terminalSession,
+            },
+            sessionOrder: [terminalSession.sessionId],
+            activeSessionId: terminalSession.sessionId,
+            lastFocusedSessionId: terminalSession.sessionId,
+            selectedRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+        });
+
+        await useChatStore.getState().deleteSession(terminalSession.sessionId);
+
+        expect(useChatStore.getState().sessionsById).toEqual({});
+        expect(useChatStore.getState().sessionOrder).toEqual([]);
+        expect(invokeMock).not.toHaveBeenCalledWith(
+            "ai_get_setup_status",
+            expect.anything(),
+        );
+        expect(invokeMock).not.toHaveBeenCalledWith(
+            "ai_create_session",
+            expect.anything(),
+        );
+    });
+
     it("removes chat tabs when deleting a session", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -10865,6 +10865,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
         deleteSession: async (sessionId) => {
             const vaultPath = useVaultStore.getState().vaultPath;
             const targetSession = get().sessionsById[sessionId];
+            const shouldCreateReplacementSession =
+                !targetSession ||
+                !isClaudeTerminalRuntimeId(targetSession.runtimeId);
             const historySessionId =
                 targetSession?.historySessionId ?? sessionId;
             clearStaleStreamingCheck(sessionId);
@@ -10957,10 +10960,12 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 interruptedTurnStateBySessionId:
                     nextInterruptedTurnStateBySessionId,
             });
-            if (nextActiveId && !nextSessionsById[nextActiveId]) {
-                await get().newSession();
-            } else if (Object.keys(nextSessionsById).length === 0) {
-                await get().newSession();
+            if (shouldCreateReplacementSession) {
+                if (nextActiveId && !nextSessionsById[nextActiveId]) {
+                    await get().newSession();
+                } else if (Object.keys(nextSessionsById).length === 0) {
+                    await get().newSession();
+                }
             }
         },
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -8640,6 +8640,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const state = get();
             const session = state.sessionsById[sessionId];
             if (!session) return null;
+            // The claude-code-terminal pseudo-runtime has no ACP backend, so it
+            // can't be resumed — attempting it errors ("AI session not found")
+            // and flips the entry into a bogus reconnecting state.
+            if (isClaudeTerminalRuntimeId(session.runtimeId)) return sessionId;
             if (session.isPendingSessionCreation) return sessionId;
             if (isLiveRuntimeSession(session)) return sessionId;
             if (session.isResumingSession) return sessionId;

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -341,6 +341,12 @@ export interface AIChatSession {
     historySessionId: string;
     parentSessionId?: string | null;
     runtimeSessionId?: string | null;
+    /**
+     * For the "claude-code-terminal" pseudo-runtime: the terminal runtime this
+     * agent entry stands in for. Clicking the entry focuses that terminal tab
+     * instead of opening an ACP chat pane. Unset for real ACP sessions.
+     */
+    terminalId?: string | null;
     vaultPath?: string | null;
     status: AIChatSessionStatus;
     activeWorkCycleId?: string | null;

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
@@ -137,6 +137,10 @@ describe("openClaudeCodeTerminalWithContext", () => {
             "cd '/vault root'\n",
             "claude --dangerously-skip-permissions --model claude-sonnet-4-6 --continue --max-turns 7\n",
         ]);
+        expect(vi.mocked(invoke)).not.toHaveBeenCalledWith(
+            "devtools_read_claude_transcript",
+            expect.anything(),
+        );
     });
 
     it("ignores unsupported persisted Claude Code models before writing to the shell", async () => {

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
@@ -7,7 +7,9 @@ import {
 import { isTerminalTab } from "../../app/store/editorTabs";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
+import { resetClaudeTerminalAgentSessionsForTests } from "../ai/claudeTerminalAgentSession";
 import type { FileTreeNoteDragDetail } from "../ai/dragEvents";
+import { resetChatStore } from "../ai/store/chatStore";
 import type { TerminalSessionSnapshot } from "./terminalTypes";
 import { openClaudeCodeTerminalWithContext } from "./claudeCodeTerminal";
 import {
@@ -79,10 +81,16 @@ function getWrittenInputs() {
         });
 }
 
+const FIXED_SESSION_UUID = "2198181b-9c2d-4c4b-b646-0c219657a6ff";
+
 describe("openClaudeCodeTerminalWithContext", () => {
     beforeEach(() => {
         vi.useRealTimers();
         vi.mocked(invoke).mockClear();
+        // Deterministic --session-id so command assertions are stable.
+        vi.spyOn(crypto, "randomUUID").mockReturnValue(FIXED_SESSION_UUID);
+        resetClaudeTerminalAgentSessionsForTests();
+        resetChatStore();
         useSettingsStore.getState().reset();
         useVaultStore.setState({ vaultPath: "/vault root" });
         useEditorStore.getState().hydrateWorkspace(
@@ -100,6 +108,9 @@ describe("openClaudeCodeTerminalWithContext", () => {
 
     afterEach(() => {
         vi.useRealTimers();
+        vi.restoreAllMocks();
+        resetClaudeTerminalAgentSessionsForTests();
+        resetChatStore();
         resetTerminalRuntimeStoreForTests();
     });
 
@@ -197,7 +208,7 @@ describe("openClaudeCodeTerminalWithContext", () => {
 
         expect(getWrittenInputs()).toEqual([
             "cd '/vault root/Draft Folder'\n",
-            "claude\n",
+            `claude --session-id ${FIXED_SESSION_UUID}\n`,
             [
                 '@"Project Notes/One note.md"',
                 '@"assets/chart (v1).png"',

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
@@ -6,6 +6,7 @@ import {
 import { isTerminalTab } from "../../app/store/editorTabs";
 import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
+import { registerClaudeTerminalAgentSession } from "../ai/claudeTerminalAgentSession";
 import type { FileTreeNoteDragDetail } from "../ai/dragEvents";
 import { useTerminalRuntimeStore } from "./terminalRuntimeStore";
 
@@ -191,6 +192,10 @@ export async function openClaudeCodeTerminalWithContext(
     const { terminalId } = tab;
     const ready = await waitForTerminalRunning(terminalId);
     if (!ready) return;
+
+    // Surface this terminal in the Agents sidebar. The entry is non-persisted
+    // and removed when the terminal tab closes.
+    registerClaudeTerminalAgentSession({ terminalId, title: tab.title });
 
     const store = useTerminalRuntimeStore.getState();
 

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
@@ -204,22 +204,23 @@ export async function openClaudeCodeTerminalWithContext(
         claudeCodeMaxTurns,
     } = useSettingsStore.getState();
 
-    // claude runs in cdTarget after the cd below, so that's where it writes its
-    // session transcript. Fall back to the vault / the terminal's spawn cwd.
-    const cdTarget = resolveCdTarget(detail, vaultPath);
-    const transcriptCwd =
-        cdTarget ??
-        vaultPath ??
-        store.runtimesById[terminalId]?.snapshot.cwd ??
-        null;
-
     // Pin a fresh session id so we can locate this terminal's transcript exactly.
     // --session-id can't combine with --continue (which resumes an existing
-    // session we can't name up front), so skip pinning in that case and fall
-    // back to the newest transcript in the project dir.
+    // session we can't name up front), so transcript-derived title/preview are
+    // disabled in that case rather than guessed from another terminal's JSONL.
     const pinnedSessionId = claudeCodeContinueSession
         ? null
         : crypto.randomUUID();
+
+    // claude runs in cdTarget after the cd below, so that's where it writes its
+    // session transcript. Fall back to the vault / the terminal's spawn cwd.
+    const cdTarget = resolveCdTarget(detail, vaultPath);
+    const transcriptCwd = pinnedSessionId
+        ? (cdTarget ??
+          vaultPath ??
+          store.runtimesById[terminalId]?.snapshot.cwd ??
+          null)
+        : null;
 
     // Surface this terminal in the Agents sidebar, with title (first prompt) and
     // preview (latest answer) sourced from the Claude Code transcript. The entry

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
@@ -193,21 +193,7 @@ export async function openClaudeCodeTerminalWithContext(
     const ready = await waitForTerminalRunning(terminalId);
     if (!ready) return;
 
-    // Surface this terminal in the Agents sidebar. The entry is non-persisted
-    // and removed when the terminal tab closes.
-    registerClaudeTerminalAgentSession({ terminalId, title: tab.title });
-
     const store = useTerminalRuntimeStore.getState();
-
-    // cd into the target directory so the user can see where claude starts,
-    // and so relative @mentions resolve correctly.
-    const cdTarget = resolveCdTarget(detail, vaultPath);
-    if (cdTarget) {
-        // Single-quote the path so $, backticks, and backslash are inert.
-        // Escape any embedded single quotes as '\'' (end-quote, literal, re-open).
-        const cdQuoted = `'${cdTarget.replace(/'/g, "'\\''")}'`;
-        await store.writeInput(terminalId, `cd ${cdQuoted}\n`);
-    }
 
     // Build the claude command from settings. Treat persisted settings as data,
     // not trusted shell text, before writing into the interactive PTY.
@@ -218,8 +204,45 @@ export async function openClaudeCodeTerminalWithContext(
         claudeCodeMaxTurns,
     } = useSettingsStore.getState();
 
+    // claude runs in cdTarget after the cd below, so that's where it writes its
+    // session transcript. Fall back to the vault / the terminal's spawn cwd.
+    const cdTarget = resolveCdTarget(detail, vaultPath);
+    const transcriptCwd =
+        cdTarget ??
+        vaultPath ??
+        store.runtimesById[terminalId]?.snapshot.cwd ??
+        null;
+
+    // Pin a fresh session id so we can locate this terminal's transcript exactly.
+    // --session-id can't combine with --continue (which resumes an existing
+    // session we can't name up front), so skip pinning in that case and fall
+    // back to the newest transcript in the project dir.
+    const pinnedSessionId = claudeCodeContinueSession
+        ? null
+        : crypto.randomUUID();
+
+    // Surface this terminal in the Agents sidebar, with title (first prompt) and
+    // preview (latest answer) sourced from the Claude Code transcript. The entry
+    // is non-persisted and removed when the terminal tab closes.
+    registerClaudeTerminalAgentSession({
+        terminalId,
+        title: tab.title,
+        transcriptSessionId: pinnedSessionId,
+        cwd: transcriptCwd,
+    });
+
+    // cd into the target directory so the user can see where claude starts,
+    // and so relative @mentions resolve correctly.
+    if (cdTarget) {
+        // Single-quote the path so $, backticks, and backslash are inert.
+        // Escape any embedded single quotes as '\'' (end-quote, literal, re-open).
+        const cdQuoted = `'${cdTarget.replace(/'/g, "'\\''")}'`;
+        await store.writeInput(terminalId, `cd ${cdQuoted}\n`);
+    }
+
     const args = ["claude"];
     if (claudeCodeSkipPermissions) args.push("--dangerously-skip-permissions");
+    if (pinnedSessionId) args.push("--session-id", pinnedSessionId);
     const safeModel = getSafeClaudeCodeModel(claudeCodeModel);
     if (safeModel) args.push("--model", safeModel);
     if (claudeCodeContinueSession) args.push("--continue");


### PR DESCRIPTION
## Summary

Claude Code launched in a terminal had no presence in the Agents sidebar — the launcher just wrote to the PTY. This adds a first-class sidebar entry for each launcher-started Claude Code terminal, with its title and preview sourced live from Claude Code's own session transcript.

What you get:
- A sidebar entry appears when you open Claude Code, at the top like a fresh chat.
- **Title = the first prompt, preview = the latest answer**, refreshed every few seconds from the transcript.
- Clicking (or dragging) the entry **focuses its terminal tab** instead of opening an ACP chat.
- The entry shows as **selected** when its terminal tab is focused, sits under **Open** while the tab is open, and is **removed** when the tab closes.

## How it works

- **Entry**: a lightweight, non-persisted `AIChatSession` with `runtimeId: "claude-code-terminal"`, linked to the terminal via a new `terminalId` field. Never becomes the active chat session; never written to disk (no messages).
- **Topic**: the launcher pins `claude --session-id <uuid>` (skipped under `--continue`), and a new backend command `devtools_read_claude_transcript` reads `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, extracting the first user text and last assistant text. Parsing is defensive (skips unparseable lines, sidechain/meta, tool/thinking blocks) with an mtime guard; it degrades to the static "Claude Code N" label if anything's missing. The command is allow-listed in the Electron sidecar bridge and routed to the Rust backend.
- **Robustness**: chatStore is rebuilt from the backend on several events (init, runtime reconnect), which would drop a client-only entry. The entry is backed by a registry of live terminals and **self-heals** — re-asserted if a rebuild drops it while its terminal is alive, removed when the terminal closes. `resumeSession` and the workspace-open paths are guarded so the pseudo-runtime never hits the ACP backend ("AI session not found").

## Tests

- TS: register/idempotency/focus, transcript-driven title/preview + not-yet-written fallback, workspace-open focuses the terminal (no chat tab), and a self-heal regression test (a store rebuild that drops the entry is recovered).
- Rust: transcript path encoding and first-prompt/last-answer extraction, including garbage-line tolerance.
- Full desktop suite green; lint and typecheck clean.

## Note on stacking

This is **stacked on #173** (the xterm direct-pipe rewrite) — it builds on the same terminal subsystem and was developed/tested against it. Until #173 merges, the first commit here is the redraw rewrite from that PR; once #173 lands I'll rebase this onto `main` so it shows only the Agents-tab commits. Review the four `…terminal agent…` commits for this PR's scope.

## Known limits

- Launcher-only: typing `claude` manually in a plain terminal isn't detected.
- After a full reload, a restored Claude Code terminal tab won't re-list itself (the entry is intentionally non-persisted).
- Transcript location/`--session-id` are documented contracts; the JSONL schema is internal, so the reader is defensive and degrades gracefully.