### PR TITLE
Fix APT release asset publishing

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -821,13 +821,14 @@ jobs:
             - name: Build APT repository
               shell: bash
               env:
-                  PAGES_DIR: ${{ runner.temp }}/gh-pages
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
               run: |
                   node scripts/build-apt-repository.mjs \
+                    --layout flat-release \
                     --version "${{ needs.prepare.outputs.version }}" \
                     --release-assets-dir .artifacts/release-assets \
-                    --pages-dir "$PAGES_DIR" \
-                    --base-url "${{ needs.prepare.outputs.pages_base_url }}/apt" \
+                    --output-dir "$APT_RELEASE_DIR" \
+                    --repo-slug "${{ needs.prepare.outputs.repo_slug }}" \
                     --suite stable \
                     --component main
 
@@ -837,7 +838,7 @@ jobs:
                   APT_REPO_GPG_PRIVATE_KEY: ${{ secrets.APT_REPO_GPG_PRIVATE_KEY }}
                   APT_REPO_GPG_PASSPHRASE: ${{ secrets.APT_REPO_GPG_PASSPHRASE }}
                   APT_REPO_GPG_KEY_ID: ${{ secrets.APT_REPO_GPG_KEY_ID }}
-                  PAGES_DIR: ${{ runner.temp }}/gh-pages
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
               run: |
                   for name in APT_REPO_GPG_PRIVATE_KEY APT_REPO_GPG_PASSPHRASE APT_REPO_GPG_KEY_ID; do
                     if [[ -z "${!name}" ]]; then
@@ -853,17 +854,20 @@ jobs:
                   printf '%s' "$APT_REPO_GPG_PRIVATE_KEY" | gpg --batch --import
 
                   node scripts/sign-apt-repository.mjs \
-                    --apt-dir "$PAGES_DIR/apt" \
+                    --layout flat-release \
+                    --apt-dir "$APT_RELEASE_DIR" \
                     --key-id "$APT_REPO_GPG_KEY_ID" \
                     --suite stable
 
             - name: Validate APT repository
               shell: bash
               env:
-                  PAGES_DIR: ${{ runner.temp }}/gh-pages
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
               run: |
                   node scripts/validate-apt-repository.mjs \
-                    --apt-dir "$PAGES_DIR/apt" \
+                    --layout flat-release \
+                    --apt-dir "$APT_RELEASE_DIR" \
+                    --package-assets-dir .artifacts/release-assets \
                     --version "${{ needs.prepare.outputs.version }}" \
                     --suite stable \
                     --component main
@@ -871,12 +875,24 @@ jobs:
             - name: Validate APT repository with apt
               shell: bash
               env:
-                  PAGES_DIR: ${{ runner.temp }}/gh-pages
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
                   VERSION: ${{ needs.prepare.outputs.version }}
               run: |
+                  APT_SMOKE_DIR="$RUNNER_TEMP/apt-smoke"
+                  mkdir -p "$APT_SMOKE_DIR"
+                  cp "$APT_RELEASE_DIR"/InRelease \
+                    "$APT_RELEASE_DIR"/Release \
+                    "$APT_RELEASE_DIR"/Release.gpg \
+                    "$APT_RELEASE_DIR"/Packages \
+                    "$APT_RELEASE_DIR"/Packages.gz \
+                    "$APT_RELEASE_DIR"/neverwrite-archive-keyring.asc \
+                    "$APT_RELEASE_DIR"/neverwrite.sources.example \
+                    "$APT_SMOKE_DIR"/
+                  find .artifacts/release-assets -type f -name '*.deb' -exec cp {} "$APT_SMOKE_DIR"/ \;
+
                   docker run --rm \
                     -e VERSION="$VERSION" \
-                    -v "$PAGES_DIR/apt:/repo:ro" \
+                    -v "$APT_SMOKE_DIR:/repo:ro" \
                     ubuntu:24.04 \
                     bash -lc '
                       set -euo pipefail
@@ -895,20 +911,72 @@ jobs:
                       apt-get install -y --download-only "neverwrite=$VERSION"
                     '
 
-            - name: Publish APT repository to gh-pages
+            - name: Upload APT repository metadata to GitHub release
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
+              run: |
+                  gh release upload "${{ needs.prepare.outputs.tag }}" \
+                    "$APT_RELEASE_DIR/InRelease" \
+                    "$APT_RELEASE_DIR/Release" \
+                    "$APT_RELEASE_DIR/Release.gpg" \
+                    "$APT_RELEASE_DIR/Packages" \
+                    "$APT_RELEASE_DIR/Packages.gz" \
+                    "$APT_RELEASE_DIR/neverwrite-archive-keyring.asc" \
+                    "$APT_RELEASE_DIR/neverwrite.sources.example" \
+                    --clobber
+
+            - name: Validate published APT release endpoint
+              shell: bash
+              env:
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
+                  REPO_SLUG: ${{ needs.prepare.outputs.repo_slug }}
+                  RELEASE_TAG: ${{ needs.prepare.outputs.tag }}
+                  VERSION: ${{ needs.prepare.outputs.version }}
+              run: |
+                  docker run --rm \
+                    -e REPO_SLUG="$REPO_SLUG" \
+                    -e RELEASE_TAG="$RELEASE_TAG" \
+                    -e VERSION="$VERSION" \
+                    -v "$APT_RELEASE_DIR:/repo:ro" \
+                    ubuntu:24.04 \
+                    bash -lc '
+                      set -euo pipefail
+                      apt-get update
+                      apt-get install -y ca-certificates gnupg
+                      install -d -m 0755 /etc/apt/keyrings
+                      cp /repo/neverwrite-archive-keyring.asc /etc/apt/keyrings/neverwrite.asc
+                      chmod 0644 /etc/apt/keyrings/neverwrite.asc
+                      sed "s|^URIs: .*|URIs: https://github.com/${REPO_SLUG}/releases/download/${RELEASE_TAG}|" \
+                        /repo/neverwrite.sources.example \
+                        >/etc/apt/sources.list.d/neverwrite.sources
+                      apt-get update
+                      apt-cache policy neverwrite | grep -F "$VERSION"
+                      apt-get --print-uris install "neverwrite=$VERSION" | tee /tmp/neverwrite-uris.txt
+                      grep -F "https://github.com/${REPO_SLUG}/releases/download/${RELEASE_TAG}" /tmp/neverwrite-uris.txt
+                      grep -F "NeverWrite-${VERSION}-amd64.deb" /tmp/neverwrite-uris.txt
+                    '
+
+            - name: Publish APT source example to gh-pages
               shell: bash
               env:
                   PAGES_DIR: ${{ runner.temp }}/gh-pages
+                  APT_RELEASE_DIR: ${{ runner.temp }}/apt-release
               run: |
+                  mkdir -p "$PAGES_DIR/apt"
+                  rm -rf "$PAGES_DIR/apt/dists" "$PAGES_DIR/apt/pool"
+                  cp "$APT_RELEASE_DIR/neverwrite-archive-keyring.asc" "$PAGES_DIR/apt/"
+                  cp "$APT_RELEASE_DIR/neverwrite.sources.example" "$PAGES_DIR/apt/"
                   (
                     cd "$PAGES_DIR"
                     git config user.name "github-actions[bot]"
                     git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
                     git add apt .nojekyll
                     if git diff --cached --quiet; then
-                      echo "No APT repository changes to publish."
+                      echo "No APT source example changes to publish."
                     else
-                      git commit -m "Publish APT repository for ${{ needs.prepare.outputs.tag }}"
+                      git commit -m "Publish APT source example for ${{ needs.prepare.outputs.tag }}"
                       git push origin HEAD:gh-pages
                     fi
                   )

--- a/release/apt/README.md
+++ b/release/apt/README.md
@@ -1,10 +1,10 @@
 # NeverWrite APT Repository
 
 NeverWrite publishes a signed third-party APT repository for Ubuntu/Debian
-packages at:
+packages through the latest GitHub Release:
 
 ```text
-https://jsgrrchg.github.io/NeverWrite/apt
+https://github.com/jsgrrchg/NeverWrite/releases/latest/download
 ```
 
 This repository is separate from the Electron updater feeds. AppImage builds use
@@ -20,9 +20,8 @@ curl -fsSL https://jsgrrchg.github.io/NeverWrite/apt/neverwrite-archive-keyring.
 sudo chmod 0644 /etc/apt/keyrings/neverwrite.asc
 sudo tee /etc/apt/sources.list.d/neverwrite.sources >/dev/null <<'EOF'
 Types: deb
-URIs: https://jsgrrchg.github.io/NeverWrite/apt
-Suites: stable
-Components: main
+URIs: https://github.com/jsgrrchg/NeverWrite/releases/latest/download
+Suites: ./
 Architectures: amd64 arm64
 Signed-By: /etc/apt/keyrings/neverwrite.asc
 EOF
@@ -43,41 +42,35 @@ Do not use `apt-key`; the source is scoped to
 
 ## Published Layout
 
-The release workflow publishes these files to `gh-pages`:
+The release workflow uploads the repository metadata as GitHub Release assets:
+
+```text
+InRelease
+Release
+Release.gpg
+Packages
+Packages.gz
+NeverWrite-0.3.2-amd64.deb
+NeverWrite-0.3.2-arm64.deb
+```
+
+The `.deb` binary packages stay on GitHub Releases with the other release
+assets. The `Filename` field in each `Packages` stanza is the release asset file
+name, for example `NeverWrite-0.3.2-amd64.deb`. APT resolves it relative to the
+configured `latest/download` release URL.
+
+GitHub Pages only publishes the install helper files:
 
 ```text
 apt/
   neverwrite-archive-keyring.asc
   neverwrite.sources.example
-  pool/
-    main/
-      n/
-        neverwrite/
-          neverwrite_0.3.0_amd64.deb
-          neverwrite_0.3.0_arm64.deb
-  dists/
-    stable/
-      InRelease
-      Release
-      Release.gpg
-      main/
-        binary-amd64/
-          Packages
-          Packages.gz
-        binary-arm64/
-          Packages
-          Packages.gz
 ```
 
-The `.deb` binary packages are stored inside the APT repository pool. The
-`Filename` field in each `Packages` index must be a relative pool path, for
-example `pool/main/n/neverwrite/neverwrite_0.3.0_amd64.deb`. APT then resolves
-the package relative to the configured repository URL.
-
 The workflow reads the `.deb` metadata from the staged release assets,
-copies the packages into `apt/pool/`, generates `Packages` and `Release`, signs
-the repository, validates checksums and signatures, then publishes the result
-with the existing Electron feeds.
+generates flat `Packages` and `Release` metadata, signs the repository,
+validates checksums and signatures, uploads the metadata to the GitHub Release,
+then publishes the source example with the existing Electron feeds.
 
 ## Required GitHub Secrets
 
@@ -112,8 +105,8 @@ node scripts/validate-apt-repository.mjs ...
 Manual post-release checks:
 
 ```bash
-curl -fsSL https://jsgrrchg.github.io/NeverWrite/apt/dists/stable/InRelease | head
-curl -fsSL https://jsgrrchg.github.io/NeverWrite/apt/dists/stable/main/binary-amd64/Packages.gz \
+curl -fsSL https://github.com/jsgrrchg/NeverWrite/releases/latest/download/InRelease | head
+curl -fsSL https://github.com/jsgrrchg/NeverWrite/releases/latest/download/Packages.gz \
   | gunzip \
   | grep -E '^(Package|Version|Architecture|Filename):'
 apt-cache policy neverwrite
@@ -121,7 +114,7 @@ apt-cache policy neverwrite
 
 ## Rollback
 
-Rollback is done by regenerating repository metadata so APT no longer advertises
-the bad version. Do not delete release assets first. Keep at least one previous
-version in `apt/pool/`, regenerate `Packages` and `Release`, sign again, and
-publish `gh-pages`.
+Rollback is done by regenerating and re-uploading repository metadata so APT no
+longer advertises the bad version. Do not delete release assets first. Rebuild
+`Packages` and `Release`, sign again, upload the metadata to the relevant
+GitHub Release, and update the source example if the public endpoint changes.

--- a/scripts/apt-repo-lib.mjs
+++ b/scripts/apt-repo-lib.mjs
@@ -4,24 +4,32 @@ import path from "node:path";
 
 import {
     CANONICAL_RELEASE_PAGES_BASE_URL,
+    CANONICAL_RELEASE_REPO_SLUG,
     PUBLIC_PRODUCT_NAME,
     buildDebianPackageAssetName,
+    parseGitHubRepoSlug,
     normalizeReleaseVersion,
 } from "./appcast-lib.mjs";
 
 export const APT_REPOSITORY_RELATIVE_ROOT = "apt";
+export const APT_RELEASE_REPOSITORY_RELATIVE_ROOT = "apt-release";
 export const APT_PACKAGE_NAME = "neverwrite";
 export const APT_ORIGIN = PUBLIC_PRODUCT_NAME;
 export const APT_LABEL = PUBLIC_PRODUCT_NAME;
 export const APT_DESCRIPTION =
     "NeverWrite desktop Debian package repository";
 export const APT_DEFAULT_SUITE = "stable";
+export const APT_EXACT_PATH_SUITE = "./";
 export const APT_DEFAULT_CODENAME = "neverwrite-stable";
 export const APT_DEFAULT_COMPONENT = "main";
 export const APT_SUPPORTED_ARCHITECTURES = ["amd64", "arm64"];
 export const APT_DEFAULT_BASE_URL = `${CANONICAL_RELEASE_PAGES_BASE_URL}/apt`;
+export const APT_RELEASE_DOWNLOAD_BASE_URL = `https://github.com/${CANONICAL_RELEASE_REPO_SLUG}/releases/latest/download`;
 export const APT_PUBLIC_KEY_FILE_NAME = "neverwrite-archive-keyring.asc";
 export const APT_SOURCES_EXAMPLE_FILE_NAME = "neverwrite.sources.example";
+export const APT_LAYOUT_CLASSIC = "classic";
+export const APT_LAYOUT_FLAT_RELEASE = "flat-release";
+export const APT_LAYOUTS = [APT_LAYOUT_CLASSIC, APT_LAYOUT_FLAT_RELEASE];
 
 export const APT_RELEASE_CHECKSUMS = [
     { fieldName: "MD5Sum", algorithm: "md5" },
@@ -79,6 +87,16 @@ export function normalizeAptComponent(value) {
     return normalized;
 }
 
+export function normalizeAptLayout(value) {
+    const normalized = String(value ?? "").trim().toLowerCase();
+    if (!APT_LAYOUTS.includes(normalized)) {
+        throw new Error(
+            `Unsupported APT layout "${value}". Supported layouts: ${APT_LAYOUTS.join(", ")}.`,
+        );
+    }
+    return normalized;
+}
+
 export function normalizeDebianArchitecture(value) {
     const normalized = String(value ?? "").trim().toLowerCase();
     if (!APT_SUPPORTED_ARCHITECTURES.includes(normalized)) {
@@ -95,6 +113,20 @@ export function buildDebianReleaseAssetName(version, debianArchitecture) {
         normalizeReleaseVersion(version),
         BUILD_TARGET_BY_DEBIAN_ARCHITECTURE[arch],
     );
+}
+
+export function parseDebianReleaseAssetName(fileName) {
+    const normalizedName = String(fileName ?? "");
+    const match = new RegExp(
+        `^${PUBLIC_PRODUCT_NAME}-(\\d+\\.\\d+\\.\\d+)-(amd64|arm64)\\.deb$`,
+    ).exec(normalizedName);
+    if (!match) {
+        return null;
+    }
+    return {
+        version: match[1],
+        architecture: normalizeDebianArchitecture(match[2]),
+    };
 }
 
 export function buildAptPoolPackageName(version, debianArchitecture) {
@@ -135,6 +167,13 @@ export function getAptRepositoryRoot(pagesDir) {
     return path.join(pagesDir, APT_REPOSITORY_RELATIVE_ROOT);
 }
 
+export function getAptReleaseRepositoryRoot(rootDir) {
+    if (typeof rootDir !== "string" || !rootDir.trim()) {
+        throw new Error("rootDir must be a non-empty string.");
+    }
+    return path.join(rootDir, APT_RELEASE_REPOSITORY_RELATIVE_ROOT);
+}
+
 export function normalizeAptBaseUrl(baseUrl) {
     const normalized = String(baseUrl ?? "").trim().replace(/\/+$/, "");
     if (!normalized) {
@@ -148,18 +187,42 @@ export function normalizeAptBaseUrl(baseUrl) {
     return normalized;
 }
 
+export function buildGitHubReleaseDownloadBaseUrl(repoSlug, tag = "latest") {
+    parseGitHubRepoSlug(repoSlug);
+    const normalizedTag = String(tag ?? "").trim();
+    if (normalizedTag === "latest") {
+        return `https://github.com/${repoSlug}/releases/latest/download`;
+    }
+    const releaseTag = normalizedTag.startsWith("v")
+        ? normalizedTag
+        : `v${normalizeReleaseVersion(normalizedTag)}`;
+    return `https://github.com/${repoSlug}/releases/download/${releaseTag}`;
+}
+
 export function buildNeverWriteSourcesExample(
     baseUrl = APT_DEFAULT_BASE_URL,
+    {
+        suite = APT_DEFAULT_SUITE,
+        component = APT_DEFAULT_COMPONENT,
+    } = {},
 ) {
-    return [
+    const lines = [
         "Types: deb",
         `URIs: ${normalizeAptBaseUrl(baseUrl)}`,
-        `Suites: ${APT_DEFAULT_SUITE}`,
-        `Components: ${APT_DEFAULT_COMPONENT}`,
+        `Suites: ${suite}`,
+    ];
+
+    if (component) {
+        lines.push(`Components: ${component}`);
+    }
+
+    lines.push(
         `Architectures: ${APT_SUPPORTED_ARCHITECTURES.join(" ")}`,
         `Signed-By: /etc/apt/keyrings/${APT_PACKAGE_NAME}.asc`,
         "",
-    ].join("\n");
+    );
+
+    return lines.join("\n");
 }
 
 export function parseDebianControlStanza(input) {
@@ -299,7 +362,9 @@ export function buildAptReleaseContent({
     generatedAt = new Date(),
 }) {
     const normalizedSuite = normalizeAptSuite(suite);
-    const normalizedComponent = normalizeAptComponent(component);
+    const normalizedComponent = component
+        ? normalizeAptComponent(component)
+        : null;
     const normalizedArchitectures = architectures.map((arch) =>
         normalizeDebianArchitecture(arch),
     );
@@ -313,9 +378,12 @@ export function buildAptReleaseContent({
         `Codename: ${codename}`,
         `Date: ${generatedAt.toUTCString()}`,
         `Architectures: ${normalizedArchitectures.join(" ")}`,
-        `Components: ${normalizedComponent}`,
         `Description: ${APT_DESCRIPTION}`,
     ];
+
+    if (normalizedComponent) {
+        lines.splice(7, 0, `Components: ${normalizedComponent}`);
+    }
 
     for (const { fieldName } of APT_RELEASE_CHECKSUMS) {
         lines.push(`${fieldName}:`);

--- a/scripts/apt-repo.test.mjs
+++ b/scripts/apt-repo.test.mjs
@@ -9,6 +9,9 @@ import zlib from "node:zlib";
 
 import {
     APT_DEFAULT_BASE_URL,
+    APT_EXACT_PATH_SUITE,
+    APT_LAYOUT_FLAT_RELEASE,
+    APT_RELEASE_DOWNLOAD_BASE_URL,
     APT_PUBLIC_KEY_FILE_NAME,
     APT_SOURCES_EXAMPLE_FILE_NAME,
     APT_SUPPORTED_ARCHITECTURES,
@@ -128,6 +131,104 @@ function validateFixtureAptRepository(aptDir) {
     );
 }
 
+function writeFixtureFlatAptRepository({ filenamesByArchitecture = {} } = {}) {
+    const rootDir = fs.mkdtempSync(
+        path.join(os.tmpdir(), "neverwrite-flat-apt-test-"),
+    );
+    const aptDir = path.join(rootDir, "apt-release");
+    const packageAssetsDir = path.join(rootDir, "release-assets");
+    const releaseFiles = [];
+
+    fs.mkdirSync(aptDir, { recursive: true });
+    fs.mkdirSync(packageAssetsDir, { recursive: true });
+    fs.writeFileSync(
+        path.join(aptDir, APT_PUBLIC_KEY_FILE_NAME),
+        "fixture public key\n",
+        "utf8",
+    );
+    fs.writeFileSync(
+        path.join(aptDir, APT_SOURCES_EXAMPLE_FILE_NAME),
+        buildNeverWriteSourcesExample(APT_RELEASE_DOWNLOAD_BASE_URL, {
+            suite: APT_EXACT_PATH_SUITE,
+            component: null,
+        }),
+        "utf8",
+    );
+
+    const stanzas = [];
+    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
+        const assetName = buildDebianReleaseAssetName("0.3.0", architecture);
+        const assetPath = path.join(packageAssetsDir, assetName);
+        const assetBytes = Buffer.from(`fixture package ${architecture}\n`);
+        fs.writeFileSync(assetPath, assetBytes);
+
+        stanzas.push(
+            renderPackagesStanza({
+                controlFields: parseDebianControlStanza([
+                    "Package: neverwrite",
+                    "Version: 0.3.0",
+                    `Architecture: ${architecture}`,
+                    "Description: NeverWrite desktop",
+                    "",
+                ].join("\n")),
+                filename: filenamesByArchitecture[architecture] ?? assetName,
+                sizeBytes: assetBytes.length,
+                hashes: getFileHashes(assetPath),
+            }),
+        );
+    }
+
+    const packagesContent = stanzas.join("\n");
+    fs.writeFileSync(path.join(aptDir, "Packages"), packagesContent, "utf8");
+    fs.writeFileSync(
+        path.join(aptDir, "Packages.gz"),
+        zlib.gzipSync(Buffer.from(packagesContent, "utf8")),
+    );
+
+    for (const relativePath of ["Packages", "Packages.gz"]) {
+        const absolutePath = path.join(aptDir, relativePath);
+        releaseFiles.push({
+            relativePath,
+            sizeBytes: fs.statSync(absolutePath).size,
+            hashes: getFileHashes(absolutePath),
+        });
+    }
+
+    fs.writeFileSync(
+        path.join(aptDir, "Release"),
+        buildAptReleaseContent({
+            component: null,
+            files: releaseFiles,
+        }),
+        "utf8",
+    );
+    fs.writeFileSync(path.join(aptDir, "InRelease"), "fixture inrelease\n", "utf8");
+    fs.writeFileSync(path.join(aptDir, "Release.gpg"), "fixture signature\n", "utf8");
+
+    return { rootDir, aptDir, packageAssetsDir };
+}
+
+function validateFixtureFlatAptRepository(aptDir, packageAssetsDir) {
+    return childProcess.spawnSync(
+        process.execPath,
+        [
+            VALIDATE_APT_REPOSITORY_SCRIPT,
+            "--layout",
+            APT_LAYOUT_FLAT_RELEASE,
+            "--apt-dir",
+            aptDir,
+            "--package-assets-dir",
+            packageAssetsDir,
+            "--version",
+            "0.3.0",
+            "--skip-signature-check",
+        ],
+        {
+            encoding: "utf8",
+        },
+    );
+}
+
 test("APT package paths use Debian pool conventions", () => {
     assert.equal(
         buildAptPoolPackageName("0.2.8", "amd64"),
@@ -175,6 +276,18 @@ test("NeverWrite Deb822 source example uses the public APT endpoint", () => {
     assert.match(source, new RegExp(`URIs: ${APT_DEFAULT_BASE_URL}`));
     assert.match(source, /Suites: stable/);
     assert.match(source, /Components: main/);
+    assert.match(source, /Architectures: amd64 arm64/);
+    assert.match(source, /Signed-By: \/etc\/apt\/keyrings\/neverwrite\.asc/);
+});
+
+test("NeverWrite Deb822 source example supports the flat release endpoint", () => {
+    const source = buildNeverWriteSourcesExample(APT_RELEASE_DOWNLOAD_BASE_URL, {
+        suite: APT_EXACT_PATH_SUITE,
+        component: null,
+    });
+    assert.match(source, new RegExp(`URIs: ${APT_RELEASE_DOWNLOAD_BASE_URL}`));
+    assert.match(source, /Suites: \.\//);
+    assert.doesNotMatch(source, /^Components:/m);
     assert.match(source, /Architectures: amd64 arm64/);
     assert.match(source, /Signed-By: \/etc\/apt\/keyrings\/neverwrite\.asc/);
 });
@@ -277,4 +390,42 @@ test("APT repository validator rejects package Filename URLs", (t) => {
     assert.notEqual(result.status, 0);
     assert.match(result.stderr, /invalid Filename/);
     assert.match(result.stderr, /Expected a normalized relative path under "pool\/main\/n\/neverwrite\/"/);
+});
+
+test("APT repository validator accepts flat release asset filenames", (t) => {
+    const { rootDir, aptDir, packageAssetsDir } = writeFixtureFlatAptRepository();
+    t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+
+    const result = validateFixtureFlatAptRepository(aptDir, packageAssetsDir);
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /APT repository is valid for version 0\.3\.0/);
+});
+
+test("APT repository validator rejects flat package Filename paths", (t) => {
+    const { rootDir, aptDir, packageAssetsDir } = writeFixtureFlatAptRepository({
+        filenamesByArchitecture: {
+            amd64: "pool/main/n/neverwrite/neverwrite_0.3.0_amd64.deb",
+        },
+    });
+    t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+
+    const result = validateFixtureFlatAptRepository(aptDir, packageAssetsDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Expected a GitHub Release asset file name/);
+});
+
+test("APT repository validator rejects flat package Filename URLs", (t) => {
+    const { rootDir, aptDir, packageAssetsDir } = writeFixtureFlatAptRepository({
+        filenamesByArchitecture: {
+            amd64: "https://github.com/jsgrrchg/NeverWrite/releases/download/v0.3.0/NeverWrite-0.3.0-amd64.deb",
+        },
+    });
+    t.after(() => fs.rmSync(rootDir, { recursive: true, force: true }));
+
+    const result = validateFixtureFlatAptRepository(aptDir, packageAssetsDir);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Expected a GitHub Release asset file name/);
 });

--- a/scripts/build-apt-repository.mjs
+++ b/scripts/build-apt-repository.mjs
@@ -6,11 +6,15 @@ import zlib from "node:zlib";
 import {
     APT_DEFAULT_COMPONENT,
     APT_DEFAULT_SUITE,
+    APT_EXACT_PATH_SUITE,
+    APT_LAYOUT_CLASSIC,
+    APT_LAYOUT_FLAT_RELEASE,
     APT_SOURCES_EXAMPLE_FILE_NAME,
     APT_SUPPORTED_ARCHITECTURES,
     buildAptPoolPackagePath,
     buildAptReleaseContent,
     buildDebianReleaseAssetName,
+    buildGitHubReleaseDownloadBaseUrl,
     buildNeverWriteSourcesExample,
     compareReleaseVersionsDescending,
     getAptBinaryPackagesGzipPath,
@@ -21,11 +25,13 @@ import {
     listFilesRecursively,
     normalizeAptBaseUrl,
     normalizeAptComponent,
+    normalizeAptLayout,
     normalizeAptSuite,
     parseAptPoolPackageFileName,
     parseDebianControlStanza,
     renderPackagesStanza,
 } from "./apt-repo-lib.mjs";
+import { CANONICAL_RELEASE_REPO_SLUG } from "./appcast-lib.mjs";
 import { normalizeReleaseVersion } from "./appcast-lib.mjs";
 
 function parseArgs(argv) {
@@ -33,10 +39,13 @@ function parseArgs(argv) {
         version: null,
         releaseAssetsDir: null,
         pagesDir: null,
+        outputDir: null,
         baseUrl: null,
         suite: APT_DEFAULT_SUITE,
         component: APT_DEFAULT_COMPONENT,
         retainVersions: 3,
+        layout: APT_LAYOUT_CLASSIC,
+        repoSlug: CANONICAL_RELEASE_REPO_SLUG,
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -55,6 +64,11 @@ function parseArgs(argv) {
         }
         if (arg === "--pages-dir") {
             args.pagesDir = path.resolve(next);
+            index += 1;
+            continue;
+        }
+        if (arg === "--output-dir") {
+            args.outputDir = path.resolve(next);
             index += 1;
             continue;
         }
@@ -78,8 +92,18 @@ function parseArgs(argv) {
             index += 1;
             continue;
         }
+        if (arg === "--layout") {
+            args.layout = next;
+            index += 1;
+            continue;
+        }
+        if (arg === "--repo-slug") {
+            args.repoSlug = next;
+            index += 1;
+            continue;
+        }
         throw new Error(
-            `Unknown argument "${arg}". Supported args: --version, --release-assets-dir, --pages-dir, --base-url, --suite, --component, --retain-versions.`,
+            `Unknown argument "${arg}". Supported args: --version, --release-assets-dir, --pages-dir, --output-dir, --base-url, --suite, --component, --retain-versions, --layout, --repo-slug.`,
         );
     }
 
@@ -91,22 +115,36 @@ function parseArgs(argv) {
             "Missing required argument --release-assets-dir <path>.",
         );
     }
-    if (!args.pagesDir) {
-        throw new Error("Missing required argument --pages-dir <path>.");
-    }
-    if (!args.baseUrl) {
-        throw new Error("Missing required argument --base-url <url>.");
-    }
     if (!Number.isInteger(args.retainVersions) || args.retainVersions < 1) {
         throw new Error("--retain-versions must be a positive integer.");
     }
 
+    const layout = normalizeAptLayout(args.layout);
+    if (layout === APT_LAYOUT_CLASSIC && !args.pagesDir) {
+        throw new Error("Missing required argument --pages-dir <path>.");
+    }
+    if (layout === APT_LAYOUT_FLAT_RELEASE && !args.outputDir) {
+        throw new Error(
+            "Missing required argument --output-dir <path> for flat-release layout.",
+        );
+    }
+
+    const baseUrl =
+        args.baseUrl ??
+        (layout === APT_LAYOUT_FLAT_RELEASE
+            ? buildGitHubReleaseDownloadBaseUrl(args.repoSlug, "latest")
+            : null);
+    if (!baseUrl) {
+        throw new Error("Missing required argument --base-url <url>.");
+    }
+
     return {
         ...args,
+        layout,
+        baseUrl: normalizeAptBaseUrl(baseUrl),
         version: normalizeReleaseVersion(args.version),
         suite: normalizeAptSuite(args.suite),
         component: normalizeAptComponent(args.component),
-        baseUrl: normalizeAptBaseUrl(args.baseUrl),
     };
 }
 
@@ -272,6 +310,34 @@ function collectPoolPackages({ aptDir }) {
     return packages;
 }
 
+function collectCurrentReleasePackages({ version, releaseAssetsDir }) {
+    const packages = [];
+
+    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
+        const assetName = buildDebianReleaseAssetName(version, architecture);
+        const source = findSingleReleaseAsset(releaseAssetsDir, assetName);
+        const fields = readDebianControlFields(source);
+        validateDebianPackageFields({
+            packagePath: source,
+            relativePath: assetName,
+            fields,
+            architecture,
+        });
+        packages.push({
+            version,
+            architecture,
+            content: renderPackagesStanza({
+                controlFields: fields,
+                filename: assetName,
+                sizeBytes: fs.statSync(source).size,
+                hashes: getFileHashes(source),
+            }),
+        });
+    }
+
+    return packages;
+}
+
 function renderPackagesFileForArchitecture({ packages, architecture }) {
     const stanzas = packages
         .filter((pkg) => pkg.architecture === architecture)
@@ -297,7 +363,7 @@ function gzipDeterministic(input) {
     return zlib.gzipSync(Buffer.from(input, "utf8"), { level: 9, mtime: 0 });
 }
 
-function writePackagesIndexes({ aptDir, packages }) {
+function writeClassicPackagesIndexes({ aptDir, packages }) {
     const written = [];
 
     for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
@@ -320,7 +386,37 @@ function writePackagesIndexes({ aptDir, packages }) {
     return written;
 }
 
-function collectReleaseFiles(aptDir, suite) {
+function renderFlatPackagesFile({ packages }) {
+    return packages
+        .sort((left, right) => {
+            const versionOrder = compareReleaseVersionsDescending(
+                left.version,
+                right.version,
+            );
+            if (versionOrder !== 0) {
+                return versionOrder;
+            }
+            return left.architecture.localeCompare(right.architecture);
+        })
+        .map((pkg) => pkg.content)
+        .join("\n");
+}
+
+function writeFlatPackagesIndex({ aptDir, packages }) {
+    const content = renderFlatPackagesFile({ packages });
+    const packagesPath = path.join(aptDir, "Packages");
+
+    fs.mkdirSync(aptDir, { recursive: true });
+    fs.writeFileSync(packagesPath, content, "utf8");
+    fs.writeFileSync(
+        path.join(aptDir, "Packages.gz"),
+        gzipDeterministic(content),
+    );
+
+    return ["Packages", "Packages.gz"];
+}
+
+function collectClassicReleaseFiles(aptDir, suite) {
     const distsDir = path.join(aptDir, "dists", suite);
     return listFilesRecursively(distsDir)
         .map((filePath) => ({
@@ -343,16 +439,29 @@ function collectReleaseFiles(aptDir, suite) {
         }));
 }
 
-function removeStaleSignatures(aptDir, suite) {
+function collectFlatReleaseFiles(aptDir) {
+    return ["Packages", "Packages.gz"].map((relativePath) => {
+        const absolutePath = path.join(aptDir, relativePath);
+        return {
+            relativePath,
+            sizeBytes: fs.statSync(absolutePath).size,
+            hashes: getFileHashes(absolutePath),
+        };
+    });
+}
+
+function removeClassicStaleSignatures(aptDir, suite) {
     const suiteDir = path.join(aptDir, "dists", suite);
     fs.rmSync(path.join(suiteDir, "InRelease"), { force: true });
     fs.rmSync(path.join(suiteDir, "Release.gpg"), { force: true });
 }
 
-function main() {
-    const args = parseArgs(process.argv.slice(2));
-    assertDpkgDebAvailable();
+function removeFlatStaleSignatures(aptDir) {
+    fs.rmSync(path.join(aptDir, "InRelease"), { force: true });
+    fs.rmSync(path.join(aptDir, "Release.gpg"), { force: true });
+}
 
+function buildClassicRepository(args) {
     const aptDir = getAptRepositoryRoot(args.pagesDir);
     fs.mkdirSync(aptDir, { recursive: true });
 
@@ -379,14 +488,12 @@ function main() {
         console.log(`Pruned old Debian packages: ${retention.removed.length}`);
     }
 
-    // Rebuild metadata from collected packages so stale indexes never leak
-    // into the published repository.
     fs.rmSync(path.join(aptDir, "dists", args.suite), {
         recursive: true,
         force: true,
     });
-    const packagesIndexes = writePackagesIndexes({ aptDir, packages });
-    const releaseFiles = collectReleaseFiles(aptDir, args.suite);
+    const packagesIndexes = writeClassicPackagesIndexes({ aptDir, packages });
+    const releaseFiles = collectClassicReleaseFiles(aptDir, args.suite);
     const releasePath = path.join(aptDir, "dists", args.suite, "Release");
 
     fs.writeFileSync(
@@ -403,7 +510,54 @@ function main() {
         buildNeverWriteSourcesExample(args.baseUrl),
         "utf8",
     );
-    removeStaleSignatures(aptDir, args.suite);
+    removeClassicStaleSignatures(aptDir, args.suite);
+
+    return { aptDir, packages, packagesIndexes, releasePath };
+}
+
+function buildFlatReleaseRepository(args) {
+    const aptDir = args.outputDir;
+    fs.rmSync(aptDir, { recursive: true, force: true });
+    fs.mkdirSync(aptDir, { recursive: true });
+
+    const packages = collectCurrentReleasePackages({
+        version: args.version,
+        releaseAssetsDir: args.releaseAssetsDir,
+    });
+    const packagesIndexes = writeFlatPackagesIndex({ aptDir, packages });
+    const releaseFiles = collectFlatReleaseFiles(aptDir);
+    const releasePath = path.join(aptDir, "Release");
+
+    fs.writeFileSync(
+        releasePath,
+        buildAptReleaseContent({
+            suite: args.suite,
+            component: null,
+            files: releaseFiles,
+        }),
+        "utf8",
+    );
+    fs.writeFileSync(
+        path.join(aptDir, APT_SOURCES_EXAMPLE_FILE_NAME),
+        buildNeverWriteSourcesExample(args.baseUrl, {
+            suite: APT_EXACT_PATH_SUITE,
+            component: null,
+        }),
+        "utf8",
+    );
+    removeFlatStaleSignatures(aptDir);
+
+    return { aptDir, packages, packagesIndexes, releasePath };
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    assertDpkgDebAvailable();
+
+    const { aptDir, packages, packagesIndexes, releasePath } =
+        args.layout === APT_LAYOUT_FLAT_RELEASE
+            ? buildFlatReleaseRepository(args)
+            : buildClassicRepository(args);
 
     console.log(
         `APT package versions indexed: ${packages.map((pkg) => `${pkg.version} (${pkg.architecture})`).join(", ")}`,

--- a/scripts/release-assets-lib.mjs
+++ b/scripts/release-assets-lib.mjs
@@ -13,6 +13,10 @@ import {
     getSignatureAssetName,
     normalizeReleaseVersion,
 } from "./appcast-lib.mjs";
+import {
+    APT_DEFAULT_BASE_URL,
+    APT_RELEASE_DOWNLOAD_BASE_URL,
+} from "./apt-repo-lib.mjs";
 
 export const PUBLIC_DOWNLOAD_VARIANTS = [
     {
@@ -303,14 +307,13 @@ export function buildReleaseBody(version, releaseNotes) {
         "",
         "```bash",
         "sudo install -d -m 0755 /etc/apt/keyrings",
-        "curl -fsSL https://jsgrrchg.github.io/NeverWrite/apt/neverwrite-archive-keyring.asc \\",
+        `curl -fsSL ${APT_DEFAULT_BASE_URL}/neverwrite-archive-keyring.asc \\`,
         "  | sudo tee /etc/apt/keyrings/neverwrite.asc >/dev/null",
         "sudo chmod 0644 /etc/apt/keyrings/neverwrite.asc",
         "sudo tee /etc/apt/sources.list.d/neverwrite.sources >/dev/null <<'EOF'",
         "Types: deb",
-        "URIs: https://jsgrrchg.github.io/NeverWrite/apt",
-        "Suites: stable",
-        "Components: main",
+        `URIs: ${APT_RELEASE_DOWNLOAD_BASE_URL}`,
+        "Suites: ./",
         "Architectures: amd64 arm64",
         "Signed-By: /etc/apt/keyrings/neverwrite.asc",
         "EOF",

--- a/scripts/sign-apt-repository.mjs
+++ b/scripts/sign-apt-repository.mjs
@@ -4,7 +4,10 @@ import path from "node:path";
 
 import {
     APT_DEFAULT_SUITE,
+    APT_LAYOUT_CLASSIC,
+    APT_LAYOUT_FLAT_RELEASE,
     APT_PUBLIC_KEY_FILE_NAME,
+    normalizeAptLayout,
     normalizeAptSuite,
 } from "./apt-repo-lib.mjs";
 
@@ -13,6 +16,7 @@ function parseArgs(argv) {
         aptDir: null,
         keyId: null,
         suite: APT_DEFAULT_SUITE,
+        layout: APT_LAYOUT_CLASSIC,
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -34,9 +38,14 @@ function parseArgs(argv) {
             index += 1;
             continue;
         }
+        if (arg === "--layout") {
+            args.layout = next;
+            index += 1;
+            continue;
+        }
 
         throw new Error(
-            `Unknown argument "${arg}". Supported args: --apt-dir, --key-id, --suite.`,
+            `Unknown argument "${arg}". Supported args: --apt-dir, --key-id, --suite, --layout.`,
         );
     }
 
@@ -51,6 +60,7 @@ function parseArgs(argv) {
         ...args,
         keyId: args.keyId.trim(),
         suite: normalizeAptSuite(args.suite),
+        layout: normalizeAptLayout(args.layout),
     };
 }
 
@@ -89,7 +99,10 @@ function signingPassphraseArgs(passphrase) {
 
 function main() {
     const args = parseArgs(process.argv.slice(2));
-    const suiteDir = path.join(args.aptDir, "dists", args.suite);
+    const suiteDir =
+        args.layout === APT_LAYOUT_FLAT_RELEASE
+            ? args.aptDir
+            : path.join(args.aptDir, "dists", args.suite);
     const releasePath = path.join(suiteDir, "Release");
     const inReleasePath = path.join(suiteDir, "InRelease");
     const detachedSignaturePath = path.join(suiteDir, "Release.gpg");

--- a/scripts/validate-apt-repository.mjs
+++ b/scripts/validate-apt-repository.mjs
@@ -8,6 +8,8 @@ import {
     APT_DEFAULT_CODENAME,
     APT_DEFAULT_COMPONENT,
     APT_DEFAULT_SUITE,
+    APT_LAYOUT_CLASSIC,
+    APT_LAYOUT_FLAT_RELEASE,
     APT_PACKAGE_NAME,
     APT_PACKAGE_CHECKSUMS,
     APT_PUBLIC_KEY_FILE_NAME,
@@ -18,9 +20,12 @@ import {
     getAptBinaryPackagesPath,
     getDebianControlField,
     hashFile,
+    listFilesRecursively,
+    normalizeAptLayout,
     normalizeAptComponent,
     normalizeAptSuite,
     normalizeDebianArchitecture,
+    parseDebianReleaseAssetName,
     parseDebianControlStanza,
 } from "./apt-repo-lib.mjs";
 import { normalizeReleaseVersion } from "./appcast-lib.mjs";
@@ -30,9 +35,11 @@ const APT_PACKAGE_FILENAME_PREFIX = "pool/main/n/neverwrite/";
 function parseArgs(argv) {
     const args = {
         aptDir: null,
+        packageAssetsDir: null,
         version: null,
         suite: APT_DEFAULT_SUITE,
         component: APT_DEFAULT_COMPONENT,
+        layout: APT_LAYOUT_CLASSIC,
         skipSignatureCheck: false,
     };
 
@@ -42,6 +49,11 @@ function parseArgs(argv) {
 
         if (arg === "--apt-dir") {
             args.aptDir = path.resolve(next);
+            index += 1;
+            continue;
+        }
+        if (arg === "--package-assets-dir") {
+            args.packageAssetsDir = path.resolve(next);
             index += 1;
             continue;
         }
@@ -60,13 +72,18 @@ function parseArgs(argv) {
             index += 1;
             continue;
         }
+        if (arg === "--layout") {
+            args.layout = next;
+            index += 1;
+            continue;
+        }
         if (arg === "--skip-signature-check") {
             args.skipSignatureCheck = true;
             continue;
         }
 
         throw new Error(
-            `Unknown argument "${arg}". Supported args: --apt-dir, --version, --suite, --component, --skip-signature-check.`,
+            `Unknown argument "${arg}". Supported args: --apt-dir, --package-assets-dir, --version, --suite, --component, --layout, --skip-signature-check.`,
         );
     }
 
@@ -79,6 +96,7 @@ function parseArgs(argv) {
         version: args.version ? normalizeReleaseVersion(args.version) : null,
         suite: normalizeAptSuite(args.suite),
         component: normalizeAptComponent(args.component),
+        layout: normalizeAptLayout(args.layout),
     };
 }
 
@@ -120,8 +138,14 @@ function parseReleaseChecksums(releaseFields, fieldName) {
         });
 }
 
-function validateReleaseFile({ aptDir, suite, component }) {
-    const suiteDir = path.join(aptDir, "dists", suite);
+function getReleaseDir({ aptDir, suite, layout }) {
+    return layout === APT_LAYOUT_FLAT_RELEASE
+        ? aptDir
+        : path.join(aptDir, "dists", suite);
+}
+
+function validateReleaseFile({ aptDir, suite, component, layout }) {
+    const suiteDir = getReleaseDir({ aptDir, suite, layout });
     const releasePath = path.join(suiteDir, "Release");
     const releaseFields = parseDebianControlStanza(
         fs.readFileSync(releasePath, "utf8"),
@@ -132,8 +156,10 @@ function validateReleaseFile({ aptDir, suite, component }) {
         Suite: suite,
         Codename: APT_DEFAULT_CODENAME,
         Architectures: APT_SUPPORTED_ARCHITECTURES.join(" "),
-        Components: component,
     };
+    if (layout === APT_LAYOUT_CLASSIC) {
+        expectedFields.Components = component;
+    }
 
     for (const [fieldName, expectedValue] of Object.entries(expectedFields)) {
         const actualValue = getDebianControlField(releaseFields, fieldName);
@@ -164,7 +190,7 @@ function validateReleaseFile({ aptDir, suite, component }) {
     }
 }
 
-function resolvePackageFilename({ aptDir, arch, filename }) {
+function resolveClassicPackageFilename({ aptDir, arch, filename }) {
     const normalizedFilename = path.posix.normalize(filename);
     if (
         filename !== normalizedFilename ||
@@ -192,7 +218,118 @@ function resolvePackageFilename({ aptDir, arch, filename }) {
     return packagePath;
 }
 
-function validatePackagesForArchitecture({
+function findPackageAsset(packageAssetsDir, filename) {
+    if (!packageAssetsDir) {
+        return null;
+    }
+    const matches = listFilesRecursively(packageAssetsDir).filter(
+        (filePath) => path.basename(filePath) === filename,
+    );
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected exactly one package asset named ${filename} in ${packageAssetsDir}, found ${matches.length}.`,
+        );
+    }
+    return matches[0];
+}
+
+function resolveFlatPackageFilename({
+    packageAssetsDir,
+    arch,
+    filename,
+    version,
+}) {
+    const normalizedFilename = path.posix.normalize(filename);
+    if (
+        filename !== normalizedFilename ||
+        filename.includes("\\") ||
+        filename.includes("/") ||
+        path.posix.isAbsolute(normalizedFilename)
+    ) {
+        throw new Error(
+            `${arch} Packages contains invalid Filename "${filename}". Expected a GitHub Release asset file name without path separators.`,
+        );
+    }
+
+    const metadata = parseDebianReleaseAssetName(normalizedFilename);
+    if (!metadata) {
+        throw new Error(
+            `${arch} Packages contains invalid Filename "${filename}". Expected a NeverWrite Debian release asset name.`,
+        );
+    }
+    if (metadata.architecture !== arch) {
+        throw new Error(
+            `${arch} Packages Filename "${filename}" targets ${metadata.architecture}.`,
+        );
+    }
+    if (version && metadata.version !== version) {
+        throw new Error(
+            `${arch} Packages Filename "${filename}" does not match version ${version}.`,
+        );
+    }
+
+    return findPackageAsset(packageAssetsDir, normalizedFilename);
+}
+
+function validatePackageStanza({
+    aptDir,
+    packageAssetsDir,
+    architecture,
+    version,
+    stanza,
+    layout,
+}) {
+    const arch = normalizeDebianArchitecture(architecture);
+    const packageName = getDebianControlField(stanza, "Package");
+    const packageVersion = getDebianControlField(stanza, "Version");
+    const packageArchitecture = getDebianControlField(stanza, "Architecture");
+    const filename = getDebianControlField(stanza, "Filename");
+    const size = Number.parseInt(getDebianControlField(stanza, "Size"), 10);
+
+    if (packageName !== APT_PACKAGE_NAME) {
+        throw new Error(
+            `${arch} Packages contains unexpected package "${packageName}".`,
+        );
+    }
+    if (packageArchitecture !== arch) {
+        throw new Error(
+            `${arch} Packages contains unexpected Architecture "${packageArchitecture}".`,
+        );
+    }
+    if (!filename) {
+        throw new Error(`${arch} Packages contains package with missing Filename.`);
+    }
+
+    const packagePath =
+        layout === APT_LAYOUT_FLAT_RELEASE
+            ? resolveFlatPackageFilename({
+                  packageAssetsDir,
+                  arch,
+                  filename,
+                  version: packageVersion,
+              })
+            : resolveClassicPackageFilename({ aptDir, arch, filename });
+
+    if (packagePath) {
+        if (fs.statSync(packagePath).size !== size) {
+            throw new Error(`${filename} Size does not match package file.`);
+        }
+        for (const { fieldName, algorithm } of APT_PACKAGE_CHECKSUMS) {
+            const expectedHash = getDebianControlField(stanza, fieldName);
+            if (!expectedHash) {
+                throw new Error(`${filename} is missing ${fieldName}.`);
+            }
+            const actualHash = hashFile(packagePath, algorithm);
+            if (expectedHash !== actualHash) {
+                throw new Error(`${filename} ${fieldName} does not match.`);
+            }
+        }
+    }
+
+    return !version || packageVersion === version;
+}
+
+function validateClassicPackagesForArchitecture({
     aptDir,
     architecture,
     version,
@@ -219,55 +356,71 @@ function validatePackagesForArchitecture({
 
     let foundExpectedVersion = !version;
     for (const stanza of stanzas) {
-        const packageName = getDebianControlField(stanza, "Package");
-        const packageVersion = getDebianControlField(stanza, "Version");
-        const packageArchitecture = getDebianControlField(
-            stanza,
-            "Architecture",
-        );
-        const filename = getDebianControlField(stanza, "Filename");
-        const size = Number.parseInt(getDebianControlField(stanza, "Size"), 10);
-
-        if (packageName !== APT_PACKAGE_NAME) {
-            throw new Error(
-                `${arch} Packages contains unexpected package "${packageName}".`,
-            );
-        }
-        if (packageArchitecture !== arch) {
-            throw new Error(
-                `${arch} Packages contains unexpected Architecture "${packageArchitecture}".`,
-            );
-        }
-        if (!filename) {
-            throw new Error(
-                `${arch} Packages contains package with missing Filename.`,
-            );
-        }
-
-        const packagePath = resolvePackageFilename({ aptDir, arch, filename });
-        assertFileExists(packagePath, `${arch} package file`);
-
-        if (fs.statSync(packagePath).size !== size) {
-            throw new Error(`${filename} Size does not match package file.`);
-        }
-        for (const { fieldName, algorithm } of APT_PACKAGE_CHECKSUMS) {
-            const expectedHash = getDebianControlField(stanza, fieldName);
-            if (!expectedHash) {
-                throw new Error(`${filename} is missing ${fieldName}.`);
-            }
-            const actualHash = hashFile(packagePath, algorithm);
-            if (expectedHash !== actualHash) {
-                throw new Error(`${filename} ${fieldName} does not match.`);
-            }
-        }
-
-        if (version && packageVersion === version) {
+        if (
+            validatePackageStanza({
+                aptDir,
+                architecture: arch,
+                version,
+                stanza,
+                layout: APT_LAYOUT_CLASSIC,
+            })
+        ) {
             foundExpectedVersion = true;
         }
     }
 
     if (!foundExpectedVersion) {
         throw new Error(`${arch} Packages does not contain version ${version}.`);
+    }
+}
+
+function validateFlatPackages({ aptDir, packageAssetsDir, version }) {
+    const packagesPath = path.join(aptDir, "Packages");
+    const packagesGzipPath = path.join(aptDir, "Packages.gz");
+    assertFileExists(packagesPath, "flat Packages index");
+    assertFileExists(packagesGzipPath, "flat Packages.gz index");
+
+    const packagesContent = fs.readFileSync(packagesPath, "utf8");
+    const inflated = zlib.gunzipSync(fs.readFileSync(packagesGzipPath));
+    if (!inflated.equals(Buffer.from(packagesContent, "utf8"))) {
+        throw new Error("Flat Packages.gz does not match Packages.");
+    }
+
+    const stanzas = parseDebianControlFile(packagesContent);
+    if (stanzas.length === 0) {
+        throw new Error("Flat Packages index contains no packages.");
+    }
+
+    const foundArchitectures = new Set();
+    const foundVersionArchitectures = new Set();
+    for (const stanza of stanzas) {
+        const arch = normalizeDebianArchitecture(
+            getDebianControlField(stanza, "Architecture"),
+        );
+        foundArchitectures.add(arch);
+        if (
+            validatePackageStanza({
+                aptDir,
+                packageAssetsDir,
+                architecture: arch,
+                version,
+                stanza,
+                layout: APT_LAYOUT_FLAT_RELEASE,
+            })
+        ) {
+            foundVersionArchitectures.add(arch);
+        }
+    }
+
+    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
+        if (!foundArchitectures.has(architecture)) {
+            throw new Error(`Flat Packages does not contain ${architecture}.`);
+        }
+        if (version && !foundVersionArchitectures.has(architecture)) {
+            throw new Error(
+                `Flat Packages does not contain version ${version} for ${architecture}.`,
+            );
+        }
     }
 }
 
@@ -294,11 +447,11 @@ function runCommand(command, args, options = {}) {
     return result.stdout ?? "";
 }
 
-function verifySignatures({ aptDir, suite }) {
+function verifySignatures({ aptDir, suite, layout }) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "neverwrite-apt-gpg-"));
     const keyringPath = path.join(tempDir, "neverwrite-archive-keyring.gpg");
     const publicKeyPath = path.join(aptDir, APT_PUBLIC_KEY_FILE_NAME);
-    const suiteDir = path.join(aptDir, "dists", suite);
+    const suiteDir = getReleaseDir({ aptDir, suite, layout });
 
     try {
         runCommand("gpg", [
@@ -332,17 +485,24 @@ function verifySignatures({ aptDir, suite }) {
     }
 }
 
-function validateSourcesExample(aptDir) {
+function validateSourcesExample(aptDir, layout) {
     const sourcePath = path.join(aptDir, APT_SOURCES_EXAMPLE_FILE_NAME);
     assertFileExists(sourcePath, "Deb822 source example");
     const source = fs.readFileSync(sourcePath, "utf8");
-    for (const expectedLine of [
+    const expectedLines = [
         "Types: deb",
-        "Suites: stable",
-        "Components: main",
+        layout === APT_LAYOUT_FLAT_RELEASE ? "Suites: ./" : "Suites: stable",
         "Architectures: amd64 arm64",
         "Signed-By: /etc/apt/keyrings/neverwrite.asc",
-    ]) {
+    ];
+    if (layout === APT_LAYOUT_CLASSIC) {
+        expectedLines.push("Components: main");
+    } else if (/^Components:/m.test(source)) {
+        throw new Error(
+            `${APT_SOURCES_EXAMPLE_FILE_NAME} must omit Components for the flat release layout.`,
+        );
+    }
+    for (const expectedLine of expectedLines) {
         if (!source.includes(expectedLine)) {
             throw new Error(
                 `${APT_SOURCES_EXAMPLE_FILE_NAME} is missing "${expectedLine}".`,
@@ -353,7 +513,11 @@ function validateSourcesExample(aptDir) {
 
 function main() {
     const args = parseArgs(process.argv.slice(2));
-    const suiteDir = path.join(args.aptDir, "dists", args.suite);
+    const suiteDir = getReleaseDir({
+        aptDir: args.aptDir,
+        suite: args.suite,
+        layout: args.layout,
+    });
 
     assertFileExists(args.aptDir, "APT repository root");
     assertFileExists(path.join(args.aptDir, APT_PUBLIC_KEY_FILE_NAME), "APT public key");
@@ -361,23 +525,36 @@ function main() {
     assertFileExists(path.join(suiteDir, "InRelease"), "APT InRelease");
     assertFileExists(path.join(suiteDir, "Release.gpg"), "APT Release.gpg");
 
-    validateSourcesExample(args.aptDir);
+    validateSourcesExample(args.aptDir, args.layout);
     validateReleaseFile({
         aptDir: args.aptDir,
         suite: args.suite,
         component: args.component,
+        layout: args.layout,
     });
 
-    for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
-        validatePackagesForArchitecture({
+    if (args.layout === APT_LAYOUT_FLAT_RELEASE) {
+        validateFlatPackages({
             aptDir: args.aptDir,
-            architecture,
+            packageAssetsDir: args.packageAssetsDir,
             version: args.version,
         });
+    } else {
+        for (const architecture of APT_SUPPORTED_ARCHITECTURES) {
+            validateClassicPackagesForArchitecture({
+                aptDir: args.aptDir,
+                architecture,
+                version: args.version,
+            });
+        }
     }
 
     if (!args.skipSignatureCheck) {
-        verifySignatures({ aptDir: args.aptDir, suite: args.suite });
+        verifySignatures({
+            aptDir: args.aptDir,
+            suite: args.suite,
+            layout: args.layout,
+        });
     }
 
     console.log(


### PR DESCRIPTION
## Summary

- Move the APT repository publication path to a flat GitHub Release asset repository so large `.deb` files stay on the release instead of `gh-pages`.
- Generate signed `Packages`, `Packages.gz`, `Release`, `InRelease`, and `Release.gpg` metadata as release assets, while `gh-pages` only keeps the public key and source example.
- Add flat-layout validation so package `Filename` values must be release asset names, not absolute URLs or `pool/` paths.
- Update release-body and APT docs to point Ubuntu/Debian users at `https://github.com/jsgrrchg/NeverWrite/releases/latest/download` with `Suites: ./`.

Closes #190

## Validation

- `node --check scripts/apt-repo-lib.mjs && node --check scripts/build-apt-repository.mjs && node --check scripts/sign-apt-repository.mjs && node --check scripts/validate-apt-repository.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-desktop.yml"); puts "yaml ok"'`
- `node --test scripts/appcast.test.mjs scripts/apt-repo.test.mjs scripts/platform-validation.test.mjs scripts/release-assets.test.mjs`
- `node scripts/validate-release-metadata.mjs --tag v0.3.2`
- `git diff --check`
