### PR TITLE
Fix edited files tray overflow

### DIFF
--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.test.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.test.tsx
@@ -7,6 +7,11 @@ import { renderComponent, setVaultEntries } from "../../../test/test-utils";
 import type { AIChatSession } from "../types";
 import type { TrackedFile } from "../diff/actionLogTypes";
 import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
+import {
+    COMPACT_REVIEW_MAX_LIST_HEIGHT_PX,
+    COMPACT_REVIEW_MAX_VISIBLE_ROWS,
+    COMPACT_REVIEW_ROW_HEIGHT_PX,
+} from "./editedFilesReviewStyles";
 import { resetChatStore, useChatStore } from "../store/chatStore";
 import { emptyPatch, syncDerivedLinePatch } from "../store/actionLogModel";
 
@@ -516,14 +521,22 @@ describe("EditedFilesBufferPanel", () => {
         expect(reviewTab?.title).toBe("Review Kilo");
     });
 
-    it("limits the expanded compact list to four visible items and scrolls the rest", () => {
-        const session = createSession("session-scroll", [
-            createTrackedFile("/vault/src/one.ts"),
-            createTrackedFile("/vault/src/two.ts"),
-            createTrackedFile("/vault/src/three.ts"),
-            createTrackedFile("/vault/src/four.ts"),
-            createTrackedFile("/vault/src/five.ts"),
-        ]);
+    it("keeps the expanded compact list bounded and row-stable for many pending edits", () => {
+        const files = Array.from({ length: 17 }, (_, index) => {
+            const lineCount = index + 12;
+            return createTrackedFile(
+                `/vault/src/feature-${index + 1}/very-long-edited-file-name-${index + 1}.tsx`,
+                {
+                    diffBase: "previous line\n",
+                    currentText: Array.from(
+                        { length: lineCount },
+                        (_, lineIndex) =>
+                            `new line ${lineIndex + 1} for edited file ${index + 1}`,
+                    ).join("\n"),
+                },
+            );
+        });
+        const session = createSession("session-scroll", files);
 
         useChatStore.setState((state) => ({
             ...state,
@@ -543,11 +556,27 @@ describe("EditedFilesBufferPanel", () => {
         ).not.toBeInTheDocument();
         expect(
             screen.getAllByRole("button", { name: "Open File" }),
-        ).toHaveLength(5);
+        ).toHaveLength(17);
         expect(screen.getByTestId("edited-files-buffer-list")).toHaveStyle({
-            maxHeight: "208px",
+            maxHeight: `${COMPACT_REVIEW_MAX_LIST_HEIGHT_PX}px`,
             overflowY: "auto",
         });
+        expect(screen.getAllByTestId("edited-files-buffer-row")).toHaveLength(
+            17,
+        );
+        expect(17).toBeGreaterThan(COMPACT_REVIEW_MAX_VISIBLE_ROWS);
+        expect(screen.getAllByTestId("edited-files-buffer-row")[0]).toHaveStyle(
+            {
+                height: `${COMPACT_REVIEW_ROW_HEIGHT_PX}px`,
+                minHeight: `${COMPACT_REVIEW_ROW_HEIGHT_PX}px`,
+                maxHeight: `${COMPACT_REVIEW_ROW_HEIGHT_PX}px`,
+            },
+        );
+        expect(screen.getAllByRole("button", { name: "Open File" })[0])
+            .toHaveStyle({
+                width: "24px",
+                height: "24px",
+            });
     });
 
     it("uses a chevron button to collapse and expand the edits list", () => {

--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
@@ -11,6 +11,7 @@ import {
 } from "../store/editedFilesBufferModel";
 import { EditedFilesReviewList } from "./EditedFilesReviewList";
 import {
+    COMPACT_REVIEW_MAX_LIST_HEIGHT_PX,
     getAccentButtonStyle,
     getDangerButtonStyle,
     getNeutralButtonStyle,
@@ -21,7 +22,6 @@ import {
 } from "../diff/editedFilesPresentationModel";
 import { canOpenAiEditedFileByAbsolutePath } from "../chatFileNavigation";
 
-const COMPACT_MAX_LIST_HEIGHT = "208px";
 const UNDO_ONLY_BANNER_TIMEOUT_MS = 5000;
 
 function CollapseToggle({
@@ -401,7 +401,7 @@ export function EditedFilesBufferPanel({
                     data-scrollbar-active="true"
                     className="flex flex-col"
                     style={{
-                        maxHeight: COMPACT_MAX_LIST_HEIGHT,
+                        maxHeight: COMPACT_REVIEW_MAX_LIST_HEIGHT_PX,
                         overflowY: "auto",
                     }}
                 >

--- a/apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx
@@ -8,6 +8,7 @@ import {
 import type { ReviewFileItem } from "../diff/editedFilesPresentationModel";
 import type { ReviewHunkId } from "../diff/reviewProjection";
 import {
+    COMPACT_REVIEW_ROW_HEIGHT_PX,
     getAccentButtonStyle,
     getDangerButtonStyle,
     getNeutralButtonStyle,
@@ -24,6 +25,15 @@ const FULL_ROW_ACTION_BUTTON_STYLE: React.CSSProperties = {
     lineHeight: "20px",
     letterSpacing: "0.04em",
     textTransform: "uppercase",
+};
+
+const COMPACT_ACTION_BUTTON_STYLE: React.CSSProperties = {
+    width: 24,
+    height: 24,
+    padding: 0,
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
 };
 
 function FullRowActionButton({
@@ -320,23 +330,40 @@ function CompactRow({
 
     return (
         <div
+            data-testid="edited-files-buffer-row"
             className="overflow-hidden"
             style={{
                 borderTop:
                     "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
+                boxSizing: "border-box",
+                height: COMPACT_REVIEW_ROW_HEIGHT_PX,
+                minHeight: COMPACT_REVIEW_ROW_HEIGHT_PX,
+                maxHeight: COMPACT_REVIEW_ROW_HEIGHT_PX,
             }}
         >
-            <div className="flex items-center gap-2.5 px-2.5 py-1.5">
+            <div
+                style={{
+                    display: "grid",
+                    gridTemplateColumns: "6px 14px minmax(0, 1fr) auto auto",
+                    columnGap: 8,
+                    alignItems: "center",
+                    height: "100%",
+                    padding: "0 10px",
+                    minWidth: 0,
+                }}
+            >
                 <div
                     className="h-1.5 w-1.5 shrink-0 rounded-full"
                     style={{ backgroundColor: tone.accent }}
                 />
                 <FileTypeIcon fileName={file.path} opacity={0.74} size={12} />
                 <span
-                    className="min-w-0 flex-1 truncate"
+                    className="min-w-0 truncate"
                     style={{
+                        display: "block",
                         fontSize: "0.84em",
                         fontWeight: 600,
+                        lineHeight: "18px",
                         color: "var(--text-primary)",
                     }}
                 >
@@ -358,8 +385,12 @@ function CompactRow({
                     ) : null}
                 </span>
                 <div
-                    className="flex shrink-0 items-center gap-1 text-right"
-                    style={{ fontSize: "0.76em" }}
+                    className="flex items-center justify-end gap-1 text-right"
+                    style={{
+                        minWidth: 48,
+                        fontSize: "0.76em",
+                        lineHeight: "16px",
+                    }}
                 >
                     {stats.additions > 0 ? (
                         <div
@@ -384,47 +415,27 @@ function CompactRow({
                         </div>
                     ) : null}
                 </div>
-                {/* Open File — external-link icon */}
-                <button
-                    type="button"
-                    title="Open File"
-                    onClick={() => {
-                        if (!canOpen) return;
-                        void openAiEditedFileByAbsolutePath(file.path);
-                    }}
-                    disabled={!canOpen}
-                    className="review-action-btn shrink-0 rounded-md p-1"
-                    style={{
-                        ...getAccentButtonStyle(
-                            canOpen ? tone.accent : "var(--text-secondary)",
-                        ),
-                        opacity: canOpen ? 1 : 0.45,
-                        cursor: canOpen ? "pointer" : "not-allowed",
-                    }}
-                >
-                    <svg
-                        width="12"
-                        height="12"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                    >
-                        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
-                        <polyline points="15 3 21 3 21 9" />
-                        <line x1="10" y1="14" x2="21" y2="3" />
-                    </svg>
-                </button>
-                {/* Reject — X icon */}
-                {canReject ? (
+                <div className="flex items-center gap-1">
+                    {/* Open File — external-link icon */}
                     <button
                         type="button"
-                        title="Reject"
-                        onClick={onReject}
-                        className="review-action-btn shrink-0 rounded-md p-1"
-                        style={getDangerButtonStyle()}
+                        title="Open File"
+                        onClick={() => {
+                            if (!canOpen) return;
+                            void openAiEditedFileByAbsolutePath(file.path);
+                        }}
+                        disabled={!canOpen}
+                        className="review-action-btn shrink-0 rounded-md"
+                        style={{
+                            ...getAccentButtonStyle(
+                                canOpen
+                                    ? tone.accent
+                                    : "var(--text-secondary)",
+                            ),
+                            ...COMPACT_ACTION_BUTTON_STYLE,
+                            opacity: canOpen ? 1 : 0.45,
+                            cursor: canOpen ? "pointer" : "not-allowed",
+                        }}
                     >
                         <svg
                             width="12"
@@ -436,32 +447,63 @@ function CompactRow({
                             strokeLinecap="round"
                             strokeLinejoin="round"
                         >
-                            <line x1="18" y1="6" x2="6" y2="18" />
-                            <line x1="6" y1="6" x2="18" y2="18" />
+                            <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6" />
+                            <polyline points="15 3 21 3 21 9" />
+                            <line x1="10" y1="14" x2="21" y2="3" />
                         </svg>
                     </button>
-                ) : null}
-                {/* Keep — checkmark icon */}
-                <button
-                    type="button"
-                    title="Keep"
-                    onClick={onKeep}
-                    className="review-action-btn shrink-0 rounded-md p-1"
-                    style={getAccentButtonStyle()}
-                >
-                    <svg
-                        width="12"
-                        height="12"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2.2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
+                    {/* Reject — X icon */}
+                    {canReject ? (
+                        <button
+                            type="button"
+                            title="Reject"
+                            onClick={onReject}
+                            className="review-action-btn shrink-0 rounded-md"
+                            style={{
+                                ...getDangerButtonStyle(),
+                                ...COMPACT_ACTION_BUTTON_STYLE,
+                            }}
+                        >
+                            <svg
+                                width="12"
+                                height="12"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2.2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            >
+                                <line x1="18" y1="6" x2="6" y2="18" />
+                                <line x1="6" y1="6" x2="18" y2="18" />
+                            </svg>
+                        </button>
+                    ) : null}
+                    {/* Keep — checkmark icon */}
+                    <button
+                        type="button"
+                        title="Keep"
+                        onClick={onKeep}
+                        className="review-action-btn shrink-0 rounded-md"
+                        style={{
+                            ...getAccentButtonStyle(),
+                            ...COMPACT_ACTION_BUTTON_STYLE,
+                        }}
                     >
-                        <polyline points="20 6 9 17 4 12" />
-                    </svg>
-                </button>
+                        <svg
+                            width="12"
+                            height="12"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2.2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                        >
+                            <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/editedFilesReviewStyles.ts
+++ b/apps/desktop/src/features/ai/components/editedFilesReviewStyles.ts
@@ -34,6 +34,13 @@ export function getNeutralButtonStyle(): React.CSSProperties {
     };
 }
 
+export const COMPACT_REVIEW_ROW_HEIGHT_PX = 30;
+// Eight rows keeps large edit batches reviewable without pushing the composer
+// out of reach; additional files scroll inside the tray.
+export const COMPACT_REVIEW_MAX_VISIBLE_ROWS = 8;
+export const COMPACT_REVIEW_MAX_LIST_HEIGHT_PX =
+    COMPACT_REVIEW_ROW_HEIGHT_PX * COMPACT_REVIEW_MAX_VISIBLE_ROWS;
+
 /* ---------- Shared review-view visual tokens ---------- */
 
 /** Stat chip used in the review header for files / additions / deletions / conflicts */


### PR DESCRIPTION
## Summary

Fixes the compact Edits tray layout when many pending edited files are visible above the chat composer.

- derives the tray max height from a stable visible-row contract
- gives compact rows fixed height and predictable grid columns
- fixes compact action buttons to stable dimensions
- expands coverage with a 17-file pending edits scenario using long paths and larger stats

## Root cause

The tray already had a max height, but the compact rows inside it did not have a strong height or column contract. Large edit batches could therefore render as an unstable stack instead of a compact scrollable list.

## Validation

- npm run test -- src/features/ai/components/EditedFilesBufferPanel.test.tsx
- npx eslint src/features/ai/components/editedFilesReviewStyles.ts src/features/ai/components/EditedFilesBufferPanel.tsx src/features/ai/components/EditedFilesReviewList.tsx src/features/ai/components/EditedFilesBufferPanel.test.tsx
- git diff --check

Note: full TypeScript build still fails on an unrelated pre-existing error in src/app/windowSession.ts:263 (`vaultPath` on PersistedWindowSessionEntry).

Closes #176