### PR TITLE
Fix window session primary vault type narrowing

### DIFF
--- a/apps/desktop/src/app/windowSession.ts
+++ b/apps/desktop/src/app/windowSession.ts
@@ -255,12 +255,15 @@ export async function restoreWindowSession(args: {
         await args.restorePrimaryVaultSession();
     }
 
+    const primaryVaultPath =
+        primaryVault?.kind === "vault" ? primaryVault.vaultPath : null;
+
     for (const entry of entries) {
         if (entry === primaryVault) continue;
         if (liveLabels.has(entry.label)) continue;
 
         if (entry.kind === "vault") {
-            if (entry.vaultPath === primaryVault?.vaultPath) continue;
+            if (entry.vaultPath === primaryVaultPath) continue;
             await args.openVaultWindow(entry.vaultPath);
             continue;
         }


### PR DESCRIPTION
## Summary

Fixes the desktop typecheck failure in `restoreWindowSession` by making the primary vault path narrowing explicit before comparing restored vault entries.

## Root cause

`primaryVault` is selected through `Array.find()` predicates that check `kind === "vault"`, but TypeScript does not infer those predicates as type guards. As a result, `primaryVault?.vaultPath` was still considered unsafe because `PersistedWindowSessionEntry` can also be a note window.

## Introduced in

The typecheck failure was introduced on May 26, 2026 in commit `744970a56b6cb6ee09048e34b4cee4dd2864579b` (`Fix terminal rendering crashes, jank, and AI provider default selection (#150)`). That change added the duplicate-vault restore guard that compared `entry.vaultPath` with `primaryVault?.vaultPath`.

## Impact

This keeps the restore behavior unchanged while allowing `tsc -b` to prove the invariant without casts or compatibility shims.

## Verification

- `cd apps/desktop && npm run build -- --help`