### PR TITLE
Adjust screenshot retention options

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -788,6 +788,52 @@ describe("AIChatComposer mention picker", () => {
         });
     });
 
+    it("resyncs screenshot metadata when the visible label is unchanged", () => {
+        const label = "Screenshot 10:42 hrs";
+        const baseProps = {
+            notes: [],
+            status: "idle" as const,
+            runtimeName: "Assistant",
+            composerFontFamily: "system" as const,
+            availableCommands: [],
+            onChange: vi.fn(),
+            onMentionAttach: vi.fn(),
+            onFolderAttach: vi.fn(),
+            onSubmit: vi.fn(),
+            onStop: vi.fn(),
+        };
+        const legacyScreenshot: Extract<
+            AIComposerPart,
+            { type: "screenshot" }
+        > = {
+            id: "shot-1",
+            type: "screenshot",
+            filePath: "/vault/assets/chat/shot.png",
+            mimeType: "image/png",
+            label,
+        };
+        const legacyParts: AIComposerPart[] = [legacyScreenshot];
+        const timestampedParts: AIComposerPart[] = [
+            {
+                ...legacyScreenshot,
+                createdAt: 5_000,
+            },
+        ];
+
+        const { rerender } = renderComponent(
+            <AIChatComposer {...baseProps} parts={legacyParts} />,
+        );
+
+        expect(screen.getByText(label)).not.toHaveAttribute("data-created-at");
+
+        rerender(<AIChatComposer {...baseProps} parts={timestampedParts} />);
+
+        expect(screen.getByText(label)).toHaveAttribute(
+            "data-created-at",
+            "5000",
+        );
+    });
+
     it("applies the selected composer font family to the textbox", () => {
         const { composer } = renderComposer({
             composerFontFamily: "serif",

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -518,6 +518,79 @@ function readPartsFromDom(root: HTMLElement): AIComposerPart[] {
     return normalizeComposerParts(normalized);
 }
 
+function assertNeverComposerPart(part: never): never {
+    throw new Error(`Unsupported composer part: ${JSON.stringify(part)}`);
+}
+
+function getComposerPartsDomSignature(parts: AIComposerPart[]) {
+    return JSON.stringify(
+        parts.map((part) => {
+            if (part.type === "text") {
+                return { type: part.type, text: part.text };
+            }
+            if (part.type === "mention") {
+                return {
+                    type: part.type,
+                    noteId: part.noteId,
+                    label: part.label,
+                    path: part.path,
+                };
+            }
+            if (part.type === "file_mention") {
+                return {
+                    type: part.type,
+                    label: part.label,
+                    path: part.path,
+                    relativePath: part.relativePath,
+                    mimeType: part.mimeType ?? null,
+                };
+            }
+            if (part.type === "folder_mention") {
+                return {
+                    type: part.type,
+                    folderPath: part.folderPath,
+                    label: part.label,
+                };
+            }
+            if (part.type === "fetch_mention") {
+                return { type: part.type };
+            }
+            if (part.type === "plan_mention") {
+                return { type: part.type };
+            }
+            if (part.type === "selection_mention") {
+                return {
+                    type: part.type,
+                    noteId: part.noteId ?? null,
+                    label: part.label,
+                    path: part.path,
+                    selectedText: part.selectedText,
+                    startLine: part.startLine,
+                    endLine: part.endLine,
+                };
+            }
+            if (part.type === "screenshot") {
+                return {
+                    type: part.type,
+                    filePath: part.filePath,
+                    mimeType: part.mimeType,
+                    label: part.label,
+                    createdAt: part.createdAt ?? null,
+                };
+            }
+            if (part.type === "file_attachment") {
+                return {
+                    type: part.type,
+                    filePath: part.filePath,
+                    mimeType: part.mimeType,
+                    label: part.label,
+                };
+            }
+            return assertNeverComposerPart(part);
+        }),
+    );
+}
+
 function setCaretAfterNode(node: Node) {
     const selection = window.getSelection();
     if (!selection) return;
@@ -1021,6 +1094,10 @@ export function AIChatComposer({
         () => serializeComposerParts(parts),
         [parts],
     );
+    const partsDomSignature = useMemo(
+        () => getComposerPartsDomSignature(parts),
+        [parts],
+    );
     const folderPaths = useMemo(
         () => extractFolderPaths(notes, fallbackEntries),
         [fallbackEntries, notes],
@@ -1104,15 +1181,15 @@ export function AIChatComposer({
         if (!composer) return;
 
         if (
-            serializeComposerParts(readPartsFromDom(composer)) ===
-                serializedValue &&
+            getComposerPartsDomSignature(readPartsFromDom(composer)) ===
+                partsDomSignature &&
             composer.dataset.pillMetricsSignature === pillMetricsSignature
         ) {
             return;
         }
 
         syncComposerDom(composer, parts, pillMetrics, pillMetricsSignature);
-    }, [parts, pillMetrics, pillMetricsSignature, serializedValue]);
+    }, [parts, partsDomSignature, pillMetrics, pillMetricsSignature]);
 
     const isStreaming = status === "streaming";
     const isStopTransitionActive = isStopping || hasPendingSubmitAfterStop;

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -337,6 +337,9 @@ function createScreenshotNode(
     element.dataset.filePath = part.filePath;
     element.dataset.mimeType = part.mimeType;
     element.dataset.label = part.label;
+    if (part.createdAt != null) {
+        element.dataset.createdAt = String(part.createdAt);
+    }
     element.contentEditable = "false";
     element.textContent = part.label;
     applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.file);
@@ -465,6 +468,9 @@ function readPartsFromNode(node: Node, parts: AIComposerPart[]) {
             filePath: node.dataset.filePath,
             mimeType: node.dataset.mimeType,
             label: node.dataset.label,
+            createdAt: node.dataset.createdAt
+                ? Number(node.dataset.createdAt)
+                : undefined,
         });
         return;
     }

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -107,4 +107,41 @@ describe("AIChatSessionView", () => {
 
         expect(screen.getByText("Renamed workspace chat")).toBeInTheDocument();
     });
+
+    it("removes expired screenshots from the composer", async () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                "session-a": createSession("session-a", "Workspace chat"),
+            },
+            activeSessionId: "session-a",
+            screenshotRetentionSeconds: 60,
+            composerPartsBySessionId: {
+                "session-a": [
+                    { id: "text-1", type: "text", text: "Review " },
+                    {
+                        id: "shot-1",
+                        type: "screenshot",
+                        filePath: "/vault/assets/chat/old.png",
+                        mimeType: "image/png",
+                        label: "Screenshot 10:42 hrs",
+                        createdAt: Date.now() - 61_000,
+                    },
+                    { id: "text-2", type: "text", text: " please" },
+                ],
+            },
+        }));
+        useEditorStore.getState().openChat("session-a", {
+            title: "Workspace chat",
+            paneId: "primary",
+        });
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().composerPartsBySessionId["session-a"],
+            ).toEqual([{ id: "text-1", type: "text", text: "Review  please" }]);
+        });
+    });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -43,6 +43,11 @@ import {
     createEmptyComposerParts,
 } from "../composerParts";
 import {
+    getNextScreenshotExpiryDelayMs,
+    normalizeScreenshotPartTimestamps,
+    pruneExpiredScreenshotParts,
+} from "../screenshotRetention";
+import {
     findSessionForHistorySelection,
     getSessionTitle,
     getSessionTitleText,
@@ -81,6 +86,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         queuedMessageEdit,
         interruptedTurnState,
         tokenUsage,
+        screenshotRetentionSeconds,
     } = useChatStore(
         useShallow((state) => {
             const s = sessionId
@@ -113,6 +119,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 tokenUsage: sid
                     ? (state.tokenUsageBySessionId[sid] ?? null)
                     : null,
+                screenshotRetentionSeconds: state.screenshotRetentionSeconds,
             };
         }),
     );
@@ -317,6 +324,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                         filePath: saved.path,
                         mimeType: saved.mime_type ?? file.type,
                         label: timeLabel,
+                        createdAt: now.getTime(),
                     }),
                     sessionId,
                 );
@@ -326,6 +334,62 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         },
         [chatActions, refreshEntries, sessionId],
     );
+
+    useEffect(() => {
+        if (!sessionId || screenshotRetentionSeconds <= 0) return;
+
+        const now = Date.now();
+        const normalizedParts = normalizeScreenshotPartTimestamps(
+            composerParts,
+            now,
+        );
+        const prunedParts = pruneExpiredScreenshotParts(
+            normalizedParts,
+            screenshotRetentionSeconds,
+            now,
+        );
+
+        if (prunedParts !== composerParts) {
+            chatActions.setComposerParts(prunedParts, sessionId);
+            return;
+        }
+
+        const nextDelay = getNextScreenshotExpiryDelayMs(
+            composerParts,
+            screenshotRetentionSeconds,
+            now,
+        );
+        if (nextDelay == null) return;
+
+        const timer = window.setTimeout(() => {
+            const state = useChatStore.getState();
+            const currentParts =
+                state.composerPartsBySessionId[sessionId] ??
+                createEmptyComposerParts();
+            const currentRetentionSeconds = state.screenshotRetentionSeconds;
+            const currentNow = Date.now();
+            const normalizedCurrentParts = normalizeScreenshotPartTimestamps(
+                currentParts,
+                currentNow,
+            );
+            const nextParts = pruneExpiredScreenshotParts(
+                normalizedCurrentParts,
+                currentRetentionSeconds,
+                currentNow,
+            );
+
+            if (nextParts !== currentParts) {
+                state.setComposerParts(nextParts, sessionId);
+            }
+        }, nextDelay);
+
+        return () => window.clearTimeout(timer);
+    }, [
+        chatActions,
+        composerParts,
+        screenshotRetentionSeconds,
+        sessionId,
+    ]);
 
     // Title sync: keep the editor tab title in sync with session title
     useEffect(() => {

--- a/apps/desktop/src/features/ai/composerParts.ts
+++ b/apps/desktop/src/features/ai/composerParts.ts
@@ -297,7 +297,12 @@ export function appendSelectionMentionPart(
 
 export function appendScreenshotPart(
     parts: AIComposerPart[],
-    screenshot: { filePath: string; mimeType: string; label: string },
+    screenshot: {
+        filePath: string;
+        mimeType: string;
+        label: string;
+        createdAt?: number;
+    },
 ): AIComposerPart[] {
     const next = [...parts];
 
@@ -315,6 +320,7 @@ export function appendScreenshotPart(
         id: crypto.randomUUID(),
         type: "screenshot",
         ...screenshot,
+        createdAt: screenshot.createdAt ?? Date.now(),
     });
     next.push({ id: crypto.randomUUID(), type: "text", text: " " });
 

--- a/apps/desktop/src/features/ai/screenshotRetention.test.ts
+++ b/apps/desktop/src/features/ai/screenshotRetention.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+    DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+    normalizeScreenshotPartTimestamps,
+    normalizeScreenshotRetentionSeconds,
+    pruneExpiredScreenshotParts,
+} from "./screenshotRetention";
+import type { AIComposerPart } from "./types";
+
+describe("screenshot retention", () => {
+    it("migrates removed retention values upward to supported options", () => {
+        expect(normalizeScreenshotRetentionSeconds(30)).toBe(60);
+        expect(normalizeScreenshotRetentionSeconds(900)).toBe(1800);
+        expect(normalizeScreenshotRetentionSeconds(0)).toBe(0);
+        expect(normalizeScreenshotRetentionSeconds(undefined)).toBe(
+            DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+        );
+    });
+
+    it("removes expired screenshots without dropping surrounding text", () => {
+        const parts: AIComposerPart[] = [
+            { id: "text-1", type: "text", text: "Before " },
+            {
+                id: "shot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/old.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:42 hrs",
+                createdAt: 1_000,
+            },
+            { id: "text-2", type: "text", text: " after" },
+        ];
+
+        expect(pruneExpiredScreenshotParts(parts, 60, 62_000)).toEqual([
+            { id: "text-1", type: "text", text: "Before  after" },
+        ]);
+    });
+
+    it("timestamps legacy screenshot parts so cleanup has a stable age", () => {
+        const parts: AIComposerPart[] = [
+            {
+                id: "shot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/old.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:42 hrs",
+            },
+        ];
+
+        expect(normalizeScreenshotPartTimestamps(parts, 5_000)).toEqual([
+            {
+                ...parts[0],
+                createdAt: 5_000,
+            },
+        ]);
+    });
+});

--- a/apps/desktop/src/features/ai/screenshotRetention.test.ts
+++ b/apps/desktop/src/features/ai/screenshotRetention.test.ts
@@ -15,6 +15,12 @@ describe("screenshot retention", () => {
         expect(normalizeScreenshotRetentionSeconds(undefined)).toBe(
             DEFAULT_SCREENSHOT_RETENTION_SECONDS,
         );
+        expect(normalizeScreenshotRetentionSeconds(-1)).toBe(
+            DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+        );
+        expect(normalizeScreenshotRetentionSeconds(0.4)).toBe(
+            DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+        );
     });
 
     it("removes expired screenshots without dropping surrounding text", () => {

--- a/apps/desktop/src/features/ai/screenshotRetention.ts
+++ b/apps/desktop/src/features/ai/screenshotRetention.ts
@@ -26,10 +26,12 @@ export function normalizeScreenshotRetentionSeconds(value: unknown): number {
         return DEFAULT_SCREENSHOT_RETENTION_SECONDS;
     }
 
-    const rounded = Math.max(0, Math.round(value));
-    if (SCREENSHOT_RETENTION_VALUES.has(rounded)) return rounded;
+    if (value === 0) return 0;
 
-    if (rounded === 0) return 0;
+    const rounded = Math.round(value);
+    if (rounded <= 0) return DEFAULT_SCREENSHOT_RETENTION_SECONDS;
+
+    if (SCREENSHOT_RETENTION_VALUES.has(rounded)) return rounded;
 
     return (
         FINITE_SCREENSHOT_RETENTION_SECONDS.find(

--- a/apps/desktop/src/features/ai/screenshotRetention.ts
+++ b/apps/desktop/src/features/ai/screenshotRetention.ts
@@ -1,0 +1,105 @@
+import { normalizeComposerParts } from "./composerParts";
+import type { AIComposerPart } from "./types";
+
+export const SCREENSHOT_RETENTION_OPTIONS = [
+    { value: 60, label: "1 minute" },
+    { value: 300, label: "5 minutes" },
+    { value: 1800, label: "30 minutes" },
+    { value: 3600, label: "1 hour" },
+    { value: 86400, label: "24 hours" },
+    { value: 604800, label: "7 days" },
+    { value: 0, label: "Forever" },
+] as const;
+
+export const DEFAULT_SCREENSHOT_RETENTION_SECONDS = 1800;
+
+const FINITE_SCREENSHOT_RETENTION_SECONDS = SCREENSHOT_RETENTION_OPTIONS.map(
+    (option) => option.value,
+).filter((value) => value > 0);
+
+const SCREENSHOT_RETENTION_VALUES: Set<number> = new Set(
+    SCREENSHOT_RETENTION_OPTIONS.map((option) => option.value),
+);
+
+export function normalizeScreenshotRetentionSeconds(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return DEFAULT_SCREENSHOT_RETENTION_SECONDS;
+    }
+
+    const rounded = Math.max(0, Math.round(value));
+    if (SCREENSHOT_RETENTION_VALUES.has(rounded)) return rounded;
+
+    if (rounded === 0) return 0;
+
+    return (
+        FINITE_SCREENSHOT_RETENTION_SECONDS.find(
+            (candidate) => candidate >= rounded,
+        ) ??
+        FINITE_SCREENSHOT_RETENTION_SECONDS.at(-1) ??
+        DEFAULT_SCREENSHOT_RETENTION_SECONDS
+    );
+}
+
+function getScreenshotCreatedAt(
+    part: Extract<AIComposerPart, { type: "screenshot" }>,
+) {
+    return typeof part.createdAt === "number" && Number.isFinite(part.createdAt)
+        ? part.createdAt
+        : null;
+}
+
+export function normalizeScreenshotPartTimestamps(
+    parts: AIComposerPart[],
+    now = Date.now(),
+): AIComposerPart[] {
+    let changed = false;
+    const normalized = parts.map((part) => {
+        if (part.type !== "screenshot") return part;
+        if (getScreenshotCreatedAt(part) != null) return part;
+        changed = true;
+        return { ...part, createdAt: now };
+    });
+
+    return changed ? normalized : parts;
+}
+
+export function pruneExpiredScreenshotParts(
+    parts: AIComposerPart[],
+    retentionSeconds: number,
+    now = Date.now(),
+): AIComposerPart[] {
+    if (retentionSeconds <= 0) return parts;
+
+    const retentionMs = retentionSeconds * 1000;
+    let changed = false;
+    const next = parts.filter((part) => {
+        if (part.type !== "screenshot") return true;
+        const createdAt = getScreenshotCreatedAt(part);
+        if (createdAt == null || now - createdAt < retentionMs) return true;
+        changed = true;
+        return false;
+    });
+
+    return changed ? normalizeComposerParts(next) : parts;
+}
+
+export function getNextScreenshotExpiryDelayMs(
+    parts: AIComposerPart[],
+    retentionSeconds: number,
+    now = Date.now(),
+): number | null {
+    if (retentionSeconds <= 0) return null;
+
+    const retentionMs = retentionSeconds * 1000;
+    let nextDelay: number | null = null;
+
+    for (const part of parts) {
+        if (part.type !== "screenshot") continue;
+        const createdAt = getScreenshotCreatedAt(part);
+        if (createdAt == null) return 0;
+        const delay = Math.max(0, createdAt + retentionMs - now);
+        nextDelay = nextDelay == null ? delay : Math.min(nextDelay, delay);
+    }
+
+    return nextDelay;
+}

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -575,6 +575,50 @@ describe("chatStore", () => {
         });
     });
 
+    it("uses a finite default for screenshot retention unless Forever is saved", () => {
+        expect(useChatStore.getState().screenshotRetentionSeconds).toBe(1800);
+
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({
+                screenshotRetentionSeconds: 0,
+            }),
+        );
+
+        resetChatStore();
+
+        expect(useChatStore.getState().screenshotRetentionSeconds).toBe(0);
+    });
+
+    it("migrates removed screenshot retention preferences into saved options", () => {
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({
+                screenshotRetentionSeconds: 900,
+            }),
+        );
+
+        resetChatStore();
+
+        expect(useChatStore.getState().screenshotRetentionSeconds).toBe(1800);
+        expect(
+            JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}"),
+        ).toMatchObject({
+            screenshotRetentionSeconds: 1800,
+        });
+    });
+
+    it("persists only supported screenshot retention updates", () => {
+        useChatStore.getState().setScreenshotRetentionSeconds(30);
+
+        expect(useChatStore.getState().screenshotRetentionSeconds).toBe(60);
+        expect(
+            JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}"),
+        ).toMatchObject({
+            screenshotRetentionSeconds: 60,
+        });
+    });
+
     it("keeps root backend streaming upserts from reviving stale sessions", () => {
         const session = createSessionWithTrackedFiles("root-session", []);
         useChatStore.getState().upsertSession(session, true);

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -59,6 +59,11 @@ import {
     serializeComposerPartsForAI,
 } from "../composerParts";
 import {
+    DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+    normalizeScreenshotPartTimestamps,
+    normalizeScreenshotRetentionSeconds,
+} from "../screenshotRetention";
+import {
     ensureSessionWorkCycle,
     startNewWorkCycle,
 } from "./editedFilesBufferModel";
@@ -231,7 +236,7 @@ const DEFAULT_AI_PREFERENCES: NormalizedAiPreferences = {
     chatFontFamily: "system",
     editDiffZoom: 0.72,
     historyRetentionDays: 0,
-    screenshotRetentionSeconds: 0,
+    screenshotRetentionSeconds: DEFAULT_SCREENSHOT_RETENTION_SECONDS,
 };
 
 interface AIRuntimeCatalogSnapshot {
@@ -369,6 +374,16 @@ function saveAutoContextPreference(
 
 function getNormalizedAiPreferences(): NormalizedAiPreferences {
     const prefs = loadAiPreferences();
+    const screenshotRetentionSeconds = normalizeScreenshotRetentionSeconds(
+        prefs.screenshotRetentionSeconds,
+    );
+    if (
+        prefs.screenshotRetentionSeconds != null &&
+        prefs.screenshotRetentionSeconds !== screenshotRetentionSeconds
+    ) {
+        saveAiPreferences({ screenshotRetentionSeconds });
+    }
+
     return {
         requireCmdEnterToSend: prefs.requireCmdEnterToSend === true,
         contextUsageBarEnabled: prefs.contextUsageBarEnabled !== false,
@@ -378,7 +393,7 @@ function getNormalizedAiPreferences(): NormalizedAiPreferences {
         chatFontFamily: normalizeEditorFontFamily(prefs.chatFontFamily),
         editDiffZoom: prefs.editDiffZoom ?? 0.72,
         historyRetentionDays: prefs.historyRetentionDays ?? 0,
-        screenshotRetentionSeconds: prefs.screenshotRetentionSeconds ?? 0,
+        screenshotRetentionSeconds,
     };
 }
 
@@ -9162,9 +9177,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const resolvedSessionId = sessionId ?? get().activeSessionId;
             if (!resolvedSessionId) return;
             set((state) => {
+                const normalizedParts = normalizeScreenshotPartTimestamps(parts);
                 const session = state.sessionsById[resolvedSessionId];
                 const mentionIds = new Set(
-                    parts
+                    normalizedParts
                         .filter(
                             (
                                 p,
@@ -9176,7 +9192,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         .map((p) => p.noteId),
                 );
                 const folderPaths = new Set(
-                    parts
+                    normalizedParts
                         .filter(
                             (
                                 p,
@@ -9188,7 +9204,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         .map((p) => p.folderPath),
                 );
                 const fileMentionPaths = new Set(
-                    parts
+                    normalizedParts
                         .filter(
                             (
                                 p,
@@ -9215,7 +9231,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 return {
                     composerPartsBySessionId: {
                         ...state.composerPartsBySessionId,
-                        [resolvedSessionId]: parts,
+                        [resolvedSessionId]: normalizedParts,
                     },
                     ...(session &&
                     prunedAttachments.length !== session.attachments.length
@@ -11370,7 +11386,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         },
 
         setScreenshotRetentionSeconds: (seconds) => {
-            const next = Math.max(0, Math.round(seconds));
+            const next = normalizeScreenshotRetentionSeconds(seconds);
             set({ screenshotRetentionSeconds: next });
             saveAiPreferences({ screenshotRetentionSeconds: next });
         },

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -637,6 +637,7 @@ export type AIComposerPart =
           filePath: string;
           mimeType: string;
           label: string;
+          createdAt?: number;
       }
     | {
           id: string;

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -546,6 +546,33 @@ describe("SettingsPanel", () => {
                 "How long pasted screenshots stay in the AI composer before they are removed automatically.",
             ),
         ).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: /5 minutes/ }));
+
+        expect(
+            screen.getByRole("button", { name: "1 minute" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "30 minutes" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "1 hour" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "24 hours" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "7 days" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getAllByRole("button", { name: "Forever" }).length,
+        ).toBeGreaterThan(0);
+        expect(
+            screen.queryByRole("button", { name: "30 seconds" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "15 minutes" }),
+        ).not.toBeInTheDocument();
     });
 
     it("renders and persists the context usage bar toggle in AI settings", () => {

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -51,6 +51,7 @@ import {
 } from "../../app/utils/appZoom";
 import { MarkdownContent } from "../ai/components/MarkdownContent";
 import { getChatPillMetrics } from "../ai/components/chatPillMetrics";
+import { SCREENSHOT_RETENTION_OPTIONS } from "../ai/screenshotRetention";
 import { PROVIDER_CATALOG } from "../ai/utils/runtimeMetadata";
 import { AIProvidersSettings } from "./AIProvidersSettings";
 import { ExtensionFilterInput } from "./ExtensionFilterInput";
@@ -176,6 +177,10 @@ type SelectFieldOption<T extends string | number | null> = {
     label: string;
     group?: string;
 };
+
+const SCREENSHOT_RETENTION_KEYWORDS = SCREENSHOT_RETENTION_OPTIONS.map(
+    (option) => option.label,
+);
 
 function SelectField<T extends string | number | null>({
     value,
@@ -3846,12 +3851,7 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
             [
                 "Screenshot retention",
                 "How long pasted screenshots stay in the AI composer before they are removed automatically.",
-                "Forever",
-                "30 seconds",
-                "1 minute",
-                "5 minutes",
-                "15 minutes",
-                "30 minutes",
+                ...SCREENSHOT_RETENTION_KEYWORDS,
             ],
             [
                 "Composer font family",
@@ -3973,25 +3973,11 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                 section="Composer"
                 label="Screenshot retention"
                 description="How long pasted screenshots stay in the AI composer before they are removed automatically."
-                keywords={[
-                    "Forever",
-                    "30 seconds",
-                    "1 minute",
-                    "5 minutes",
-                    "15 minutes",
-                    "30 minutes",
-                ]}
+                keywords={SCREENSHOT_RETENTION_KEYWORDS}
                 control={
                     <SelectField
                         value={screenshotRetentionSeconds}
-                        options={[
-                            { value: 0, label: "Forever" },
-                            { value: 30, label: "30 seconds" },
-                            { value: 60, label: "1 minute" },
-                            { value: 300, label: "5 minutes" },
-                            { value: 900, label: "15 minutes" },
-                            { value: 1800, label: "30 minutes" },
-                        ]}
+                        options={[...SCREENSHOT_RETENTION_OPTIONS]}
                         onChange={(value) =>
                             setScreenshotRetentionSeconds(Number(value))
                         }


### PR DESCRIPTION
## Summary
- Updates Screenshot retention to the requested option set: 1 minute, 5 minutes, 30 minutes, 1 hour, 24 hours, 7 days, and Forever.
- Adds shared normalization so removed saved values migrate cleanly into supported options.
- Tracks screenshot pill creation time and prunes expired screenshot parts from the composer while preserving other pills.

## Root Cause
The setting only changed stored seconds, but screenshot composer parts did not carry age metadata and no cleanup path applied the retention preference consistently.

## Validation
- npm run test -- src/features/ai/screenshotRetention.test.ts src/features/ai/store/chatStore.test.ts src/features/settings/SettingsPanel.test.tsx src/features/ai/components/AIChatSessionView.test.tsx
- npx tsc -b --pretty false (blocked by existing src/app/windowSession.ts:263 PersistedWindowSessionEntry.vaultPath type error)

Closes #180
