### PR TITLE
Top-align new chat messages

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -204,7 +204,21 @@ describe("AIChatMessageList streaming run indicator", () => {
         });
     });
 
-    it("bottom-aligns short transcripts near the composer", () => {
+    it("keeps empty new chats top-aligned", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-empty"
+                messages={[]}
+                status="idle"
+            />,
+        );
+
+        expect(
+            view.container.querySelector('[data-selectable="true"]'),
+        ).not.toHaveClass("mt-auto");
+    });
+
+    it("keeps short transcripts top-aligned", () => {
         const view = renderComponent(
             <AIChatMessageList
                 sessionId="session-short"
@@ -216,7 +230,7 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(getScrollContainer(view.container)).toHaveClass("flex-col");
         expect(
             view.container.querySelector('[data-selectable="true"]'),
-        ).toHaveClass("mt-auto");
+        ).not.toHaveClass("mt-auto");
     });
 
     it("keeps the transcript top-aligned while older messages can load", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -441,8 +441,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         status,
         visiblePinnedPlan?.id,
     ]);
-    const bottomAlignTranscript = !hasOlderMessages && !isLoadingOlderMessages;
-
     const rowRenderOptions = useMemo(
         () => ({
             sessionId,
@@ -681,7 +679,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 data-scrollbar-active="true"
             >
                 <div
-                    className={`min-w-0 ${bottomAlignTranscript ? "mt-auto" : ""}`}
+                    className="min-w-0"
                     data-selectable="true"
                     style={{
                         fontSize: chatFontSize,


### PR DESCRIPTION
## Summary
- remove the bottom-alignment class from the chat timeline content
- keep empty and short new chat threads top-aligned
- update message list tests to cover empty and short transcripts

## Root cause
Short transcripts were given `mt-auto`, which pushed the first messages of a new thread down toward the composer.

## Validation
- `npm test -- src/features/ai/components/AIChatMessageList.test.tsx`