### PR TITLE
Update recent feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Today the repository combines:
 - An Electron desktop app with a Rust sidecar that opens a local vault and keeps working state on disk.
 - A Markdown, CSV, and text/code editing workflow with wikilinks, live preview, frontmatter editing, spellcheck, and grammar checking.
 - Knowledge navigation tools such as backlinks, tags, advanced search, bookmarks, concept maps, and a 2D/3D graph view.
-- An ACP-based AI layer with Codex, Claude, Gemini, and Kilo runtimes.
+- An ACP-based AI layer with Codex, Claude, Gemini, Kilo, and OpenCode runtimes.
 - An explicit AI change-review system with inline review inside the editor and a dedicated surface in chat and a tab with changes pending approval.
 - A separate browser web clipper that can save directly into the desktop app through a local API, with deep-link fallback. Compatible with both Firefox and Chromium.
 
@@ -31,8 +31,8 @@ Today the repository combines:
 The current product already includes:
 
 - Local vault opening with progress reporting, persisted snapshots, filesystem watching, and incremental re-sync
-- A desktop workspace with tabs, sidebars, command palette, quick switcher, detached windows, and a developer terminal
-- Native-feeling editing for Markdown notes, CSV files, PDFs, images, and generic text/code files
+- A desktop workspace with tabs, sidebars, command palette, quick switcher, detached windows, and first-class terminal tabs
+- Native-feeling editing for Markdown notes, CSV files, PDFs, images, HTML previews, and generic text/code files
 - Embedded Excalidraw-based concept maps stored as `.excalidraw` files in the vault. The map format is visible and editable by agents.
 - A graph view with global, local, and overview modes plus 2D and 3D rendering
 - AI chat sessions with attachments from the vault, slash commands, transcript persistence, and runtime-specific capabilities
@@ -56,9 +56,11 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 - Open, index, and watch a local vault.
 - Recent vaults, pinned vaults, reopen-last-vault behavior
 - File tree with drag and drop, multi-selection, sorting, and context actions
+- File tree modes for curated writing/media files, all vault files, or an explicit extension allowlist
 - Persistent bookmarks per vault
 - Persistent tabs and window session restore
 - Detached note windows and separate vault windows
+- First-class terminal tabs with themed xterm rendering, persistent workspace state, search, and Claude Code integration in the Agents sidebar
 
 ### Editing and reading
 
@@ -69,6 +71,7 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 - Frontmatter/properties editing
 - CSV editing with table and raw fallback views
 - Editable text/code files with syntax highlighting and autosave
+- Sandboxed in-app HTML viewing for `.html` and `.htm` files
 - PDF viewing with visual filters
 - Internal image viewing with fit and zoom
 - App-owned Hunspell-based spellcheck with bundled `en-US` and `es-ES`
@@ -84,7 +87,7 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 
 ### AI and change control
 
-- ACP runtime integration for Codex, Claude, Gemini, and Kilo
+- ACP runtime integration for Codex, Claude, Gemini, Kilo, and OpenCode
 - Attachment flows for notes, folders, files, PDFs, audio, images, and screenshots
 - Session history, transcript viewing, session export, fork, resume, and rename flows
 - Crash recovery for saved chats through `Chat History` and local `.neverwrite/sessions/` transcripts
@@ -207,12 +210,13 @@ The repository already contains broad Vitest coverage in the desktop app and web
 
 ## AI Runtime Notes
 
-NeverWrite currently wires four ACP runtimes:
+NeverWrite currently wires five ACP runtimes:
 
 - `codex-acp`
 - `claude-acp`
 - `gemini-acp`
 - `kilo-acp`
+- `opencode-acp`
 
 Current packaging status:
 
@@ -220,6 +224,7 @@ Current packaging status:
 - Claude is intended to be bundled through an embedded Node runtime plus vendored runtime files.
 - Gemini is integrated in the app, but not bundled by default today.
 - Kilo is integrated in the app, but not bundled by default today.
+- OpenCode is integrated in the app, but not bundled by default today.
 
 Useful runtime overrides during development:
 
@@ -227,6 +232,7 @@ Useful runtime overrides during development:
 - `NEVERWRITE_CLAUDE_ACP_BIN`
 - `NEVERWRITE_GEMINI_ACP_BIN`
 - `NEVERWRITE_KILO_ACP_BIN`
+- `NEVERWRITE_OPENCODE_ACP_BIN`
 
 For release builds, see `apps/desktop/scripts/stage-electron-sidecar.mjs` and `release/appcast/README.md`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ polish and hardening.
 
 - [AI Change Control](ai-change-control.md): the ActionLog model, tracked files, pending review, keep/reject flows, inline review, conflicts, persistence, and known limits.
 - [Review Hardening Checklist](review-hardening-checklist.md): manual QA checklist for inline review, Review tab, Edits surface, keep/reject, lifecycle cases, multi-session, reload/recovery, conflicts, performance, and release sign-off.
-- [AI Runtime Setup](ai-runtime-setup.md): ACP providers, runtime discovery, authentication methods, `NEVERWRITE_*` overrides, release bundling, and troubleshooting for Codex, Claude, Gemini, and Kilo.
+- [AI Runtime Setup](ai-runtime-setup.md): ACP providers, runtime discovery, authentication methods, `NEVERWRITE_*` overrides, release bundling, and troubleshooting for Codex, Claude, Gemini, Kilo, and OpenCode.
 - [AI Session History And Crash Recovery](ai-session-history.md): where chat transcripts are stored, how restore/fork/reconnect works, and what to check after a crash.
 
 Read these before changing AI editing behavior, provider setup, session
@@ -27,10 +27,12 @@ remain reviewable.
 ## Editor And Workspace
 
 - [Editor Architecture](editor-architecture.md): CodeMirror, live preview, wikilinks, frontmatter/properties, autosave, dirty tabs, merge view, inline review overlays, and power-user invariants.
+- [Terminal Architecture](terminal-integration.md): PTY sidecar boundary, xterm rendering, terminal persistence, Claude Code integration, and validation notes.
 - [Subagents Working State Map](concept-maps/codex-subagents-working-state-map.excalidraw): visual working map for subagent state and coordination.
 
 Use these when touching the editor surface, tab model, pane/workspace behavior,
-selection/cursor handling, live preview, or inline review rendering.
+selection/cursor handling, live preview, inline review rendering, or terminal
+tabs.
 
 ## Data, Privacy, And Diagnostics
 
@@ -50,4 +52,4 @@ tokens, provider credentials, or personally sensitive paths.
 These currently live next to their implementation/release artifacts because
 they are tightly coupled to package-specific workflows.
 
-Last updated: May 30, 2026.
+Last updated: June 1, 2026.

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -80,10 +80,11 @@ Codex ChatGPT auth is implemented through the ACP `authenticate` request and
 requires a resolved Codex runtime binary before NeverWrite marks it connected.
 Codex does not use the integrated auth terminal.
 
-Claude, Gemini, Kilo, and OpenCode expose integrated terminal auth methods. NeverWrite
-starts the provider CLI in a PTY and marks auth pending before launch. A zero
-exit code marks the provider verified; Gemini can also be marked verified when
-the terminal output contains the success strings recognized by the backend.
+Claude, Gemini, Kilo, and OpenCode expose integrated terminal auth methods.
+NeverWrite starts the provider CLI in a PTY and marks auth pending before
+launch. A zero exit code marks the provider verified; Gemini and OpenCode can
+also be marked verified when terminal output contains success strings recognized
+by the backend.
 
 Claude adapts its visible terminal login methods to the environment. In remote
 or no-browser environments (`NO_BROWSER`, `SSH_CONNECTION`, `SSH_CLIENT`,
@@ -155,9 +156,10 @@ the CLI separately or configure `NEVERWRITE_KILO_ACP_BIN`.
 
 Use OpenCode terminal login from the setup UI, pre-existing OpenCode CLI auth, a
 provider key inherited by the OpenCode CLI, or `/connect` inside OpenCode.
-NeverWrite does not store OpenCode provider secrets in V1; auth remains owned by
-the OpenCode CLI. Disconnecting OpenCode clears NeverWrite's local selection and
-persists an invalidation marker, but it does not delete `opencode/auth.json`.
+The current UI keeps OpenCode auth primarily owned by the OpenCode CLI rather
+than exposing a first-party API key form. Disconnecting OpenCode clears
+NeverWrite's local selection and persists an invalidation marker, but it does
+not delete `opencode/auth.json`.
 
 Because OpenCode is not bundled by default, install the CLI separately or
 configure `NEVERWRITE_OPENCODE_ACP_BIN`. NeverWrite launches sessions as
@@ -255,6 +257,7 @@ Current packaging expectations:
 - Claude is bundled through embedded Node plus vendored runtime files.
 - Gemini is integrated but not bundled by default.
 - Kilo is integrated but not bundled by default.
+- OpenCode is integrated but not bundled by default.
 
 ## Troubleshooting
 
@@ -326,8 +329,8 @@ GUI-launched apps often inherit a different PATH than interactive shells.
 Development can resolve Codex and Claude from vendor paths if those artifacts
 exist. Packaged builds should resolve Codex and Claude from
 `NEVERWRITE_ELECTRON_ACP_RESOURCE_DIR`, which Electron sets to the staged
-resources directory. Gemini and Kilo still require an external CLI or explicit
-runtime override in both development and packaged builds.
+resources directory. Gemini, Kilo, and OpenCode still require an external CLI or
+explicit runtime override in both development and packaged builds.
 
 If a provider works in `npm run dev` but not in a packaged app, verify:
 
@@ -364,4 +367,4 @@ cd apps/desktop
 npm run electron:package:unsigned
 ```
 
-Last updated: May 11, 2026.
+Last updated: June 1, 2026.

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -224,7 +224,7 @@ Secret account names are runtime/key pairs such as `codex:OPENAI_API_KEY` or
 `claude:ANTHROPIC_API_KEY`. Supported secret env keys include `CODEX_API_KEY`,
 `OPENAI_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`,
 `ANTHROPIC_CUSTOM_HEADERS`, `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and
-`KILO_API_KEY`.
+`KILO_API_KEY`, and `OPENCODE_API_KEY`.
 
 Do not share `runtime-setup.json` without reviewing it: even when secret values
 are not stored there, it can reveal private endpoint URLs, local binary paths,
@@ -352,4 +352,4 @@ the contents.
 - Third-party AI runtime CLIs can store their own auth state outside NeverWrite.
   Check that provider's documentation before sharing provider config folders.
 
-Last updated: May 11, 2026.
+Last updated: June 1, 2026.

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -202,10 +202,10 @@ Settings / AI chat UI
   -> chat store, review UI, transcript persistence
 ```
 
-The backend currently supports Codex, Claude, Gemini, and Kilo runtime IDs. Codex
-and Claude have vendored release inputs under `vendor/`; Gemini and Kilo are
-integrated as external runtimes that must be found on `PATH` or configured by
-override.
+The backend currently supports Codex, Claude, Gemini, Kilo, and OpenCode runtime
+IDs. Codex and Claude have vendored release inputs under `vendor/`; Gemini, Kilo,
+and OpenCode are integrated as external runtimes that must be found on `PATH` or
+configured by override.
 
 ACP session notifications are normalized into renderer events for assistant
 message deltas, thinking deltas, tool activity, file diffs, permission requests,
@@ -315,4 +315,4 @@ and Electron smoke tests when possible.
   [`apps/web-clipper/src/lib/desktop-api.ts`](../apps/web-clipper/src/lib/desktop-api.ts),
   and [`apps/desktop/src-electron/main/webClipper.ts`](../apps/desktop/src-electron/main/webClipper.ts).
 
-Last updated: May 11, 2026.
+Last updated: June 1, 2026.

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -169,7 +169,7 @@ preferences, workspace state, or privacy-relevant local state.
 | `neverwrite.session.tabs:<vault-path>` | Per-vault | Current workspace | `editorSession.ts` | Editor tabs and workspace restore state. |
 | `neverwrite.chat.tabs:<vault-path>` | Per-vault | Initial chat tab state | `chatTabsStore.ts` | Chat tab workspace for the vault. |
 | `neverwrite.ai.review.view:<vault-or-__global__>:<session-id>` | Per-vault plus session | None | `reviewTabPersistence.ts` | Review tab UI state such as expanded files, scroll, anchors, zoom, and wide mode. |
-| `neverwrite.devtools.terminal.tabs:<vault-path>` | Per-vault | Initial terminal tab | `useTerminalTabs.ts` | Terminal workspace tabs for the vault. |
+| `neverwrite.devtools.terminal.tabs:<vault-path>` | Per-vault legacy migration | Initial terminal tab | `useTerminalTabs.ts` / `legacyTerminalMigration.ts` | Older standalone terminal workspace state, migrated into `neverwrite.session.tabs:<vault-path>`. |
 | `neverwrite.workspace.terminal.legacyMigrated:<vault-path>` | Per-vault migration marker | None | `legacyTerminalMigration.ts` | Marks migration from older terminal workspace state. |
 | `neverwrite.terminal.replay:<terminal-id>` | Per-terminal | None | `terminalRuntimeStore.ts` | Terminal replay buffer snapshot; cache/state, not a setting. |
 | `neverwrite.sidebar.width` | Global layout | `280` | `layoutStore.ts` | Sidebar width. |
@@ -244,4 +244,4 @@ when they are persisted or visible in Settings:
 - Review anchors, resolved hunk positions, and transient review synchronization
   state.
 
-Last updated: May 30, 2026.
+Last updated: June 1, 2026.

--- a/docs/terminal-followups.md
+++ b/docs/terminal-followups.md
@@ -1,211 +1,75 @@
-# Terminal Integration — Follow-up Items
+# Terminal Follow-up Items
 
-From the Opus code review of `feature/terminal-first-class`. These are not blockers
-for merge but should be addressed in follow-up PRs.
+This page tracks terminal and Claude Code integration work that is still worth
+doing after the first-class terminal rollout. It intentionally omits follow-ups
+that have already landed, so this file can be used as a real backlog.
 
----
+Resolved items from the original review:
 
-## 1. Cache the binary check — eliminate three redundant `sh` spawns
+- `checkClaudeCodeInstalled()` now uses a module-level cache in
+  [`claudeCodeTerminal.ts`](../apps/desktop/src/features/terminal/claudeCodeTerminal.ts).
+- `CLAUDE_TERMINAL_DESCRIPTOR` and `buildClaudeTerminalSetupStatus()` now live in
+  [`claudeTerminalRuntime.ts`](../apps/desktop/src/features/ai/utils/claudeTerminalRuntime.ts).
+- `waitForTerminalRunning()` now uses a Zustand subscription with a timeout and a
+  visible console warning on failure.
+- `CLAUDE_TUI_SETTLE_MS` was raised to `3_500` and documented as a heuristic.
+- Claude Code is no longer auto-promoted to the default runtime just because a
+  `claude` binary exists on `PATH`; explicit user/default runtime selection is
+  preferred.
 
-**What:** `checkClaudeCodeInstalled()` is called independently from three places:
-`chatStore.initialize`, `AIProvidersSettings`, and `TerminalSettings`. Each spawns
-`sh -lc 'command -v claude'` (~40–80ms on macOS). They can disagree mid-session and
-waste 3× the startup time.
+## 1. Detect Claude Code Readiness From Output
 
-**Fix:** Add a module-level cache in `claudeCodeTerminal.ts`:
+**What:** Claude Code prompt prefill still waits for a fixed TUI settle delay
+before writing `@` mentions. This is intentionally conservative but imperfect:
+cold starts can need more time, while warm starts wait longer than necessary.
 
-```ts
-let _cached: boolean | null = null;
+**Better fix:** Watch terminal output for a stable Claude Code ready marker, then
+inject the prefilled context as soon as the TUI is ready. Candidate signals might
+include the prompt block or a stable hint line, but this depends on Claude Code's
+output format staying stable across versions.
 
-export async function checkClaudeCodeInstalled(): Promise<boolean> {
-    if (_cached !== null) return _cached;
-    try {
-        const result = await invoke<{ found: boolean }>(
-            "devtools_check_binary", { name: "claude" }
-        );
-        _cached = result.found;
-        return _cached;
-    } catch { return false; }
-}
-```
+**Fallback:** Keep the fixed delay if no reliable marker exists. It is better to
+be a little slow than to write context into a half-initialized TUI.
 
-Additionally, `TerminalSettings` and `AIProvidersSettings` should read
-`setupStatusByRuntimeId[CLAUDE_TERMINAL_RUNTIME_ID]?.binaryReady` from the chatStore
-when the store is already initialized, rather than issuing their own IPC calls. The
-module-level cache handles the cold path (settings opened before store finishes).
+**Effort:** Medium.
 
-**Effort:** Small — 1–2 file changes.
+## 2. Tighten Runtime Selection Semantics
 
----
+**What:** `chatStore` now has `defaultRuntimeId` and `selectedRuntimeId`, but
+`getDefaultNewChatRuntimeId()` can still fall back to `selectedRuntimeId` when no
+explicit default is selectable. That keeps behavior forgiving, but it still lets
+the current session influence the runtime for a new chat.
 
-## 2. De-duplicate `CLAUDE_TERMINAL_DESCRIPTOR` and setup status builder
+**Fix:** Decide whether new-chat runtime selection should be driven only by
+`defaultRuntimeId` plus the implicit ACP fallback. If so, remove
+`selectedRuntimeId` from `getDefaultNewChatRuntimeId()` and adjust tests and UI
+copy around "current session runtime" vs "default for new chats".
 
-**What:** The descriptor (`{ runtime: { id, name, description, capabilities }, ... }`)
-and `buildClaudeTerminalSetupStatus` are inline in `chatStore.ts`. The message text
-slightly diverges from what `AIProvidersSettings` builds locally. Same shape, two
-sources.
+**Effort:** Small to medium.
 
-**Fix:** Move both to a new `features/ai/utils/claudeTerminalRuntime.ts` file and
-import from `chatStore.ts` and `AIProvidersSettings.tsx`. Unify the "not found" message
-copy at the same time.
+## 3. Surface Terminal Startup Failures In The UI
 
-**Effort:** Small — 1 new file, 2 import updates.
+**What:** `waitForTerminalRunning()` logs a warning when startup times out, but
+the user-facing failure path is still indirect. A timeout during Claude Code
+launch should be obvious in the workspace, especially when a context action
+opened the terminal automatically.
 
----
+**Fix:** Route timeout/error state to the terminal tab or a toast so the user
+knows the Claude Code startup action failed and can retry from the same context.
 
-## 3. Replace `waitForTerminalRunning` poll with Zustand subscribe
+**Effort:** Small.
 
-**What:** The function uses `setInterval(100ms)` + `setTimeout(10s)` to detect when
-the PTY reaches `"running"` state. Polling introduces up to 100ms extra lag and is
-stylistically wrong given Zustand's synchronous subscription API.
+## 4. Review Claude Code Version Detection
 
-**Fix:**
+**What:** The binary check verifies that `claude` exists, but does not validate
+that it is the expected Claude Code CLI or that the version supports the flags
+NeverWrite sends.
 
-```ts
-function waitForTerminalRunning(terminalId: string): Promise<boolean> {
-    return new Promise((resolve) => {
-        const check = () => {
-            const status =
-                useTerminalRuntimeStore.getState().runtimesById[terminalId]
-                    ?.snapshot.status;
-            if (status === "running") return "ready";
-            if (status === "error" || status === "exited") return "failed";
-            return null;
-        };
+**Fix:** Consider a lightweight `claude --version` probe when diagnosing setup or
+before enabling version-sensitive flags. Avoid doing this on every startup unless
+the result is cached, because GUI app startup is already sensitive to shell
+spawns.
 
-        // Synchronous check before subscribing — avoids missing events
-        // that fired between openTerminal() and subscribe().
-        const immediate = check();
-        if (immediate) { resolve(immediate === "ready"); return; }
+**Effort:** Medium.
 
-        const deadline = setTimeout(() => {
-            unsub();
-            resolve(false);
-        }, TERMINAL_READY_TIMEOUT_MS);
-
-        const unsub = useTerminalRuntimeStore.subscribe(() => {
-            const result = check();
-            if (result) {
-                clearTimeout(deadline);
-                unsub();
-                resolve(result === "ready");
-            }
-        });
-    });
-}
-```
-
-Also: when the timeout fires (terminal never became ready), surface a visible error
-rather than silently abandoning. A console.warn is the minimum; a toast or tab
-error state is better.
-
-**Effort:** Small — one function replacement.
-
----
-
-## 4. Raise `CLAUDE_TUI_SETTLE_MS` and document the limitation
-
-**What:** The 2-second fixed delay before pre-filling @mentions is a guess that's too
-short on cold starts (slow disk, first auth) and wastes 1.6s on warm ones. The right
-fix is detecting Claude Code's ready state from its output.
-
-**Short-term fix:** Raise the constant to 3.5s and add a comment explaining why it
-exists and what a proper fix would look like:
-
-```ts
-// Fixed delay waiting for Claude Code's TUI to finish initialising. This is a
-// best-effort heuristic — a cold start (first auth, slow disk) may need more time.
-// A proper fix would watch terminal rawOutput for a stable "ready" marker, or
-// use a Claude Code CLI flag for initial prompt injection once one exists.
-const CLAUDE_TUI_SETTLE_MS = 3_500;
-```
-
-**Long-term fix:** Watch `rawOutput` from the terminal session for a string that
-reliably indicates Claude Code is ready for input (e.g., the presence of the `>`
-prompt block or the "Try" hint line). This depends on Claude Code's output format
-staying stable — flag it as a known fragility.
-
-**Effort:** Trivial (constant bump) or Medium (output watching).
-
----
-
-## 5. Persist the auto-selected default; verify it's actually Claude Code
-
-**What:** When `claude` is found in PATH and no explicit preference exists, the app
-auto-defaults to Claude Code each launch by re-running the binary check. Two problems:
-
-1. If the binary becomes unavailable after first use, behavior changes silently on
-   next launch.
-2. A tool named `claude` that is not Claude Code would be auto-selected — unlikely
-   but possible (e.g., a local script or AUR package).
-
-**Fix:**
-
-*Persistence:* When `claudeFound === true` and `persistedRuntimeId === null` in
-`chatStore.initialize`, write the auto-selected default to `AiPreferences` just as
-`setSelectedRuntime` would. This makes the choice stable and visible in Settings.
-
-```ts
-const defaultRuntimeId =
-    persistedRuntimeId ??
-    (claudeFound ? CLAUDE_TERMINAL_RUNTIME_ID : null) ??
-    getDefaultRuntimeId(runtimes, setupStatusByRuntimeId);
-
-// Persist auto-selection so it survives binary removal / reinstall cleanly.
-if (!persistedRuntimeId && claudeFound && defaultRuntimeId === CLAUDE_TERMINAL_RUNTIME_ID) {
-    saveAiPreferences({ defaultRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID });
-}
-```
-
-*Verification:* Run `claude --version` and check the output contains "Claude" or
-matches a known version pattern before auto-selecting. This is a second shell spawn
-on startup but prevents false positives. Can be skipped if the team decides the
-risk is acceptable.
-
-**Effort:** Small (persistence only) or Medium (persistence + version check).
-
----
-
-## 6. Separate `selectedRuntimeId` from `userDefaultRuntimeId` in chatStore
-
-**What:** `selectedRuntimeId` in the chatStore serves two conflated purposes:
-- The runtime displayed in the chat header for the current session
-- The user's default for new chats
-
-This forced `getDefaultNewChatRuntimeId()` to reach around the store and read from
-`AiPreferences` directly, because the active session's runtime was overwriting the
-user's default in the second `set()` call inside `initialize()`.
-
-**Fix:** Introduce `userDefaultRuntimeId: string | null` as a separate, first-class
-store field:
-
-- Set during `initialize()` (from persisted pref or auto-detection), never overridden
-  by session restore
-- Written via `setUserDefaultRuntime(id)` (which also persists to `AiPreferences`)
-- Read directly in `handleAttachToNewChat`, `ai:new-agent`, and anywhere else that
-  needs "what does the user want for new chats"
-- `selectedRuntimeId` retains its existing role as the UI-visible "active session
-  runtime" and is NOT persisted
-
-`getDefaultNewChatRuntimeId()` can be deleted once this is in place. The AI Providers
-"Default agent" dropdown would bind to `userDefaultRuntimeId`.
-
-**Effort:** Medium — touches chatStore interface, initialize, setSelectedRuntime,
-and 3–4 call sites. No new behaviour, pure refactor. Worth doing before the store
-gets any larger.
-
----
-
-## Sequencing
-
-| # | Item | Effort | Priority | Blocks |
-|---|---|---|---|---|
-| 2 | De-duplicate descriptor | Small | Low | Nothing |
-| 3 | Subscribe-based terminal ready | Small | Medium | Nothing |
-| 1 | Cache binary check | Small | Medium | Informed by #6 |
-| 4 | Raise settle delay | Trivial→Medium | Medium | Nothing |
-| 5 | Persist auto-selection | Small | Medium | Nothing |
-| 6 | Split selectedRuntimeId | Medium | High | #1 simplifies after |
-
-Items 2, 3, 4, 5 can be done in any order in a single small PR.
-Item 6 is the architectural cleanup — worth its own PR once the dust settles.
+Last updated: June 1, 2026.

--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -1,272 +1,142 @@
-# Terminal: First-Class Integration Plan
+# Terminal Architecture
 
-Related issue: [jsgrrchg/NeverWrite#107](https://github.com/jsgrrchg/NeverWrite/issues/107)
+The terminal is a first-class workspace surface. It is available from workspace
+commands and tab menus without requiring Developer Mode, and terminal tabs
+participate in pane layout, tab persistence, and workspace restore.
 
-## Background
+This page documents the current architecture. Older implementation plans used
+`features/devtools/terminal`; the terminal UI now lives under
+[`apps/desktop/src/features/terminal`](../apps/desktop/src/features/terminal).
+The `devtools_*` command names and `devtools://terminal-*` event names remain
+part of the IPC protocol and should not be renamed just because the renderer
+folder moved.
 
-The terminal is now a first-class workspace surface. It is available from workspace commands and tab menus without requiring Developer Mode.
+## Runtime Boundary
 
-**The PTY backend is a Rust sidecar** (`apps/desktop/native-backend/src/devtools.rs`) using `portable-pty`, spawned and managed by `nativeBackend.ts` over JSON-line stdio. There is no node-pty. This matters for Step 6: any change to env vars or spawn options crosses a language boundary and requires the sidecar binary to be rebuilt and repackaged. `TERM=xterm-256color` is already set at `devtools.rs:345`. `COLORTERM=truecolor` is not.
+The PTY backend is the Rust sidecar in
+[`apps/desktop/native-backend/src/devtools.rs`](../apps/desktop/native-backend/src/devtools.rs).
+It uses `portable-pty`, not `node-pty`, and is reached through the Electron main
+process allowlist in
+[`nativeBackend.ts`](../apps/desktop/src-electron/main/nativeBackend.ts).
 
-The IPC struct is `DevTerminalCreateInput` (Rust, `devtools.rs:55`), currently with only `cwd`, `cols`, `rows`. Adding env var passthrough requires extending this struct in Rust and the corresponding TypeScript call sites.
+Terminal session creation flows through:
 
-The rendering layer (xterm.js v6 in `TerminalViewport.tsx`) is sound but has three gaps: font is hardcoded, the ANSI color palette is only partially wired to theme tokens, and `COLORTERM` is missing from the PTY environment.
-
-There is no viable drop-in replacement for xterm.js today. The most promising future alternative — libghostty-vt (Ghostty's VT parser as a C/WASM library) — is alpha with no usable web bindings yet. We stay on xterm.js and improve the integration.
-
-## Goals
-
-1. Terminal is a first-class workspace feature, usable without enabling Developer Mode.
-2. Font family and font size are user-configurable in Settings.
-3. The terminal looks like it belongs in the app — full ANSI palette from theme tokens.
-4. Claude Code runs correctly inside the terminal without user-side workarounds.
-5. Terminal code lives in a coherent location, not split across `features/terminal/` and `features/devtools/terminal/`.
-
-## Non-goals
-
-- PTY architecture changes (utilityProcess migration, flow control). The sidecar approach is fine.
-- Bundling fonts. Users provide their own.
-- Enumerating system fonts in the UI. No clean cross-platform API without native modules.
-- xterm.js WebGL renderer upgrade. Separate concern, not blocking.
-
----
-
-## Step 1 — Keep the terminal ungated
-
-**Files:** `src/App.tsx:921-943`, `src/features/editor/newTabMenuActions.ts:85-147`, `src/features/editor/EditorPaneBar.tsx`
-
-The "New Terminal" action should stay available from the workspace command palette entry and every pane's `+` menu unconditionally.
-
-Do not add a Developer Mode setting that promises to enable or disable terminal tabs. Terminal availability is not user-gated anymore.
-
-Restart remains a recovery action for active terminal tabs and should not depend on Developer Mode.
-
-**Also do:**
-- Keep the command id as `workspace:new-terminal-tab` and the category as `"Workspace"` — "first-class" means it shows up in the right palette group.
-- Assign a keyboard shortcut. Check for collisions in the existing shortcut registry.
-
-**Do this step last** — only ungate once the full experience (Steps 2–7) is ready.
-
----
-
-## Step 2 — Add terminal settings to the store
-
-**File:** `src/app/store/settingsStore.ts`
-
-Add to the settings interface and default object:
-
-```ts
-terminalFontFamily: string   // default: ""
-terminalFontSize: number     // default: 13
-claudeCodeOptimized: boolean // default: false
+```text
+Terminal tab / runtime store
+  -> invoke("devtools_create_terminal_session")
+  -> Electron main native backend bridge
+  -> Rust devtools PTY session
+  -> devtools://terminal-* events
+  -> terminal runtime store
+  -> TerminalViewport / xterm.js
 ```
 
-The existing persistence merge pattern at `settingsStore.ts:388-393` handles new fields via `?? defaults.X` — follow the same pattern. Empty `terminalFontFamily` means "use the built-in fallback stack" everywhere it's read; never pass an empty string to xterm.js.
+The Rust create input accepts `cwd`, `cols`, `rows`, and `extraEnv`. The sidecar
+sets `TERM=xterm-256color` and `COLORTERM=truecolor`, then applies `extraEnv`.
+Settings currently use that path to add `CLAUDE_CODE_NO_FLICKER=1` for newly
+opened Claude Code terminals when fullscreen rendering is enabled.
 
----
+Any change to PTY spawn behavior crosses the TypeScript/Rust boundary and
+requires rebuilding and repackaging the native sidecar.
 
-## Step 3 — Expose settings in a Terminal section
+## Renderer Pieces
 
-**File:** `src/features/settings/SettingsPanel.tsx`
+The main renderer files are:
 
-`Category` is a tagged union (`SettingsPanel.tsx:3570-3580`) with a matching `CATEGORIES` array and a render switch (~`4497+`). Adding "Terminal" means:
+- [`WorkspaceTerminalHost.tsx`](../apps/desktop/src/features/terminal/WorkspaceTerminalHost.tsx):
+  subscribes to sidecar terminal events and feeds them into the runtime store.
+- [`WorkspaceTerminalView.tsx`](../apps/desktop/src/features/terminal/WorkspaceTerminalView.tsx):
+  mounts the active terminal viewport for a workspace tab.
+- [`TerminalViewport.tsx`](../apps/desktop/src/features/terminal/TerminalViewport.tsx):
+  owns the xterm.js instance, search UI, dictation overlay, WebGL renderer, fit
+  behavior, copy/paste context menu, and replay snapshot capture.
+- [`terminalRuntimeStore.ts`](../apps/desktop/src/features/terminal/terminalRuntimeStore.ts):
+  owns live terminal runtime state and pipes PTY output directly to viewport
+  subscribers instead of storing every chunk in React state.
+- [`useTerminalTabs.ts`](../apps/desktop/src/features/terminal/useTerminalTabs.ts):
+  reads the legacy standalone terminal workspace format used by the migration
+  path.
+- [`claudeCodeTerminal.ts`](../apps/desktop/src/features/terminal/claudeCodeTerminal.ts):
+  launches Claude Code inside a terminal tab, injects safe startup arguments,
+  and registers the terminal as an agent-sidebar entry.
 
-1. Extend the union with `"terminal"`.
-2. Add an entry to `CATEGORIES` (needs an icon — pick from the existing icon set).
-3. Create a `<TerminalSettings>` component.
-4. Add `case "terminal"` in the render switch.
+Output is streamed to xterm through transient output commands. React state tracks
+session metadata, busy/error state, and whether output exists, but the terminal
+viewport is the source of truth for screen content. Reattach/reload support uses
+serialized xterm replay snapshots rather than rebuilding screen content from a
+large React string.
 
-Section contents:
-- **Font family** — text input. Placeholder: `"JetBrainsMono Nerd Font"`. Hint: "Font must be installed on this system."
-- **Font size** — number input, range 8–24. Check whether a number input control already exists in the settings component library before building a new one.
-- **Optimize for Claude Code** — toggle. Label: "Fullscreen rendering (experimental)". Hint: "Sets CLAUDE_CODE_NO_FLICKER=1. Improves rendering but disables scrollback. Only applies to new terminals." Wired to `claudeCodeOptimized`.
+## Settings And Persistence
 
-Do not reintroduce a Developer settings toggle for terminal availability. Terminal tabs are always part of the workspace.
+Terminal settings are stored with the vault-scoped Settings store:
 
----
+- `terminalFontFamily`
+- `terminalFontSize`
+- `claudeCodeOptimized`
+- `claudeCodeSkipPermissions`
+- `claudeCodeModel`
+- `claudeCodeContinueSession`
+- `claudeCodeMaxTurns`
 
-## Step 4 — Font loading in TerminalViewport
+See [Settings Scope](./settings-scope.md) for the full storage matrix.
 
-**Files:** `src/features/devtools/terminal/terminalTheme.ts`, `src/features/devtools/terminal/TerminalViewport.tsx`
+First-class workspace terminal tabs are persisted with the editor session under
+`neverwrite.session.tabs:<vault-path>`. The older standalone terminal workspace
+key, `neverwrite.devtools.terminal.tabs:<vault-path>`, is still read by the
+legacy migration path and keeps its `devtools` prefix for compatibility with
+existing user data. Replay snapshots are stored per terminal id under
+`neverwrite.terminal.replay:<terminal-id>` and are cache/state, not a user-facing
+setting.
 
-### terminalTheme.ts
+## Claude Code Integration
 
-`getTerminalTheme` currently returns a hardcoded font stack. Accept settings values:
+Claude Code is represented in two ways:
 
-```ts
-export function getTerminalTheme(
-  element: HTMLElement | null,
-  opts?: { fontFamily?: string; fontSize?: number }
-): TerminalTheme {
-  const fallback = '"SFMono-Regular", "Cascadia Code", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
-  return {
-    // ...
-    fontFamily: opts?.fontFamily?.trim() || fallback,
-    fontSize: opts?.fontSize ?? 13,
-  };
-}
+- As an integrated terminal command launched by
+  [`claudeCodeTerminal.ts`](../apps/desktop/src/features/terminal/claudeCodeTerminal.ts).
+- As a lightweight, non-persisted agent-sidebar entry managed by
+  [`claudeTerminalAgentSession.ts`](../apps/desktop/src/features/ai/claudeTerminalAgentSession.ts).
+
+When a Claude Code terminal is opened from file-tree or agent context,
+NeverWrite:
+
+1. Opens a terminal tab in the requested pane.
+2. Waits for the PTY to reach `running`.
+3. Optionally changes directory to the selected vault folder.
+4. Starts `claude` with sanitized settings-derived arguments.
+5. Registers the terminal in the Agents sidebar.
+6. Polls Claude Code transcript files, when a pinned session id is available, to
+   update the sidebar title, preview, and terminal tab title.
+
+`--continue` sessions cannot be pinned to a known transcript id up front, so
+transcript-derived title/preview are intentionally disabled in that mode rather
+than guessed from another terminal's JSONL.
+
+Claude Code prompt prefill still uses a fixed TUI settle delay before injecting
+`@` mentions. That delay is a best-effort heuristic; a future improvement should
+detect a stable ready marker from terminal output or use an upstream CLI flag if
+Claude Code exposes one.
+
+## Validation
+
+For terminal UI and runtime changes, start with targeted Vitest coverage:
+
+```bash
+cd apps/desktop
+npm test -- src/features/terminal src/features/ai/claudeTerminalAgentSession.test.ts
 ```
 
-### TerminalViewport.tsx
+When native commands or PTY behavior change, rebuild the sidecar and run the
+Electron smoke tests:
 
-Before calling `terminal.open(containerEl)`, load the font if one is configured:
-
-```ts
-const { terminalFontFamily, terminalFontSize } = useSettingsStore.getState();
-const fontFamily = terminalFontFamily.trim();
-
-if (fontFamily) {
-  try {
-    await Promise.all([
-      document.fonts.load(`normal ${terminalFontSize}px "${fontFamily}"`),
-      document.fonts.load(`bold ${terminalFontSize}px "${fontFamily}"`),
-    ]);
-    // document.fonts.load() resolves even when the font is absent.
-    // Check that it actually loaded before trusting it.
-    if (!document.fonts.check(`normal ${terminalFontSize}px "${fontFamily}"`)) {
-      console.warn(`[terminal] Font "${fontFamily}" not found, using fallback`);
-      // fontFamily falls back to empty → getTerminalTheme uses fallback stack
-    }
-  } catch {
-    console.warn(`[terminal] Font load failed for "${fontFamily}", using fallback`);
-  }
-}
-
-terminal.open(containerEl);
-fitAddon.fit();
+```bash
+cd apps/desktop
+npm run electron:sidecar:build
+npm run electron:vault-editor:smoke
+npm run electron:ai-runtime:smoke
 ```
 
-The existing `useEffect` at `TerminalViewport.tsx:354-367` that updates `terminal.options.fontFamily` / `fontSize` on settings changes needs `fitAddon.fit()` appended — font changes alter cell metrics and the viewport must reflow. Also update the dep array to include the new settings fields.
+For packaging-sensitive terminal changes, also run the packaged app and sidecar
+smokes described in [Testing and Validation](./testing.md).
 
----
-
-## Step 5 — Wire up the full ANSI palette
-
-**File:** `src/features/devtools/terminal/terminalTheme.ts`
-
-xterm.js v6 `ITheme` accepts all 16 ANSI colors (normal + bright), cursor, selection, and scrollbar. Currently `getTerminalTheme` maps only `--bg-primary`, `--text-primary`, `--accent`, a selection color hardcoded to `rgba(120, 138, 158, 0.28)` (`TerminalViewport.tsx:43`), and nothing else.
-
-**Audit first:** read the existing CSS custom properties in `src/index.css` and the theme definitions to find what color tokens exist. If ANSI-specific tokens exist (e.g. `--ansi-red`, `--syntax-string`), map to them. If not, define a fixed palette per theme variant (light/dark) that draws from the existing semantic tokens — don't attempt to compute 16 colors from 3.
-
-**At minimum, set:**
-- `black` / `brightBlack` — from `--bg-secondary` / `--text-secondary` or equivalent
-- `red`, `green`, `yellow`, `blue`, `magenta`, `cyan`, `white` and their bright variants — from syntax/status color tokens if present
-- `cursor` — `--accent`
-- `selectionBackground` — replace the hardcoded rgba with a token or derived value
-- `scrollbarSliderBackground` / `scrollbarSliderHoverBackground` / `scrollbarSliderActiveBackground`
-
-**Reactivity:** the dep array on the terminal options effect (`TerminalViewport.tsx:360-367`) currently watches only background/cursor/font/text. Adding 16 colors means updating that dep array. CSS vars read via `getComputedStyle` aren't reactive — they only re-read when the React render runs. Verify theme switching actually triggers a re-render (the `useThemeStore` subscription at `TerminalViewport.tsx:104` should handle this, but test it).
-
----
-
-## Step 6a — Rust: extend the PTY spawn input
-
-**File:** `apps/desktop/native-backend/src/devtools.rs`
-
-Extend `DevTerminalCreateInput` to accept additional environment variables:
-
-```rust
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct DevTerminalCreateInput {
-    cwd: Option<String>,
-    cols: Option<u16>,
-    rows: Option<u16>,
-    #[serde(default)]
-    extra_env: HashMap<String, String>,
-}
-```
-
-`#[serde(default)]` makes it backwards-compatible — existing callers that don't send `extraEnv` get an empty map, no IPC break.
-
-In `spawn_session`, after the existing `command.env("TERM", "xterm-256color")`, add:
-
-```rust
-command.env("COLORTERM", "truecolor");
-for (key, value) in &input.extra_env {
-    command.env(key, value);
-}
-```
-
-**Sidecar rebuild:** this requires rebuilding the native backend binary. Update CI to run the Rust build step and ensure the rebuilt binary is included in the package. On macOS, verify code signing still applies to the new binary.
-
-## Step 6b — TypeScript: thread extra_env through and add the Claude Code toggle
-
-**Files:** `src/features/terminal/terminalRuntimeStore.ts`, `src/features/devtools/terminal/useTerminalTabs.ts`
-
-Update the `devtools_create_terminal_session` call sites to pass `extraEnv` when `claudeCodeOptimized` is set in settings:
-
-```ts
-const { claudeCodeOptimized } = useSettingsStore.getState();
-const extraEnv = claudeCodeOptimized ? { CLAUDE_CODE_NO_FLICKER: "1" } : {};
-
-await invoke("devtools_create_terminal_session", { cwd, cols, rows, extraEnv });
-```
-
-`CLAUDE_CODE_NO_FLICKER=1` applies only at session creation. Document this in the Settings UI hint: the toggle only affects newly opened terminals.
-
----
-
-## Step 7 — Consolidate terminal code
-
-**This is a refactor, not a pure rename.** Two directories exist and already cross-import each other:
-
-- `src/features/terminal/` — `WorkspaceTerminalHost`, `WorkspaceTerminalView`, `terminalRuntimeStore`, `legacyTerminalMigration` (plus tests)
-- `src/features/devtools/terminal/` — `TerminalViewport`, `terminalTypes`, `terminalTheme`, `useTerminalTabs`, `terminalSessionTracking` (plus tests)
-
-**Move** the `devtools/terminal/` files into `src/features/terminal/`. Update all imports — including files not in the terminal directories:
-
-- `src/App.tsx`
-- `src/features/editor/EditorPaneBar.tsx`
-- `src/features/ai/components/AIAuthTerminalModal.tsx` ← easy to miss; imports `terminalTypes`
-- Any test files referencing the old paths
-
-**CSS:** `.devtools-terminal-surface` at `src/index.css:607` is referenced by `TerminalViewport.tsx:559`. Decide: rename the CSS class to `.terminal-surface` (update both files) or leave it as-is. If renaming, do it in this commit.
-
-**Event names:** `devtools://terminal-output`, `devtools://terminal-started`, etc. are constants defined in Rust and matched in TypeScript. Leave them as-is — the `devtools://` prefix is in the IPC protocol, not the file path. Document this decision so future readers don't wonder.
-
-**Dead code:** `useTerminalTabs.ts` is only called by `legacyTerminalMigration.ts` for `readPersistedTerminalWorkspace`. Audit whether other exports are still used before moving; delete unused ones rather than dragging them forward.
-
-**Do this as a standalone commit** with zero logic changes so the diff is reviewable and bisectable.
-
----
-
-## Step 8 — Update tests
-
-Several test files assert the developer-gate behaviour and will break after Step 1:
-
-- `src/App.noteWindow.test.tsx` — asserts terminal tab behaviour, references `openTerminal()`
-- `src/features/terminal/WorkspaceTerminalHost.test.tsx`
-- `src/features/terminal/terminalRuntimeStore.test.ts`
-- `src/features/settings/SettingsPanel.test.tsx` — may enumerate categories
-- `src/app/store/settingsStore.ts` — `settingsStore.test.ts` for new fields
-
-Update assertions to reflect ungated behaviour and new settings fields. Add tests for font loading fallback path and `claudeCodeOptimized` env passthrough.
-
----
-
-## Sequence
-
-| Step | Scope | Dependency | Risk |
-|---|---|---|---|
-| 7 — consolidate | Refactor, imports | None | Low — no logic changes |
-| 6a — Rust env passthrough | Rust + sidecar build | None | Medium — crosses language boundary, needs CI |
-| 2 — settings fields | TS store only | None | Low |
-| 5 — full ANSI palette | `terminalTheme.ts` | None | Low — visual only |
-| 6b — TS Claude Code toggle | TS call sites | 6a, 2 | Low |
-| 4 — font loading | `TerminalViewport.tsx` | 2 | Medium — async open() path |
-| 3 — Settings UI | `SettingsPanel.tsx` | 2 | Low |
-| 8 — tests | Test files | All above | Low |
-| 1 — ungate | `App.tsx`, menus | All above | Low |
-
-Steps 7, 6a, 2, and 5 have no dependencies on each other and can be done in parallel.
-
----
-
-## Future / out of scope for this iteration
-
-- **libghostty-vt** — Ghostty's VT parser as a standalone C/WASM library (alpha, Sept 2025). No web bindings yet. When it ships, it's the most accurate available parser; worth evaluating as a drop-in under xterm.js's rendering layer.
-- **WebGL renderer** (`@xterm/addon-webgl`) — up to 9x faster than canvas under heavy output. Not loaded currently. Add after this work settles.
-- **utilityProcess PTY isolation** — migrate the Rust sidecar invocation to use Electron's `utilityProcess` API so sidecar crashes can't bring down the main process. Not urgent for a single-window app.
-- **`CLAUDE_CODE_NO_FLICKER=1` fullscreen rendering** — already exposed as a toggle in Step 3, but Anthropic still marks it experimental. Promote the toggle to non-experimental once Anthropic stabilises scrollback behaviour.
-- **Keyboard shortcut for New Terminal** — decide on a shortcut and register it. Deferred to avoid shortcut collision analysis blocking the main work.
+Last updated: June 1, 2026.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -140,6 +140,7 @@ NEVERWRITE_CODEX_ACP_BIN
 NEVERWRITE_CLAUDE_ACP_BIN
 NEVERWRITE_GEMINI_ACP_BIN
 NEVERWRITE_KILO_ACP_BIN
+NEVERWRITE_OPENCODE_ACP_BIN
 ```
 
 Important packaging expectations:
@@ -147,8 +148,8 @@ Important packaging expectations:
 - Codex is intended to be bundled as a sidecar runtime in release builds.
 - Claude is intended to be bundled through embedded Node plus vendored runtime
   files.
-- Gemini and Kilo are integrated but not bundled by default, so they need an
-  external CLI or explicit binary override.
+- Gemini, Kilo, and OpenCode are integrated but not bundled by default, so they
+  need an external CLI or explicit binary override.
 
 If a provider works in your terminal but not in the app:
 
@@ -164,10 +165,10 @@ Secure credential storage is unavailable. Reconnect this AI provider or configur
 
 For terminal auth issues:
 
-- Integrated terminal auth applies to Claude, Gemini, and Kilo. Codex ChatGPT
-  auth does not use the integrated auth terminal.
-- Confirm the terminal process exits successfully. For Gemini, successful auth
-  output can mark the provider verified before exit.
+- Integrated terminal auth applies to Claude, Gemini, Kilo, and OpenCode. Codex
+  ChatGPT auth does not use the integrated auth terminal.
+- Confirm the terminal process exits successfully. For Gemini and OpenCode,
+  successful auth output can mark the provider verified before exit.
 - If the auth terminal cannot start, check whether the configured runtime command
   exists and whether the requested working directory exists.
 - Reopen Diagnostics after auth; setup status is the source of truth.
@@ -420,4 +421,4 @@ npm run electron:sidecar:smoke:packaged
 Documentation-only changes do not require code validation in CI, but command
 examples should still match [Testing and validation](testing.md).
 
-Last updated: May 11, 2026.
+Last updated: June 1, 2026.


### PR DESCRIPTION
## Summary

- Update README and maintainer docs for recent OpenCode ACP support.
- Document first-class terminal tabs, Claude Code terminal integration, HTML previews, and file tree filtering.
- Rewrite terminal architecture/follow-up docs so they reflect the current implementation instead of stale rollout notes.
- Align troubleshooting, privacy, settings scope, and architecture docs with current runtime and terminal behavior.

## Validation

- `git diff --check`
- Text audit with `rg` for stale four-runtime and terminal-doc references

No code tests were run because this is documentation-only.