### PR TITLE
Add native Grok ACP provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Today the repository combines:
 - An Electron desktop app with a Rust sidecar that opens a local vault and keeps working state on disk.
 - A Markdown, CSV, and text/code editing workflow with wikilinks, live preview, frontmatter editing, spellcheck, and grammar checking.
 - Knowledge navigation tools such as backlinks, tags, advanced search, bookmarks, concept maps, and a 2D/3D graph view.
-- An ACP-based AI layer with Codex, Claude, Gemini, Kilo, and OpenCode runtimes.
+- An ACP-based AI layer with Codex, Claude, Gemini, Grok, Kilo, and OpenCode runtimes.
 - An explicit AI change-review system with inline review inside the editor and a dedicated surface in chat and a tab with changes pending approval.
 - A separate browser web clipper that can save directly into the desktop app through a local API, with deep-link fallback. Compatible with both Firefox and Chromium.
 
@@ -87,7 +87,7 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 
 ### AI and change control
 
-- ACP runtime integration for Codex, Claude, Gemini, Kilo, and OpenCode
+- ACP runtime integration for Codex, Claude, Gemini, Grok, Kilo, and OpenCode
 - Attachment flows for notes, folders, files, PDFs, audio, images, and screenshots
 - Session history, transcript viewing, session export, fork, resume, and rename flows
 - Crash recovery for saved chats through `Chat History` and local `.neverwrite/sessions/` transcripts
@@ -210,11 +210,12 @@ The repository already contains broad Vitest coverage in the desktop app and web
 
 ## AI Runtime Notes
 
-NeverWrite currently wires five ACP runtimes:
+NeverWrite currently wires six ACP runtimes:
 
 - `codex-acp`
 - `claude-acp`
 - `gemini-acp`
+- `grok`
 - `kilo-acp`
 - `opencode-acp`
 
@@ -223,6 +224,7 @@ Current packaging status:
 - Codex is intended to be bundled as a sidecar binary in desktop release builds.
 - Claude is intended to be bundled through an embedded Node runtime plus vendored runtime files.
 - Gemini is integrated in the app, but not bundled by default today.
+- Grok is integrated in the app, but not bundled by default today.
 - Kilo is integrated in the app, but not bundled by default today.
 - OpenCode is integrated in the app, but not bundled by default today.
 
@@ -231,6 +233,7 @@ Useful runtime overrides during development:
 - `NEVERWRITE_CODEX_ACP_BIN`
 - `NEVERWRITE_CLAUDE_ACP_BIN`
 - `NEVERWRITE_GEMINI_ACP_BIN`
+- `NEVERWRITE_GROK_ACP_BIN`
 - `NEVERWRITE_KILO_ACP_BIN`
 - `NEVERWRITE_OPENCODE_ACP_BIN`
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -37,7 +37,7 @@ use neverwrite_ai::{
     AI_SESSION_ERROR_EVENT, AI_SESSION_UPDATED_EVENT, AI_STATUS_EVENT, AI_THINKING_COMPLETED_EVENT,
     AI_THINKING_DELTA_EVENT, AI_THINKING_STARTED_EVENT, AI_TOKEN_USAGE_EVENT,
     AI_TOOL_ACTIVITY_EVENT, CLAUDE_RUNTIME_ID, CODEX_RUNTIME_ID, GEMINI_RUNTIME_ID,
-    KILO_RUNTIME_ID, OPENCODE_RUNTIME_ID,
+    GROK_RUNTIME_ID, KILO_RUNTIME_ID, OPENCODE_RUNTIME_ID,
 };
 use portable_pty::{
     native_pty_system, Child as PtyChild, ChildKiller, CommandBuilder, MasterPty, PtySize,
@@ -107,6 +107,7 @@ struct RuntimeDefinition {
 
 const NO_ACP_ARGS: &[&str] = &[];
 const GEMINI_ACP_ARGS: &[&str] = &["--acp"];
+const GROK_ACP_ARGS: &[&str] = &["--no-auto-update", "agent", "stdio"];
 const SHELL_ACP_ARGS: &[&str] = &["acp"];
 
 const RUNTIME_DEFINITIONS: &[RuntimeDefinition] = &[
@@ -135,6 +136,15 @@ const RUNTIME_DEFINITIONS: &[RuntimeDefinition] = &[
         default_executable: "gemini",
         bin_env_var: "NEVERWRITE_GEMINI_ACP_BIN",
         acp_args: GEMINI_ACP_ARGS,
+        supports_native_resume: false,
+    },
+    RuntimeDefinition {
+        id: GROK_RUNTIME_ID,
+        name: "Grok",
+        description: "Grok ACP-compatible agent runtime.",
+        default_executable: "grok",
+        bin_env_var: "NEVERWRITE_GROK_ACP_BIN",
+        acp_args: GROK_ACP_ARGS,
         supports_native_resume: false,
     },
     RuntimeDefinition {
@@ -4685,7 +4695,7 @@ fn runtime_binary_name(base: &str) -> String {
 
 #[cfg(target_os = "macos")]
 fn resolve_macos_homebrew_runtime_fallback(runtime_id: &str) -> Option<PathBuf> {
-    if runtime_id != OPENCODE_RUNTIME_ID {
+    if !matches!(runtime_id, GROK_RUNTIME_ID | OPENCODE_RUNTIME_ID) {
         return None;
     }
     ["/opt/homebrew/bin", "/usr/local/bin"]
@@ -7040,8 +7050,49 @@ mod tests {
         assert!(runtime_supports_native_resume(CODEX_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(CLAUDE_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(GEMINI_RUNTIME_ID));
+        assert!(!runtime_supports_native_resume(GROK_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(KILO_RUNTIME_ID));
         assert!(!runtime_supports_native_resume(OPENCODE_RUNTIME_ID));
+    }
+
+    #[test]
+    fn grok_runtime_is_registered_with_expected_launch_contract() {
+        let definition = runtime_definition(GROK_RUNTIME_ID).unwrap();
+        assert_eq!(definition.name, "Grok");
+        assert_eq!(definition.default_executable, "grok");
+        assert_eq!(definition.bin_env_var, "NEVERWRITE_GROK_ACP_BIN");
+        assert_eq!(definition.acp_args, ["--no-auto-update", "agent", "stdio"]);
+
+        let descriptors = runtime_descriptors();
+        let descriptor = descriptors
+            .iter()
+            .find(|descriptor| descriptor.runtime.id == GROK_RUNTIME_ID)
+            .unwrap();
+        assert_eq!(descriptor.runtime.name, "Grok");
+        assert!(descriptor
+            .runtime
+            .capabilities
+            .iter()
+            .all(|capability| capability != "resume_session"));
+        assert!(diagnostic_executable_names().contains(&"grok"));
+    }
+
+    #[test]
+    fn grok_setup_status_reports_missing_binary_without_auth_ready() {
+        let status = setup_status_for(
+            GROK_RUNTIME_ID,
+            RuntimeSetupState {
+                custom_binary_path: Some("/neverwrite/missing/grok".to_string()),
+                ..RuntimeSetupState::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(status.runtime_id, GROK_RUNTIME_ID);
+        assert!(!status.binary_ready);
+        assert_eq!(status.binary_source, AiRuntimeBinarySource::Missing);
+        assert!(!status.auth_ready);
+        assert!(status.onboarding_required);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -217,6 +217,8 @@ struct AiRuntimeSetupPayload {
     #[serde(default)]
     gemini_api_key: Option<AiSecretPatch>,
     #[serde(default)]
+    xai_api_key: Option<AiSecretPatch>,
+    #[serde(default)]
     kilo_api_key: Option<AiSecretPatch>,
     #[serde(default)]
     google_api_key: Option<AiSecretPatch>,
@@ -695,6 +697,7 @@ fn is_secret_runtime_env_key(key: &str) -> bool {
             | "ANTHROPIC_CUSTOM_HEADERS"
             | "GEMINI_API_KEY"
             | "GOOGLE_API_KEY"
+            | "XAI_API_KEY"
             | "OPENCODE_API_KEY"
             | "KILO_API_KEY"
     )
@@ -709,6 +712,7 @@ fn secret_env_keys_for_runtime(runtime_id: &str) -> &'static [&'static str] {
             "ANTHROPIC_CUSTOM_HEADERS",
         ],
         GEMINI_RUNTIME_ID => &["GEMINI_API_KEY", "GOOGLE_API_KEY"],
+        GROK_RUNTIME_ID => &["XAI_API_KEY"],
         KILO_RUNTIME_ID => &["KILO_API_KEY"],
         _ => &[],
     }
@@ -4515,6 +4519,11 @@ fn acp_process_spec(
         )
     })?;
     let mut env = setup.env.clone();
+    for key in secret_env_keys_for_runtime(runtime_id) {
+        if env_secret_present(key) {
+            env.remove(*key);
+        }
+    }
     if let Some(method) = setup.auth_method.as_deref() {
         if runtime_id == GEMINI_RUNTIME_ID {
             env.insert(
@@ -4995,6 +5004,15 @@ fn inherited_auth_method(
                     auth_invalidated_at_ms,
                 )
             }),
+        GROK_RUNTIME_ID => env_secret_present("XAI_API_KEY")
+            .then(|| "xai-api-key".to_string())
+            .or_else(|| {
+                inherited_persisted_auth_method(
+                    runtime_id,
+                    include_persisted,
+                    auth_invalidated_at_ms,
+                )
+            }),
         KILO_RUNTIME_ID => env_secret_present("KILO_API_KEY")
             .then(|| "kilo-api-key".to_string())
             .or_else(|| {
@@ -5244,6 +5262,10 @@ fn auth_method_has_local_config(setup: &RuntimeSetupState, method_id: &str) -> b
             .env
             .get("KILO_API_KEY")
             .is_some_and(|value| !value.is_empty()),
+        "xai-api-key" => setup
+            .env
+            .get("XAI_API_KEY")
+            .is_some_and(|value| !value.is_empty()),
         "gateway" => {
             setup.has_gateway_config
                 && !setup
@@ -5283,6 +5305,7 @@ fn is_local_auth_method(method_id: &str) -> bool {
             | "anthropic-api-key"
             | "use_gemini"
             | "kilo-api-key"
+            | "xai-api-key"
             | "gateway"
             | "gateway-bedrock"
     )
@@ -5331,6 +5354,11 @@ fn local_auth_method_for_runtime(runtime_id: &str, setup: &RuntimeSetupState) ->
             .get("KILO_API_KEY")
             .is_some_and(|value| !value.is_empty())
             .then(|| "kilo-api-key".to_string()),
+        GROK_RUNTIME_ID => setup
+            .env
+            .get("XAI_API_KEY")
+            .is_some_and(|value| !value.is_empty())
+            .then(|| "xai-api-key".to_string()),
         _ => None,
     }
 }
@@ -5374,6 +5402,7 @@ fn clear_runtime_auth_state(runtime_id: &str, setup: &mut RuntimeSetupState) {
         "AWS_BEARER_TOKEN_BEDROCK",
         "GEMINI_API_KEY",
         "GOOGLE_API_KEY",
+        "XAI_API_KEY",
         "OPENCODE_API_KEY",
         "KILO_API_KEY",
         "GOOGLE_CLOUD_PROJECT",
@@ -5454,6 +5483,19 @@ fn auth_methods(runtime_id: &str) -> Vec<AiAuthMethod> {
                 description: "Use a Gemini Developer API key stored locally.".to_string(),
             },
         ],
+        GROK_RUNTIME_ID => vec![
+            AiAuthMethod {
+                id: "grok-login".to_string(),
+                name: "Grok login".to_string(),
+                description: "Open the Grok CLI sign-in flow in an integrated terminal."
+                    .to_string(),
+            },
+            AiAuthMethod {
+                id: "xai-api-key".to_string(),
+                name: "xAI API key".to_string(),
+                description: "Use an xAI API key stored locally.".to_string(),
+            },
+        ],
         KILO_RUNTIME_ID => vec![
             AiAuthMethod {
                 id: "kilo-login".to_string(),
@@ -5482,6 +5524,7 @@ fn auth_method_ids(runtime_id: &str) -> Vec<&'static str> {
         CODEX_RUNTIME_ID => vec!["chatgpt", "openai-api-key", "codex-api-key"],
         CLAUDE_RUNTIME_ID => claude_auth_method_ids_for_environment(is_claude_remote_environment()),
         GEMINI_RUNTIME_ID => vec!["login_with_google", "use_gemini"],
+        GROK_RUNTIME_ID => vec!["grok-login", "xai-api-key"],
         KILO_RUNTIME_ID => vec!["kilo-login", "kilo-api-key"],
         OPENCODE_RUNTIME_ID => vec!["opencode-login"],
         _ => vec![],
@@ -5723,6 +5766,11 @@ fn update_auth_state(
         }
         if let Some(patch) = input.google_api_key.clone() {
             touched_auth |= apply_secret_patch(setup, "GOOGLE_API_KEY", patch, "use_gemini");
+        }
+    }
+    if runtime_id == GROK_RUNTIME_ID {
+        if let Some(patch) = input.xai_api_key.clone() {
+            touched_auth |= apply_secret_patch(setup, "XAI_API_KEY", patch, "xai-api-key");
         }
     }
     if runtime_id == KILO_RUNTIME_ID {
@@ -6522,7 +6570,10 @@ mod tests {
     };
     use std::fs;
     use std::sync::mpsc;
+    use std::sync::Mutex as StdMutex;
     use std::time::Duration as StdDuration;
+
+    static ENV_TEST_LOCK: StdMutex<()> = StdMutex::new(());
 
     fn test_client(event_tx: mpsc::Sender<RpcOutput>) -> NativeAcpClient {
         test_client_with_state(event_tx, Arc::new(Mutex::new(NativeAiInner::default())))
@@ -7074,6 +7125,16 @@ mod tests {
             .capabilities
             .iter()
             .all(|capability| capability != "resume_session"));
+        assert!(descriptor
+            .runtime
+            .capabilities
+            .iter()
+            .any(|capability| capability == "xai-api-key"));
+        assert!(descriptor
+            .runtime
+            .capabilities
+            .iter()
+            .any(|capability| capability == "grok-login"));
         assert!(diagnostic_executable_names().contains(&"grok"));
     }
 
@@ -9776,6 +9837,54 @@ mod tests {
     }
 
     #[test]
+    fn grok_xai_api_key_setup_persists_across_native_ai_instances() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+
+        let status = native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-test-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            status.get("auth_method").and_then(Value::as_str),
+            Some("xai-api-key")
+        );
+
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(!encoded.contains("xai-test-secret"));
+        assert!(encoded.contains("XAI_API_KEY"));
+
+        let rehydrated_native_ai = test_native_ai_with_secret_store(store_path, secrets);
+        let status = rehydrated_native_ai
+            .get_setup_status(&json!({ "runtime_id": GROK_RUNTIME_ID }))
+            .unwrap();
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(true)
+        );
+        assert_eq!(
+            status.get("auth_method").and_then(Value::as_str),
+            Some("xai-api-key")
+        );
+        assert!(!status.to_string().contains("xai-test-secret"));
+    }
+
+    #[test]
     fn opencode_login_selection_persists_without_local_secret() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
@@ -9994,17 +10103,27 @@ mod tests {
                 },
             }))
             .unwrap();
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "xai_api_key": { "action": "set", "value": "xai-secret" },
+                },
+            }))
+            .unwrap();
 
         let encoded = fs::read_to_string(&store_path).unwrap();
         assert!(!encoded.contains("gemini-secret"));
         assert!(!encoded.contains("openai-secret"));
         assert!(!encoded.contains("claude-secret"));
         assert!(!encoded.contains("kilo-secret"));
+        assert!(!encoded.contains("xai-secret"));
         assert!(encoded.contains("\"secret_env_keys\""));
         assert!(encoded.contains("GEMINI_API_KEY"));
         assert!(encoded.contains("OPENAI_API_KEY"));
         assert!(encoded.contains("ANTHROPIC_API_KEY"));
         assert!(encoded.contains("KILO_API_KEY"));
+        assert!(encoded.contains("XAI_API_KEY"));
     }
 
     #[test]
@@ -10194,6 +10313,47 @@ mod tests {
     }
 
     #[test]
+    fn logout_removes_persisted_grok_xai_api_key_setup() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-test-secret",
+                    },
+                },
+            }))
+            .unwrap();
+        assert!(store_path.exists());
+
+        native_ai
+            .logout(&json!({ "runtime_id": GROK_RUNTIME_ID }))
+            .unwrap();
+
+        assert!(!store_path.exists());
+        assert_eq!(
+            secrets
+                .get_secret(GROK_RUNTIME_ID, "XAI_API_KEY")
+                .expect("secret store should remain readable"),
+            None
+        );
+        let setup = native_ai.inner.lock().unwrap();
+        let grok_setup = setup
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .expect("Grok setup entry should remain in memory");
+        assert!(!grok_setup.env.contains_key("XAI_API_KEY"));
+        assert_eq!(grok_setup.auth_method, None);
+        assert!(!grok_setup.auth_ready);
+    }
+
+    #[test]
     fn logout_secret_store_failure_does_not_commit_memory() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
@@ -10303,6 +10463,67 @@ mod tests {
             spec.env.get("KILO_API_KEY").map(String::as_str),
             Some("kilo-test-secret")
         );
+    }
+
+    #[test]
+    fn acp_process_spec_injects_xai_api_key_from_setup_env() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-test-secret".to_string());
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("xai-api-key".to_string()),
+            env,
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(
+            spec.env.get("XAI_API_KEY").map(String::as_str),
+            Some("xai-test-secret")
+        );
+    }
+
+    #[test]
+    fn acp_process_spec_lets_inherited_xai_api_key_override_stored_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::set_var("XAI_API_KEY", "xai-env-secret");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-stored-secret".to_string());
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("xai-api-key".to_string()),
+            env,
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+
+        assert_eq!(
+            inherited_auth_method(GROK_RUNTIME_ID, true, None),
+            Some("xai-api-key".to_string())
+        );
+        assert_eq!(spec.env.get("XAI_API_KEY"), None);
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1081,10 +1081,9 @@ impl NativeAi {
         }
         let setup = pending_setup.entry(runtime_id.clone()).or_default();
 
-        setup.custom_binary_path = input
-            .custom_binary_path
-            .clone()
-            .and_then(normalize_optional_string);
+        if let Some(custom_binary_path) = input.custom_binary_path.clone() {
+            setup.custom_binary_path = normalize_optional_string(custom_binary_path);
+        }
         update_auth_state(setup, &runtime_id, input)?;
         let status = setup_status_for(&runtime_id, setup.clone())?;
         self.setup_store.save(&pending_setup)?;
@@ -7563,6 +7562,65 @@ mod tests {
         assert!(status.auth_ready);
         assert!(!status.onboarding_required);
         assert_eq!(status.auth_method.as_deref(), Some("xai-api-key"));
+    }
+
+    #[test]
+    fn grok_xai_key_update_preserves_custom_binary_path() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_secret_store(
+            store_path,
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let current_exe = std::env::current_exe().unwrap();
+        let current_exe_display = current_exe.display().to_string();
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": current_exe,
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-first-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": null,
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-second-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        let setup = native_ai.inner.lock().unwrap();
+        let grok_setup = setup
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .expect("Grok setup should remain configured");
+        assert_eq!(
+            grok_setup.custom_binary_path.as_deref(),
+            Some(current_exe_display.as_str())
+        );
+        assert_eq!(grok_setup.auth_method.as_deref(), Some("xai-api-key"));
+        assert!(grok_setup.auth_ready);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4818,7 +4818,9 @@ fn acp_process_spec(
     })?;
     let mut env = setup.env.clone();
     for key in secret_env_keys_for_runtime(runtime_id) {
-        if env_secret_present(key) {
+        let inherited_secret_should_win = env_secret_present(key)
+            && !setup_secret_env_overrides_inherited(runtime_id, setup, key);
+        if inherited_secret_should_win {
             env.remove(*key);
         }
     }
@@ -4857,6 +4859,18 @@ fn acp_process_spec(
         auth_method,
         auth_handshake: acp_auth_handshake_for_runtime(runtime_id),
     })
+}
+
+fn setup_secret_env_overrides_inherited(
+    runtime_id: &str,
+    setup: &RuntimeSetupState,
+    env_key: &str,
+) -> bool {
+    runtime_id == GROK_RUNTIME_ID
+        && env_key == "XAI_API_KEY"
+        && setup.auth_method.as_deref() == Some("xai-api-key")
+        && setup.auth_ready
+        && auth_method_has_local_config(setup, "xai-api-key")
 }
 
 fn effective_auth_method_for_acp_process_spec(
@@ -6766,6 +6780,15 @@ fn auth_terminal_output_indicates_success(runtime_id: &str, buffer: &str) -> boo
                 || lower.contains("login successful")
                 || lower.contains("successfully authenticated")
                 || lower.contains("successfully logged in")
+        }
+        GROK_RUNTIME_ID => {
+            let lower = buffer.to_ascii_lowercase();
+            lower.contains("authentication successful")
+                || lower.contains("login successful")
+                || lower.contains("logged in successfully")
+                || lower.contains("successfully authenticated")
+                || lower.contains("successfully logged in")
+                || lower.contains("successfully signed in")
         }
         _ => false,
     }
@@ -10633,6 +10656,18 @@ mod tests {
     }
 
     #[test]
+    fn grok_auth_terminal_success_output_is_detected_before_exit() {
+        assert!(auth_terminal_output_indicates_success(
+            GROK_RUNTIME_ID,
+            "Grok login successful"
+        ));
+        assert!(!auth_terminal_output_indicates_success(
+            GROK_RUNTIME_ID,
+            "Grok login required"
+        ));
+    }
+
+    #[test]
     fn runtime_secret_store_mode_requires_explicit_memory_value() {
         assert_eq!(
             runtime_secret_store_mode_from_env(Some("memory")),
@@ -11836,6 +11871,38 @@ mod tests {
             Some("xai-api-key".to_string())
         );
         assert_eq!(spec.env.get("XAI_API_KEY"), None);
+        assert_eq!(spec.auth_method.as_deref(), Some("xai-api-key"));
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn acp_process_spec_lets_ready_stored_xai_key_override_inherited_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::set_var("XAI_API_KEY", "xai-env-secret");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-stored-secret".to_string());
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("xai-api-key".to_string()),
+            auth_ready: true,
+            env,
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+
+        assert_eq!(
+            spec.env.get("XAI_API_KEY").map(String::as_str),
+            Some("xai-stored-secret")
+        );
         assert_eq!(spec.auth_method.as_deref(), Some("xai-api-key"));
 
         match previous {

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -3034,21 +3034,32 @@ async fn run_acp_auth_handshake(
     spec: &AcpProcessSpec,
     initialize_response: &InitializeResponse,
 ) -> Result<(), agent_client_protocol::Error> {
-    let Some(request) = acp_auth_handshake_request(spec)
+    let Some(request) = validate_acp_auth_handshake_request(spec, initialize_response)
         .map_err(|message| agent_client_protocol::Error::internal_error().data(message))?
     else {
         return Ok(());
     };
 
+    send_acp_authenticate_request(connection, request.method_id, request.meta).await
+}
+
+fn validate_acp_auth_handshake_request(
+    spec: &AcpProcessSpec,
+    initialize_response: &InitializeResponse,
+) -> Result<Option<AcpAuthHandshakeRequest>, String> {
+    let Some(request) = acp_auth_handshake_request(spec)? else {
+        return Ok(None);
+    };
+
     if !acp_initialize_response_has_auth_method(initialize_response, request.method_id) {
-        return Err(agent_client_protocol::Error::internal_error().data(format!(
+        return Err(format!(
             "{} ACP runtime did not advertise required auth method '{}'.",
             runtime_name(&spec.runtime_id),
             request.method_id
-        )));
+        ));
     }
 
-    send_acp_authenticate_request(connection, request.method_id, request.meta).await
+    Ok(Some(request))
 }
 
 fn acp_auth_handshake_request(
@@ -7522,6 +7533,66 @@ mod tests {
     }
 
     #[test]
+    fn setup_status_accepts_grok_xai_api_key() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-test-secret".to_string());
+        let status = setup_status_for(
+            GROK_RUNTIME_ID,
+            RuntimeSetupState {
+                custom_binary_path: Some(current_exe.display().to_string()),
+                auth_method: Some("xai-api-key".to_string()),
+                auth_ready: true,
+                env,
+                ..RuntimeSetupState::default()
+            },
+        )
+        .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(status.runtime_id, GROK_RUNTIME_ID);
+        assert!(status.binary_ready);
+        assert!(status.auth_ready);
+        assert!(!status.onboarding_required);
+        assert_eq!(status.auth_method.as_deref(), Some("xai-api-key"));
+    }
+
+    #[test]
+    fn inherited_xai_api_key_marks_grok_ready() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::set_var("XAI_API_KEY", "xai-env-secret");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let status = setup_status_for(
+            GROK_RUNTIME_ID,
+            RuntimeSetupState {
+                custom_binary_path: Some(current_exe.display().to_string()),
+                ..RuntimeSetupState::default()
+            },
+        )
+        .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert!(status.binary_ready);
+        assert!(status.auth_ready);
+        assert!(!status.onboarding_required);
+        assert_eq!(status.auth_method.as_deref(), Some("xai-api-key"));
+    }
+
+    #[test]
     fn unsupported_native_resume_fails_before_creating_placeholder_session() {
         let (event_tx, _event_rx) = mpsc::channel();
         let native_ai = NativeAi::new(event_tx);
@@ -10058,6 +10129,20 @@ mod tests {
     }
 
     #[test]
+    fn grok_login_auth_store_detects_non_empty_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(&auth_file, r#"{"token":"redacted"}"#).unwrap();
+
+        assert!(active_grok_auth_file_exists(temp.path(), None));
+        assert_eq!(
+            persisted_cli_auth_method_for_home(GROK_RUNTIME_ID, temp.path(), false),
+            Some("grok-login".to_string())
+        );
+    }
+
+    #[test]
     fn ignores_inactive_or_invalid_opencode_credentials() {
         let temp = tempfile::tempdir().unwrap();
         let auth_file = temp
@@ -10163,6 +10248,29 @@ mod tests {
     }
 
     #[test]
+    fn grok_login_respects_auth_invalidated_at_ms() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(&auth_file, r#"{"token":"redacted"}"#).unwrap();
+        let modified_at_ms = fs::metadata(&auth_file)
+            .unwrap()
+            .modified()
+            .ok()
+            .and_then(system_time_epoch_ms)
+            .unwrap();
+
+        assert!(!active_grok_auth_file_exists(
+            temp.path(),
+            Some(modified_at_ms)
+        ));
+        assert!(active_grok_auth_file_exists(
+            temp.path(),
+            Some(modified_at_ms.saturating_sub(1))
+        ));
+    }
+
+    #[test]
     fn inherited_kilo_login_does_not_satisfy_selected_kilo_api_key() {
         let current_exe = std::env::current_exe().unwrap();
         let setup = RuntimeSetupState {
@@ -10261,6 +10369,27 @@ mod tests {
         .unwrap();
 
         assert_eq!(default_terminal_auth_method(GROK_RUNTIME_ID), "grok-login");
+        assert_eq!(config.args, vec!["login".to_string()]);
+        assert_eq!(config.display_name, "Grok Login");
+    }
+
+    #[test]
+    fn auth_terminal_launch_config_starts_grok_login() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let config = auth_terminal_launch_config(
+            GROK_RUNTIME_ID,
+            "grok-login",
+            &setup,
+            std::env::current_dir().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(config.program, current_exe);
         assert_eq!(config.args, vec!["login".to_string()]);
         assert_eq!(config.display_name, "Grok Login");
     }
@@ -10466,6 +10595,45 @@ mod tests {
             Some("xai-api-key")
         );
         assert!(!status.to_string().contains("xai-test-secret"));
+    }
+
+    #[test]
+    fn grok_xai_api_key_is_secret_keyring_value() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": current_exe,
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-keyring-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("XAI_API_KEY"));
+        assert!(!encoded.contains("xai-keyring-secret"));
+        assert_eq!(
+            secrets.stored_secret(GROK_RUNTIME_ID, "XAI_API_KEY"),
+            Some("xai-keyring-secret".to_string())
+        );
     }
 
     #[test]
@@ -11397,6 +11565,67 @@ mod tests {
     }
 
     #[test]
+    fn grok_acp_process_spec_uses_no_auto_update_agent_stdio() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+
+        assert_eq!(spec.program, current_exe);
+        assert_eq!(
+            spec.args,
+            vec![
+                "--no-auto-update".to_string(),
+                "agent".to_string(),
+                "stdio".to_string()
+            ]
+        );
+        assert_eq!(spec.runtime_id, GROK_RUNTIME_ID);
+        assert!(spec.auth_handshake.is_some());
+    }
+
+    #[test]
+    fn grok_auth_handshake_selects_xai_api_key() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-test-secret".to_string());
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("xai-api-key".to_string()),
+            env,
+            ..RuntimeSetupState::default()
+        };
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+        let handshake_request = acp_auth_handshake_request(&spec)
+            .expect("Grok handshake should map API key auth")
+            .expect("Grok API key auth should request an ACP authenticate call");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(handshake_request.method_id, "xai.api_key");
+        assert_eq!(
+            handshake_request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("headless"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
     fn acp_process_spec_lets_inherited_xai_api_key_override_stored_secret() {
         let _guard = ENV_TEST_LOCK.lock().unwrap();
         let previous = std::env::var_os("XAI_API_KEY");
@@ -11430,6 +11659,41 @@ mod tests {
 
     #[test]
     fn acp_auth_handshake_maps_grok_login_to_cached_token() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("grok-login".to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+        let handshake_request = acp_auth_handshake_request(&spec)
+            .expect("Grok handshake should map login auth")
+            .expect("Grok login auth should request an ACP authenticate call");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(handshake_request.method_id, "cached_token");
+        assert_eq!(
+            handshake_request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("headless"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn grok_auth_handshake_selects_cached_token() {
         let _guard = ENV_TEST_LOCK.lock().unwrap();
         let previous = std::env::var_os("XAI_API_KEY");
         std::env::remove_var("XAI_API_KEY");
@@ -11553,6 +11817,41 @@ mod tests {
             &response,
             "xai.api_key"
         ));
+    }
+
+    #[test]
+    fn grok_auth_handshake_rejects_missing_advertised_method() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let mut env = HashMap::new();
+        env.insert("XAI_API_KEY".to_string(), "xai-test-secret".to_string());
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("xai-api-key".to_string()),
+            env,
+            ..RuntimeSetupState::default()
+        };
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+        let response = InitializeResponse::new(ProtocolVersion::LATEST).auth_methods(vec![
+            agent_client_protocol::schema::AuthMethod::Agent(
+                agent_client_protocol::schema::AuthMethodAgent::new("cached_token", "Cached token"),
+            ),
+        ]);
+
+        let error = validate_acp_auth_handshake_request(&spec, &response)
+            .expect_err("Missing xai.api_key should be rejected");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert!(error.contains("Grok ACP runtime did not advertise"));
+        assert!(error.contains("xai.api_key"));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -54,6 +54,12 @@ const ELECTRON_AI_INTERACTIVE_AUTH_UNAVAILABLE: &str =
     "Interactive AI authentication is not available in Electron yet. Use an existing CLI login, an environment/API key, or a custom gateway.";
 const ELECTRON_AI_USER_INPUT_UNAVAILABLE: &str =
     "Interactive AI user input prompts are not available in Electron yet.";
+const GROK_LOGIN_INVALIDATED_MESSAGE: &str =
+    "Grok login looks invalid or expired. Run Grok login again to reconnect.";
+const GROK_STORED_XAI_API_KEY_INVALID_MESSAGE: &str =
+    "Stored xAI API key looks invalid. Add a new xAI API key to reconnect Grok.";
+const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
+    "Inherited XAI_API_KEY looks invalid. Update the environment variable to reconnect Grok.";
 const AGENT_WRITE_ORIGIN_WINDOW: Duration = Duration::from_secs(15);
 const MAX_TERMINAL_SUMMARY_CHARS: usize = 8_000;
 const ACP_STATUS_EVENT_TYPE_KEY: &str = "neverwriteEventType";
@@ -1245,7 +1251,7 @@ impl NativeAi {
                 .unwrap_or_default()
         };
         let spec = acp_process_spec(&input.runtime_id, &setup, vault_root_for_spec)?;
-        let created = start_acp_session(
+        let created = match start_acp_session(
             spec,
             AcpSessionStartMode::New {
                 additional_directories: normalized.kept.clone(),
@@ -1254,7 +1260,21 @@ impl NativeAi {
             Arc::clone(&self.inner),
             self.tool_diffs.clone(),
             self.agent_writes.clone(),
-        )?;
+        ) {
+            Ok(created) => created,
+            Err(error) => {
+                if let Err(update_error) = self.invalidate_grok_auth_after_session_start_error(
+                    &input.runtime_id,
+                    &setup,
+                    &error,
+                ) {
+                    return Err(format!(
+                        "{error}\n\nFailed to update Grok auth state: {update_error}"
+                    ));
+                }
+                return Err(error);
+            }
+        };
         let mut session = created.session;
         let handle = created.handle;
         session.discarded_additional_roots = normalized.discarded.clone();
@@ -1340,7 +1360,7 @@ impl NativeAi {
                 .unwrap_or_default()
         };
         let spec = acp_process_spec(&input.runtime_id, &setup, vault_root_for_spec)?;
-        let created = start_acp_session(
+        let created = match start_acp_session(
             spec,
             AcpSessionStartMode::Load {
                 session_id: input.session_id,
@@ -1350,7 +1370,21 @@ impl NativeAi {
             Arc::clone(&self.inner),
             self.tool_diffs.clone(),
             self.agent_writes.clone(),
-        )?;
+        ) {
+            Ok(created) => created,
+            Err(error) => {
+                if let Err(update_error) = self.invalidate_grok_auth_after_session_start_error(
+                    &input.runtime_id,
+                    &setup,
+                    &error,
+                ) {
+                    return Err(format!(
+                        "{error}\n\nFailed to update Grok auth state: {update_error}"
+                    ));
+                }
+                return Err(error);
+            }
+        };
         let mut session = created.session;
         let handle = created.handle;
         session.discarded_additional_roots = normalized.discarded.clone();
@@ -1670,6 +1704,44 @@ impl NativeAi {
             pending.auth_invalidated_at_ms = None;
         }
         pending.message = None;
+        self.setup_store.save(&pending_setup)?;
+
+        let mut state = self
+            .inner
+            .lock()
+            .map_err(|error| format!("Internal AI state error: {error}"))?;
+        state.setup = pending_setup;
+        state.setup_load_error = None;
+        Ok(())
+    }
+
+    fn invalidate_grok_auth_after_session_start_error(
+        &self,
+        runtime_id: &str,
+        setup_at_start: &RuntimeSetupState,
+        error: &str,
+    ) -> Result<(), String> {
+        if runtime_id != GROK_RUNTIME_ID || !is_grok_auth_error(error) {
+            return Ok(());
+        }
+
+        let Some(source) = grok_auth_failure_source(setup_at_start) else {
+            return Ok(());
+        };
+
+        let (mut pending_setup, setup_load_error) = {
+            let state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            (state.setup.clone(), state.setup_load_error.clone())
+        };
+        if setup_load_error.is_some() {
+            pending_setup = self.setup_store.load().map_err(runtime_setup_load_error)?;
+        }
+
+        let setup = pending_setup.entry(runtime_id.to_string()).or_default();
+        apply_grok_auth_failure(setup, source);
         self.setup_store.save(&pending_setup)?;
 
         let mut state = self
@@ -4587,6 +4659,10 @@ fn inherited_auth_method_applies_to_setup(
     setup: &RuntimeSetupState,
     inherited_method: &str,
 ) -> bool {
+    if inherited_method == "xai-api-key" && grok_inherited_xai_api_key_marked_invalid(setup) {
+        return false;
+    }
+
     match setup.auth_method.as_deref() {
         Some(selected_method)
             if is_local_auth_method(selected_method)
@@ -4670,6 +4746,9 @@ fn acp_process_spec(
             env.remove(*key);
         }
     }
+    if runtime_id == GROK_RUNTIME_ID && grok_inherited_xai_api_key_marked_invalid(setup) {
+        env.insert("XAI_API_KEY".to_string(), String::new());
+    }
     if let Some(method) = setup.auth_method.as_deref() {
         if runtime_id == GEMINI_RUNTIME_ID {
             env.insert(
@@ -4708,6 +4787,10 @@ fn effective_auth_method_for_acp_process_spec(
     runtime_id: &str,
     setup: &RuntimeSetupState,
 ) -> Option<String> {
+    if runtime_id == GROK_RUNTIME_ID && grok_inherited_xai_api_key_marked_invalid(setup) {
+        return None;
+    }
+
     let inherited_auth_method = inherited_auth_method_for_setup(runtime_id, setup)
         .filter(|method| inherited_auth_method_applies_to_setup(setup, method));
     if let Some(selected_method) = setup.auth_method.as_deref() {
@@ -5616,6 +5699,82 @@ fn clear_runtime_auth_state(runtime_id: &str, setup: &mut RuntimeSetupState) {
     ] {
         setup.env.remove(key);
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum GrokAuthFailureSource {
+    Login,
+    StoredXaiApiKey,
+    InheritedXaiApiKey,
+}
+
+fn is_grok_auth_error(error: &str) -> bool {
+    let normalized = error.to_lowercase();
+    [
+        "run grok login",
+        "set xai_api_key",
+        "authentication required",
+        "auth_required",
+        "unauthorized",
+        "401",
+        "invalid api key",
+        "cached_token",
+    ]
+    .into_iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn grok_auth_failure_source(setup: &RuntimeSetupState) -> Option<GrokAuthFailureSource> {
+    match effective_auth_method_for_acp_process_spec(GROK_RUNTIME_ID, setup).as_deref() {
+        Some("grok-login") => Some(GrokAuthFailureSource::Login),
+        Some("xai-api-key") if env_secret_present("XAI_API_KEY") => {
+            Some(GrokAuthFailureSource::InheritedXaiApiKey)
+        }
+        Some("xai-api-key") => Some(GrokAuthFailureSource::StoredXaiApiKey),
+        _ if env_secret_present("XAI_API_KEY") => Some(GrokAuthFailureSource::InheritedXaiApiKey),
+        _ if setup
+            .env
+            .get("XAI_API_KEY")
+            .is_some_and(|value| !value.trim().is_empty()) =>
+        {
+            Some(GrokAuthFailureSource::StoredXaiApiKey)
+        }
+        _ => None,
+    }
+}
+
+fn apply_grok_auth_failure(setup: &mut RuntimeSetupState, source: GrokAuthFailureSource) {
+    match source {
+        GrokAuthFailureSource::Login => {
+            setup.auth_method = Some("grok-login".to_string());
+            setup.auth_ready = false;
+            setup.suppress_persisted_auth = false;
+            setup.auth_invalidated_at_ms = Some(current_epoch_ms());
+            setup.message = Some(GROK_LOGIN_INVALIDATED_MESSAGE.to_string());
+        }
+        GrokAuthFailureSource::StoredXaiApiKey => {
+            setup.env.remove("XAI_API_KEY");
+            setup.auth_method = None;
+            setup.auth_ready = false;
+            setup.suppress_persisted_auth = true;
+            setup.auth_invalidated_at_ms = None;
+            setup.message = Some(GROK_STORED_XAI_API_KEY_INVALID_MESSAGE.to_string());
+        }
+        GrokAuthFailureSource::InheritedXaiApiKey => {
+            setup.auth_method = Some("xai-api-key".to_string());
+            setup.auth_ready = false;
+            setup.suppress_persisted_auth = false;
+            setup.auth_invalidated_at_ms = None;
+            setup.message = Some(GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE.to_string());
+        }
+    }
+    refresh_runtime_setup_flags(GROK_RUNTIME_ID, setup);
+}
+
+fn grok_inherited_xai_api_key_marked_invalid(setup: &RuntimeSetupState) -> bool {
+    setup.auth_method.as_deref() == Some("xai-api-key")
+        && !setup.auth_ready
+        && setup.message.as_deref() == Some(GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE)
 }
 
 fn env_secret_present(key: &str) -> bool {
@@ -8334,6 +8493,10 @@ mod tests {
 
     #[test]
     fn logout_marks_grok_external_auth_invalidated() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
         let (event_tx, _event_rx) = mpsc::channel();
         let ai = NativeAi::new(event_tx);
         let temp = tempfile::tempdir().unwrap();
@@ -8358,6 +8521,11 @@ mod tests {
             Some(false)
         );
         assert_eq!(status.get("auth_method").and_then(Value::as_str), None);
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
         let state = ai.inner.lock().unwrap();
         let setup = state
             .setup
@@ -10301,6 +10469,222 @@ mod tests {
     }
 
     #[test]
+    fn grok_auth_error_detector_matches_cli_auth_failures() {
+        for error in [
+            "Please run grok login to continue",
+            "set XAI_API_KEY before starting",
+            "authentication required",
+            "auth_required",
+            "Unauthorized request",
+            "HTTP 401",
+            "invalid api key",
+            "cached_token is expired",
+        ] {
+            assert!(is_grok_auth_error(error), "{error:?} should be detected");
+        }
+
+        assert!(!is_grok_auth_error("model does not support that option"));
+    }
+
+    #[test]
+    fn grok_login_auth_error_marks_external_auth_invalidated() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_secret_store(
+            store_path.clone(),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let setup_at_start = RuntimeSetupState {
+            auth_method: Some("grok-login".to_string()),
+            auth_ready: true,
+            ..RuntimeSetupState::default()
+        };
+        native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .insert(GROK_RUNTIME_ID.to_string(), setup_at_start.clone());
+
+        native_ai
+            .invalidate_grok_auth_after_session_start_error(
+                GROK_RUNTIME_ID,
+                &setup_at_start,
+                "cached_token unauthorized",
+            )
+            .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        let setup = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .cloned()
+            .expect("Grok setup should remain");
+        assert_eq!(setup.auth_method.as_deref(), Some("grok-login"));
+        assert!(!setup.auth_ready);
+        assert!(setup.auth_invalidated_at_ms.is_some());
+        assert_eq!(
+            setup.message.as_deref(),
+            Some(GROK_LOGIN_INVALIDATED_MESSAGE)
+        );
+
+        let persisted_setup = native_ai
+            .setup_store
+            .load()
+            .unwrap()
+            .remove(GROK_RUNTIME_ID)
+            .expect("Grok setup should persist invalidated login");
+        assert_eq!(persisted_setup.auth_method.as_deref(), Some("grok-login"));
+        assert!(persisted_setup.auth_invalidated_at_ms.is_some());
+    }
+
+    #[test]
+    fn grok_stored_xai_key_auth_error_clears_local_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path, secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": current_exe,
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-stored-secret",
+                    },
+                },
+            }))
+            .unwrap();
+        assert_eq!(
+            secrets.stored_secret(GROK_RUNTIME_ID, "XAI_API_KEY"),
+            Some("xai-stored-secret".to_string())
+        );
+
+        let setup_at_start = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .cloned()
+            .expect("Grok setup should exist");
+        native_ai
+            .invalidate_grok_auth_after_session_start_error(
+                GROK_RUNTIME_ID,
+                &setup_at_start,
+                "401 invalid api key",
+            )
+            .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(secrets.stored_secret(GROK_RUNTIME_ID, "XAI_API_KEY"), None);
+        let setup = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .cloned()
+            .expect("Grok setup should remain");
+        assert_eq!(setup.auth_method, None);
+        assert!(!setup.auth_ready);
+        assert_eq!(
+            setup.message.as_deref(),
+            Some(GROK_STORED_XAI_API_KEY_INVALID_MESSAGE)
+        );
+    }
+
+    #[test]
+    fn grok_inherited_xai_key_auth_error_preserves_local_secret() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::set_var("XAI_API_KEY", "xai-env-secret");
+
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let secrets = Arc::new(FailableRuntimeSecretStore::default());
+        let native_ai = test_native_ai_with_secret_store(store_path, secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
+
+        native_ai
+            .update_setup(&json!({
+                "runtime_id": GROK_RUNTIME_ID,
+                "input": {
+                    "custom_binary_path": current_exe,
+                    "xai_api_key": {
+                        "action": "set",
+                        "value": "xai-stored-secret",
+                    },
+                },
+            }))
+            .unwrap();
+
+        let setup_at_start = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .cloned()
+            .expect("Grok setup should exist");
+        native_ai
+            .invalidate_grok_auth_after_session_start_error(
+                GROK_RUNTIME_ID,
+                &setup_at_start,
+                "unauthorized",
+            )
+            .unwrap();
+
+        let status = native_ai
+            .get_setup_status(&json!({ "runtime_id": GROK_RUNTIME_ID }))
+            .unwrap();
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+
+        assert_eq!(
+            secrets.stored_secret(GROK_RUNTIME_ID, "XAI_API_KEY"),
+            Some("xai-stored-secret".to_string())
+        );
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(
+            status.get("auth_method").and_then(Value::as_str),
+            Some("xai-api-key")
+        );
+        assert_eq!(
+            status.get("message").and_then(Value::as_str),
+            Some(GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE)
+        );
+    }
+
+    #[test]
     fn opencode_login_selection_persists_without_local_secret() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
@@ -11046,6 +11430,10 @@ mod tests {
 
     #[test]
     fn acp_auth_handshake_maps_grok_login_to_cached_token() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
         let current_exe = std::env::current_exe().unwrap();
         let setup = RuntimeSetupState {
             custom_binary_path: Some(current_exe.display().to_string()),
@@ -11058,6 +11446,11 @@ mod tests {
         let handshake_request = acp_auth_handshake_request(&spec)
             .expect("Grok handshake should map login auth")
             .expect("Grok login auth should request an ACP authenticate call");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
 
         assert_eq!(handshake_request.method_id, "cached_token");
         assert_eq!(

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -10697,11 +10697,13 @@ mod tests {
         let store_path = temp.path().join("runtime-setup.json");
         let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
         let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
 
         native_ai
             .update_setup(&json!({
                 "runtime_id": GEMINI_RUNTIME_ID,
                 "input": {
+                    "custom_binary_path": current_exe,
                     "gemini_api_key": {
                         "action": "set",
                         "value": "gemini-test-secret",
@@ -10736,11 +10738,13 @@ mod tests {
         let store_path = temp.path().join("runtime-setup.json");
         let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
         let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
 
         native_ai
             .update_setup(&json!({
                 "runtime_id": KILO_RUNTIME_ID,
                 "input": {
+                    "custom_binary_path": current_exe,
                     "kilo_api_key": {
                         "action": "set",
                         "value": "kilo-test-secret",
@@ -11402,13 +11406,14 @@ mod tests {
     fn legacy_plaintext_runtime_setup_is_migrated_to_secret_store() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
+        let current_exe = std::env::current_exe().unwrap();
         fs::write(
             &store_path,
             serde_json::to_string_pretty(&json!({
                 "version": 1,
                 "runtimes": {
                     GEMINI_RUNTIME_ID: {
-                        "custom_binary_path": null,
+                        "custom_binary_path": current_exe,
                         "auth_method": "use_gemini",
                         "env": {
                             "GEMINI_API_KEY": "legacy-gemini-secret"

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1422,8 +1422,11 @@ impl NativeAi {
     pub(crate) fn set_mode(&self, args: &Value) -> Result<Value, String> {
         let session_id = required_string(args, &["sessionId", "session_id"])?;
         let mode_id = required_string(args, &["modeId", "mode_id"])?;
-        if let Some(handle) = self.session_handle(&session_id)? {
-            handle.set_mode(&session_id, &mode_id)?;
+        let runtime_id = self.session_runtime_id(&session_id)?;
+        if runtime_supports_remote_mode_change(&runtime_id) {
+            if let Some(handle) = self.session_handle(&session_id)? {
+                handle.set_mode(&session_id, &mode_id)?;
+            }
         }
         self.update_session(&session_id, |session| {
             session.mode_id = mode_id;
@@ -3511,9 +3514,18 @@ fn session_from_acp_response(
         .as_ref()
         .map(|state| map_session_modes(runtime_id, state))
         .unwrap_or_else(|| default_modes(runtime_id));
-    let mut config_options = config_options
-        .map(|options| map_session_config_options(runtime_id, options))
-        .unwrap_or_else(|| default_config_options(runtime_id, &models, &modes));
+    let mut config_options = match config_options {
+        Some(options) => map_session_config_options(runtime_id, options),
+        None => {
+            let mut options = default_config_options(runtime_id, &models, &modes);
+            align_synthesized_config_options_to_acp_state(
+                &mut options,
+                models_state.as_ref(),
+                modes_state.as_ref(),
+            );
+            options
+        }
+    };
     config_options = ensure_reasoning_config_option(
         runtime_id,
         config_options,
@@ -3643,6 +3655,36 @@ fn map_session_config_options(
             })
         })
         .collect()
+}
+
+fn align_synthesized_config_options_to_acp_state(
+    config_options: &mut [AiConfigOption],
+    models_state: Option<&SessionModelState>,
+    modes_state: Option<&SessionModeState>,
+) {
+    if let Some(model_id) = models_state
+        .map(|state| strip_effort_suffix(state.current_model_id.0.as_ref()).to_string())
+        .filter(|value| !value.trim().is_empty())
+    {
+        if let Some(option) = config_options
+            .iter_mut()
+            .find(|option| matches!(option.category, AiConfigOptionCategory::Model))
+        {
+            option.value = model_id;
+        }
+    }
+
+    if let Some(mode_id) = modes_state
+        .map(|state| state.current_mode_id.0.to_string())
+        .filter(|value| !value.trim().is_empty())
+    {
+        if let Some(option) = config_options
+            .iter_mut()
+            .find(|option| matches!(option.category, AiConfigOptionCategory::Mode))
+        {
+            option.value = mode_id;
+        }
+    }
 }
 
 fn map_config_option_category(
@@ -3821,6 +3863,20 @@ fn acp_config_option_remote_command(
     config_options: &[AiConfigOption],
     option_id: &str,
 ) -> AcpConfigOptionRemoteCommand {
+    if runtime_id == GROK_RUNTIME_ID {
+        let category = config_options
+            .iter()
+            .find(|option| option.id == option_id)
+            .map(|option| &option.category);
+        return match category {
+            Some(AiConfigOptionCategory::Model) => AcpConfigOptionRemoteCommand::SetModel,
+            Some(AiConfigOptionCategory::Mode) => AcpConfigOptionRemoteCommand::LocalOnly,
+            Some(_) => AcpConfigOptionRemoteCommand::LocalOnly,
+            None if option_id == "model" => AcpConfigOptionRemoteCommand::SetModel,
+            None => AcpConfigOptionRemoteCommand::LocalOnly,
+        };
+    }
+
     if runtime_id != GEMINI_RUNTIME_ID {
         return AcpConfigOptionRemoteCommand::SetConfigOption;
     }
@@ -4335,6 +4391,10 @@ fn runtime_supports_native_resume(runtime_id: &str) -> bool {
     runtime_definition(runtime_id)
         .map(|definition| definition.supports_native_resume)
         .unwrap_or(false)
+}
+
+fn runtime_supports_remote_mode_change(runtime_id: &str) -> bool {
+    runtime_id != GROK_RUNTIME_ID
 }
 
 trait RuntimeDescriptorAuthTags {
@@ -8930,6 +8990,51 @@ mod tests {
     }
 
     #[test]
+    fn grok_session_uses_acp_models_without_static_model_list() {
+        let models_state = SessionModelState::new(
+            "grok-build",
+            vec![
+                ModelInfo::new("grok-composer-2.5-fast", "Composer 2.5")
+                    .description("Cursor's latest coding model"),
+                ModelInfo::new("grok-build", "Grok Build")
+                    .description("Best for advanced coding tasks"),
+            ],
+        );
+
+        let session = session_from_acp_response(
+            GROK_RUNTIME_ID,
+            "session-1".to_string(),
+            Some(models_state),
+            None,
+            None,
+        );
+
+        assert_eq!(session.model_id, "grok-build");
+        assert_eq!(
+            session
+                .models
+                .iter()
+                .map(|model| model.id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["grok-composer-2.5-fast", "grok-build"]
+        );
+        let model_config = session
+            .config_options
+            .iter()
+            .find(|option| matches!(option.category, AiConfigOptionCategory::Model))
+            .expect("model config should be synthesized from ACP models");
+        assert_eq!(model_config.value, "grok-build");
+        assert_eq!(
+            acp_config_option_remote_command(
+                &session.runtime_id,
+                &session.config_options,
+                &model_config.id
+            ),
+            AcpConfigOptionRemoteCommand::SetModel
+        );
+    }
+
+    #[test]
     fn acp_config_mapping_treats_effort_category_as_reasoning() {
         let mapped = map_session_config_options(
             CODEX_RUNTIME_ID,
@@ -8996,6 +9101,51 @@ mod tests {
             acp_config_option_remote_command(CODEX_RUNTIME_ID, &options, "model"),
             AcpConfigOptionRemoteCommand::SetConfigOption
         );
+    }
+
+    #[test]
+    fn grok_config_options_route_model_to_supported_acp_method() {
+        let options = map_session_config_options(
+            GROK_RUNTIME_ID,
+            vec![
+                SessionConfigOption::select(
+                    "model",
+                    "Model",
+                    "grok-build",
+                    vec![
+                        SessionConfigSelectOption::new("grok-composer-2.5-fast", "Composer 2.5"),
+                        SessionConfigSelectOption::new("grok-build", "Grok Build"),
+                    ],
+                )
+                .category(SessionConfigOptionCategory::Model),
+                SessionConfigOption::select(
+                    "mode",
+                    "Mode",
+                    "default",
+                    vec![SessionConfigSelectOption::new("default", "Default")],
+                )
+                .category(SessionConfigOptionCategory::Mode),
+            ],
+        );
+
+        assert_eq!(
+            acp_config_option_remote_command(GROK_RUNTIME_ID, &options, "model"),
+            AcpConfigOptionRemoteCommand::SetModel
+        );
+        assert_eq!(
+            acp_config_option_remote_command(GROK_RUNTIME_ID, &options, "mode"),
+            AcpConfigOptionRemoteCommand::LocalOnly
+        );
+        assert_eq!(
+            acp_config_option_remote_command(GROK_RUNTIME_ID, &[], "model"),
+            AcpConfigOptionRemoteCommand::SetModel
+        );
+    }
+
+    #[test]
+    fn grok_synthetic_modes_are_local_only() {
+        assert!(!runtime_supports_remote_mode_change(GROK_RUNTIME_ID));
+        assert!(runtime_supports_remote_mode_change(CODEX_RUNTIME_ID));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1648,7 +1648,7 @@ impl NativeAi {
         pending.auth_method = Some(method_id.to_string());
         pending.auth_ready = false;
         pending.suppress_persisted_auth = false;
-        if runtime_id != OPENCODE_RUNTIME_ID {
+        if !is_invalidation_tracked_external_auth_runtime(runtime_id) {
             pending.auth_invalidated_at_ms = None;
         }
         pending.message = None;
@@ -4408,7 +4408,7 @@ fn setup_status_for_with_inherited_auth(
     };
     let inherited_auth_method = inherited_auth_method
         .filter(|method| inherited_auth_method_applies_to_setup(&setup, method));
-    let auth_ready = setup.auth_ready || inherited_auth_method.is_some();
+    let auth_ready = binary_ready && (setup.auth_ready || inherited_auth_method.is_some());
     let auth_method = setup.auth_method.or(inherited_auth_method);
     let message = if !binary_ready {
         setup.message
@@ -4722,6 +4722,7 @@ fn default_terminal_auth_method(runtime_id: &str) -> &'static str {
     match runtime_id {
         CLAUDE_RUNTIME_ID => default_claude_terminal_auth_method(),
         GEMINI_RUNTIME_ID => "login_with_google",
+        GROK_RUNTIME_ID => "grok-login",
         KILO_RUNTIME_ID => "kilo-login",
         OPENCODE_RUNTIME_ID => "opencode-login",
         _ => "terminal-login",
@@ -4781,6 +4782,10 @@ fn auth_terminal_launch_config(
                 gemini_cli_auth_type(method_id).to_string(),
             );
             "Gemini Login".to_string()
+        }
+        (GROK_RUNTIME_ID, "grok-login") => {
+            args.push("login".to_string());
+            "Grok Login".to_string()
         }
         (KILO_RUNTIME_ID, "kilo-login") => {
             args.extend(["auth".to_string(), "login".to_string()]);
@@ -5090,6 +5095,9 @@ fn persisted_cli_auth_method_for_home_with_invalidated_at(
         KILO_RUNTIME_ID if non_empty_file_exists_any(kilo_auth_file_candidates(home)) => {
             Some("kilo-login".to_string())
         }
+        GROK_RUNTIME_ID if active_grok_auth_file_exists(home, auth_invalidated_at_ms) => {
+            Some("grok-login".to_string())
+        }
         OPENCODE_RUNTIME_ID if active_opencode_auth_file_exists(home, auth_invalidated_at_ms) => {
             Some("opencode-login".to_string())
         }
@@ -5144,6 +5152,14 @@ fn opencode_env_auth_present() -> bool {
         .any(|key| env_secret_present(key))
 }
 
+fn grok_auth_file_path(home: &Path) -> PathBuf {
+    home.join(".grok").join("auth.json")
+}
+
+fn active_grok_auth_file_exists(home: &Path, auth_invalidated_at_ms: Option<u64>) -> bool {
+    timestamped_non_empty_file_is_active(&grok_auth_file_path(home), auth_invalidated_at_ms)
+}
+
 fn opencode_auth_file_candidates(home: &Path) -> Vec<PathBuf> {
     let mut candidates = Vec::new();
     if let Some(xdg_data_home) = std::env::var_os("XDG_DATA_HOME") {
@@ -5180,6 +5196,22 @@ fn active_opencode_auth_file_exists(home: &Path, auth_invalidated_at_ms: Option<
         .any(|path| opencode_auth_file_is_active(&path, auth_invalidated_at_ms))
 }
 
+fn timestamped_non_empty_file_is_active(path: &Path, auth_invalidated_at_ms: Option<u64>) -> bool {
+    let metadata = match std::fs::metadata(path) {
+        Ok(metadata) if metadata.is_file() && metadata.len() > 0 => metadata,
+        _ => return false,
+    };
+    if let Some(invalidated_at_ms) = auth_invalidated_at_ms {
+        let Some(modified_at_ms) = metadata.modified().ok().and_then(system_time_epoch_ms) else {
+            return false;
+        };
+        if modified_at_ms <= invalidated_at_ms {
+            return false;
+        }
+    }
+    true
+}
+
 fn opencode_auth_file_status(path: &Path) -> &'static str {
     let metadata = match std::fs::metadata(path) {
         Ok(metadata) if metadata.is_file() => metadata,
@@ -5200,17 +5232,8 @@ fn opencode_auth_file_status(path: &Path) -> &'static str {
 }
 
 fn opencode_auth_file_is_active(path: &Path, auth_invalidated_at_ms: Option<u64>) -> bool {
-    let metadata = match std::fs::metadata(path) {
-        Ok(metadata) if metadata.is_file() && metadata.len() > 0 => metadata,
-        _ => return false,
-    };
-    if let Some(invalidated_at_ms) = auth_invalidated_at_ms {
-        let Some(modified_at_ms) = metadata.modified().ok().and_then(system_time_epoch_ms) else {
-            return false;
-        };
-        if modified_at_ms <= invalidated_at_ms {
-            return false;
-        }
+    if !timestamped_non_empty_file_is_active(path, auth_invalidated_at_ms) {
+        return false;
     }
 
     match std::fs::read_to_string(path)
@@ -5293,8 +5316,12 @@ fn should_persist_auth_method(
 fn is_persistable_external_auth_method(runtime_id: &str, method_id: &str) -> bool {
     matches!(
         (runtime_id, method_id),
-        (OPENCODE_RUNTIME_ID, "opencode-login")
+        (GROK_RUNTIME_ID, "grok-login") | (OPENCODE_RUNTIME_ID, "opencode-login")
     )
+}
+
+fn is_invalidation_tracked_external_auth_runtime(runtime_id: &str) -> bool {
+    matches!(runtime_id, GROK_RUNTIME_ID | OPENCODE_RUNTIME_ID)
 }
 
 fn is_local_auth_method(method_id: &str) -> bool {
@@ -5386,7 +5413,8 @@ fn clear_runtime_auth_state(runtime_id: &str, setup: &mut RuntimeSetupState) {
     setup.auth_ready = false;
     setup.auth_method = None;
     setup.suppress_persisted_auth = true;
-    setup.auth_invalidated_at_ms = (runtime_id == OPENCODE_RUNTIME_ID).then(current_epoch_ms);
+    setup.auth_invalidated_at_ms =
+        is_invalidation_tracked_external_auth_runtime(runtime_id).then(current_epoch_ms);
     setup.has_gateway_config = false;
     setup.has_gateway_url = false;
     setup.message = None;
@@ -8127,6 +8155,40 @@ mod tests {
     }
 
     #[test]
+    fn logout_marks_grok_external_auth_invalidated() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let ai = NativeAi::new(event_tx);
+        let temp = tempfile::tempdir().unwrap();
+
+        ai.update_setup(&json!({
+            "runtimeId": GROK_RUNTIME_ID,
+            "input": {
+                "custom_binary_path": temp.path().join("missing-grok"),
+            }
+        }))
+        .expect("setup should update");
+
+        let status = ai
+            .logout(&json!({
+                "runtimeId": GROK_RUNTIME_ID,
+                "vaultPath": temp.path()
+            }))
+            .expect("logout should clear local setup");
+
+        assert_eq!(
+            status.get("auth_ready").and_then(Value::as_bool),
+            Some(false)
+        );
+        assert_eq!(status.get("auth_method").and_then(Value::as_str), None);
+        let state = ai.inner.lock().unwrap();
+        let setup = state
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .expect("Grok setup should remain in memory");
+        assert!(setup.auth_invalidated_at_ms.is_some());
+    }
+
+    #[test]
     fn logout_does_not_require_acp_for_codex_api_keys() {
         let (event_tx, _event_rx) = mpsc::channel();
         let ai = NativeAi::new(event_tx);
@@ -9543,6 +9605,23 @@ mod tests {
     }
 
     #[test]
+    fn detects_active_persisted_grok_credentials() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(
+            &auth_file,
+            r#"{"https://accounts.x.ai/sign-in":{"key":"redacted"}}"#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            persisted_cli_auth_method_for_home(GROK_RUNTIME_ID, temp.path(), false),
+            Some("grok-login".to_string())
+        );
+    }
+
+    #[test]
     fn ignores_inactive_or_invalid_opencode_credentials() {
         let temp = tempfile::tempdir().unwrap();
         let auth_file = temp
@@ -9561,6 +9640,19 @@ mod tests {
                 "{raw:?} should not count as active OpenCode auth"
             );
         }
+    }
+
+    #[test]
+    fn ignores_empty_persisted_grok_credentials() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(&auth_file, "").unwrap();
+
+        assert_eq!(
+            persisted_cli_auth_method_for_home(GROK_RUNTIME_ID, temp.path(), false),
+            None
+        );
     }
 
     #[test]
@@ -9598,6 +9690,39 @@ mod tests {
                 Some(modified_at_ms.saturating_sub(1)),
             ),
             Some("opencode-login".to_string())
+        );
+    }
+
+    #[test]
+    fn grok_auth_invalidation_blocks_stale_auth_store() {
+        let temp = tempfile::tempdir().unwrap();
+        let auth_file = temp.path().join(".grok").join("auth.json");
+        fs::create_dir_all(auth_file.parent().unwrap()).unwrap();
+        fs::write(&auth_file, r#"{"token":"redacted"}"#).unwrap();
+        let modified_at_ms = fs::metadata(&auth_file)
+            .unwrap()
+            .modified()
+            .ok()
+            .and_then(system_time_epoch_ms)
+            .unwrap();
+
+        assert_eq!(
+            persisted_cli_auth_method_for_home_with_invalidated_at(
+                GROK_RUNTIME_ID,
+                temp.path(),
+                false,
+                Some(modified_at_ms),
+            ),
+            None
+        );
+        assert_eq!(
+            persisted_cli_auth_method_for_home_with_invalidated_at(
+                GROK_RUNTIME_ID,
+                temp.path(),
+                false,
+                Some(modified_at_ms.saturating_sub(1)),
+            ),
+            Some("grok-login".to_string())
         );
     }
 
@@ -9681,6 +9806,27 @@ mod tests {
 
         assert_eq!(config.args, vec!["auth".to_string(), "login".to_string()]);
         assert_eq!(config.display_name, "OpenCode Login");
+    }
+
+    #[test]
+    fn auth_terminal_launch_config_uses_grok_login_command() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let config = auth_terminal_launch_config(
+            GROK_RUNTIME_ID,
+            "grok-login",
+            &setup,
+            std::env::current_dir().unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(default_terminal_auth_method(GROK_RUNTIME_ID), "grok-login");
+        assert_eq!(config.args, vec!["login".to_string()]);
+        assert_eq!(config.display_name, "Grok Login");
     }
 
     #[test]
@@ -9842,11 +9988,13 @@ mod tests {
         let store_path = temp.path().join("runtime-setup.json");
         let secrets = Arc::new(InMemoryRuntimeSecretStore::default());
         let native_ai = test_native_ai_with_secret_store(store_path.clone(), secrets.clone());
+        let current_exe = std::env::current_exe().unwrap();
 
         let status = native_ai
             .update_setup(&json!({
                 "runtime_id": GROK_RUNTIME_ID,
                 "input": {
+                    "custom_binary_path": current_exe,
                     "xai_api_key": {
                         "action": "set",
                         "value": "xai-test-secret",
@@ -9916,6 +10064,37 @@ mod tests {
     }
 
     #[test]
+    fn grok_login_selection_persists_without_local_secret() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let store = RuntimeSetupStore::with_secret_store(
+            store_path.clone(),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let mut setup = HashMap::new();
+        setup.insert(
+            GROK_RUNTIME_ID.to_string(),
+            RuntimeSetupState {
+                auth_method: Some("grok-login".to_string()),
+                auth_invalidated_at_ms: Some(123),
+                ..RuntimeSetupState::default()
+            },
+        );
+
+        store.save(&setup).unwrap();
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("grok-login"));
+        assert!(encoded.contains("auth_invalidated_at_ms"));
+
+        let loaded = store.load().unwrap();
+        let grok = loaded
+            .get(GROK_RUNTIME_ID)
+            .expect("Grok setup should reload");
+        assert_eq!(grok.auth_method.as_deref(), Some("grok-login"));
+        assert_eq!(grok.auth_invalidated_at_ms, Some(123));
+    }
+
+    #[test]
     fn opencode_pending_terminal_auth_preserves_disconnect_invalidation_until_verified() {
         let temp = tempfile::tempdir().unwrap();
         let store_path = temp.path().join("runtime-setup.json");
@@ -9963,6 +10142,57 @@ mod tests {
             .get(OPENCODE_RUNTIME_ID)
             .expect("OpenCode setup should persist verified method");
         assert_eq!(verified.auth_method.as_deref(), Some("opencode-login"));
+        assert_eq!(verified.auth_invalidated_at_ms, None);
+    }
+
+    #[test]
+    fn grok_pending_terminal_auth_preserves_disconnect_invalidation_until_verified() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_secret_store(
+            store_path.clone(),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+
+        native_ai
+            .persist_auth_terminal_pending_setup(
+                GROK_RUNTIME_ID,
+                "grok-login",
+                RuntimeSetupState {
+                    auth_invalidated_at_ms: Some(123),
+                    suppress_persisted_auth: true,
+                    ..RuntimeSetupState::default()
+                },
+            )
+            .unwrap();
+
+        let grok = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(GROK_RUNTIME_ID)
+            .cloned()
+            .expect("Grok setup should be pending");
+        assert_eq!(grok.auth_method.as_deref(), Some("grok-login"));
+        assert!(!grok.auth_ready);
+        assert_eq!(grok.auth_invalidated_at_ms, Some(123));
+
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("auth_invalidated_at_ms"));
+
+        mark_runtime_auth_verified(
+            &native_ai.inner,
+            Some(&native_ai.setup_store),
+            GROK_RUNTIME_ID,
+            "grok-login",
+        );
+
+        let loaded = native_ai.setup_store.load().unwrap();
+        let verified = loaded
+            .get(GROK_RUNTIME_ID)
+            .expect("Grok setup should persist verified method");
+        assert_eq!(verified.auth_method.as_deref(), Some("grok-login"));
         assert_eq!(verified.auth_invalidated_at_ms, None);
     }
 
@@ -10336,7 +10566,10 @@ mod tests {
             .logout(&json!({ "runtime_id": GROK_RUNTIME_ID }))
             .unwrap();
 
-        assert!(!store_path.exists());
+        let encoded = fs::read_to_string(&store_path).unwrap();
+        assert!(encoded.contains("auth_invalidated_at_ms"));
+        assert!(!encoded.contains("xai-test-secret"));
+        assert!(!encoded.contains("XAI_API_KEY"));
         assert_eq!(
             secrets
                 .get_secret(GROK_RUNTIME_ID, "XAI_API_KEY")
@@ -10351,6 +10584,7 @@ mod tests {
         assert!(!grok_setup.env.contains_key("XAI_API_KEY"));
         assert_eq!(grok_setup.auth_method, None);
         assert!(!grok_setup.auth_ready);
+        assert!(grok_setup.auth_invalidated_at_ms.is_some());
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -10,12 +10,13 @@ use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use agent_client_protocol::schema::{
-    AuthenticateRequest, CancelNotification, ClientCapabilities, ContentBlock, ContentChunk,
-    FileSystemCapabilities, Implementation, InitializeRequest, InitializeResponse,
-    LoadSessionRequest, LogoutRequest, Meta, NewSessionRequest, PermissionOption,
-    PermissionOptionKind, Plan, PlanEntryPriority, PlanEntryStatus, PromptRequest, ProtocolVersion,
-    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
-    SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    AuthenticateRequest, AvailableCommand, AvailableCommandInput, AvailableCommandsUpdate,
+    CancelNotification, ClientCapabilities, ContentBlock, ContentChunk, FileSystemCapabilities,
+    Implementation, InitializeRequest, InitializeResponse, LoadSessionRequest, LogoutRequest, Meta,
+    NewSessionRequest, PermissionOption, PermissionOptionKind, Plan, PlanEntryPriority,
+    PlanEntryStatus, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
+    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOptions, SessionId, SessionModeState, SessionModelState,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
     SetSessionModelRequest, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolKind,
@@ -31,13 +32,13 @@ use neverwrite_ai::{
     AiTokenUsageCostPayload, AiTokenUsagePayload, AiToolActivityActionPayload,
     AiToolActivityPayload, DiscardedAdditionalRoot, DiscardedAdditionalRootReason, ToolDiffState,
     AI_AUTH_TERMINAL_ERROR_EVENT, AI_AUTH_TERMINAL_EXITED_EVENT, AI_AUTH_TERMINAL_OUTPUT_EVENT,
-    AI_AUTH_TERMINAL_STARTED_EVENT, AI_IMAGE_GENERATION_EVENT, AI_MESSAGE_COMPLETED_EVENT,
-    AI_MESSAGE_DELTA_EVENT, AI_MESSAGE_STARTED_EVENT, AI_PERMISSION_REQUEST_EVENT,
-    AI_PLAN_UPDATED_EVENT, AI_RUNTIME_CONNECTION_EVENT, AI_SESSION_CREATED_EVENT,
-    AI_SESSION_ERROR_EVENT, AI_SESSION_UPDATED_EVENT, AI_STATUS_EVENT, AI_THINKING_COMPLETED_EVENT,
-    AI_THINKING_DELTA_EVENT, AI_THINKING_STARTED_EVENT, AI_TOKEN_USAGE_EVENT,
-    AI_TOOL_ACTIVITY_EVENT, CLAUDE_RUNTIME_ID, CODEX_RUNTIME_ID, GEMINI_RUNTIME_ID,
-    GROK_RUNTIME_ID, KILO_RUNTIME_ID, OPENCODE_RUNTIME_ID,
+    AI_AUTH_TERMINAL_STARTED_EVENT, AI_AVAILABLE_COMMANDS_UPDATED_EVENT, AI_IMAGE_GENERATION_EVENT,
+    AI_MESSAGE_COMPLETED_EVENT, AI_MESSAGE_DELTA_EVENT, AI_MESSAGE_STARTED_EVENT,
+    AI_PERMISSION_REQUEST_EVENT, AI_PLAN_UPDATED_EVENT, AI_RUNTIME_CONNECTION_EVENT,
+    AI_SESSION_CREATED_EVENT, AI_SESSION_ERROR_EVENT, AI_SESSION_UPDATED_EVENT, AI_STATUS_EVENT,
+    AI_THINKING_COMPLETED_EVENT, AI_THINKING_DELTA_EVENT, AI_THINKING_STARTED_EVENT,
+    AI_TOKEN_USAGE_EVENT, AI_TOOL_ACTIVITY_EVENT, CLAUDE_RUNTIME_ID, CODEX_RUNTIME_ID,
+    GEMINI_RUNTIME_ID, GROK_RUNTIME_ID, KILO_RUNTIME_ID, OPENCODE_RUNTIME_ID,
 };
 use portable_pty::{
     native_pty_system, Child as PtyChild, ChildKiller, CommandBuilder, MasterPty, PtySize,
@@ -2927,6 +2928,12 @@ impl NativeAcpClient {
                     .apply_current_mode_update(&session_id, update.current_mode_id.0.to_string());
                 self.emit_session_update_from_result(result);
             }
+            SessionUpdate::AvailableCommandsUpdate(update) => {
+                self.emit(
+                    AI_AVAILABLE_COMMANDS_UPDATED_EVENT,
+                    map_available_commands_update(&session_id, update),
+                );
+            }
             _ => {}
         }
         Ok(())
@@ -3595,7 +3602,7 @@ fn session_from_acp_response(
     let modes = modes_state
         .as_ref()
         .map(|state| map_session_modes(runtime_id, state))
-        .unwrap_or_else(|| default_modes(runtime_id));
+        .unwrap_or_else(|| default_modes_for_acp_session(runtime_id));
     let mut config_options = match config_options {
         Some(options) => map_session_config_options(runtime_id, options),
         None => {
@@ -3619,7 +3626,8 @@ fn session_from_acp_response(
         .unwrap_or_default();
     let mode_id = selected_mode_id(modes_state.as_ref(), &config_options)
         .or_else(|| modes.first().map(|mode| mode.id.clone()))
-        .unwrap_or_else(|| "default".to_string());
+        .or_else(|| default_mode_id_for_runtime(runtime_id))
+        .unwrap_or_default();
 
     AiSession {
         session_id,
@@ -4036,6 +4044,36 @@ fn map_plan_update(session_id: &str, plan: Plan, meta: Option<&Meta>) -> AiPlanU
     }
 }
 
+fn map_available_commands_update(
+    session_id: &str,
+    update: AvailableCommandsUpdate,
+) -> neverwrite_ai::AiAvailableCommandsPayload {
+    neverwrite_ai::AiAvailableCommandsPayload {
+        session_id: session_id.to_string(),
+        commands: update
+            .available_commands
+            .into_iter()
+            .map(map_available_command)
+            .collect(),
+    }
+}
+
+fn map_available_command(command: AvailableCommand) -> neverwrite_ai::AiAvailableCommandPayload {
+    let name = command.name.trim_start_matches('/').to_string();
+    let label = format!("/{name}");
+    let has_input = matches!(command.input, Some(AvailableCommandInput::Unstructured(_)));
+    neverwrite_ai::AiAvailableCommandPayload {
+        id: name.clone(),
+        label: label.clone(),
+        description: command.description,
+        insert_text: if has_input {
+            format!("{label} ")
+        } else {
+            label
+        },
+    }
+}
+
 fn plan_entry_priority_label(priority: &PlanEntryPriority) -> &'static str {
     match priority {
         PlanEntryPriority::High => "high",
@@ -4444,7 +4482,7 @@ fn runtime_descriptors() -> Vec<AiRuntimeDescriptor> {
         .map(|definition| {
             let runtime_id = definition.id;
             let models = default_models(runtime_id);
-            let modes = default_modes(runtime_id);
+            let modes = default_modes_for_runtime_descriptor(runtime_id);
             let mut capabilities = vec![
                 "create_session".to_string(),
                 "prompt_queueing".to_string(),
@@ -4520,13 +4558,35 @@ fn default_modes(runtime_id: &str) -> Vec<AiModeOption> {
     ]
 }
 
+fn default_modes_for_acp_session(runtime_id: &str) -> Vec<AiModeOption> {
+    if runtime_id == GROK_RUNTIME_ID {
+        Vec::new()
+    } else {
+        default_modes(runtime_id)
+    }
+}
+
+fn default_modes_for_runtime_descriptor(runtime_id: &str) -> Vec<AiModeOption> {
+    if runtime_id == GROK_RUNTIME_ID {
+        Vec::new()
+    } else {
+        default_modes(runtime_id)
+    }
+}
+
+fn default_mode_id_for_runtime(runtime_id: &str) -> Option<String> {
+    (runtime_id != GROK_RUNTIME_ID).then(|| "default".to_string())
+}
+
 fn default_config_options(
     runtime_id: &str,
     models: &[AiModelOption],
     modes: &[AiModeOption],
 ) -> Vec<AiConfigOption> {
-    vec![
-        AiConfigOption {
+    let mut options = Vec::new();
+
+    if !models.is_empty() {
+        options.push(AiConfigOption {
             id: "model".to_string(),
             runtime_id: runtime_id.to_string(),
             category: AiConfigOptionCategory::Model,
@@ -4545,8 +4605,11 @@ fn default_config_options(
                     description: Some(model.description.clone()),
                 })
                 .collect(),
-        },
-        AiConfigOption {
+        });
+    }
+
+    if !modes.is_empty() {
+        options.push(AiConfigOption {
             id: "mode".to_string(),
             runtime_id: runtime_id.to_string(),
             category: AiConfigOptionCategory::Mode,
@@ -4565,8 +4628,10 @@ fn default_config_options(
                     description: Some(mode.description.clone()),
                 })
                 .collect(),
-        },
-    ]
+        });
+    }
+
+    options
 }
 
 fn new_session(runtime_id: &str) -> Result<AiSession, String> {
@@ -4581,7 +4646,7 @@ fn new_session(runtime_id: &str) -> Result<AiSession, String> {
 fn new_session_with_id(runtime_id: &str, session_id: String) -> Result<AiSession, String> {
     validate_runtime_id(runtime_id)?;
     let models = default_models(runtime_id);
-    let modes = default_modes(runtime_id);
+    let modes = default_modes_for_acp_session(runtime_id);
     let config_options = default_config_options(runtime_id, &models, &modes);
     Ok(AiSession {
         session_id,
@@ -4597,7 +4662,8 @@ fn new_session_with_id(runtime_id: &str, session_id: String) -> Result<AiSession
         mode_id: modes
             .first()
             .map(|mode| mode.id.clone())
-            .unwrap_or_else(|| "default".to_string()),
+            .or_else(|| default_mode_id_for_runtime(runtime_id))
+            .unwrap_or_default(),
         status: AiSessionStatus::Idle,
         efforts_by_model: HashMap::new(),
         models,
@@ -6938,10 +7004,11 @@ fn now_ms() -> u64 {
 mod tests {
     use super::*;
     use agent_client_protocol::schema::{
-        ConfigOptionUpdate, Meta, ModelInfo, PermissionOptionKind, PlanEntry, SessionConfigOption,
-        SessionConfigOptionCategory, SessionConfigSelectOption, SessionInfoUpdate,
-        SessionModelState, SessionNotification, SessionUpdate, ToolCallContent, ToolCallId,
-        ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+        AvailableCommandInput, AvailableCommandsUpdate, ConfigOptionUpdate, Meta, ModelInfo,
+        PermissionOptionKind, PlanEntry, SessionConfigOption, SessionConfigOptionCategory,
+        SessionConfigSelectOption, SessionInfoUpdate, SessionModelState, SessionNotification,
+        SessionUpdate, ToolCallContent, ToolCallId, ToolCallUpdate, ToolCallUpdateFields, ToolKind,
+        UnstructuredCommandInput,
     };
     use std::fs;
     use std::sync::mpsc;
@@ -9321,6 +9388,14 @@ mod tests {
             .find(|option| matches!(option.category, AiConfigOptionCategory::Model))
             .expect("model config should be synthesized from ACP models");
         assert_eq!(model_config.value, "grok-build");
+        assert!(session.modes.is_empty());
+        assert!(
+            session
+                .config_options
+                .iter()
+                .all(|option| !matches!(option.category, AiConfigOptionCategory::Mode)),
+            "Grok must not receive synthetic modes when ACP does not advertise them"
+        );
         assert_eq!(
             acp_config_option_remote_command(
                 &session.runtime_id,
@@ -9443,6 +9518,60 @@ mod tests {
     fn grok_synthetic_modes_are_local_only() {
         assert!(!runtime_supports_remote_mode_change(GROK_RUNTIME_ID));
         assert!(runtime_supports_remote_mode_change(CODEX_RUNTIME_ID));
+    }
+
+    #[test]
+    fn acp_available_commands_update_is_forwarded_to_renderer() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-commands",
+            SessionUpdate::AvailableCommandsUpdate(AvailableCommandsUpdate::new(vec![
+                AvailableCommand::new("login", "Sign in to the provider"),
+                AvailableCommand::new("search", "Search the workspace").input(
+                    AvailableCommandInput::Unstructured(UnstructuredCommandInput::new("query")),
+                ),
+            ])),
+        )))
+        .unwrap();
+
+        let event = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("available commands event");
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event
+        else {
+            panic!("expected event");
+        };
+
+        assert_eq!(event_name, AI_AVAILABLE_COMMANDS_UPDATED_EVENT);
+        assert_eq!(
+            payload.pointer("/session_id").and_then(Value::as_str),
+            Some("session-commands")
+        );
+        assert_eq!(
+            payload.pointer("/commands/0/label").and_then(Value::as_str),
+            Some("/login")
+        );
+        assert_eq!(
+            payload
+                .pointer("/commands/0/insert_text")
+                .and_then(Value::as_str),
+            Some("/login")
+        );
+        assert_eq!(
+            payload.pointer("/commands/1/label").and_then(Value::as_str),
+            Some("/search")
+        );
+        assert_eq!(
+            payload
+                .pointer("/commands/1/insert_text")
+                .and_then(Value::as_str),
+            Some("/search ")
+        );
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -11,11 +11,11 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use agent_client_protocol::schema::{
     AuthenticateRequest, CancelNotification, ClientCapabilities, ContentBlock, ContentChunk,
-    FileSystemCapabilities, Implementation, InitializeRequest, LoadSessionRequest, LogoutRequest,
-    Meta, NewSessionRequest, PermissionOption, PermissionOptionKind, Plan, PlanEntryPriority,
-    PlanEntryStatus, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
-    RequestPermissionRequest, RequestPermissionResponse, SelectedPermissionOutcome,
-    SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
+    FileSystemCapabilities, Implementation, InitializeRequest, InitializeResponse,
+    LoadSessionRequest, LogoutRequest, Meta, NewSessionRequest, PermissionOption,
+    PermissionOptionKind, Plan, PlanEntryPriority, PlanEntryStatus, PromptRequest, ProtocolVersion,
+    RequestPermissionOutcome, RequestPermissionRequest, RequestPermissionResponse,
+    SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOptions, SessionId, SessionModeState, SessionModelState,
     SessionNotification, SessionUpdate, SetSessionConfigOptionRequest, SetSessionModeRequest,
     SetSessionModelRequest, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolKind,
@@ -796,6 +796,21 @@ struct AcpProcessSpec {
     cwd: PathBuf,
     env: HashMap<String, String>,
     runtime_id: String,
+    auth_method: Option<String>,
+    auth_handshake: Option<AcpAuthHandshake>,
+}
+
+#[derive(Debug, Clone)]
+struct AcpAuthHandshake {
+    env_method_id: &'static str,
+    external_method_id: &'static str,
+    meta: Option<Meta>,
+}
+
+#[derive(Debug, Clone)]
+struct AcpAuthHandshakeRequest {
+    method_id: &'static str,
+    meta: Option<Meta>,
 }
 
 #[derive(Debug, Clone)]
@@ -2926,6 +2941,79 @@ fn run_acp_auth_command(spec: AcpProcessSpec, auth_command: AcpAuthCommand) -> R
         .map_err(|_| "AI runtime authentication disconnected before responding.".to_string())?
 }
 
+async fn send_acp_authenticate_request(
+    connection: &ConnectionTo<Agent>,
+    method_id: impl Into<String>,
+    meta: Option<Meta>,
+) -> Result<(), agent_client_protocol::Error> {
+    let mut request = AuthenticateRequest::new(method_id.into());
+    if let Some(meta) = meta {
+        request = request.meta(meta);
+    }
+    connection.send_request(request).block_task().await?;
+    Ok(())
+}
+
+async fn run_acp_auth_handshake(
+    connection: &ConnectionTo<Agent>,
+    spec: &AcpProcessSpec,
+    initialize_response: &InitializeResponse,
+) -> Result<(), agent_client_protocol::Error> {
+    let Some(request) = acp_auth_handshake_request(spec)
+        .map_err(|message| agent_client_protocol::Error::internal_error().data(message))?
+    else {
+        return Ok(());
+    };
+
+    if !acp_initialize_response_has_auth_method(initialize_response, request.method_id) {
+        return Err(agent_client_protocol::Error::internal_error().data(format!(
+            "{} ACP runtime did not advertise required auth method '{}'.",
+            runtime_name(&spec.runtime_id),
+            request.method_id
+        )));
+    }
+
+    send_acp_authenticate_request(connection, request.method_id, request.meta).await
+}
+
+fn acp_auth_handshake_request(
+    spec: &AcpProcessSpec,
+) -> Result<Option<AcpAuthHandshakeRequest>, String> {
+    let Some(handshake) = spec.auth_handshake.as_ref() else {
+        return Ok(None);
+    };
+    let Some(auth_method) = spec.auth_method.as_deref() else {
+        return Ok(None);
+    };
+
+    let method_id = match auth_method {
+        "xai-api-key" => handshake.env_method_id,
+        "grok-login" => handshake.external_method_id,
+        unsupported => {
+            return Err(format!(
+                "{} auth method '{}' cannot be used for the ACP auth handshake.",
+                runtime_name(&spec.runtime_id),
+                unsupported
+            ));
+        }
+    };
+
+    Ok(Some(AcpAuthHandshakeRequest {
+        method_id,
+        meta: handshake.meta.clone(),
+    }))
+}
+
+fn acp_initialize_response_has_auth_method(
+    initialize_response: &InitializeResponse,
+    method_id: &str,
+) -> bool {
+    initialize_response
+        .auth_methods
+        .iter()
+        .any(|method| method.id().0.as_ref() == method_id)
+}
+
 async fn run_acp_auth_inner(
     spec: AcpProcessSpec,
     auth_command: AcpAuthCommand,
@@ -2976,10 +3064,7 @@ async fn run_acp_auth_inner(
                         .await?;
                     match auth_command {
                         AcpAuthCommand::Authenticate(method_id) => {
-                            connection
-                                .send_request(AuthenticateRequest::new(method_id))
-                                .block_task()
-                                .await?;
+                            send_acp_authenticate_request(&connection, method_id, None).await?;
                         }
                         AcpAuthCommand::Logout => {
                             connection
@@ -3117,7 +3202,7 @@ async fn run_acp_actor_inner(
         .connect_with(transport, async move |connection: ConnectionTo<Agent>| {
             let response = tokio::select! {
                 response = async {
-                    connection
+                    let initialize_response = connection
                         .send_request(
                             InitializeRequest::new(ProtocolVersion::LATEST)
                                 .client_capabilities(
@@ -3130,6 +3215,7 @@ async fn run_acp_actor_inner(
                         )
                         .block_task()
                         .await?;
+                    run_acp_auth_handshake(&connection, &spec, &initialize_response).await?;
                     emit_event(
                         &event_tx_for_connection,
                         AI_RUNTIME_CONNECTION_EVENT,
@@ -4546,13 +4632,45 @@ fn acp_process_spec(
         env.entry("AWS_BEARER_TOKEN_BEDROCK".to_string())
             .or_default();
     }
+    let auth_method = effective_auth_method_for_acp_process_spec(runtime_id, setup);
     Ok(AcpProcessSpec {
         program,
         args: resolved.args,
         cwd,
         env,
         runtime_id: runtime_id.to_string(),
+        auth_method,
+        auth_handshake: acp_auth_handshake_for_runtime(runtime_id),
     })
+}
+
+fn effective_auth_method_for_acp_process_spec(
+    runtime_id: &str,
+    setup: &RuntimeSetupState,
+) -> Option<String> {
+    let inherited_auth_method = inherited_auth_method_for_setup(runtime_id, setup)
+        .filter(|method| inherited_auth_method_applies_to_setup(setup, method));
+    if let Some(selected_method) = setup.auth_method.as_deref() {
+        if is_persistable_external_auth_method(runtime_id, selected_method) && !setup.auth_ready {
+            return inherited_auth_method.or_else(|| setup.auth_method.clone());
+        }
+    }
+    setup.auth_method.clone().or(inherited_auth_method)
+}
+
+fn acp_auth_handshake_for_runtime(runtime_id: &str) -> Option<AcpAuthHandshake> {
+    if runtime_id == GROK_RUNTIME_ID {
+        return Some(AcpAuthHandshake {
+            env_method_id: "xai.api_key",
+            external_method_id: "cached_token",
+            meta: Some(grok_acp_auth_meta()),
+        });
+    }
+    None
+}
+
+fn grok_acp_auth_meta() -> Meta {
+    Meta::from_iter([("headless".to_string(), json!(true))])
 }
 
 #[derive(Debug)]
@@ -10727,6 +10845,21 @@ mod tests {
             spec.env.get("XAI_API_KEY").map(String::as_str),
             Some("xai-test-secret")
         );
+        assert_eq!(spec.auth_method.as_deref(), Some("xai-api-key"));
+
+        let handshake_request = acp_auth_handshake_request(&spec)
+            .expect("Grok handshake should map API key auth")
+            .expect("Grok API key auth should request an ACP authenticate call");
+
+        assert_eq!(handshake_request.method_id, "xai.api_key");
+        assert_eq!(
+            handshake_request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("headless"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]
@@ -10753,11 +10886,130 @@ mod tests {
             Some("xai-api-key".to_string())
         );
         assert_eq!(spec.env.get("XAI_API_KEY"), None);
+        assert_eq!(spec.auth_method.as_deref(), Some("xai-api-key"));
 
         match previous {
             Some(value) => std::env::set_var("XAI_API_KEY", value),
             None => std::env::remove_var("XAI_API_KEY"),
         }
+    }
+
+    #[test]
+    fn acp_auth_handshake_maps_grok_login_to_cached_token() {
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("grok-login".to_string()),
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+        let handshake_request = acp_auth_handshake_request(&spec)
+            .expect("Grok handshake should map login auth")
+            .expect("Grok login auth should request an ACP authenticate call");
+
+        assert_eq!(handshake_request.method_id, "cached_token");
+        assert_eq!(
+            handshake_request
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("headless"))
+                .and_then(Value::as_bool),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn acp_auth_handshake_uses_inherited_xai_key_when_grok_login_is_unverified() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::set_var("XAI_API_KEY", "xai-env-secret");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("grok-login".to_string()),
+            auth_ready: false,
+            ..RuntimeSetupState::default()
+        };
+
+        let spec = acp_process_spec(GROK_RUNTIME_ID, &setup, std::env::current_dir().unwrap())
+            .expect("Grok ACP process spec should resolve");
+        let handshake_request = acp_auth_handshake_request(&spec)
+            .expect("Grok handshake should map inherited API key auth")
+            .expect("Inherited xAI API key should request an ACP authenticate call");
+
+        assert_eq!(spec.auth_method.as_deref(), Some("xai-api-key"));
+        assert_eq!(handshake_request.method_id, "xai.api_key");
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn acp_auth_handshake_is_grok_only_and_requires_selected_auth() {
+        let _guard = ENV_TEST_LOCK.lock().unwrap();
+        let previous = std::env::var_os("XAI_API_KEY");
+        std::env::remove_var("XAI_API_KEY");
+
+        let current_exe = std::env::current_exe().unwrap();
+        let grok_setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            suppress_persisted_auth: true,
+            ..RuntimeSetupState::default()
+        };
+        let grok_spec = acp_process_spec(
+            GROK_RUNTIME_ID,
+            &grok_setup,
+            std::env::current_dir().unwrap(),
+        )
+        .expect("Grok ACP process spec should resolve");
+
+        assert!(acp_auth_handshake_request(&grok_spec)
+            .expect("Missing selected auth should not fail")
+            .is_none());
+
+        let codex_setup = RuntimeSetupState {
+            custom_binary_path: Some(current_exe.display().to_string()),
+            auth_method: Some("codex-api-key".to_string()),
+            ..RuntimeSetupState::default()
+        };
+        let codex_spec = acp_process_spec(
+            CODEX_RUNTIME_ID,
+            &codex_setup,
+            std::env::current_dir().unwrap(),
+        )
+        .expect("Codex ACP process spec should resolve");
+
+        assert!(acp_auth_handshake_request(&codex_spec)
+            .expect("Non-Grok runtime should not need a handshake")
+            .is_none());
+
+        match previous {
+            Some(value) => std::env::set_var("XAI_API_KEY", value),
+            None => std::env::remove_var("XAI_API_KEY"),
+        }
+    }
+
+    #[test]
+    fn acp_initialize_response_auth_method_validation_matches_acp_ids() {
+        let response = InitializeResponse::new(ProtocolVersion::LATEST).auth_methods(vec![
+            agent_client_protocol::schema::AuthMethod::Agent(
+                agent_client_protocol::schema::AuthMethodAgent::new("cached_token", "Cached token"),
+            ),
+        ]);
+
+        assert!(acp_initialize_response_has_auth_method(
+            &response,
+            "cached_token"
+        ));
+        assert!(!acp_initialize_response_has_auth_method(
+            &response,
+            "xai.api_key"
+        ));
     }
 
     #[test]

--- a/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
+++ b/apps/desktop/scripts/smoke-electron-ai-runtime.mjs
@@ -317,6 +317,134 @@ createInterface({ input: process.stdin }).on("line", (line) => {
   return runtimePath;
 }
 
+async function writeFakeGrokAcpRuntime(runtimeDir) {
+  const runtimePath = path.join(
+    runtimeDir,
+    process.platform === "win32" ? "fake-grok-acp.cmd" : "fake-grok-acp",
+  );
+  const script =
+    process.platform === "win32"
+      ? `@echo off\r\nnode "%~dp0\\fake-grok-acp.mjs"\r\n`
+      : `#!/usr/bin/env node\nimport "./fake-grok-acp.mjs";\n`;
+  const modulePath = path.join(runtimeDir, "fake-grok-acp.mjs");
+  await fs.writeFile(runtimePath, script);
+  await fs.writeFile(
+    modulePath,
+    `
+import { createInterface } from "node:readline";
+
+const sessionId = "fake-grok-acp-session";
+let authenticated = false;
+let authenticatedMethod = null;
+
+function send(message) {
+  process.stdout.write(JSON.stringify({ jsonrpc: "2.0", ...message }) + "\\n");
+}
+function result(id, value) {
+  send({ id, result: value });
+}
+function fail(id, message) {
+  send({ id, error: { code: -32000, message } });
+}
+
+createInterface({ input: process.stdin }).on("line", (line) => {
+  const message = JSON.parse(line);
+  if (message.method === "initialize") {
+    result(message.id, {
+      protocolVersion: 1,
+      agentCapabilities: {},
+      agentInfo: { name: "fake-grok-acp", title: "Fake Grok ACP", version: "0.0.0" },
+      authMethods: [
+        { id: "cached_token", name: "Cached token" },
+        { id: "xai.api_key", name: "xAI API key" }
+      ]
+    });
+    return;
+  }
+  if (message.method === "authenticate") {
+    const methodId = message.params?.methodId;
+    if (methodId !== "cached_token" && methodId !== "xai.api_key") {
+      fail(message.id, "unsupported auth method");
+      return;
+    }
+    authenticated = true;
+    authenticatedMethod = methodId;
+    result(message.id, {});
+    return;
+  }
+  if (message.method === "session/new") {
+    if (!authenticated) {
+      fail(message.id, "authentication required before session/new");
+      return;
+    }
+    result(message.id, {
+      sessionId,
+      models: {
+        currentModelId: "grok-build",
+        availableModels: [
+          { modelId: "grok-composer-2.5-fast", name: "Composer 2.5" },
+          { modelId: "grok-build", name: "Grok Build" }
+        ]
+      }
+    });
+    return;
+  }
+  if (message.method === "session/set_model") {
+    result(message.id, {});
+    return;
+  }
+  if (message.method === "session/prompt") {
+    if (!authenticated) {
+      fail(message.id, "authentication required before session/prompt");
+      return;
+    }
+    send({
+      method: "session/update",
+      params: {
+        sessionId: message.params.sessionId,
+        update: {
+          sessionUpdate: "tool_call",
+          toolCallId: "grok-tool-edit-1",
+          title: "Edit Notes/A.md with Grok",
+          kind: "edit",
+          status: "completed",
+          content: [
+            {
+              type: "diff",
+              path: "Notes/A.md",
+              oldText: "# Alpha\\n",
+              newText: "# Alpha from Grok\\n"
+            }
+          ],
+          locations: [{ path: "Notes/A.md" }]
+        }
+      }
+    });
+    send({
+      method: "session/update",
+      params: {
+        sessionId: message.params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "Fake Grok reply via " + authenticatedMethod }
+        }
+      }
+    });
+    result(message.id, { stopReason: "end_turn" });
+    return;
+  }
+  if (message.method === "session/cancel") return;
+  send({
+    id: message.id,
+    error: { code: -32601, message: "Method not found" }
+  });
+});
+`.trimStart(),
+  );
+  await fs.chmod(runtimePath, 0o755).catch(() => {});
+  return runtimePath;
+}
+
 async function main() {
   await fs.access(sidecarPath).catch(() => {
     throw new Error(
@@ -332,6 +460,7 @@ async function main() {
     path.join(os.tmpdir(), "neverwrite-fake-acp-"),
   );
   const fakeAcpPath = await writeFakeAcpRuntime(runtimeDir);
+  const fakeGrokAcpPath = await writeFakeGrokAcpRuntime(runtimeDir);
   await writeFixtureVault(vaultPath);
   const client = new SidecarClient(sidecarPath, appDataDir);
 
@@ -343,6 +472,7 @@ async function main() {
       "codex-acp",
       "claude-acp",
       "gemini-acp",
+      "grok-acp",
       "kilo-acp",
       "opencode-acp",
     ]) {
@@ -464,6 +594,77 @@ async function main() {
       cursor,
       isAiEvent("ai://message-completed"),
       "real ACP stream completion",
+    );
+
+    const grokSetup = await client.invoke("ai_update_setup", {
+      runtimeId: "grok-acp",
+      input: {
+        custom_binary_path: fakeGrokAcpPath,
+        xai_api_key: { action: "set", value: "smoke-test-xai-key" },
+      },
+    });
+    assert(
+      grokSetup.binary_ready === true && grokSetup.auth_ready === true,
+      "Grok setup should accept a configured fake ACP runtime",
+    );
+
+    cursor = client.eventCursor();
+    const grokSession = await client.invoke("ai_create_session", {
+      input: {
+        runtime_id: "grok-acp",
+        additional_roots: null,
+      },
+      vaultPath,
+    });
+    assert(grokSession.status === "idle", "Grok session should start idle");
+    assert(
+      grokSession.model_id === "grok-build",
+      "Grok session should use ACP model state",
+    );
+    await client.waitEventAfter(
+      cursor,
+      (event) =>
+        event.eventName === "ai://runtime-connection" &&
+        event.payload?.runtime_id === "grok-acp" &&
+        event.payload?.status === "ready",
+      "Grok runtime ready after authenticated session create",
+    );
+
+    cursor = client.eventCursor();
+    await client.invoke("ai_send_message", {
+      sessionId: grokSession.session_id,
+      content: "Edit with Grok.",
+      attachments: [],
+    });
+    const grokToolActivity = await client.waitEventAfter(
+      cursor,
+      (event) =>
+        event.eventName === "ai://tool-activity" &&
+        event.payload?.tool_call_id === "grok-tool-edit-1",
+      "Grok tool activity with reversible file diff",
+    );
+    const [grokFileDiff] = grokToolActivity.payload?.diffs ?? [];
+    assert(grokFileDiff, "Grok tool activity should include file diffs");
+    assert(grokFileDiff.path === "Notes/A.md", "Grok diff path mismatch");
+    assert(grokFileDiff.kind === "update", "Grok diff kind mismatch");
+    assert(grokFileDiff.is_text === true, "Grok diff should be text");
+    assert(grokFileDiff.reversible === true, "Grok diff should be reversible");
+    assert(
+      grokFileDiff.old_text === "# Alpha\n" &&
+        grokFileDiff.new_text === "# Alpha from Grok\n",
+      "Grok diff should preserve old/new text",
+    );
+    await client.waitEventAfter(
+      cursor,
+      (event) =>
+        event.eventName === "ai://message-delta" &&
+        String(event.payload?.delta ?? "").includes("Fake Grok reply via xai.api_key"),
+      "Grok authenticated ACP stream delta",
+    );
+    await client.waitEventAfter(
+      cursor,
+      isAiEvent("ai://message-completed"),
+      "Grok ACP stream completion",
     );
 
     const history = minimalHistory(session.session_id);

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -116,9 +116,9 @@ const SUPPORTED_COMMANDS = new Set([
 ]);
 
 const NATIVE_BACKEND_SECRET_JSON_KEY_PATTERN =
-    /("(?:codex_api_key|openai_api_key|gemini_api_key|google_api_key|gateway_headers|anthropic_custom_headers|anthropic_auth_token|anthropic_api_key|api[_-]?key|authorization|token|secret|password|value)"\s*:\s*")([^"]*)(")/giu;
+    /("(?:codex_api_key|openai_api_key|gemini_api_key|xai_api_key|google_api_key|gateway_headers|anthropic_custom_headers|anthropic_auth_token|anthropic_api_key|api[_-]?key|authorization|token|secret|password|value)"\s*:\s*")([^"]*)(")/giu;
 const NATIVE_BACKEND_SECRET_ENV_PATTERN =
-    /\b((?:CODEX_API_KEY|OPENAI_API_KEY|ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_CUSTOM_HEADERS|GEMINI_API_KEY|GOOGLE_API_KEY)\s*=\s*)([^\s"',}]+)/gu;
+    /\b((?:CODEX_API_KEY|OPENAI_API_KEY|ANTHROPIC_AUTH_TOKEN|ANTHROPIC_API_KEY|ANTHROPIC_CUSTOM_HEADERS|GEMINI_API_KEY|GOOGLE_API_KEY|XAI_API_KEY)\s*=\s*)([^\s"',}]+)/gu;
 
 function redactNativeBackendSecrets(value: string) {
     return value

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -301,6 +301,7 @@ export async function aiUpdateSetup(input: {
     codexApiKey: AISecretPatch;
     openaiApiKey: AISecretPatch;
     geminiApiKey: AISecretPatch;
+    xaiApiKey?: AISecretPatch;
     kiloApiKey?: AISecretPatch;
     googleApiKey: AISecretPatch;
     googleCloudProject?: string;
@@ -321,6 +322,7 @@ export async function aiUpdateSetup(input: {
                 codex_api_key: input.codexApiKey,
                 openai_api_key: input.openaiApiKey,
                 gemini_api_key: input.geminiApiKey,
+                xai_api_key: input.xaiApiKey ?? { action: "unchanged" },
                 kilo_api_key: input.kiloApiKey ?? { action: "unchanged" },
                 google_api_key: input.googleApiKey,
                 google_cloud_project: input.googleCloudProject ?? null,

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -318,7 +318,9 @@ export async function aiUpdateSetup(input: {
         "ai_update_setup",
         {
             input: {
-                custom_binary_path: input.customBinaryPath ?? null,
+                ...(input.customBinaryPath !== undefined
+                    ? { custom_binary_path: input.customBinaryPath }
+                    : {}),
                 codex_api_key: input.codexApiKey,
                 openai_api_key: input.openaiApiKey,
                 gemini_api_key: input.geminiApiKey,

--- a/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIAuthTerminalModal.test.tsx
@@ -162,6 +162,46 @@ describe("AIAuthTerminalModal", () => {
         });
     });
 
+    it("recognizes Grok terminal auth success output", async () => {
+        const snapshot = {
+            sessionId: "authterm-grok",
+            runtimeId: "grok-acp",
+            program: "grok",
+            displayName: "Grok sign-in",
+            cwd: "/vault",
+            cols: 100,
+            rows: 28,
+            buffer: "Grok login successful",
+            status: "exited",
+            exitCode: 0,
+            errorMessage: null,
+        };
+        apiMocks.aiStartAuthTerminalSession.mockResolvedValue(snapshot);
+        apiMocks.aiResizeAuthTerminalSession.mockResolvedValue(
+            snapshot as never,
+        );
+
+        renderComponent(
+            <AIAuthTerminalModal
+                open
+                runtimeId="grok-acp"
+                runtimeName="Grok"
+                vaultPath="/vault"
+                onClose={vi.fn()}
+                onRefreshSetup={vi.fn(async () => undefined)}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Grok sign-in succeeded")).toBeInTheDocument();
+            expect(
+                screen.getByText(
+                    /Sign-in completed\. You can close this dialog/,
+                ),
+            ).toBeInTheDocument();
+        });
+    });
+
     it("cleans up listeners that resolve after the modal unmounts", async () => {
         const startedDeferred = createDeferred<Mock>();
         const outputDeferred = createDeferred<Mock>();

--- a/apps/desktop/src/features/ai/components/AIAuthTerminalModal.tsx
+++ b/apps/desktop/src/features/ai/components/AIAuthTerminalModal.tsx
@@ -69,7 +69,7 @@ function authTerminalOutputIndicatesSuccess(runtimeId: string, output: string) {
         );
     }
 
-    if (runtimeId === "opencode-acp") {
+    if (runtimeId === "grok-acp" || runtimeId === "opencode-acp") {
         const normalized = output.toLowerCase();
         return (
             normalized.includes("authentication successful") ||

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -340,18 +340,10 @@ describe("AIChatAgentControls", () => {
             <AIChatAgentControls
                 runtimeId="grok-acp"
                 modelId="grok-build"
-                modeId="default"
+                modeId=""
                 effortsByModel={{}}
                 models={[]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "grok-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
+                modes={[]}
                 configOptions={[
                     {
                         id: "model",
@@ -379,6 +371,8 @@ describe("AIChatAgentControls", () => {
                 onConfigOptionChange={onConfigOptionChange}
             />,
         );
+
+        expect(screen.queryByTitle("Approval Preset")).not.toBeInTheDocument();
 
         fireEvent.click(screen.getByTitle("Model"));
 

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -333,6 +333,76 @@ describe("AIChatAgentControls", () => {
         );
     });
 
+    it("shows a model search field for Grok and filters ACP models", () => {
+        const onConfigOptionChange = vi.fn();
+
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="grok-acp"
+                modelId="grok-build"
+                modeId="default"
+                effortsByModel={{}}
+                models={[]}
+                modes={[
+                    {
+                        id: "default",
+                        runtimeId: "grok-acp",
+                        name: "Auto",
+                        description: "",
+                        disabled: false,
+                    },
+                ]}
+                configOptions={[
+                    {
+                        id: "model",
+                        runtimeId: "grok-acp",
+                        category: "model",
+                        label: "Model",
+                        type: "select",
+                        value: "grok-build",
+                        options: [
+                            {
+                                value: "grok-composer-2.5-fast",
+                                label: "Composer 2.5",
+                                description: "Cursor's latest coding model",
+                            },
+                            {
+                                value: "grok-build",
+                                label: "Grok Build",
+                                description: "Best for advanced coding tasks",
+                            },
+                        ],
+                    },
+                ]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={onConfigOptionChange}
+            />,
+        );
+
+        fireEvent.click(screen.getByTitle("Model"));
+
+        const search = screen.getByLabelText("Model search");
+        expect(search).toBeInTheDocument();
+        expect(screen.getByText("Composer 2.5")).toBeInTheDocument();
+
+        fireEvent.change(search, { target: { value: "build" } });
+
+        expect(screen.getAllByText("Grok Build").length).toBeGreaterThan(0);
+        expect(screen.queryByText("Composer 2.5")).not.toBeInTheDocument();
+
+        const grokBuildOption = screen
+            .getAllByRole("button", { name: "Grok Build" })
+            .at(-1);
+        expect(grokBuildOption).toBeDefined();
+        fireEvent.click(grokBuildOption!);
+
+        expect(onConfigOptionChange).toHaveBeenCalledWith(
+            "model",
+            "grok-build",
+        );
+    });
+
     it("does not show the model search field for non-searchable runtimes", () => {
         renderComponent(
             <AIChatAgentControls

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -333,7 +333,7 @@ describe("AIChatAgentControls", () => {
         );
     });
 
-    it("shows a model search field for Grok and filters ACP models", () => {
+    it("shows Grok ACP models without a model search field", () => {
         const onConfigOptionChange = vi.fn();
 
         renderComponent(
@@ -376,14 +376,9 @@ describe("AIChatAgentControls", () => {
 
         fireEvent.click(screen.getByTitle("Model"));
 
-        const search = screen.getByLabelText("Model search");
-        expect(search).toBeInTheDocument();
+        expect(screen.queryByLabelText("Model search")).not.toBeInTheDocument();
         expect(screen.getByText("Composer 2.5")).toBeInTheDocument();
-
-        fireEvent.change(search, { target: { value: "build" } });
-
         expect(screen.getAllByText("Grok Build").length).toBeGreaterThan(0);
-        expect(screen.queryByText("Composer 2.5")).not.toBeInTheDocument();
 
         const grokBuildOption = screen
             .getAllByRole("button", { name: "Grok Build" })

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -33,7 +33,11 @@ interface DropdownFieldProps {
     onChange: (value: string) => void;
 }
 
-const SEARCHABLE_MODEL_RUNTIME_IDS = new Set(["kilo-acp", "opencode-acp"]);
+const SEARCHABLE_MODEL_RUNTIME_IDS = new Set([
+    "grok-acp",
+    "kilo-acp",
+    "opencode-acp",
+]);
 
 function shouldUseSearchableModelMenu(runtimeId?: string) {
     return (

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -384,18 +384,20 @@ export function AIChatAgentControls({
 
     return (
         <div className="flex min-w-0 flex-wrap items-center gap-1">
-            <DropdownField
-                disabled={disabled}
-                label="Approval Preset"
-                value={modeId}
-                options={modes.map((mode) => ({
-                    value: mode.id,
-                    label: formatFallbackLabel(mode.name),
-                    description: mode.description,
-                    disabled: mode.disabled,
-                }))}
-                onChange={onModeChange}
-            />
+            {modes.length > 0 ? (
+                <DropdownField
+                    disabled={disabled}
+                    label="Approval Preset"
+                    value={modeId}
+                    options={modes.map((mode) => ({
+                        value: mode.id,
+                        label: formatFallbackLabel(mode.name),
+                        description: mode.description,
+                        disabled: mode.disabled,
+                    }))}
+                    onChange={onModeChange}
+                />
+            ) : null}
             <DropdownField
                 disabled={disabled}
                 label="Model"

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -34,7 +34,6 @@ interface DropdownFieldProps {
 }
 
 const SEARCHABLE_MODEL_RUNTIME_IDS = new Set([
-    "grok-acp",
     "kilo-acp",
     "opencode-acp",
 ]);

--- a/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
@@ -102,8 +102,8 @@ export function AIChatCommandPicker({
                 top: position.y,
                 left: position.x,
                 zIndex: 10010,
-                width: 340,
-                maxWidth: "min(340px, calc(100vw - 24px))",
+                width: 420,
+                maxWidth: "min(420px, calc(100vw - 24px))",
                 maxHeight: 280,
                 overflow: "hidden",
                 borderRadius: 10,
@@ -152,6 +152,7 @@ export function AIChatCommandPicker({
                                     padding: "6px 10px",
                                     textAlign: "left",
                                     cursor: "pointer",
+                                    width: "100%",
                                     minWidth: 0,
                                     transition: "background-color 80ms ease",
                                 }}
@@ -165,7 +166,8 @@ export function AIChatCommandPicker({
                                         whiteSpace: "nowrap",
                                         overflow: "hidden",
                                         textOverflow: "ellipsis",
-                                        flex: 1,
+                                        flex: "0 0 auto",
+                                        maxWidth: "46%",
                                         minWidth: 0,
                                     }}
                                 >
@@ -176,7 +178,10 @@ export function AIChatCommandPicker({
                                         fontSize: 11,
                                         color: "var(--text-secondary)",
                                         opacity: 0.6,
-                                        flexShrink: 0,
+                                        flex: "1 1 0",
+                                        minWidth: 0,
+                                        overflow: "hidden",
+                                        textOverflow: "ellipsis",
                                         whiteSpace: "nowrap",
                                     }}
                                 >

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -600,7 +600,16 @@ describe("AIChatComposer mention picker", () => {
     });
 
     it("opens the slash picker when the caret is on the root element", async () => {
-        const { composer } = renderComposer();
+        const { composer } = renderComposer({
+            availableCommands: [
+                {
+                    id: "plan",
+                    label: "/plan",
+                    description: "step-by-step plan",
+                    insert_text: "/plan ",
+                },
+            ],
+        });
         composer.textContent = "/pl";
 
         setCaret(composer, 1);
@@ -611,9 +620,63 @@ describe("AIChatComposer mention picker", () => {
         });
     });
 
-    it("uses runtime-aware slash fallbacks for Claude sessions", async () => {
+    it("keeps slash command labels visible when descriptions are long", async () => {
+        const { composer } = renderComposer({
+            availableCommands: [
+                {
+                    id: "compact",
+                    label: "/compact",
+                    description:
+                        "Compress conversation history to save context window space",
+                    insert_text: "/compact",
+                },
+            ],
+        });
+        composer.textContent = "/co";
+
+        setCaret(composer.firstChild as Text, 3);
+        fireEvent.input(composer);
+
+        const label = await screen.findByText("/compact");
+        const description = screen.getByText(
+            "Compress conversation history to save context window space",
+        );
+
+        expect(label).toHaveStyle({ flex: "0 0 auto" });
+        expect(description).toHaveStyle({
+            flex: "1 1 0",
+            overflow: "hidden",
+            textOverflow: "ellipsis",
+        });
+    });
+
+    it("shows Codex builtin slash commands while ACP commands are still loading", async () => {
+        const { composer } = renderComposer({
+            runtimeId: "codex-acp",
+            availableCommands: [],
+        });
+        composer.textContent = "/co";
+
+        setCaret(composer.firstChild as Text, 3);
+        fireEvent.input(composer);
+
+        await waitFor(() => {
+            expect(screen.getByText("/compact")).toBeInTheDocument();
+            expect(screen.queryByText("No commands found")).not.toBeInTheDocument();
+        });
+    });
+
+    it("uses only ACP-provided slash commands for Claude sessions", async () => {
         const { composer } = renderComposer({
             runtimeId: "claude-acp",
+            availableCommands: [
+                {
+                    id: "compact",
+                    label: "/compact",
+                    description: "compact thread",
+                    insert_text: "/compact",
+                },
+            ],
         });
         composer.textContent = "/co";
 
@@ -623,6 +686,37 @@ describe("AIChatComposer mention picker", () => {
         await waitFor(() => {
             expect(screen.getByText("/compact")).toBeInTheDocument();
             expect(screen.queryByText("/undo")).not.toBeInTheDocument();
+        });
+    });
+
+    it("uses only ACP-provided slash commands for Grok sessions", async () => {
+        const { composer } = renderComposer({
+            runtimeId: "grok-acp",
+            availableCommands: [
+                {
+                    id: "workspace-search",
+                    label: "/workspace-search",
+                    description: "search workspace",
+                    insert_text: "/workspace-search ",
+                },
+            ],
+        });
+        composer.textContent = "/pl";
+
+        setCaret(composer.firstChild as Text, 3);
+        fireEvent.input(composer);
+
+        await waitFor(() => {
+            expect(screen.queryByText("/plan")).not.toBeInTheDocument();
+            expect(screen.getByText("No commands found")).toBeInTheDocument();
+        });
+
+        composer.textContent = "/work";
+        setCaret(composer.firstChild as Text, 5);
+        fireEvent.input(composer);
+
+        await waitFor(() => {
+            expect(screen.getByText("/workspace-search")).toBeInTheDocument();
         });
     });
 

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -139,66 +139,53 @@ const EMPTY_SLASH_STATE: SlashState = {
     range: null,
 };
 
-const COMMON_SLASH_COMMANDS: AIChatSlashCommand[] = [
-    {
-        id: "init",
-        label: "/init",
-        description: "starter instructions",
-        insertText: "/init ",
-    },
+// Mirrors the bundled Codex ACP builtins so slash commands are available while
+// the runtime's AvailableCommandsUpdate notification is still in flight.
+const CODEX_BUILTIN_SLASH_COMMANDS: AIChatSlashCommand[] = [
     {
         id: "review",
         label: "/review",
-        description: "review changes",
+        description: "Review my current changes and find issues",
         insertText: "/review ",
     },
     {
-        id: "plan",
-        label: "/plan",
-        description: "step-by-step plan",
-        insertText: "/plan ",
-    },
-    {
-        id: "compact",
-        label: "/compact",
-        description: "compact thread",
-        insertText: "/compact",
-    },
-];
-
-const CODEX_SLASH_COMMANDS: AIChatSlashCommand[] = [
-    {
         id: "review-branch",
         label: "/review-branch",
-        description: "review branch",
+        description: "Review the code changes against a specific branch",
         insertText: "/review-branch ",
     },
     {
         id: "review-commit",
         label: "/review-commit",
-        description: "review commit",
+        description: "Review the code changes introduced by a commit",
         insertText: "/review-commit ",
     },
     {
-        id: "undo",
-        label: "/undo",
-        description: "undo last change",
-        insertText: "/undo",
+        id: "init",
+        label: "/init",
+        description: "create an AGENTS.md file with instructions for Codex",
+        insertText: "/init",
+    },
+    {
+        id: "compact",
+        label: "/compact",
+        description: "summarize conversation to prevent hitting the context limit",
+        insertText: "/compact",
     },
     {
         id: "logout",
         label: "/logout",
-        description: "sign out",
+        description: "logout of Codex",
         insertText: "/logout",
     },
 ];
 
-function getFallbackSlashCommands(runtimeId?: string) {
+function getPendingRuntimeSlashCommands(runtimeId?: string) {
     if (runtimeId === "codex-acp") {
-        return [...COMMON_SLASH_COMMANDS, ...CODEX_SLASH_COMMANDS];
+        return CODEX_BUILTIN_SLASH_COMMANDS;
     }
 
-    return COMMON_SLASH_COMMANDS;
+    return [];
 }
 
 function applyComposerPillStyles(
@@ -1079,10 +1066,6 @@ export function AIChatComposer({
     const [externalDragActive, setExternalDragActive] = useState(false);
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<ComposerContextMenuPayload> | null>(null);
-    const fallbackSlashCommands = useMemo(
-        () => getFallbackSlashCommands(runtimeId),
-        [runtimeId],
-    );
     const [customHeight, setCustomHeight] = useState<number | null>(null);
     const resizeSession = useRef<{
         startY: number;
@@ -1304,7 +1287,7 @@ export function AIChatComposer({
         );
         const commandSource = runtimeCommands.length
             ? runtimeCommands
-            : fallbackSlashCommands;
+            : getPendingRuntimeSlashCommands(runtimeId);
         const normalizedQuery = trigger.query.toLowerCase();
         const items = commandSource.filter((command) => {
             const haystack = [command.id, command.label, command.description]

--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.test.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.test.tsx
@@ -521,6 +521,51 @@ describe("EditedFilesBufferPanel", () => {
         expect(reviewTab?.title).toBe("Review Kilo");
     });
 
+    it("opens the full review tab with the Grok runtime title", () => {
+        const session = createSession(
+            "session-review-grok",
+            [createTrackedFile("/vault/src/review-grok.ts")],
+            "grok-acp",
+        );
+
+        useChatStore.setState((state) => ({
+            ...state,
+            activeSessionId: session.sessionId,
+            runtimes: [
+                {
+                    runtime: {
+                        id: "grok-acp",
+                        name: "Grok",
+                        description: "Grok runtime",
+                        capabilities: [],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+            rejectEditedFile: vi.fn(async () => {}),
+            rejectAllEditedFiles: vi.fn(async () => {}),
+            keepAllEditedFiles: vi.fn(),
+        }));
+
+        renderComponent(<EditedFilesBufferPanel />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Review" }));
+
+        const reviewTab = useEditorStore
+            .getState()
+            .tabs.find(
+                (tab) =>
+                    isReviewTab(tab) && tab.sessionId === session.sessionId,
+            );
+
+        expect(reviewTab?.title).toBe("Review Grok");
+    });
+
     it("keeps the expanded compact list bounded and row-stable for many pending edits", () => {
         const files = Array.from({ length: 17 }, (_, index) => {
             const lineCount = index + 12;

--- a/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
+++ b/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
@@ -38,6 +38,17 @@ const runtimes: AIRuntimeDescriptor[] = [
         modes: [],
         configOptions: [],
     },
+    {
+        runtime: {
+            id: "grok-acp",
+            name: "Grok",
+            description: "Grok runtime",
+            capabilities: [],
+        },
+        models: [],
+        modes: [],
+        configOptions: [],
+    },
 ];
 
 function MultiSessionReviewHarness() {
@@ -418,5 +429,106 @@ describe("multi-session review integration", () => {
                 }),
             ]),
         );
+    });
+
+    it("keeps Grok review tabs and visible buffers isolated from Codex and Kilo sessions", async () => {
+        setVaultEntries([
+            {
+                id: "notes/codex.md",
+                path: "/vault/notes/codex.md",
+                relative_path: "notes/codex.md",
+                title: "codex.md",
+                file_name: "codex.md",
+                extension: "md",
+                kind: "note",
+                modified_at: 0,
+                created_at: 0,
+                size: 10,
+                mime_type: "text/markdown",
+            },
+            {
+                id: "notes/kilo.md",
+                path: "/vault/notes/kilo.md",
+                relative_path: "notes/kilo.md",
+                title: "kilo.md",
+                file_name: "kilo.md",
+                extension: "md",
+                kind: "note",
+                modified_at: 0,
+                created_at: 0,
+                size: 10,
+                mime_type: "text/markdown",
+            },
+            {
+                id: "notes/grok.md",
+                path: "/vault/notes/grok.md",
+                relative_path: "notes/grok.md",
+                title: "grok.md",
+                file_name: "grok.md",
+                extension: "md",
+                kind: "note",
+                modified_at: 0,
+                created_at: 0,
+                size: 10,
+                mime_type: "text/markdown",
+            },
+        ]);
+
+        const codexSession = createSession("session-codex", [
+            createTrackedFile("/vault/notes/codex.md", 10),
+        ]);
+        const kiloSession = createSession(
+            "session-kilo",
+            [createTrackedFile("/vault/notes/kilo.md", 20)],
+            "kilo-acp",
+        );
+        const grokSession = createSession(
+            "session-grok",
+            [createTrackedFile("/vault/notes/grok.md", 30)],
+            "grok-acp",
+        );
+
+        renderComponent(<MultiSessionReviewHarness />);
+
+        await act(async () => {
+            useChatStore.setState((state) => ({
+                ...state,
+                runtimes,
+                activeSessionId: grokSession.sessionId,
+                sessionsById: {
+                    [codexSession.sessionId]: codexSession,
+                    [kiloSession.sessionId]: kiloSession,
+                    [grokSession.sessionId]: grokSession,
+                },
+            }));
+            openReviewTab(codexSession, runtimes);
+            openReviewTab(kiloSession, runtimes);
+            openReviewTab(grokSession, runtimes);
+            setReviewTabActive(grokSession.sessionId);
+        });
+
+        const reviewTabs = useEditorStore
+            .getState()
+            .tabs.filter((tab) => isReviewTab(tab));
+        expect(reviewTabs).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    sessionId: "session-codex",
+                    title: "Review Codex",
+                }),
+                expect.objectContaining({
+                    sessionId: "session-kilo",
+                    title: "Review Kilo",
+                }),
+                expect.objectContaining({
+                    sessionId: "session-grok",
+                    title: "Review Grok",
+                }),
+            ]),
+        );
+
+        expect(screen.getAllByText("grok.md")).toHaveLength(2);
+        expect(screen.queryByText("codex.md")).not.toBeInTheDocument();
+        expect(screen.queryByText("kilo.md")).not.toBeInTheDocument();
     });
 });

--- a/apps/desktop/src/features/ai/sessionPresentation.test.ts
+++ b/apps/desktop/src/features/ai/sessionPresentation.test.ts
@@ -48,6 +48,17 @@ const runtimes: AIRuntimeDescriptor[] = [
         modes: [],
         configOptions: [],
     },
+    {
+        runtime: {
+            id: "grok-acp",
+            name: "Grok",
+            description: "Grok runtime",
+            capabilities: [],
+        },
+        models: [],
+        modes: [],
+        configOptions: [],
+    },
 ];
 
 describe("sessionPresentation history selection", () => {
@@ -93,6 +104,15 @@ describe("sessionPresentation history selection", () => {
         };
 
         expect(getReviewTabTitle(session, runtimes)).toBe("Review Kilo");
+    });
+
+    it("formats review tab titles with Grok runtime ids", () => {
+        const session = {
+            ...createSession("live-session-grok", "history-grok"),
+            runtimeId: "grok-acp",
+        };
+
+        expect(getReviewTabTitle(session, runtimes)).toBe("Review Grok");
     });
 
     it("formats subagent review tab titles with the visible session name", () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1835,6 +1835,135 @@ describe("chatStore", () => {
         });
     });
 
+    it("sends Grok setup and auth payloads through the selected runtime", async () => {
+        const grokSetupStatus = {
+            ...readySetupStatus,
+            runtime_id: "grok-acp",
+            binary_path: "/usr/local/bin/grok",
+            binary_source: "custom",
+            auth_method: "xai-api-key",
+            auth_methods: [
+                {
+                    id: "grok-login",
+                    name: "Grok login",
+                    description: "Open the Grok CLI sign-in flow.",
+                },
+                {
+                    id: "xai-api-key",
+                    name: "xAI API key",
+                    description: "Use an xAI API key stored locally.",
+                },
+            ],
+        };
+        const grokDescriptor = {
+            runtime: {
+                ...runtimePayload[0].runtime,
+                id: "grok-acp",
+                name: "Grok ACP",
+            },
+            models: [],
+            modes: [],
+            configOptions: [],
+        };
+        const calls: Array<{ command: string; args: unknown }> = [];
+        invokeMock.mockImplementation(async (command, args) => {
+            calls.push({ command, args });
+            if (command === "ai_update_setup") {
+                return grokSetupStatus;
+            }
+            if (command === "ai_start_auth") {
+                return {
+                    ...grokSetupStatus,
+                    auth_method: "grok-login",
+                    onboarding_required: false,
+                };
+            }
+            if (
+                command === "ai_save_session_history" ||
+                command === "ai_prune_session_histories"
+            ) {
+                return undefined;
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.setState({
+            selectedRuntimeId: "grok-acp",
+            runtimes: [grokDescriptor],
+            setupStatusByRuntimeId: {
+                "grok-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "grok-acp",
+                    authReady: false,
+                    onboardingRequired: false,
+                },
+            },
+        });
+
+        await useChatStore.getState().saveSetup({
+            customBinaryPath: "/usr/local/bin/grok",
+            codexApiKey: { action: "unchanged" },
+            openaiApiKey: { action: "unchanged" },
+            geminiApiKey: { action: "unchanged" },
+            xaiApiKey: { action: "set", value: "xai-test-secret" },
+            googleApiKey: { action: "unchanged" },
+            gatewayHeaders: { action: "unchanged" },
+            anthropicCustomHeaders: { action: "unchanged" },
+            anthropicAuthToken: { action: "unchanged" },
+            anthropicApiKey: { action: "unchanged" },
+        });
+        await useChatStore.getState().startAuth({
+            runtimeId: "grok-acp",
+            methodId: "grok-login",
+            codexApiKey: { action: "unchanged" },
+            openaiApiKey: { action: "unchanged" },
+            geminiApiKey: { action: "unchanged" },
+            xaiApiKey: { action: "unchanged" },
+            googleApiKey: { action: "unchanged" },
+            gatewayHeaders: { action: "unchanged" },
+            anthropicCustomHeaders: { action: "unchanged" },
+            anthropicAuthToken: { action: "unchanged" },
+            anthropicApiKey: { action: "unchanged" },
+        });
+
+        expect(calls).toContainEqual(
+            expect.objectContaining({
+                command: "ai_update_setup",
+                args: expect.objectContaining({
+                    runtimeId: "grok-acp",
+                    input: expect.objectContaining({
+                        custom_binary_path: "/usr/local/bin/grok",
+                        xai_api_key: {
+                            action: "set",
+                            value: "xai-test-secret",
+                        },
+                    }),
+                }),
+            }),
+        );
+        expect(calls).toContainEqual(
+            expect.objectContaining({
+                command: "ai_start_auth",
+                args: {
+                    input: {
+                        method_id: "grok-login",
+                        runtimeId: "grok-acp",
+                    },
+                    vaultPath: null,
+                },
+            }),
+        );
+        expect(useChatStore.getState().selectedRuntimeId).toBe("grok-acp");
+        expect(
+            useChatStore.getState().setupStatusByRuntimeId["grok-acp"],
+        ).toMatchObject({
+            runtimeId: "grok-acp",
+            authReady: true,
+            authMethod: "grok-login",
+            onboardingRequired: false,
+        });
+    });
+
     it("opens the selected runtime after onboarding completes while another runtime is active", async () => {
         const claudeReadySetupStatus = {
             ...readySetupStatus,
@@ -15243,6 +15372,116 @@ describe("chatStore", () => {
             "aaXa\nBBB\nccc\nDDD",
         );
         expect(buildReviewProjection(remaining!).hunks).toHaveLength(1);
+    });
+
+    it("resolves Grok review hunks without mutating parallel Codex or Kilo sessions", async () => {
+        const codexFile = createTrackedFile(
+            "/notes/codex.md",
+            "codex before",
+            "codex after",
+        );
+        const kiloFile = createTrackedFile(
+            "/notes/kilo.md",
+            "kilo before",
+            "kilo after",
+        );
+        const grokAcceptFile = createTrackedFile(
+            "/notes/grok-accept.md",
+            "alpha\nbeta\ngamma\nomega",
+            "ALPHA\nbeta\nGAMMA\nomega",
+        );
+        const grokRejectFile = createTrackedFile(
+            "/notes/grok-reject.md",
+            "red\nblue\ngreen",
+            "red\nBLUE\ngreen",
+        );
+        const codexSession = {
+            ...createSessionWithTrackedFiles("session-codex-review", [
+                codexFile,
+            ]),
+            runtimeId: "codex-acp",
+        };
+        const kiloSession = {
+            ...createSessionWithTrackedFiles("session-kilo-review", [
+                kiloFile,
+            ]),
+            runtimeId: "kilo-acp",
+        };
+        const grokSession = {
+            ...createSessionWithTrackedFiles("session-grok-review", [
+                grokAcceptFile,
+                grokRejectFile,
+            ]),
+            runtimeId: "grok-acp",
+        };
+
+        useChatStore.setState({
+            activeSessionId: grokSession.sessionId,
+            sessionsById: {
+                [codexSession.sessionId]: codexSession,
+                [kiloSession.sessionId]: kiloSession,
+                [grokSession.sessionId]: grokSession,
+            },
+        });
+
+        const codexBefore =
+            useChatStore.getState().sessionsById[codexSession.sessionId];
+        const kiloBefore =
+            useChatStore.getState().sessionsById[kiloSession.sessionId];
+        const acceptProjection = buildReviewProjection(grokAcceptFile);
+        const rejectProjection = buildReviewProjection(grokRejectFile);
+        expect(acceptProjection.hunks).toHaveLength(2);
+        expect(rejectProjection.hunks).toHaveLength(1);
+
+        await useChatStore
+            .getState()
+            .resolveReviewHunks(
+                grokSession.sessionId,
+                grokAcceptFile.identityKey,
+                "accepted",
+                grokAcceptFile.version,
+                [acceptProjection.hunks[0]!.id],
+            );
+        await useChatStore
+            .getState()
+            .resolveReviewHunks(
+                grokSession.sessionId,
+                grokRejectFile.identityKey,
+                "rejected",
+                grokRejectFile.version,
+                [rejectProjection.hunks[0]!.id],
+            );
+
+        const codexAfter =
+            useChatStore.getState().sessionsById[codexSession.sessionId];
+        const kiloAfter =
+            useChatStore.getState().sessionsById[kiloSession.sessionId];
+        const grokAfter =
+            useChatStore.getState().sessionsById[grokSession.sessionId];
+        const remainingGrokFiles = getVisibleBuffer(grokSession.sessionId);
+        const remainingAcceptFile = remainingGrokFiles.find(
+            (file) => file.identityKey === grokAcceptFile.identityKey,
+        );
+
+        expect(codexAfter).toBe(codexBefore);
+        expect(kiloAfter).toBe(kiloBefore);
+        expect(grokAfter?.runtimeId).toBe("grok-acp");
+        expect(codexAfter?.runtimeId).toBe("codex-acp");
+        expect(kiloAfter?.runtimeId).toBe("kilo-acp");
+        expect(
+            remainingGrokFiles.some(
+                (file) => file.identityKey === grokRejectFile.identityKey,
+            ),
+        ).toBe(false);
+        expect(remainingAcceptFile).toBeDefined();
+        expectTrackedFileToMatchAccumulatedDiff(
+            remainingAcceptFile!,
+            "ALPHA\nbeta\ngamma\nomega",
+            "ALPHA\nbeta\nGAMMA\nomega",
+        );
+        expect(buildReviewProjection(remainingAcceptFile!).hunks).toHaveLength(
+            1,
+        );
     });
 
     it("keeps move-only tracked files pending after accepting the last text hunk", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -13724,6 +13724,40 @@ describe("chatStore", () => {
         expect(merged.configOptions).toEqual(existing.configOptions);
     });
 
+    it("applies ACP available commands that arrive before the session is upserted", () => {
+        const sessionId = "grok-session-early-commands";
+        const commands = [
+            {
+                id: "plan",
+                label: "Plan",
+                description: "Create a plan.",
+                insert_text: "/plan",
+            },
+        ];
+
+        useChatStore.getState().applyAvailableCommandsUpdate({
+            session_id: sessionId,
+            commands,
+        });
+        useChatStore.getState().upsertSession(
+            {
+                ...createSessionWithTrackedFiles(sessionId, []),
+                runtimeId: "grok-acp",
+                modelId: "grok-build",
+            },
+            true,
+        );
+
+        expect(
+            useChatStore.getState().sessionsById[sessionId]?.availableCommands,
+        ).toEqual(commands);
+        expect(
+            useChatStore.getState().pendingAvailableCommandsBySessionId[
+                sessionId
+            ],
+        ).toBeUndefined();
+    });
+
     it("keeps model and mode config option values aligned with incoming session updates", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1177,6 +1177,10 @@ interface ChatStore {
     runtimes: AIRuntimeDescriptor[];
     sessionsById: Record<string, AIChatSession>;
     sessionOrder: string[];
+    pendingAvailableCommandsBySessionId: Record<
+        string,
+        AIAvailableCommandsPayload["commands"]
+    >;
     activeSessionId: string | null;
     lastFocusedSessionId: string | null;
     defaultRuntimeId: string | null;
@@ -6775,6 +6779,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         runtimes: [],
         sessionsById: {},
         sessionOrder: [],
+        pendingAvailableCommandsBySessionId: {},
         activeSessionId: null,
         lastFocusedSessionId: null,
         defaultRuntimeId: null,
@@ -7646,6 +7651,16 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 if (closedQueueState) {
                     nextSession = closedQueueState.session;
                 }
+                const pendingAvailableCommands =
+                    state.pendingAvailableCommandsBySessionId[
+                        scopedSession.sessionId
+                    ];
+                if (pendingAvailableCommands) {
+                    nextSession = {
+                        ...nextSession,
+                        availableCommands: pendingAvailableCommands,
+                    };
+                }
                 const nextTokenUsageBySessionId =
                     existing && existing.modelId !== nextSession.modelId
                         ? removeSessionMapEntry(
@@ -7677,6 +7692,13 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         ...state.sessionsById,
                         [scopedSession.sessionId]: nextSession,
                     },
+                    pendingAvailableCommandsBySessionId:
+                        pendingAvailableCommands
+                            ? removeSessionMapEntry(
+                                  state.pendingAvailableCommandsBySessionId,
+                                  scopedSession.sessionId,
+                              )
+                            : state.pendingAvailableCommandsBySessionId,
                     sessionOrder: activate
                         ? touchSessionOrder(
                               state.sessionOrder,
@@ -8514,7 +8536,16 @@ export const useChatStore = create<ChatStore>((set, get) => {
         applyAvailableCommandsUpdate: (payload) => {
             set((state) => {
                 const session = state.sessionsById[payload.session_id];
-                if (!session) return state;
+                if (!session) {
+                    // ACP runtimes may publish commands during startup, before
+                    // the frontend has accepted the corresponding session.
+                    return {
+                        pendingAvailableCommandsBySessionId: {
+                            ...state.pendingAvailableCommandsBySessionId,
+                            [payload.session_id]: payload.commands,
+                        },
+                    };
+                }
 
                 return {
                     sessionsById: {
@@ -11116,6 +11147,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
             set({
                 sessionsById: nextSessionsById,
                 sessionOrder: remainingIds,
+                pendingAvailableCommandsBySessionId: removeSessionMapEntry(
+                    state.pendingAvailableCommandsBySessionId,
+                    sessionId,
+                ),
                 activeSessionId: nextActiveId,
                 lastFocusedSessionId: nextLastFocusedSessionId,
                 selectedRuntimeId: nextSelectedRuntimeId,
@@ -11184,6 +11219,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             set({
                 sessionsById: {},
                 sessionOrder: [],
+                pendingAvailableCommandsBySessionId: {},
                 activeSessionId: null,
                 lastFocusedSessionId: null,
                 selectedRuntimeId: defaultRuntimeId,
@@ -11743,6 +11779,7 @@ export function resetChatStore() {
         runtimes: [],
         sessionsById: {},
         sessionOrder: [],
+        pendingAvailableCommandsBySessionId: {},
         activeSessionId: null,
         lastFocusedSessionId: null,
         defaultRuntimeId: null,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1223,6 +1223,7 @@ interface ChatStore {
         codexApiKey: AISecretPatch;
         openaiApiKey: AISecretPatch;
         geminiApiKey: AISecretPatch;
+        xaiApiKey?: AISecretPatch;
         kiloApiKey?: AISecretPatch;
         googleApiKey: AISecretPatch;
         googleCloudProject?: string;
@@ -1242,6 +1243,7 @@ interface ChatStore {
         codexApiKey: AISecretPatch;
         openaiApiKey: AISecretPatch;
         geminiApiKey: AISecretPatch;
+        xaiApiKey?: AISecretPatch;
         kiloApiKey?: AISecretPatch;
         googleApiKey: AISecretPatch;
         googleCloudProject?: string;
@@ -7455,6 +7457,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     secretPatchChanged(input.openaiApiKey) ||
                     secretPatchChanged(input.geminiApiKey) ||
                     secretPatchChanged(
+                        input.xaiApiKey ?? { action: "unchanged" },
+                    ) ||
+                    secretPatchChanged(
                         input.kiloApiKey ?? { action: "unchanged" },
                     ) ||
                     secretPatchChanged(input.googleApiKey) ||
@@ -7476,6 +7481,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         codexApiKey: input.codexApiKey,
                         openaiApiKey: input.openaiApiKey,
                         geminiApiKey: input.geminiApiKey,
+                        xaiApiKey: input.xaiApiKey,
                         kiloApiKey: input.kiloApiKey,
                         googleApiKey: input.googleApiKey,
                         googleCloudProject: input.googleCloudProject,

--- a/apps/desktop/src/features/ai/utils/authMethods.test.ts
+++ b/apps/desktop/src/features/ai/utils/authMethods.test.ts
@@ -15,6 +15,9 @@ describe("authMethods", () => {
                 "login_with_google",
             ),
         ).toBe(true);
+        expect(isIntegratedTerminalAuthMethod("grok-acp", "grok-login")).toBe(
+            true,
+        );
         expect(isIntegratedTerminalAuthMethod("kilo-acp", "kilo-login")).toBe(
             true,
         );
@@ -31,6 +34,9 @@ describe("authMethods", () => {
             isIntegratedTerminalAuthMethod("gemini-acp", "kilo-login"),
         ).toBe(false);
         expect(
+            isIntegratedTerminalAuthMethod("grok-acp", "xai-api-key"),
+        ).toBe(false);
+        expect(
             isIntegratedTerminalAuthMethod("codex-acp", "kilo-login"),
         ).toBe(false);
         expect(
@@ -43,6 +49,7 @@ describe("authMethods", () => {
         expect(isIntegratedTerminalAuthMethodId("login_with_google")).toBe(
             true,
         );
+        expect(isIntegratedTerminalAuthMethodId("grok-login")).toBe(true);
         expect(isIntegratedTerminalAuthMethodId("kilo-login")).toBe(true);
         expect(isIntegratedTerminalAuthMethodId("opencode-login")).toBe(true);
         expect(isIntegratedTerminalAuthMethodId("openai-api-key")).toBe(false);

--- a/apps/desktop/src/features/ai/utils/authMethods.ts
+++ b/apps/desktop/src/features/ai/utils/authMethods.ts
@@ -24,6 +24,10 @@ export function isIntegratedTerminalAuthMethod(
         return methodId === "login_with_google";
     }
 
+    if (runtimeId === "grok-acp") {
+        return methodId === "grok-login";
+    }
+
     if (runtimeId === "kilo-acp") {
         return methodId === "kilo-login";
     }
@@ -39,6 +43,7 @@ export function isIntegratedTerminalAuthMethodId(methodId?: string) {
     return (
         isClaudeTerminalAuthMethodId(methodId) ||
         methodId === "login_with_google" ||
+        methodId === "grok-login" ||
         methodId === "kilo-login" ||
         methodId === "opencode-login"
     );

--- a/apps/desktop/src/features/ai/utils/runtimeMetadata.test.ts
+++ b/apps/desktop/src/features/ai/utils/runtimeMetadata.test.ts
@@ -19,6 +19,11 @@ describe("runtimeMetadata", () => {
                     name: "OpenCode",
                     company: "OpenCode",
                 }),
+                expect.objectContaining({
+                    id: "grok-acp",
+                    name: "Grok",
+                    company: "xAI",
+                }),
             ]),
         );
     });
@@ -41,6 +46,20 @@ describe("runtimeMetadata", () => {
                             "OpenCode CLI running as a native ACP agent.",
                     }),
                 }),
+                expect.objectContaining({
+                    runtime: expect.objectContaining({
+                        id: "grok-acp",
+                        name: "Grok ACP",
+                        description: "Grok CLI running as a native ACP agent.",
+                        capabilities: expect.arrayContaining([
+                            "attachments",
+                            "permissions",
+                            "plans",
+                            "terminal_output",
+                            "create_session",
+                        ]),
+                    }),
+                }),
             ]),
         );
     });
@@ -59,6 +78,7 @@ describe("runtimeMetadata", () => {
     it("normalizes runtime display names for the UI", () => {
         expect(getRuntimeDisplayName("kilo-acp", "Kilo ACP")).toBe("Kilo");
         expect(getRuntimeDisplayName("kilo-acp")).toBe("Kilo");
+        expect(getRuntimeDisplayName("grok-acp")).toBe("Grok");
         expect(getRuntimeDisplayName("opencode-acp")).toBe("OpenCode");
         expect(getRuntimeDisplayName(undefined, undefined)).toBe("Assistant");
     });

--- a/apps/desktop/src/features/ai/utils/runtimeMetadata.ts
+++ b/apps/desktop/src/features/ai/utils/runtimeMetadata.ts
@@ -57,6 +57,19 @@ const RUNTIME_METADATA: RuntimeMetadata[] = [
         ],
     },
     {
+        id: "grok-acp",
+        name: "Grok",
+        company: "xAI",
+        description: "Grok CLI running as a native ACP agent.",
+        capabilities: [
+            "attachments",
+            "permissions",
+            "plans",
+            "terminal_output",
+            "create_session",
+        ],
+    },
+    {
         id: "kilo-acp",
         name: "Kilo",
         company: "Kilo Code",

--- a/apps/desktop/src/features/editor/editorTabIcons.test.tsx
+++ b/apps/desktop/src/features/editor/editorTabIcons.test.tsx
@@ -4,6 +4,36 @@ import { renderComponent } from "../../test/test-utils";
 import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 
 describe("renderEditorTabLeadingIcon", () => {
+    it("uses the Grok logo shape for Grok chat tabs", () => {
+        const tab: Tab = {
+            id: "chat-grok",
+            kind: "ai-chat",
+            sessionId: "session-grok",
+            title: "Grok",
+        };
+
+        const { container } = renderComponent(
+            <>
+                {renderEditorTabLeadingIcon(tab, {
+                    "session-grok": { runtimeId: "grok-acp" },
+                })}
+            </>,
+        );
+
+        const svg = container.querySelector("svg");
+        const pathData = Array.from(svg?.querySelectorAll("path") ?? []).map(
+            (path) => path.getAttribute("d"),
+        );
+
+        expect(svg?.getAttribute("viewBox")).toBe("0 0 16 16");
+        expect(pathData).toContain(
+            "M3.25 8a4.75 4.75 0 1 1 4.75 4.75",
+        );
+        expect(pathData).toContain("M8 3.25v4.75h4.75");
+        expect(pathData).toContain("M4.4 11.6 11.6 4.4");
+        expect(svg?.querySelector("line")).toBeNull();
+    });
+
     it("uses the official OpenCode logo shape for OpenCode chat tabs", () => {
         const tab: Tab = {
             id: "chat-opencode",

--- a/apps/desktop/src/features/editor/editorTabIcons.tsx
+++ b/apps/desktop/src/features/editor/editorTabIcons.tsx
@@ -110,6 +110,25 @@ function ChatProviderIcon({ runtimeId }: { readonly runtimeId: string }) {
         );
     }
 
+    if (runtimeId.includes("grok")) {
+        return (
+            <svg
+                className="shrink-0 opacity-55"
+                fill="none"
+                height={12}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                viewBox="0 0 16 16"
+                width={12}
+            >
+                <path d="M3.25 8a4.75 4.75 0 1 1 4.75 4.75" strokeWidth="1.1" />
+                <path d="M8 3.25v4.75h4.75" strokeWidth="1.1" />
+                <path d="M4.4 11.6 11.6 4.4" strokeWidth="1" />
+            </svg>
+        );
+    }
+
     return (
         <svg
             className="shrink-0 opacity-55"

--- a/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
@@ -7,6 +7,7 @@ import type {
     AIRuntimeSetupStatus,
 } from "../ai/types";
 import { AIProvidersSettings } from "./AIProvidersSettings";
+import { createSettingsSearchQuery } from "./settingsSearch";
 
 const apiMocks = vi.hoisted(() => ({
     aiGetEnvironmentDiagnostics: vi.fn(),
@@ -159,6 +160,30 @@ function addOpenCodeProvider(
                 name: "OpenCode auth",
                 description:
                     "Use providers and credentials configured by the OpenCode CLI.",
+            },
+        ],
+        ...statusOverrides,
+    });
+}
+
+function addGrokProvider(
+    providers: ReturnType<typeof createDefaultProviders>,
+    statusOverrides: Partial<AIRuntimeSetupStatus> = {},
+) {
+    providers.descriptors.push(createRuntimeDescriptor("grok-acp", "Grok ACP"));
+    providers.statuses["grok-acp"] = createSetupStatus({
+        runtimeId: "grok-acp",
+        binarySource: "env",
+        authMethods: [
+            {
+                id: "grok-login",
+                name: "Grok login",
+                description: "Open a terminal-based Grok login flow.",
+            },
+            {
+                id: "xai-api-key",
+                name: "xAI API key",
+                description: "Use an xAI API key stored only for NeverWrite.",
             },
         ],
         ...statusOverrides,
@@ -547,6 +572,40 @@ describe("AIProvidersSettings", () => {
         expect(apiMocks.aiStartAuthTerminalSession).not.toHaveBeenCalled();
     });
 
+    it("submits Grok xAI API keys without opening terminal auth", async () => {
+        const providers = createDefaultProviders();
+        addGrokProvider(providers);
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("Grok");
+        fireEvent.click(getButtonFromText("xAI API key"));
+        fireEvent.change(screen.getByPlaceholderText("xAI API key"), {
+            target: { value: "xai-secret" },
+        });
+        fireEvent.click(
+            screen.getByRole("button", { name: "Save and connect" }),
+        );
+
+        await waitFor(() => {
+            expect(apiMocks.aiUpdateSetup).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    runtimeId: "grok-acp",
+                    xaiApiKey: {
+                        action: "set",
+                        value: "xai-secret",
+                    },
+                }),
+            );
+        });
+        expect(apiMocks.aiStartAuth).toHaveBeenCalledWith(
+            { methodId: "xai-api-key", runtimeId: "grok-acp" },
+            null,
+        );
+        expect(apiMocks.aiStartAuthTerminalSession).not.toHaveBeenCalled();
+    });
+
     it("expands a provider row even when setup status failed to load", async () => {
         const providers = createDefaultProviders();
         apiMocks.aiListRuntimes.mockResolvedValue(providers.descriptors);
@@ -603,6 +662,83 @@ describe("AIProvidersSettings", () => {
                 customBinaryPath: undefined,
             });
         });
+    });
+
+    it("opens integrated terminal auth for Grok providers", async () => {
+        const providers = createDefaultProviders();
+        addGrokProvider(providers);
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("Grok");
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open sign-in terminal" }),
+        );
+
+        await waitFor(() => {
+            expect(apiMocks.aiStartAuthTerminalSession).toHaveBeenCalledWith({
+                runtimeId: "grok-acp",
+                methodId: "grok-login",
+                vaultPath: null,
+                customBinaryPath: undefined,
+            });
+        });
+    });
+
+    it("preflights a Grok custom binary path before opening terminal auth", async () => {
+        const providers = createDefaultProviders();
+        addGrokProvider(providers);
+        mockProviders(providers);
+
+        renderComponent(<AIProvidersSettings />);
+
+        await openProvider("Grok");
+        fireEvent.change(screen.getByLabelText("Runtime binary"), {
+            target: { value: "/Users/jfg/.grok/bin/grok" },
+        });
+        fireEvent.click(
+            screen.getByRole("button", { name: "Open sign-in terminal" }),
+        );
+
+        await waitFor(() => {
+            expect(apiMocks.aiUpdateSetup).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    runtimeId: "grok-acp",
+                    customBinaryPath: "/Users/jfg/.grok/bin/grok",
+                    xaiApiKey: { action: "unchanged" },
+                    kiloApiKey: { action: "unchanged" },
+                    anthropicApiKey: { action: "unchanged" },
+                }),
+            );
+            expect(apiMocks.aiStartAuthTerminalSession).toHaveBeenCalledWith({
+                runtimeId: "grok-acp",
+                methodId: "grok-login",
+                vaultPath: null,
+                customBinaryPath: "/Users/jfg/.grok/bin/grok",
+            });
+        });
+
+        expect(
+            apiMocks.aiUpdateSetup.mock.invocationCallOrder[0],
+        ).toBeLessThan(
+            apiMocks.aiStartAuthTerminalSession.mock.invocationCallOrder[0],
+        );
+    });
+
+    it("finds Grok providers by xAI runtime setup search values", async () => {
+        mockProviders(createDefaultProviders());
+
+        renderComponent(
+            <AIProvidersSettings
+                searchQuery={createSettingsSearchQuery(
+                    "NEVERWRITE_GROK_ACP_BIN",
+                )}
+            />,
+        );
+
+        expect((await screen.findAllByText("Grok")).length).toBeGreaterThan(0);
+        expect(screen.queryByText("OpenCode")).not.toBeInTheDocument();
     });
 
     it("lists OpenCode in the provider catalog before it is installed", async () => {

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -86,6 +86,7 @@ function getShortMethodDesc(id: string): string {
         case "claude-ai-login":
         case "console-login":
         case "claude-login":
+        case "grok-login":
         case "kilo-login":
         case OPENCODE_AUTH_METHOD_ID:
             return "Terminal sign-in";
@@ -122,6 +123,8 @@ function getAuthHelpText(id: string): string {
             return "Opens a sign-in terminal for Anthropic Console inside the app.";
         case "claude-login":
             return "Opens a sign-in terminal inside the app.";
+        case "grok-login":
+            return "Opens a Grok sign-in terminal inside the app.";
         case "kilo-login":
             return "Opens a Kilo sign-in terminal inside the app.";
         case OPENCODE_AUTH_METHOD_ID:
@@ -167,6 +170,7 @@ function getActionLabel(
     if (methodId === "chatgpt") return "Continue with ChatGPT";
     if (isClaudeTerminalAuthMethodId(methodId)) return "Open sign-in terminal";
     if (methodId === "login_with_google") return "Open sign-in terminal";
+    if (methodId === "grok-login") return "Open sign-in terminal";
     if (methodId === "kilo-login") return "Open sign-in terminal";
     if (methodId === OPENCODE_AUTH_METHOD_ID) return "Open sign-in terminal";
     if (isApiKeyMethod(methodId)) {

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -44,6 +44,7 @@ import type {
 
 const OPENCODE_RUNTIME_ID = "opencode-acp";
 const OPENCODE_AUTH_METHOD_ID = "opencode-login";
+const GROK_RUNTIME_ID = "grok-acp";
 
 function getErrorMessage(error: unknown, fallback: string): string {
     if (error instanceof Error && error.message.trim()) return error.message;
@@ -244,12 +245,15 @@ function setSecretPatch(value: string): AISecretPatch {
 }
 
 function supportsRuntimeBinaryOverride(runtimeId: string): boolean {
-    return runtimeId === OPENCODE_RUNTIME_ID;
+    return runtimeId === OPENCODE_RUNTIME_ID || runtimeId === GROK_RUNTIME_ID;
 }
 
 function getRuntimeBinaryPlaceholder(runtimeId: string): string {
     if (runtimeId === OPENCODE_RUNTIME_ID) {
         return "Custom OpenCode runtime path, for example opencode";
+    }
+    if (runtimeId === GROK_RUNTIME_ID) {
+        return "Custom Grok runtime path, for example grok";
     }
     return "Custom runtime path";
 }
@@ -257,6 +261,9 @@ function getRuntimeBinaryPlaceholder(runtimeId: string): string {
 function getRuntimeBinaryHelpText(runtimeId: string): string {
     if (runtimeId === OPENCODE_RUNTIME_ID) {
         return "Leave empty to use opencode from PATH.";
+    }
+    if (runtimeId === GROK_RUNTIME_ID) {
+        return "Leave empty to use grok from PATH.";
     }
     return "Leave empty to use the bundled runtime or PATH.";
 }
@@ -335,6 +342,15 @@ function getProviderSearchValues(
             ? getRuntimeBinaryHelpText(provider.id)
             : undefined,
         provider.id === OPENCODE_RUNTIME_ID ? "opencode acp" : undefined,
+        provider.id === GROK_RUNTIME_ID ? "grok acp" : undefined,
+        provider.id === GROK_RUNTIME_ID ? "xAI" : undefined,
+        provider.id === GROK_RUNTIME_ID ? "XAI_API_KEY" : undefined,
+        provider.id === GROK_RUNTIME_ID
+            ? "grok --no-auto-update agent stdio"
+            : undefined,
+        provider.id === GROK_RUNTIME_ID
+            ? "NEVERWRITE_GROK_ACP_BIN"
+            : undefined,
         getMethodDisplayName(setupStatus),
         error,
         ...(setupStatus?.authMethods.flatMap((method) => [

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -57,6 +57,7 @@ function isApiKeyMethod(id?: string) {
         id === "codex-api-key" ||
         id === "anthropic-api-key" ||
         id === "use_gemini" ||
+        id === "xai-api-key" ||
         id === "kilo-api-key"
     );
 }
@@ -102,6 +103,8 @@ function getShortMethodDesc(id: string): string {
             return "Google sign-in";
         case "use_gemini":
             return "Gemini API key";
+        case "xai-api-key":
+            return "xAI API key";
         case "kilo-api-key":
             return "Kilo API key";
         default:
@@ -137,6 +140,8 @@ function getAuthHelpText(id: string): string {
             return "Opens a Gemini sign-in terminal inside the app.";
         case "use_gemini":
             return `Store a Gemini API key locally for ${APP_BRAND_NAME} only.`;
+        case "xai-api-key":
+            return `Store an xAI API key locally for ${APP_BRAND_NAME} only.`;
         case "kilo-api-key":
             return `Store a Kilo API key locally for ${APP_BRAND_NAME} only.`;
         default:
@@ -149,6 +154,7 @@ function getApiKeyPlaceholder(id?: string): string {
     if (id === "openai-api-key") return "OpenAI API key";
     if (id === "anthropic-api-key") return "Anthropic API key";
     if (id === "use_gemini") return "Gemini API key";
+    if (id === "xai-api-key") return "xAI API key";
     if (id === "kilo-api-key") return "Kilo API key";
     return "API key";
 }
@@ -217,6 +223,7 @@ interface ProviderAuthInput {
     codexApiKey: AISecretPatch;
     openaiApiKey: AISecretPatch;
     geminiApiKey: AISecretPatch;
+    xaiApiKey: AISecretPatch;
     kiloApiKey: AISecretPatch;
     anthropicBaseUrl?: string;
     anthropicBedrockBaseUrl?: string;
@@ -272,6 +279,7 @@ function hasPendingSetupUpdate(input: ProviderAuthInput): boolean {
         input.codexApiKey.action !== "unchanged" ||
         input.openaiApiKey.action !== "unchanged" ||
         input.geminiApiKey.action !== "unchanged" ||
+        input.xaiApiKey.action !== "unchanged" ||
         input.kiloApiKey.action !== "unchanged" ||
         input.anthropicApiKey.action !== "unchanged" ||
         input.anthropicBaseUrl !== undefined ||
@@ -548,6 +556,7 @@ function ProviderExpandedPanel({
     const isCodex = selectedMethodId === "codex-api-key";
     const isAnthropic = selectedMethodId === "anthropic-api-key";
     const isGemini = selectedMethodId === "use_gemini";
+    const isXai = selectedMethodId === "xai-api-key";
     const isKilo = selectedMethodId === "kilo-api-key";
     const gatewayUrlError = gatewaySelected
         ? getClaudeGatewayUrlValidationMessage(gatewayUrl)
@@ -574,6 +583,7 @@ function ProviderExpandedPanel({
             geminiApiKey: isGemini
                 ? setSecretPatch(apiKey)
                 : unchangedSecretPatch,
+            xaiApiKey: isXai ? setSecretPatch(apiKey) : unchangedSecretPatch,
             kiloApiKey: isKilo ? setSecretPatch(apiKey) : unchangedSecretPatch,
             anthropicApiKey: isAnthropic
                 ? setSecretPatch(apiKey)
@@ -1121,6 +1131,7 @@ export function AIProvidersSettings({
                         codexApiKey: input.codexApiKey,
                         openaiApiKey: input.openaiApiKey,
                         geminiApiKey: input.geminiApiKey,
+                        xaiApiKey: input.xaiApiKey,
                         kiloApiKey: input.kiloApiKey,
                         googleApiKey: unchangedSecretPatch,
                         googleCloudProject: undefined,
@@ -1223,6 +1234,7 @@ export function AIProvidersSettings({
                     codexApiKey: unchangedSecretPatch,
                     openaiApiKey: unchangedSecretPatch,
                     geminiApiKey: unchangedSecretPatch,
+                    xaiApiKey: unchangedSecretPatch,
                     googleApiKey: unchangedSecretPatch,
                     googleCloudProject: undefined,
                     googleCloudLocation: undefined,

--- a/crates/ai/src/domain.rs
+++ b/crates/ai/src/domain.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub const CODEX_RUNTIME_ID: &str = "codex-acp";
 pub const CLAUDE_RUNTIME_ID: &str = "claude-acp";
 pub const GEMINI_RUNTIME_ID: &str = "gemini-acp";
+pub const GROK_RUNTIME_ID: &str = "grok-acp";
 pub const KILO_RUNTIME_ID: &str = "kilo-acp";
 pub const OPENCODE_RUNTIME_ID: &str = "opencode-acp";
 

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -1150,6 +1150,45 @@ mod tests {
     }
 
     #[test]
+    fn grok_like_acp_content_diffs_remain_text_and_reversible_for_review() {
+        let call = ToolCall::new(ToolCallId::from("grok-tool-1"), "Edit Grok files")
+            .kind(ToolKind::Edit)
+            .status(ToolCallStatus::Completed)
+            .content(vec![
+                ToolCallContent::Diff(Diff::new("notes/existing.md", "new").old_text("old")),
+                ToolCallContent::Diff(Diff::new("notes/new.md", "created")),
+                ToolCallContent::Diff(Diff::new("notes/removed.md", "").old_text("removed")),
+                ToolCallContent::Diff(Diff::new("notes/renamed.md", "body").old_text("body").meta(
+                    Meta::from_iter([(
+                        ACP_DIFF_PREVIOUS_PATH_KEY.to_string(),
+                        serde_json::json!("notes/original.md"),
+                    )]),
+                )),
+            ]);
+
+        let diffs = collect_tool_call_diffs(&call, None);
+
+        assert_eq!(diffs.len(), 4);
+        for diff in &diffs {
+            assert!(
+                diff.is_text,
+                "Grok ACP review diffs must remain text-trackable: {diff:?}"
+            );
+            assert!(
+                diff.reversible,
+                "Grok ACP review diffs must remain reversible: {diff:?}"
+            );
+        }
+        assert_eq!(
+            diffs
+                .iter()
+                .map(|diff| diff.kind.as_str())
+                .collect::<Vec<_>>(),
+            vec!["update", "add", "delete", "move"]
+        );
+    }
+
+    #[test]
     fn content_diff_extracts_hunks_from_meta() {
         let call = ToolCall::new(ToolCallId::from("tool-1"), "Edit file")
             .kind(ToolKind::Edit)

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ polish and hardening.
 
 - [AI Change Control](ai-change-control.md): the ActionLog model, tracked files, pending review, keep/reject flows, inline review, conflicts, persistence, and known limits.
 - [Review Hardening Checklist](review-hardening-checklist.md): manual QA checklist for inline review, Review tab, Edits surface, keep/reject, lifecycle cases, multi-session, reload/recovery, conflicts, performance, and release sign-off.
-- [AI Runtime Setup](ai-runtime-setup.md): ACP providers, runtime discovery, authentication methods, `NEVERWRITE_*` overrides, release bundling, and troubleshooting for Codex, Claude, Gemini, Kilo, and OpenCode.
+- [AI Runtime Setup](ai-runtime-setup.md): ACP providers, runtime discovery, authentication methods, `NEVERWRITE_*` overrides, release bundling, and troubleshooting for Codex, Claude, Gemini, Grok, Kilo, and OpenCode.
 - [AI Session History And Crash Recovery](ai-session-history.md): where chat transcripts are stored, how restore/fork/reconnect works, and what to check after a crash.
 
 Read these before changing AI editing behavior, provider setup, session
@@ -52,4 +52,4 @@ tokens, provider credentials, or personally sensitive paths.
 These currently live next to their implementation/release artifacts because
 they are tightly coupled to package-specific workflows.
 
-Last updated: June 1, 2026.
+Last updated: June 2, 2026.

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -178,8 +178,10 @@ auth-method error.
 Saved xAI API keys live in the OS keyring as `XAI_API_KEY`; they are not written
 to `ai/runtime-setup.json`. The JSON setup file only records the selected auth
 method and secret-key marker. If the app process inherits `XAI_API_KEY`, that
-environment value wins over any stored keyring secret and NeverWrite does not
-delete or overwrite the inherited environment variable.
+environment value is preferred by default. A locally saved xAI key that is
+selected and ready is passed to the Grok ACP process explicitly, so it can
+recover from an inherited `XAI_API_KEY` that NeverWrite has marked invalid.
+NeverWrite does not delete or overwrite the inherited environment variable.
 
 Disconnecting Grok in NeverWrite clears local NeverWrite setup state. For stored
 xAI API keys, it also deletes the local keyring secret. For Grok CLI login, it

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -26,9 +26,12 @@ and terminal-auth routing helpers are in
 | `kilo-acp` | `kilo acp` | No. Must be available from PATH or a configured binary override. | Kilo terminal login |
 | `opencode-acp` | `opencode acp` | No. Must be available from PATH or a configured binary override. | OpenCode terminal login |
 
-Runtime descriptors returned by the backend currently use default `auto` model
-selection and `default` / `review` modes for every provider. The frontend falls
-back to the static catalog if backend inventory cannot be loaded.
+Runtime descriptors returned by the backend use default `auto` model selection.
+Providers only show modes and slash commands that are either declared by ACP or
+kept as provider-owned fallback behavior. Grok does not receive synthetic
+`default` / `review` modes or hardcoded slash commands when its ACP runtime does
+not advertise them. The frontend falls back to the static catalog if backend
+inventory cannot be loaded.
 
 ## Runtime Discovery
 

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -22,7 +22,7 @@ and terminal-auth routing helpers are in
 | `codex-acp` | `codex-acp` | Yes. Staged as a sidecar binary. | ChatGPT account, OpenAI API key, Codex API key |
 | `claude-acp` | Claude ACP adapter | Yes. Staged as vendored JS plus embedded Node. | Claude subscription terminal login, Anthropic Console terminal login, Anthropic API key, custom Anthropic-compatible gateway |
 | `gemini-acp` | `gemini --acp` | No. Must be available from PATH or a configured binary override. | Google terminal login, Gemini API key |
-| `grok-acp` | `grok --no-auto-update agent stdio` | No. Must be available from PATH or a configured binary override. | Planned: Grok login, xAI API key |
+| `grok-acp` | `grok --no-auto-update agent stdio` | No. Must be available from PATH or a configured binary override. | Grok terminal login, xAI API key |
 | `kilo-acp` | `kilo acp` | No. Must be available from PATH or a configured binary override. | Kilo terminal login |
 | `opencode-acp` | `opencode acp` | No. Must be available from PATH or a configured binary override. | OpenCode terminal login |
 
@@ -77,6 +77,7 @@ The backend also detects existing CLI auth files and environment secrets:
 | Codex | `CODEX_API_KEY`, `OPENAI_API_KEY`, or non-empty `~/.codex/auth.json` |
 | Claude | `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_BEDROCK_BASE_URL`, or non-empty `~/.claude.json` |
 | Gemini | `GEMINI_API_KEY`, `GOOGLE_API_KEY`, or non-empty `~/.gemini/oauth_creds.json` |
+| Grok | `XAI_API_KEY` or active non-empty Grok CLI auth under `~/.grok/`, currently `~/.grok/auth.json` |
 | Kilo | Non-empty Kilo auth file, including `~/.local/share/kilo/auth.json` on Unix-like systems |
 | OpenCode | `OPENCODE_API_KEY`, provider keys inherited by OpenCode, or active `opencode/auth.json` in the platform data directory |
 
@@ -84,11 +85,12 @@ Codex ChatGPT auth is implemented through the ACP `authenticate` request and
 requires a resolved Codex runtime binary before NeverWrite marks it connected.
 Codex does not use the integrated auth terminal.
 
-Claude, Gemini, Kilo, and OpenCode expose integrated terminal auth methods.
+Claude, Gemini, Grok, Kilo, and OpenCode expose integrated terminal auth methods.
 NeverWrite starts the provider CLI in a PTY and marks auth pending before
 launch. A zero exit code marks the provider verified; Gemini and OpenCode can
 also be marked verified when terminal output contains success strings recognized
-by the backend.
+by the backend. Grok is marked verified when `grok login` exits successfully or
+prints recognized success output.
 
 Claude adapts its visible terminal login methods to the environment. In remote
 or no-browser environments (`NO_BROWSER`, `SSH_CONNECTION`, `SSH_CLIENT`,
@@ -149,6 +151,39 @@ methods: `oauth-personal` for Google login and `gemini-api-key` for API-key
 auth. `GOOGLE_CLOUD_PROJECT` and `GOOGLE_CLOUD_LOCATION` are supported in the
 backend setup payload, but the current provider settings UI does not expose
 fields for them.
+
+### Grok
+
+Use one of:
+
+- Grok terminal login from the setup UI, exposed as `grok-login`.
+- xAI API key saved in the setup UI, exposed as `xai-api-key` and stored as `XAI_API_KEY`.
+- Existing Grok CLI auth under `~/.grok/`, currently `~/.grok/auth.json`.
+- Process environment `XAI_API_KEY`.
+
+Because Grok is not bundled by default, install the Grok CLI separately or
+configure `NEVERWRITE_GROK_ACP_BIN`. NeverWrite launches sessions as
+`grok --no-auto-update agent stdio` and opens terminal auth as `grok login`.
+
+Grok requires ACP authentication inside the same runtime process that opens the
+session. Before `session/new`, NeverWrite sends `authenticate` with
+`xai.api_key` for API-key auth and `cached_token` for Grok CLI login auth. If
+the running Grok ACP process does not advertise the selected method during
+`initialize`, setup remains local but session startup fails with an explicit
+auth-method error.
+
+Saved xAI API keys live in the OS keyring as `XAI_API_KEY`; they are not written
+to `ai/runtime-setup.json`. The JSON setup file only records the selected auth
+method and secret-key marker. If the app process inherits `XAI_API_KEY`, that
+environment value wins over any stored keyring secret and NeverWrite does not
+delete or overwrite the inherited environment variable.
+
+Disconnecting Grok in NeverWrite clears local NeverWrite setup state. For stored
+xAI API keys, it also deletes the local keyring secret. For Grok CLI login, it
+records a local invalidation marker so stale `~/.grok/auth.json` credentials are
+not immediately rehydrated, but it does not remotely log out of Grok or delete
+Grok's CLI auth files. Use the Grok CLI, or remove its auth file yourself, when
+you need a full remote/provider logout.
 
 ### Kilo
 
@@ -227,10 +262,11 @@ npm run electron:sidecar:build
 npm run electron:ai-runtime:smoke
 ```
 
-The smoke test creates a fake ACP runtime, uses
+The smoke test creates fake ACP runtimes, uses
 `NEVERWRITE_AI_SECRET_STORE=memory` by default, validates runtime inventory,
 setup status, diagnostics, session creation, ACP streaming, persisted history,
-and the Codex auth-terminal rejection path.
+the Codex auth-terminal rejection path, and the Grok ACP auth handshake plus
+reversible text-diff path.
 
 ## Release Packaging
 
@@ -279,7 +315,7 @@ Common fixes:
 - Set the provider-specific `NEVERWRITE_*_ACP_BIN` variable before launching the app.
 - Supply a custom binary path through `ai_update_setup` if you are exercising
   the backend API directly or a caller that exposes this field.
-- For Gemini, Kilo, or OpenCode, install the CLI separately; they are not bundled in releases.
+- For Gemini, Grok, Kilo, or OpenCode, install the CLI separately; they are not bundled in releases.
 - For packaged Codex or Claude, check that `native-backend/binaries/` and
   `native-backend/embedded/` exist inside the packaged app resources.
 
@@ -296,12 +332,15 @@ reconnected or configured through environment variables.
 
 ### Provider Terminal Auth
 
-Integrated terminal auth is supported for Claude, Gemini, Kilo, and OpenCode. If terminal
-auth opens but the provider remains unready:
+Integrated terminal auth is supported for Claude, Gemini, Grok, Kilo, and
+OpenCode. If terminal auth opens but the provider remains unready:
 
 - Confirm the terminal process exited successfully.
 - For Gemini, look for provider success output such as authentication succeeded
   or successful Google sign-in.
+- For Grok, confirm `grok login` completed successfully and that active CLI auth
+  exists under `~/.grok/`, currently `~/.grok/auth.json`. You can also configure
+  `XAI_API_KEY` through the setup UI or the process environment.
 - For OpenCode, confirm `opencode auth login` completed or use `/connect` in
   OpenCode itself.
 - Reopen diagnostics and confirm the runtime launch command points to the CLI
@@ -373,4 +412,4 @@ cd apps/desktop
 npm run electron:package:unsigned
 ```
 
-Last updated: June 1, 2026.
+Last updated: June 2, 2026.

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -22,6 +22,7 @@ and terminal-auth routing helpers are in
 | `codex-acp` | `codex-acp` | Yes. Staged as a sidecar binary. | ChatGPT account, OpenAI API key, Codex API key |
 | `claude-acp` | Claude ACP adapter | Yes. Staged as vendored JS plus embedded Node. | Claude subscription terminal login, Anthropic Console terminal login, Anthropic API key, custom Anthropic-compatible gateway |
 | `gemini-acp` | `gemini --acp` | No. Must be available from PATH or a configured binary override. | Google terminal login, Gemini API key |
+| `grok-acp` | `grok --no-auto-update agent stdio` | No. Must be available from PATH or a configured binary override. | Planned: Grok login, xAI API key |
 | `kilo-acp` | `kilo acp` | No. Must be available from PATH or a configured binary override. | Kilo terminal login |
 | `opencode-acp` | `opencode acp` | No. Must be available from PATH or a configured binary override. | OpenCode terminal login |
 
@@ -38,6 +39,7 @@ For every provider, the backend resolves the runtime command in this order:
 3. Packaged release resources, when available.
 4. Development vendor fallback for Codex and Claude.
 5. A command found on the app process `PATH`.
+6. macOS Homebrew fallback paths for Grok and OpenCode.
 
 The provider-specific runtime binary overrides are:
 
@@ -46,12 +48,14 @@ The provider-specific runtime binary overrides are:
 | `NEVERWRITE_CODEX_ACP_BIN` | Codex |
 | `NEVERWRITE_CLAUDE_ACP_BIN` | Claude |
 | `NEVERWRITE_GEMINI_ACP_BIN` | Gemini |
+| `NEVERWRITE_GROK_ACP_BIN` | Grok |
 | `NEVERWRITE_KILO_ACP_BIN` | Kilo |
 | `NEVERWRITE_OPENCODE_ACP_BIN` | OpenCode |
 
 The values may be absolute paths or command names resolvable on `PATH`. For
-Gemini, Kilo, and OpenCode, NeverWrite appends the ACP arguments automatically:
-`gemini --acp`, `kilo acp`, and `opencode acp`.
+Gemini, Grok, Kilo, and OpenCode, NeverWrite appends the ACP arguments automatically:
+`gemini --acp`, `grok --no-auto-update agent stdio`, `kilo acp`, and
+`opencode acp`.
 
 Packaged builds use `NEVERWRITE_ELECTRON_ACP_RESOURCE_DIR` internally to point
 the native backend at staged Electron resources. In normal app usage this is set
@@ -174,6 +178,7 @@ These `NEVERWRITE_*` variables are relevant to AI runtime setup and packaging:
 | `NEVERWRITE_CODEX_ACP_BIN` | Runtime launch override for Codex in dev or local troubleshooting. |
 | `NEVERWRITE_CLAUDE_ACP_BIN` | Runtime launch override for Claude in dev or local troubleshooting. |
 | `NEVERWRITE_GEMINI_ACP_BIN` | Runtime launch override for Gemini in dev or local troubleshooting. |
+| `NEVERWRITE_GROK_ACP_BIN` | Runtime launch override for Grok in dev or local troubleshooting. |
 | `NEVERWRITE_KILO_ACP_BIN` | Runtime launch override for Kilo in dev or local troubleshooting. |
 | `NEVERWRITE_OPENCODE_ACP_BIN` | Runtime launch override for OpenCode in dev or local troubleshooting. |
 | `NEVERWRITE_APP_DATA_DIR` | Overrides app data storage, including `ai/runtime-setup.json`; Electron sets this for the sidecar. |
@@ -256,6 +261,7 @@ Current packaging expectations:
 - Codex is bundled as a native sidecar binary.
 - Claude is bundled through embedded Node plus vendored runtime files.
 - Gemini is integrated but not bundled by default.
+- Grok is integrated but not bundled by default.
 - Kilo is integrated but not bundled by default.
 - OpenCode is integrated but not bundled by default.
 
@@ -329,8 +335,8 @@ GUI-launched apps often inherit a different PATH than interactive shells.
 Development can resolve Codex and Claude from vendor paths if those artifacts
 exist. Packaged builds should resolve Codex and Claude from
 `NEVERWRITE_ELECTRON_ACP_RESOURCE_DIR`, which Electron sets to the staged
-resources directory. Gemini, Kilo, and OpenCode still require an external CLI or
-explicit runtime override in both development and packaged builds.
+resources directory. Gemini, Grok, Kilo, and OpenCode still require an external
+CLI or explicit runtime override in both development and packaged builds.
 
 If a provider works in `npm run dev` but not in a packaged app, verify:
 

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -202,10 +202,10 @@ Settings / AI chat UI
   -> chat store, review UI, transcript persistence
 ```
 
-The backend currently supports Codex, Claude, Gemini, Kilo, and OpenCode runtime
-IDs. Codex and Claude have vendored release inputs under `vendor/`; Gemini, Kilo,
-and OpenCode are integrated as external runtimes that must be found on `PATH` or
-configured by override.
+The backend currently supports Codex, Claude, Gemini, Grok, Kilo, and OpenCode
+runtime IDs. Codex and Claude have vendored release inputs under `vendor/`;
+Gemini, Grok, Kilo, and OpenCode are integrated as external runtimes that must
+be found on `PATH` or configured by override.
 
 ACP session notifications are normalized into renderer events for assistant
 message deltas, thinking deltas, tool activity, file diffs, permission requests,

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -139,6 +139,7 @@ For local troubleshooting, the most useful overrides are:
 NEVERWRITE_CODEX_ACP_BIN
 NEVERWRITE_CLAUDE_ACP_BIN
 NEVERWRITE_GEMINI_ACP_BIN
+NEVERWRITE_GROK_ACP_BIN
 NEVERWRITE_KILO_ACP_BIN
 NEVERWRITE_OPENCODE_ACP_BIN
 ```
@@ -148,8 +149,8 @@ Important packaging expectations:
 - Codex is intended to be bundled as a sidecar runtime in release builds.
 - Claude is intended to be bundled through embedded Node plus vendored runtime
   files.
-- Gemini, Kilo, and OpenCode are integrated but not bundled by default, so they
-  need an external CLI or explicit binary override.
+- Gemini, Grok, Kilo, and OpenCode are integrated but not bundled by default, so
+  they need an external CLI or explicit binary override.
 
 If a provider works in your terminal but not in the app:
 
@@ -165,10 +166,12 @@ Secure credential storage is unavailable. Reconnect this AI provider or configur
 
 For terminal auth issues:
 
-- Integrated terminal auth applies to Claude, Gemini, Kilo, and OpenCode. Codex
-  ChatGPT auth does not use the integrated auth terminal.
-- Confirm the terminal process exits successfully. For Gemini and OpenCode,
-  successful auth output can mark the provider verified before exit.
+- Integrated terminal auth applies to Claude, Gemini, Grok, Kilo, and OpenCode.
+  Codex ChatGPT auth does not use the integrated auth terminal.
+- Confirm the terminal process exits successfully. For Gemini, Grok, and
+  OpenCode, successful auth output can mark the provider verified before exit.
+- For Grok, verify `grok login`, `XAI_API_KEY`, or active CLI auth under
+  `~/.grok/`, currently `~/.grok/auth.json`.
 - If the auth terminal cannot start, check whether the configured runtime command
   exists and whether the requested working directory exists.
 - Reopen Diagnostics after auth; setup status is the source of truth.


### PR DESCRIPTION
## Summary
- add Grok as a native ACP provider with setup, auth, runtime metadata, and model/config handling
- preserve ACP-declared controls and slash commands without synthetic Grok defaults
- harden Grok review isolation, tab icon, docs, and smoke/test coverage

## Tests
- cargo test -p neverwrite-native-backend
- npm test -- src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatAgentControls.test.tsx
- npm test -- src/features/editor/editorTabIcons.test.tsx
- npm test -- src/features/settings/AIProvidersSettings.test.tsx src/features/ai/store/chatStore.test.ts -- --runNamePattern "default runtime|Default agent|explicit default|falls back when a persisted default|keeps current runtime|uses the explicit default runtime"
- npx tsc -b --pretty false
- git diff --check

Closes #183