### PR TITLE
Prepare 0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,34 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.3.2] - 2026-06-01
+
+### Added
+
+- Added opt-in Vim mode for the editor, including Settings controls, relative line numbers, a Vim status bar, and Vim command handling. Thanks to @Abdulkader-Safi.
+- Added a terminal dictation overlay for composing terminal input before sending it. Thanks to @spamsch.
+- Added Claude Code terminal sessions to the Agents sidebar, with live transcript-derived titles and previews plus focus and close actions. Thanks to @spamsch.
+- Added screenshot retention controls for AI chat screenshots, including automatic cleanup for expired screenshots and a `Forever` option.
+
+### Changed
+
+- Reworked terminal output rendering so PTY output streams directly into xterm, improving reliability and responsiveness under heavy Claude Code output. Thanks to @spamsch.
+- Updated the embedded Claude ACP runtime to `0.39.0`.
+- Clarified recent feature documentation and settings scope docs, including which settings are global and which are vault-scoped.
+- Changed Debian release publishing so updater feeds are published before APT validation.
+
+### Fixed
+
+- Fixed historical AI chat diff cards so older diffs remain inspectable after later file edits.
+- Fixed Pending Changes edited-files tray overflow so large review lists remain usable.
+- Fixed closed subagent sessions so closed child-agent conversations stay closed across store rebuilds and resume paths.
+- Fixed primary-vault window session restoration when the stored vault value is narrowed to a path.
+- Fixed Debian APT repository publication and validation for release assets hosted on GitHub Releases.
+
+### Security
+
+- Updated the Web Clipper workspace dependency metadata to address the transitive `tmp` advisory.
+
 ## [0.3.1] - 2026-05-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "agent-client-protocol",
  "keyring",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.1",
+            "version": "0.3.2",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.1",
+    "version": "0.3.2",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.1",
+    "version": "0.3.2",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary
- Add 0.3.2 release notes to CHANGELOG.md
- Align desktop, native backend, Cargo.lock, and Web Clipper versions to 0.3.2

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.3.2
- cargo check --locked -p neverwrite-native-backend
- node --test scripts/release-metadata.test.mjs
- node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs
- node --test scripts/appcast.test.mjs scripts/apt-repo.test.mjs scripts/platform-validation.test.mjs scripts/release-assets.test.mjs
- node --check scripts/build-apt-repository.mjs && node --check scripts/sign-apt-repository.mjs && node --check scripts/validate-apt-repository.mjs