### PR TITLE
Remove Claude Code max-turns setting

### DIFF
--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -37,7 +37,6 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().claudeCodeContinueSession).toBe(
             false,
         );
-        expect(useSettingsStore.getState().claudeCodeMaxTurns).toBe(0);
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(true);
         expect(useSettingsStore.getState().pdfFilter).toBe("none");
         expect(useSettingsStore.getState().editorSpellcheck).toBe(false);
@@ -155,7 +154,6 @@ describe("settingsStore", () => {
         useSettingsStore
             .getState()
             .setSetting("claudeCodeContinueSession", true);
-        useSettingsStore.getState().setSetting("claudeCodeMaxTurns", 12);
 
         expect(
             JSON.parse(
@@ -170,9 +168,14 @@ describe("settingsStore", () => {
                 claudeCodeSkipPermissions: true,
                 claudeCodeModel: "claude-sonnet-4-6",
                 claudeCodeContinueSession: true,
-                claudeCodeMaxTurns: 12,
             },
         });
+        expect(
+            JSON.parse(
+                localStorage.getItem("neverwrite:settings:/vaults/terminal") ??
+                    "",
+            ).state,
+        ).not.toHaveProperty("claudeCodeMaxTurns");
     });
 
     it("normalizes persisted terminal numeric settings", () => {
@@ -181,7 +184,6 @@ describe("settingsStore", () => {
             JSON.stringify({
                 state: {
                     terminalFontSize: 99,
-                    claudeCodeMaxTurns: -3,
                 },
             }),
         );
@@ -190,7 +192,30 @@ describe("settingsStore", () => {
         initializeSettingsStore();
 
         expect(useSettingsStore.getState().terminalFontSize).toBe(24);
-        expect(useSettingsStore.getState().claudeCodeMaxTurns).toBe(0);
+    });
+
+    it("ignores legacy Claude Code max-turns settings", () => {
+        localStorage.setItem(
+            "neverwrite:settings",
+            JSON.stringify({
+                state: {
+                    terminalFontSize: 16,
+                    claudeCodeMaxTurns: 12,
+                },
+            }),
+        );
+
+        disposeSettingsStoreRuntime();
+        initializeSettingsStore();
+
+        expect(useSettingsStore.getState().terminalFontSize).toBe(16);
+        expect(useSettingsStore.getState()).not.toHaveProperty(
+            "claudeCodeMaxTurns",
+        );
+        useSettingsStore.getState().setSetting("terminalFontSize", 17);
+        expect(
+            JSON.parse(localStorage.getItem("neverwrite:settings") ?? "").state,
+        ).not.toHaveProperty("claudeCodeMaxTurns");
     });
 
     it("persists custom spellcheck language tags as plain strings", () => {

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -44,7 +44,6 @@ export interface Settings {
     claudeCodeSkipPermissions: boolean;
     claudeCodeModel: string; // "" = Claude Code default
     claudeCodeContinueSession: boolean;
-    claudeCodeMaxTurns: number; // 0 = unlimited
 
     // Developers
     fileTreeContentMode: "notes_only" | "all_files";
@@ -198,7 +197,6 @@ const defaults: Settings = {
     claudeCodeSkipPermissions: false,
     claudeCodeModel: "",
     claudeCodeContinueSession: false,
-    claudeCodeMaxTurns: 0,
     fileTreeContentMode: "notes_only",
     fileTreeShowExtensions: false,
     fileTreeExtensionFilter: [],
@@ -488,12 +486,6 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             claudeCodeContinueSession:
                 parsed.state.claudeCodeContinueSession ??
                 defaults.claudeCodeContinueSession,
-            claudeCodeMaxTurns: normalizeIntInRange(
-                parsed.state.claudeCodeMaxTurns,
-                defaults.claudeCodeMaxTurns,
-                0,
-                1000,
-            ),
             fileTreeContentMode: normalizeFileTreeContentMode(
                 parsed.state.fileTreeContentMode,
             ),
@@ -573,7 +565,6 @@ function pickSettings(state: SettingsStore): Settings {
         claudeCodeSkipPermissions: state.claudeCodeSkipPermissions,
         claudeCodeModel: state.claudeCodeModel,
         claudeCodeContinueSession: state.claudeCodeContinueSession,
-        claudeCodeMaxTurns: state.claudeCodeMaxTurns,
         fileTreeContentMode: state.fileTreeContentMode,
         fileTreeShowExtensions: state.fileTreeShowExtensions,
         fileTreeExtensionFilter: state.fileTreeExtensionFilter,

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -1674,8 +1674,8 @@ export function AIProvidersSettings({
                                                     }}
                                                 >
                                                     Model, skip permissions,
-                                                    max turns, and other Claude
-                                                    Code options are in{" "}
+                                                    and other Claude Code
+                                                    options are in{" "}
                                                     <strong
                                                         style={{
                                                             color: "var(--text-primary)",

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -711,15 +711,7 @@ describe("SettingsPanel", () => {
             true,
         );
 
-        const maxTurnsRow =
-            screen.getByText("Max turns").parentElement?.parentElement;
-        expect(maxTurnsRow).not.toBeNull();
-        const maxTurnsInput =
-            within(maxTurnsRow as HTMLElement).getByDisplayValue("0");
-        fireEvent.focus(maxTurnsInput);
-        fireEvent.change(maxTurnsInput, { target: { value: "12" } });
-        fireEvent.keyDown(maxTurnsInput, { key: "Enter" });
-        expect(useSettingsStore.getState().claudeCodeMaxTurns).toBe(12);
+        expect(screen.queryByText("Max turns")).not.toBeInTheDocument();
     });
 
     it("checks updater metadata manually without starting an install", async () => {

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3340,7 +3340,6 @@ function TerminalSettings({
         claudeCodeSkipPermissions,
         claudeCodeModel,
         claudeCodeContinueSession,
-        claudeCodeMaxTurns,
         setSetting,
     } = useSettingsStore();
 
@@ -3386,10 +3385,6 @@ function TerminalSettings({
             [
                 "Continue last session",
                 "Passes --continue. Resumes your most recent Claude Code conversation instead of starting fresh.",
-            ],
-            [
-                "Max turns",
-                "Passes --max-turns. Stops an agentic session after this many turns. Set to 0 for no limit.",
             ],
         ]);
 
@@ -3535,25 +3530,6 @@ function TerminalSettings({
                             value={claudeCodeContinueSession}
                             onChange={(v) =>
                                 setSetting("claudeCodeContinueSession", v)
-                            }
-                        />
-                    }
-                />
-            )}
-            {showClaudeCode && (
-                <SearchableRow
-                    searchQuery={searchQuery}
-                    section="Claude Code"
-                    label="Max turns"
-                    description="Passes --max-turns N. Stops an agentic run after this many turns to prevent runaway sessions. Set to 0 for no limit."
-                    keywords={["max turns", "limit", "agentic", "turns"]}
-                    control={
-                        <NumberStepper
-                            value={claudeCodeMaxTurns}
-                            min={0}
-                            max={200}
-                            onChange={(v) =>
-                                setSetting("claudeCodeMaxTurns", v)
                             }
                         />
                     }
@@ -4427,8 +4403,6 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "haiku",
         "Continue last session",
         "resume",
-        "Max turns",
-        "agentic",
         "shell",
         "monospace",
     ],

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.test.ts
@@ -120,7 +120,7 @@ describe("openClaudeCodeTerminalWithContext", () => {
             claudeCodeModel: " claude-sonnet-4-6 ",
             claudeCodeContinueSession: true,
             claudeCodeMaxTurns: 7,
-        });
+        } as Partial<ReturnType<typeof useSettingsStore.getState>>);
 
         const opening = openClaudeCodeTerminalWithContext();
         await attachOpenedTerminalRuntime();
@@ -135,7 +135,7 @@ describe("openClaudeCodeTerminalWithContext", () => {
         });
         expect(getWrittenInputs()).toEqual([
             "cd '/vault root'\n",
-            "claude --dangerously-skip-permissions --model claude-sonnet-4-6 --continue --max-turns 7\n",
+            "claude --dangerously-skip-permissions --model claude-sonnet-4-6 --continue\n",
         ]);
         expect(vi.mocked(invoke)).not.toHaveBeenCalledWith(
             "devtools_read_claude_transcript",

--- a/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
+++ b/apps/desktop/src/features/terminal/claudeCodeTerminal.ts
@@ -201,7 +201,6 @@ export async function openClaudeCodeTerminalWithContext(
         claudeCodeSkipPermissions,
         claudeCodeModel,
         claudeCodeContinueSession,
-        claudeCodeMaxTurns,
     } = useSettingsStore.getState();
 
     // Pin a fresh session id so we can locate this terminal's transcript exactly.
@@ -247,7 +246,6 @@ export async function openClaudeCodeTerminalWithContext(
     const safeModel = getSafeClaudeCodeModel(claudeCodeModel);
     if (safeModel) args.push("--model", safeModel);
     if (claudeCodeContinueSession) args.push("--continue");
-    if (claudeCodeMaxTurns > 0) args.push("--max-turns", String(claudeCodeMaxTurns));
 
     await store.writeInput(terminalId, buildShellCommand(args));
 

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -105,7 +105,6 @@ the same Settings stores.
 | Terminal / Claude Code | `claudeCodeSkipPermissions` | Per-vault | `false` | `neverwrite:settings:<vault-path>` | Enables the Claude Code skip-permissions launch flag. |
 | Terminal / Claude Code | `claudeCodeModel` | Per-vault | `""` | `neverwrite:settings:<vault-path>` | Empty string means Claude Code default. |
 | Terminal / Claude Code | `claudeCodeContinueSession` | Per-vault | `false` | `neverwrite:settings:<vault-path>` | Adds continue/resume behavior for new Claude Code terminal launches. |
-| Terminal / Claude Code | `claudeCodeMaxTurns` | Per-vault | `0` | `neverwrite:settings:<vault-path>` | `0` means unlimited; storage normalization clamps to `0..1000`. |
 | File Tree | `fileTreeContentMode` | Per-vault | `notes_only` | `neverwrite:settings:<vault-path>` | Valid values are `notes_only` and `all_files`. Affects file tree, file pickers, mentions, and wikilink suggestions. |
 | File Tree | `fileTreeShowExtensions` | Per-vault | `false` | `neverwrite:settings:<vault-path>` | Shows full filenames with extensions. |
 | File Tree | `fileTreeExtensionFilter` | Per-vault | `[]` | `neverwrite:settings:<vault-path>` | Lowercase extension allowlist; normalized by stripping leading dots and duplicates. |

--- a/docs/terminal-integration.md
+++ b/docs/terminal-integration.md
@@ -76,7 +76,6 @@ Terminal settings are stored with the vault-scoped Settings store:
 - `claudeCodeSkipPermissions`
 - `claudeCodeModel`
 - `claudeCodeContinueSession`
-- `claudeCodeMaxTurns`
 
 See [Settings Scope](./settings-scope.md) for the full storage matrix.
 


### PR DESCRIPTION
## Summary

Removes the Claude Code max-turns setting from the interactive terminal flow.

## Why

Claude Code is launched interactively inside a terminal, and `--max-turns` is only documented for print mode. Keeping the setting exposed suggested a safety limit that the interactive launcher could not reliably enforce.

## Changes

- Stop passing `--max-turns` when launching Claude Code terminals.
- Remove the Max turns control from Terminal settings and search metadata.
- Remove `claudeCodeMaxTurns` from active settings/defaults/persistence.
- Keep legacy persisted values harmless by ignoring them and dropping them on the next settings save.
- Update terminal/settings docs and focused tests.

Closes #189

## Validation

- `npm test -- src/app/store/settingsStore.test.ts src/features/terminal/claudeCodeTerminal.test.ts src/features/settings/SettingsPanel.test.tsx`
- `npx tsc -b`