### PR TITLE
Harden closed subagent sessions

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1451,6 +1451,12 @@ impl NativeAi {
                 .sessions
                 .get_mut(&session_id)
                 .ok_or_else(|| format!("AI session not found: {session_id}"))?;
+            if managed.session.parent_session_id.is_some() && managed.session.closed_at.is_some() {
+                return Err(
+                    "This subagent was closed by its parent thread and can't receive new messages."
+                        .to_string(),
+                );
+            }
             let prompt = build_prompt_with_attachments(
                 &content,
                 &attachments,
@@ -2338,10 +2344,30 @@ impl NativeAcpClient {
         }
     }
 
+    fn mark_subagent_closed_by_parent(&self, session_id: &str) {
+        self.end_thinking(session_id);
+        self.end_message(session_id);
+
+        let session = self.session_state.lock().ok().and_then(|mut state| {
+            let managed = state.sessions.get_mut(session_id)?;
+            if managed.session.parent_session_id.is_none() {
+                return None;
+            }
+            managed.active_turn_id = None;
+            managed.session.status = AiSessionStatus::Idle;
+            managed.session.closed_at = Some(epoch_millis_string());
+            Some(managed.session.clone())
+        });
+        if let Some(session) = session {
+            self.emit(AI_SESSION_UPDATED_EVENT, session);
+        }
+    }
+
     fn begin_session_turn(&self, session_id: &str, turn_id: Option<String>) {
         let session = self.session_state.lock().ok().and_then(|mut state| {
             let managed = state.sessions.get_mut(session_id)?;
             managed.active_turn_id = turn_id;
+            managed.session.closed_at = None;
             if managed.session.status == AiSessionStatus::Streaming {
                 return None;
             }
@@ -2549,7 +2575,7 @@ impl NativeAcpClient {
             self.child_session_ids_for_terminal_subagent_breadcrumb(parent_session_id, meta);
         for child_session_id in child_session_ids {
             if child_session_id != parent_session_id {
-                self.mark_session_idle(&child_session_id);
+                self.mark_subagent_closed_by_parent(&child_session_id);
             }
         }
     }
@@ -3405,6 +3431,7 @@ fn session_from_acp_response(
         session_id,
         parent_session_id: None,
         runtime_session_id: None,
+        closed_at: None,
         title: None,
         runtime_id: runtime_id.to_string(),
         model_id,
@@ -4318,6 +4345,7 @@ fn new_session_with_id(runtime_id: &str, session_id: String) -> Result<AiSession
         session_id,
         parent_session_id: None,
         runtime_session_id: None,
+        closed_at: None,
         title: None,
         runtime_id: runtime_id.to_string(),
         model_id: models
@@ -6452,6 +6480,13 @@ fn touch_session(state: &mut NativeAiInner, session_id: &str) {
     state.session_order.insert(0, session_id.to_string());
 }
 
+fn epoch_millis_string() -> String {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis().to_string())
+        .unwrap_or_else(|_| "0".to_string())
+}
+
 fn emit_event(event_tx: &Sender<RpcOutput>, event_name: &str, payload: Value) {
     let _ = event_tx.send(RpcOutput::Event {
         event_name: event_name.to_string(),
@@ -7264,6 +7299,15 @@ mod tests {
             CHILD_RUNTIME_SESSION_ID,
             CHILD_RUNTIME_SESSION_ID,
         );
+        {
+            let mut state = session_state.lock().unwrap();
+            state
+                .sessions
+                .get_mut(CHILD_RUNTIME_SESSION_ID)
+                .expect("child session should exist")
+                .session
+                .closed_at = Some("123".to_string());
+        }
         let client = test_client_with_state(event_tx, Arc::clone(&session_state));
 
         run_client_future(
@@ -7293,6 +7337,7 @@ mod tests {
             payload.get("status").and_then(Value::as_str),
             Some("streaming")
         );
+        assert!(payload.get("closed_at").is_none());
     }
 
     #[test]
@@ -7461,7 +7506,7 @@ mod tests {
     }
 
     #[test]
-    fn subagent_close_breadcrumb_marks_child_idle() {
+    fn subagent_close_breadcrumb_marks_child_closed() {
         let (event_tx, event_rx) = mpsc::channel();
         let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
         insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, PARENT_RUNTIME_SESSION_ID);
@@ -7512,7 +7557,7 @@ mod tests {
         .unwrap();
 
         let mut saw_message_completed = false;
-        let mut saw_idle_update = false;
+        let mut saw_closed_update = false;
         for _ in 0..3 {
             let RpcOutput::Event {
                 event_name,
@@ -7531,18 +7576,50 @@ mod tests {
                 && payload.get("session_id").and_then(Value::as_str)
                     == Some(CHILD_RUNTIME_SESSION_ID)
                 && payload.get("status").and_then(Value::as_str) == Some("idle")
+                && payload.get("closed_at").and_then(Value::as_str).is_some()
             {
-                saw_idle_update = true;
+                saw_closed_update = true;
             }
         }
 
         assert!(saw_message_completed);
-        assert!(saw_idle_update);
+        assert!(saw_closed_update);
         assert!(!client
             .message_ids
             .lock()
             .unwrap()
             .contains_key(CHILD_RUNTIME_SESSION_ID));
+    }
+
+    #[test]
+    fn send_message_rejects_subagent_closed_by_parent() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let ai = NativeAi::new(event_tx);
+        insert_test_managed_session(&ai.inner, CODEX_RUNTIME_ID, PARENT_RUNTIME_SESSION_ID);
+        insert_test_managed_session(&ai.inner, CODEX_RUNTIME_ID, CHILD_RUNTIME_SESSION_ID);
+        mark_test_session_as_child(
+            &ai.inner,
+            CHILD_RUNTIME_SESSION_ID,
+            CHILD_RUNTIME_SESSION_ID,
+        );
+        {
+            let mut state = ai.inner.lock().unwrap();
+            let child = state
+                .sessions
+                .get_mut(CHILD_RUNTIME_SESSION_ID)
+                .expect("child session should exist");
+            child.session.closed_at = Some("123".to_string());
+        }
+
+        let error = ai
+            .send_message(&json!({
+                "session_id": CHILD_RUNTIME_SESSION_ID,
+                "content": "continue",
+                "attachments": [],
+            }))
+            .expect_err("closed child should reject direct prompts");
+
+        assert!(error.contains("closed by its parent thread"));
     }
 
     #[test]

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -89,6 +89,7 @@ export function normalizeBackendSession(
         historySessionId: session.session_id,
         parentSessionId: session.parent_session_id ?? null,
         runtimeSessionId: session.runtime_session_id ?? null,
+        closedAt: session.closed_at ?? null,
         customTitle: session.title ?? null,
         persistedTitle: session.title ?? null,
         runtimeId: session.runtime_id,

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -205,8 +205,10 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
 
     const runtimeLabel =
         activeRuntime?.runtime.name.replace(/ ACP$/, "") ?? "Assistant";
+    const isClosedSubagent = Boolean(session?.parentSessionId && session.closedAt);
     const agentControlsDisabled =
         !session ||
+        isClosedSubagent ||
         isPendingSessionCreation ||
         Boolean(session.isResumingSession);
 
@@ -605,15 +607,18 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     onToggleExpanded={() => setComposerExpanded((v) => !v)}
                     disabled={
                         !session ||
+                        isClosedSubagent ||
                         isPendingSessionCreation ||
                         activeConnection.status === "loading" ||
                         Boolean(session.isResumingSession)
                     }
                     placeholderText={
-                        isPendingSessionCreation
-                            ? pendingSessionError
-                                ? "Agent unavailable"
-                                : "Loading agent"
+                        isClosedSubagent
+                            ? "This subagent was closed by its parent thread."
+                            : isPendingSessionCreation
+                              ? pendingSessionError
+                                  ? "Agent unavailable"
+                                  : "Loading agent"
                             : undefined
                     }
                     contextBar={

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -12473,6 +12473,265 @@ describe("chatStore", () => {
         });
     });
 
+    it("does not send direct prompts to subagents closed by their parent", async () => {
+        const parent = {
+            ...createSessionWithTrackedFiles("session-parent", []),
+            runtimeId: "codex-acp",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+        const child = {
+            ...createSessionWithTrackedFiles("session-child", []),
+            parentSessionId: parent.sessionId,
+            closedAt: "123",
+            runtimeId: "codex-acp",
+            runtimeSessionId: "runtime-child",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            sessionsById: {
+                [parent.sessionId]: parent,
+                [child.sessionId]: child,
+            },
+            sessionOrder: [parent.sessionId, child.sessionId],
+            activeSessionId: child.sessionId,
+            composerPartsBySessionId: {
+                [child.sessionId]: createTextParts("Continue"),
+            },
+        });
+        invokeMock.mockClear();
+
+        await useChatStore.getState().sendMessage(child.sessionId);
+
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_send_message",
+            ),
+        ).toBe(false);
+    });
+
+    it("persists closed child session state", async () => {
+        const parent = {
+            ...createSessionWithTrackedFiles("session-parent", []),
+            runtimeId: "codex-acp",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+        const child = {
+            ...createSessionWithTrackedFiles("session-child", []),
+            parentSessionId: parent.sessionId,
+            closedAt: "123",
+            runtimeId: "codex-acp",
+            runtimeSessionId: "runtime-child",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            sessionsById: { [parent.sessionId]: parent },
+            sessionOrder: [parent.sessionId],
+            activeSessionId: parent.sessionId,
+        });
+        invokeMock.mockClear();
+
+        useChatStore.getState().upsertSession(child);
+        await Promise.resolve();
+
+        expect(invokeMock).toHaveBeenCalledWith("ai_save_session_history", {
+            vaultPath: "/vault",
+            history: expect.objectContaining({
+                session_id: child.sessionId,
+                parent_session_id: parent.sessionId,
+                closed_at: "123",
+            }),
+        });
+    });
+
+    it("clears queued child messages with a status note when the parent closes the subagent", async () => {
+        const parent = {
+            ...createSessionWithTrackedFiles("session-parent", []),
+            runtimeId: "codex-acp",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+        const child = {
+            ...createSessionWithTrackedFiles("session-child", []),
+            parentSessionId: parent.sessionId,
+            runtimeId: "codex-acp",
+            runtimeSessionId: "runtime-child",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+        const activeQueuedItem = createQueuedMessage(
+            "queued-active",
+            "Already sending",
+            { status: "sending" },
+        );
+
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            sessionsById: {
+                [parent.sessionId]: parent,
+                [child.sessionId]: child,
+            },
+            sessionOrder: [parent.sessionId, child.sessionId],
+            activeSessionId: child.sessionId,
+            queuedMessagesBySessionId: {
+                [child.sessionId]: [
+                    createQueuedMessage("queued-1", "Follow up"),
+                ],
+            },
+            activeQueuedMessageBySessionId: {
+                [child.sessionId]: {
+                    item: activeQueuedItem,
+                    originalIndex: 0,
+                    previousItemId: null,
+                    nextItemId: null,
+                },
+            },
+        });
+        invokeMock.mockClear();
+
+        useChatStore.getState().upsertSession({
+            ...child,
+            closedAt: "123",
+        });
+        await Promise.resolve();
+
+        const closedChild =
+            useChatStore.getState().sessionsById[child.sessionId];
+        expect(
+            useChatStore.getState().queuedMessagesBySessionId[child.sessionId],
+        ).toBeUndefined();
+        expect(
+            useChatStore.getState().activeQueuedMessageBySessionId[
+                child.sessionId
+            ],
+        ).toBeUndefined();
+        expect(closedChild?.messages).toEqual([
+            expect.objectContaining({
+                kind: "status",
+                content:
+                    "Queued messages were cancelled because this subagent was closed by its parent thread.",
+                meta: expect.objectContaining({
+                    status_event: "subagent_lifecycle",
+                    status: "cancelled",
+                }),
+            }),
+        ]);
+        expect(invokeMock).toHaveBeenCalledWith("ai_save_session_history", {
+            vaultPath: "/vault",
+            history: expect.objectContaining({
+                session_id: child.sessionId,
+                closed_at: "123",
+                messages: expect.arrayContaining([
+                    expect.objectContaining({
+                        kind: "status",
+                        content:
+                            "Queued messages were cancelled because this subagent was closed by its parent thread.",
+                    }),
+                ]),
+            }),
+        });
+    });
+
+    it("restores composer state when closing a subagent with an edited queued message", () => {
+        const parent = {
+            ...createSessionWithTrackedFiles("session-parent", []),
+            runtimeId: "codex-acp",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+        };
+        const previousAttachment: AIChatAttachment = {
+            id: "previous-file",
+            type: "file",
+            noteId: null,
+            label: "Previous.txt",
+            path: null,
+            filePath: "/tmp/previous.txt",
+            mimeType: "text/plain",
+            status: "ready",
+        };
+        const queuedAttachment: AIChatAttachment = {
+            id: "queued-file",
+            type: "file",
+            noteId: null,
+            label: "Queued.txt",
+            path: null,
+            filePath: "/tmp/queued.txt",
+            mimeType: "text/plain",
+            status: "ready",
+        };
+        const child = {
+            ...createSessionWithTrackedFiles("session-child", []),
+            parentSessionId: parent.sessionId,
+            runtimeId: "codex-acp",
+            runtimeSessionId: "runtime-child",
+            runtimeState: "live" as const,
+            status: "idle" as const,
+            vaultPath: "/vault",
+            attachments: [queuedAttachment],
+        };
+        const editingItem = createQueuedMessage("queued-edit", "Edited queue", {
+            attachments: [queuedAttachment],
+        });
+
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            sessionsById: {
+                [parent.sessionId]: parent,
+                [child.sessionId]: child,
+            },
+            sessionOrder: [parent.sessionId, child.sessionId],
+            activeSessionId: child.sessionId,
+            composerPartsBySessionId: {
+                [child.sessionId]: createTextParts("Edited queue"),
+            },
+            queuedMessageEditBySessionId: {
+                [child.sessionId]: {
+                    item: editingItem,
+                    originalIndex: 0,
+                    previousItemId: null,
+                    nextItemId: null,
+                    previousComposerParts: createTextParts("Previous draft"),
+                    previousAttachments: [previousAttachment],
+                },
+            },
+        });
+
+        useChatStore.getState().upsertSession({
+            ...child,
+            closedAt: "123",
+        });
+
+        expect(
+            useChatStore.getState().queuedMessageEditBySessionId[
+                child.sessionId
+            ],
+        ).toBeUndefined();
+        expect(
+            serializeComposerParts(
+                useChatStore.getState().composerPartsBySessionId[
+                    child.sessionId
+                ] ?? [],
+            ),
+        ).toBe("Previous draft");
+        expect(
+            useChatStore.getState().sessionsById[child.sessionId]?.attachments,
+        ).toEqual([previousAttachment]);
+    });
+
     it("deletes a child session without stopping or deleting its parent", async () => {
         const parent = {
             ...createSessionWithTrackedFiles("session-parent", []),

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -181,9 +181,13 @@ const SAVED_CHAT_RECONNECTING_STATUS_EVENT_ID =
     "neverwrite:recovery:reconnecting-saved-chat";
 const RUNTIME_CONTEXT_RECOVERY_STATUS_EVENT_ID =
     "neverwrite:recovery:runtime-context";
+const CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_EVENT_ID =
+    "neverwrite:subagent:queue-cancelled";
 const SAVED_CHAT_RECONNECTING_STATUS_TITLE = "Reconnecting saved chat...";
 const RUNTIME_CONTEXT_RECOVERY_STATUS_TITLE =
     "The AI runtime lost its connection. Reconnecting with saved context...";
+const CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_TITLE =
+    "Queued messages were cancelled because this subagent was closed by its parent thread.";
 const SAVED_CHAT_RECONNECT_FAILED_MESSAGE =
     "Could not reconnect this chat. Start a new session with saved transcript context?";
 const _pendingTrackedPersistedReconcileByKey = new Map<
@@ -511,6 +515,10 @@ function isLiveRuntimeSession(session: AIChatSession) {
         session.runtimeState === "live" &&
         getPersistedHistorySessionId(session.sessionId) === null
     );
+}
+
+function isClosedSubagentSession(session: AIChatSession) {
+    return Boolean(session.parentSessionId && session.closedAt);
 }
 
 function getWorkspaceHistorySessionIdForSession(sessionId: string) {
@@ -1529,7 +1537,11 @@ function isProviderQuotaErrorMessage(message: string) {
 
 function isRuntimeSessionDisconnectedErrorMessage(message: string) {
     const normalized = message.trim().toLowerCase();
-    return normalized.includes("runtime session is not connected");
+    return (
+        normalized.includes("runtime session is not connected") ||
+        normalized.includes("resource_not_found") ||
+        normalized.includes("ai session not found")
+    );
 }
 
 function normalizeAiErrorMessage(message: string, runtimeId?: string | null) {
@@ -1956,6 +1968,19 @@ function createRuntimeContextRecoveryStatus(
         kind: "session_recovery",
         status: "in_progress",
         title: RUNTIME_CONTEXT_RECOVERY_STATUS_TITLE,
+        detail: null,
+        emphasis: "warning",
+    });
+}
+
+function createClosedSubagentQueueCancelledStatus(
+    sessionId: string,
+): AIStatusEventPayload {
+    return createLocalStatusPayload(sessionId, {
+        event_id: CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_EVENT_ID,
+        kind: "subagent_lifecycle",
+        status: "cancelled",
+        title: CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_TITLE,
         detail: null,
         emphasis: "warning",
     });
@@ -2933,6 +2958,78 @@ function reconcileIdleQueuedState(
                   null,
               )
             : state.activeQueuedMessageBySessionId,
+        };
+}
+
+function clearClosedSubagentQueueState(
+    state: Pick<
+        ChatStore,
+        | "queuedMessagesBySessionId"
+        | "activeQueuedMessageBySessionId"
+        | "queuedMessageEditBySessionId"
+        | "pausedQueueBySessionId"
+        | "composerPartsBySessionId"
+    >,
+    sessionId: string,
+    session: AIChatSession,
+) {
+    const queue = state.queuedMessagesBySessionId[sessionId] ?? [];
+    const activeQueuedMessage =
+        state.activeQueuedMessageBySessionId[sessionId] ?? null;
+    const editState = state.queuedMessageEditBySessionId[sessionId] ?? null;
+    const pausedQueue = state.pausedQueueBySessionId[sessionId] ?? null;
+    const hasQueuedState =
+        queue.length > 0 ||
+        activeQueuedMessage != null ||
+        editState != null ||
+        pausedQueue != null;
+
+    if (!hasQueuedState) {
+        return null;
+    }
+
+    const nextQueuedMessageEditBySessionId = {
+        ...state.queuedMessageEditBySessionId,
+    };
+    delete nextQueuedMessageEditBySessionId[sessionId];
+
+    _queueDrainLocks.delete(sessionId);
+
+    return {
+        session: upsertSessionStatusMessage(
+            editState
+                ? {
+                      ...session,
+                      attachments:
+                          editState.previousAttachments.map(cloneAttachment),
+                  }
+                : session,
+            createClosedSubagentQueueCancelledStatus(sessionId),
+        ),
+        composerPartsBySessionId: editState
+            ? {
+                  ...state.composerPartsBySessionId,
+                  [sessionId]: cloneComposerParts(
+                      editState.previousComposerParts,
+                  ),
+              }
+            : state.composerPartsBySessionId,
+        queuedMessagesBySessionId: cleanupQueuedMessagesBySessionId(
+            state.queuedMessagesBySessionId,
+            sessionId,
+            [],
+        ),
+        activeQueuedMessageBySessionId: cleanupDeferredQueuedMessagesBySessionId(
+            state.activeQueuedMessageBySessionId,
+            sessionId,
+            null,
+        ),
+        queuedMessageEditBySessionId: nextQueuedMessageEditBySessionId,
+        pausedQueueBySessionId: cleanupPausedQueueBySessionId(
+            state.pausedQueueBySessionId,
+            sessionId,
+            null,
+        ),
     };
 }
 
@@ -4804,6 +4901,7 @@ function applyPersistedHistoryMetadata(
                 history.parent_session_id ??
                 nextSession.parentSessionId ??
                 null,
+            closedAt: history.closed_at ?? nextSession.closedAt ?? null,
             persistedCreatedAt: history.created_at,
             persistedUpdatedAt: history.updated_at,
             persistedTitle: history.title ?? null,
@@ -4834,6 +4932,7 @@ function applyPersistedHistoryPage(
         version: 1,
         session_id: page.session_id,
         parent_session_id: session.parentSessionId ?? undefined,
+        closed_at: session.closedAt ?? undefined,
         runtime_id: session.runtimeId,
         model_id: session.modelId,
         mode_id: session.modeId,
@@ -4916,6 +5015,7 @@ function createPersistedSession(
             sessionId: `persisted:${history.session_id}`,
             historySessionId: history.session_id,
             parentSessionId: history.parent_session_id ?? null,
+            closedAt: history.closed_at ?? null,
             runtimeSessionId: null,
             vaultPath,
             runtimeId,
@@ -5101,6 +5201,10 @@ function mergeSession(
     existing: AIChatSession | undefined,
     incoming: AIChatSession,
 ): AIChatSession {
+    const incomingHasClosedAt = Object.prototype.hasOwnProperty.call(
+        incoming,
+        "closedAt",
+    );
     const canAcceptBackendStreaming =
         incoming.status === "streaming" &&
         incoming.parentSessionId != null &&
@@ -5136,6 +5240,7 @@ function mergeSession(
                     customTitle: incoming.customTitle ?? null,
                     persistedPreview: incoming.persistedPreview ?? null,
                     parentSessionId: incoming.parentSessionId ?? null,
+                    closedAt: incoming.closedAt ?? null,
                     persistedMessageCount:
                         incoming.persistedMessageCount ??
                         incoming.messages.length,
@@ -5196,6 +5301,9 @@ function mergeSession(
             incoming.parentSessionId ??
             normalizedExisting.parentSessionId ??
             null,
+        closedAt: incomingHasClosedAt
+            ? (incoming.closedAt ?? null)
+            : (normalizedExisting.closedAt ?? null),
         vaultPath: incoming.vaultPath ?? normalizedExisting.vaultPath ?? null,
         isPersistedSession:
             incoming.isPersistedSession ??
@@ -5510,6 +5618,7 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
         version: 1,
         session_id: session.historySessionId || session.sessionId,
         parent_session_id: session.parentSessionId ?? undefined,
+        closed_at: session.closedAt ?? undefined,
         runtime_id: session.runtimeId,
         model_id: session.modelId,
         mode_id: session.modeId,
@@ -6451,6 +6560,15 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (!session) {
                 return;
             }
+        }
+
+        if (isClosedSubagentSession(session)) {
+            if (source === "queue") {
+                patchQueuedMessage(activeSessionId, currentItem.id, {
+                    status: "failed",
+                });
+            }
+            return;
         }
 
         if (source === "queue") {
@@ -7508,7 +7626,20 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     : hydrateRuntimesFromSessions(state.runtimes, [
                           scopedSession,
                       ]);
-                const nextSession = mergeSession(existing, scopedSession);
+                let nextSession = mergeSession(existing, scopedSession);
+                const closedQueueState =
+                    existing &&
+                    !isClosedSubagentSession(existing) &&
+                    isClosedSubagentSession(nextSession)
+                        ? clearClosedSubagentQueueState(
+                              state,
+                              scopedSession.sessionId,
+                              nextSession,
+                          )
+                        : null;
+                if (closedQueueState) {
+                    nextSession = closedQueueState.session;
+                }
                 const nextTokenUsageBySessionId =
                     existing && existing.modelId !== nextSession.modelId
                         ? removeSessionMapEntry(
@@ -7519,7 +7650,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const reconciledQueueState =
                     existing &&
                     nextSession.status === "idle" &&
-                    !nextSession.isResumingSession
+                    !nextSession.isResumingSession &&
+                    !isClosedSubagentSession(nextSession)
                         ? reconcileIdleQueuedState(
                               state,
                               scopedSession.sessionId,
@@ -7529,7 +7661,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     nextSession.status === "idle" &&
                     (existing?.status !== "idle" ||
                         Boolean(reconciledQueueState)) &&
-                    !nextSession.isResumingSession;
+                    !nextSession.isResumingSession &&
+                    !isClosedSubagentSession(nextSession);
                 sessionToPersist = nextSession;
 
                 return {
@@ -7559,17 +7692,29 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         activate || !state.activeSessionId
                             ? nextSession.runtimeId
                             : state.selectedRuntimeId,
-                    composerPartsBySessionId: state.composerPartsBySessionId[
-                        scopedSession.sessionId
-                    ]
-                        ? state.composerPartsBySessionId
-                        : {
-                              ...state.composerPartsBySessionId,
-                              [scopedSession.sessionId]:
-                                  createEmptyComposerParts(),
-                          },
+                    composerPartsBySessionId:
+                        closedQueueState?.composerPartsBySessionId ??
+                        (state.composerPartsBySessionId[scopedSession.sessionId]
+                            ? state.composerPartsBySessionId
+                            : {
+                                  ...state.composerPartsBySessionId,
+                                  [scopedSession.sessionId]:
+                                      createEmptyComposerParts(),
+                              }),
                     tokenUsageBySessionId: nextTokenUsageBySessionId,
                     ...(reconciledQueueState ?? {}),
+                    ...(closedQueueState
+                        ? {
+                              queuedMessagesBySessionId:
+                                  closedQueueState.queuedMessagesBySessionId,
+                              activeQueuedMessageBySessionId:
+                                  closedQueueState.activeQueuedMessageBySessionId,
+                              queuedMessageEditBySessionId:
+                                  closedQueueState.queuedMessageEditBySessionId,
+                              pausedQueueBySessionId:
+                                  closedQueueState.pausedQueueBySessionId,
+                          }
+                        : {}),
                 };
             });
 
@@ -9457,6 +9602,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 return;
             }
 
+            if (isClosedSubagentSession(session)) {
+                return;
+            }
+
             if (
                 !isLiveRuntimeSession(session) ||
                 needsFullResumeContextTranscript(session)
@@ -9660,7 +9809,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (
                 !currentSession ||
                 !queuedItem ||
-                queuedItem.status === "sending"
+                queuedItem.status === "sending" ||
+                isClosedSubagentSession(currentSession)
             ) {
                 return;
             }
@@ -9707,6 +9857,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 !session ||
                 session.status !== "idle" ||
                 session.isResumingSession ||
+                isClosedSubagentSession(session) ||
                 Boolean(get().queuedMessageEditBySessionId[sessionId]) ||
                 Boolean(get().pausedQueueBySessionId[sessionId])
             ) {

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -341,6 +341,7 @@ export interface AIChatSession {
     historySessionId: string;
     parentSessionId?: string | null;
     runtimeSessionId?: string | null;
+    closedAt?: string | null;
     /**
      * For the "claude-code-terminal" pseudo-runtime: the terminal runtime this
      * agent entry stands in for. Clicking the entry focuses that terminal tab
@@ -411,6 +412,7 @@ export interface AIBackendSessionPayload {
     session_id: string;
     parent_session_id?: string | null;
     runtime_session_id?: string | null;
+    closed_at?: string | null;
     title?: string | null;
     runtime_id: string;
     model_id: string;
@@ -683,6 +685,7 @@ export interface PersistedSessionHistory {
     version: number;
     session_id: string;
     parent_session_id?: string | null;
+    closed_at?: string | null;
     runtime_id?: string;
     model_id: string;
     mode_id: string;

--- a/crates/ai/src/domain.rs
+++ b/crates/ai/src/domain.rs
@@ -96,6 +96,8 @@ pub struct AiSession {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     pub runtime_id: String,
     pub model_id: String,

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -60,6 +60,8 @@ pub struct PersistedSessionHistory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parent_session_id: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub closed_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub runtime_id: Option<String>,
     pub model_id: String,
     pub mode_id: String,
@@ -117,6 +119,8 @@ struct PersistedSessionMetadata {
     session_id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     parent_session_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    closed_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     runtime_id: Option<String>,
     model_id: String,
@@ -388,6 +392,7 @@ fn metadata_from_history(
         version: history.version,
         session_id: history.session_id.clone(),
         parent_session_id: history.parent_session_id.clone(),
+        closed_at: history.closed_at.clone(),
         runtime_id: history.runtime_id.clone(),
         model_id: history.model_id.clone(),
         mode_id: history.mode_id.clone(),
@@ -419,6 +424,7 @@ fn history_from_metadata(
         version: metadata.version,
         session_id: metadata.session_id,
         parent_session_id: metadata.parent_session_id,
+        closed_at: metadata.closed_at,
         runtime_id: metadata.runtime_id,
         model_id: metadata.model_id,
         mode_id: metadata.mode_id,
@@ -443,6 +449,7 @@ fn load_legacy_history_file(path: &Path) -> Result<PersistedSessionHistory, Stri
         version: history.version,
         session_id: history.session_id,
         parent_session_id: history.parent_session_id,
+        closed_at: history.closed_at,
         runtime_id: history.runtime_id,
         model_id: history.model_id,
         mode_id: history.mode_id,
@@ -1340,6 +1347,7 @@ pub fn load_all_session_histories(
                     version: history.version,
                     session_id: history.session_id,
                     parent_session_id: history.parent_session_id,
+                    closed_at: history.closed_at,
                     runtime_id: history.runtime_id,
                     model_id: history.model_id,
                     mode_id: history.mode_id,
@@ -1369,6 +1377,7 @@ pub fn load_all_session_histories(
                     version: history.version,
                     session_id: history.session_id,
                     parent_session_id: history.parent_session_id,
+                    closed_at: history.closed_at,
                     runtime_id: history.runtime_id,
                     model_id: history.model_id,
                     mode_id: history.mode_id,
@@ -1587,6 +1596,7 @@ pub fn fork_session_history(vault_root: &Path, source_session_id: &str) -> Resul
         version: source_meta.version,
         session_id: new_session_id.clone(),
         parent_session_id: None,
+        closed_at: None,
         runtime_id: source_meta.runtime_id,
         model_id: source_meta.model_id,
         mode_id: source_meta.mode_id,
@@ -1665,6 +1675,7 @@ mod tests {
             version: 1,
             session_id: "session-1".to_string(),
             parent_session_id: None,
+            closed_at: None,
             runtime_id: Some("codex-acp".to_string()),
             model_id: "test-model".to_string(),
             mode_id: "default".to_string(),
@@ -1735,6 +1746,7 @@ mod tests {
             version: 1,
             session_id: "session-1".to_string(),
             parent_session_id: None,
+            closed_at: None,
             runtime_id: Some("codex-acp".to_string()),
             model_id: "test-model".to_string(),
             mode_id: "default".to_string(),
@@ -1986,6 +1998,7 @@ mod tests {
         let dir = make_temp_dir();
         let mut history = sample_history_with_session_id("child-session");
         history.parent_session_id = Some("parent-session".to_string());
+        history.closed_at = Some("123".to_string());
 
         save_session_history(&dir, &history).expect("child history should persist");
 
@@ -1995,6 +2008,7 @@ mod tests {
             metadata.parent_session_id.as_deref(),
             Some("parent-session")
         );
+        assert_eq!(metadata.closed_at.as_deref(), Some("123"));
 
         let summaries =
             load_all_session_histories(&dir, false).expect("history summaries should load");
@@ -2003,9 +2017,11 @@ mod tests {
             summaries[0].parent_session_id.as_deref(),
             Some("parent-session")
         );
+        assert_eq!(summaries[0].closed_at.as_deref(), Some("123"));
 
         let full = load_all_session_histories(&dir, true).expect("full history should load");
         assert_eq!(full[0].parent_session_id.as_deref(), Some("parent-session"));
+        assert_eq!(full[0].closed_at.as_deref(), Some("123"));
 
         fs::remove_dir_all(dir).ok();
     }
@@ -2134,6 +2150,7 @@ mod tests {
             version: 1,
             session_id: "session-1".to_string(),
             parent_session_id: None,
+            closed_at: None,
             runtime_id: Some("codex-acp".to_string()),
             model_id: "test-model".to_string(),
             mode_id: "default".to_string(),
@@ -2506,6 +2523,7 @@ mod tests {
             version: 1,
             session_id: "session-1".to_string(),
             parent_session_id: None,
+            closed_at: None,
             runtime_id: Some("codex-acp".to_string()),
             model_id: "test-model".to_string(),
             mode_id: "default".to_string(),


### PR DESCRIPTION
## Summary

This hardens closed subagent sessions end to end. Subagents closed by their parent thread now carry a persisted `closed_at` marker, reject direct prompts, and show a read-only composer state explaining that the parent closed the subagent.

The chat store also cleans any pending queue state when a subagent transitions to closed. If queued work is cancelled, the transcript gets a status note: `Queued messages were cancelled because this subagent was closed by its parent thread.` This prevents stale queued items from appearing actionable after the subagent can no longer receive work.

## Root Cause

Closed subagents were previously only moved back to idle, which made them look available. That allowed direct prompts or queued messages to target a runtime session that had already been closed by the parent thread.

## Validation

- `git diff --check`
- `npm run test -- src/features/ai/store/chatStore.test.ts`
- `npm run build`
- `cargo test -p neverwrite-ai preserves_parent_session_id_in_lazy_metadata`
- `cargo test -p neverwrite-native-backend subagent_close_breadcrumb_marks_child_closed`
- `cargo test -p neverwrite-native-backend send_message_rejects_subagent_closed_by_parent`
- `cargo test -p neverwrite-native-backend child_turn_started_lifecycle_marks_child_streaming`
