### PR TITLE
Harden runtime message timeline ordering

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -67,6 +67,8 @@ const ACP_STATUS_EVENT_TYPE_KEY: &str = "neverwriteEventType";
 const ACP_STATUS_KIND_KEY: &str = "neverwriteStatusKind";
 const ACP_STATUS_EMPHASIS_KEY: &str = "neverwriteStatusEmphasis";
 const ACP_IMAGE_GENERATION_EVENT_TYPE: &str = "image_generation";
+const NEVERWRITE_STATUS_EVENT_ID_PREFIX: &str = "neverwrite:status:";
+const NEVERWRITE_STATUS_TURN_EVENT_ID_PREFIX: &str = "neverwrite:status:turn:";
 const CODEX_ACP_EVENT_TYPE_KEY: &str = "codexAcpEventType";
 const CODEX_ACP_PARENT_SESSION_ID_KEY: &str = "codexAcpParentSessionId";
 const CODEX_ACP_CHILD_SESSION_ID_KEY: &str = "codexAcpChildSessionId";
@@ -2426,7 +2428,7 @@ impl NativeAcpClient {
         })
     }
 
-    fn end_text_message(&self, session_id: &str, role: MessageRole) {
+    fn end_text_message(&self, session_id: &str, role: MessageRole, turn_complete: bool) {
         let message_id = self
             .message_ids
             .lock()
@@ -2439,6 +2441,7 @@ impl NativeAcpClient {
                     session_id: session_id.to_string(),
                     message_id,
                     role: role.as_str().to_string(),
+                    turn_complete,
                 },
             );
         }
@@ -2453,7 +2456,11 @@ impl NativeAcpClient {
     }
 
     fn end_message(&self, session_id: &str) {
-        self.end_text_message(session_id, MessageRole::Assistant);
+        self.end_text_message(session_id, MessageRole::Assistant, true);
+    }
+
+    fn end_message_segment(&self, session_id: &str) {
+        self.end_text_message(session_id, MessageRole::Assistant, false);
     }
 
     fn begin_user_message(&self, session_id: &str) -> String {
@@ -2465,9 +2472,16 @@ impl NativeAcpClient {
     }
 
     fn end_user_message(&self, session_id: &str) {
-        self.end_text_message(session_id, MessageRole::User);
+        self.end_text_message(session_id, MessageRole::User, false);
     }
 
+    fn end_text_streams_before_activity(&self, session_id: &str) {
+        self.end_thinking(session_id);
+        self.end_user_message(session_id);
+        self.end_message_segment(session_id);
+    }
+
+    #[cfg(test)]
     fn has_active_text_message(&self, session_id: &str, role: MessageRole) -> bool {
         self.current_text_message_id(session_id, role).is_some()
     }
@@ -2964,6 +2978,7 @@ impl NativeAcpClient {
                 content: ContentBlock::Text(text),
                 ..
             }) => {
+                self.end_user_message(&session_id);
                 let thinking_id = self
                     .current_thinking_id(&session_id)
                     .unwrap_or_else(|| self.begin_thinking(&session_id));
@@ -2975,6 +2990,10 @@ impl NativeAcpClient {
             }
             SessionUpdate::ToolCall(tool_call) => {
                 let tool_call = tool_call_with_merged_meta(tool_call, meta.as_ref());
+                if should_suppress_status_tool_call(&tool_call) {
+                    return Ok(());
+                }
+                self.end_text_streams_before_activity(&session_id);
                 self.record_terminal_meta(
                     &session_id,
                     &tool_call.tool_call_id.0,
@@ -2986,6 +3005,10 @@ impl NativeAcpClient {
             }
             SessionUpdate::ToolCallUpdate(update) => {
                 let update = tool_call_update_with_merged_meta(update, meta.as_ref());
+                if should_suppress_status_tool_call_update(&update) {
+                    return Ok(());
+                }
+                self.end_text_streams_before_activity(&session_id);
                 self.record_terminal_meta(
                     &session_id,
                     &update.tool_call_id.0,
@@ -2997,6 +3020,7 @@ impl NativeAcpClient {
                 self.handle_subagent_lifecycle_breadcrumb(&session_id, meta.as_ref());
             }
             SessionUpdate::Plan(plan) => {
+                self.end_text_streams_before_activity(&session_id);
                 self.emit(
                     AI_PLAN_UPDATED_EVENT,
                     map_plan_update(&session_id, plan, meta.as_ref()),
@@ -4383,6 +4407,44 @@ fn map_status_event(
             .to_string(),
         tool_action,
     })
+}
+
+fn is_suppressed_status_title(title: &str) -> bool {
+    matches!(title.trim(), "Preparing input" | "Drafting response")
+}
+
+fn is_internal_status_activity_id(tool_call_id: &str) -> bool {
+    tool_call_id.starts_with(NEVERWRITE_STATUS_EVENT_ID_PREFIX)
+        && !tool_call_id.starts_with(NEVERWRITE_STATUS_TURN_EVENT_ID_PREFIX)
+}
+
+fn should_suppress_status_tool_call(tool_call: &ToolCall) -> bool {
+    if !is_suppressed_status_title(&tool_call.title) {
+        return false;
+    }
+
+    is_internal_status_activity_id(&tool_call.tool_call_id.0)
+        || tool_call
+            .meta
+            .as_ref()
+            .and_then(acp_event_type)
+            .is_some_and(|event_type| event_type == "status")
+}
+
+fn should_suppress_status_tool_call_update(update: &ToolCallUpdate) -> bool {
+    let Some(title) = update.fields.title.as_deref() else {
+        return false;
+    };
+    if !is_suppressed_status_title(title) {
+        return false;
+    }
+
+    is_internal_status_activity_id(&update.tool_call_id.0)
+        || update
+            .meta
+            .as_ref()
+            .and_then(acp_event_type)
+            .is_some_and(|event_type| event_type == "status")
 }
 
 fn raw_string_field(raw: Option<&Value>, keys: &[&str]) -> Option<String> {
@@ -8330,6 +8392,84 @@ mod tests {
     }
 
     #[test]
+    fn child_user_message_closes_before_child_thinking_starts() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
+        insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, PARENT_RUNTIME_SESSION_ID);
+        let client = test_client_with_state(event_tx, session_state);
+
+        run_client_future(
+            client.session_notification(subagent_child_user_message_notification_fixture()),
+        )
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message started event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_STARTED_EVENT);
+        let user_message_id = payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .expect("user message id")
+            .to_string();
+
+        let RpcOutput::Event { event_name, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message delta event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_DELTA_EVENT);
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            CHILD_RUNTIME_SESSION_ID,
+            SessionUpdate::AgentThoughtChunk(ContentChunk::new(ContentBlock::from(
+                "Thinking about the delegated task",
+            ))),
+        )))
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message completed event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_COMPLETED_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(user_message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::User.as_str())
+        );
+
+        let RpcOutput::Event { event_name, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child thinking started event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_THINKING_STARTED_EVENT);
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+    }
+
+    #[test]
     fn child_turn_started_lifecycle_marks_child_streaming() {
         let (event_tx, event_rx) = mpsc::channel();
         let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
@@ -10313,6 +10453,169 @@ mod tests {
             payload.get("kind").and_then(Value::as_str),
             Some("review_mode")
         );
+    }
+
+    #[test]
+    fn session_tool_call_suppresses_internal_drafting_status() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        let tool_call = ToolCall::new(
+            ToolCallId::from("neverwrite:status:item:agent-msg-42"),
+            "Drafting response",
+        )
+        .kind(ToolKind::Other)
+        .status(ToolCallStatus::InProgress)
+        .meta(Meta::from_iter([(
+            ACP_STATUS_EVENT_TYPE_KEY.to_string(),
+            json!("status"),
+        )]));
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCall(tool_call),
+        )))
+        .unwrap();
+
+        assert!(event_rx.recv_timeout(StdDuration::from_millis(50)).is_err());
+    }
+
+    #[test]
+    fn session_tool_call_suppresses_internal_drafting_status_update_without_meta() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        let update = ToolCallUpdate::new(
+            "neverwrite:status:item:agent-msg-42",
+            ToolCallUpdateFields::new()
+                .title("Drafting response")
+                .status(ToolCallStatus::Completed),
+        );
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCallUpdate(update),
+        )))
+        .unwrap();
+
+        assert!(event_rx.recv_timeout(StdDuration::from_millis(50)).is_err());
+    }
+
+    #[test]
+    fn session_tool_call_keeps_real_tool_with_suppressed_status_title() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        let tool_call = ToolCall::new(ToolCallId::from("normal-tool-1"), "Drafting response")
+            .kind(ToolKind::Other)
+            .status(ToolCallStatus::Completed);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCall(tool_call),
+        )))
+        .unwrap();
+
+        let event = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("tool activity event");
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event
+        else {
+            panic!("expected event");
+        };
+
+        assert_eq!(event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert_eq!(
+            payload.get("tool_call_id").and_then(Value::as_str),
+            Some("normal-tool-1")
+        );
+    }
+
+    #[test]
+    fn session_tool_call_closes_active_assistant_segment_without_finishing_turn() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::from("Before tool"))),
+        )))
+        .unwrap();
+
+        let RpcOutput::Event { payload, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("assistant message started event")
+        else {
+            panic!("expected event");
+        };
+        let first_message_id = payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .expect("assistant message id")
+            .to_string();
+        let _ = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("assistant message delta event");
+
+        run_client_future(
+            client.session_notification(SessionNotification::new(
+                "session-1",
+                SessionUpdate::ToolCall(
+                    ToolCall::new(ToolCallId::from("tool-1"), "Read file")
+                        .kind(ToolKind::Read)
+                        .status(ToolCallStatus::Completed),
+                ),
+            )),
+        )
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("assistant segment completed event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_COMPLETED_EVENT);
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(first_message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("turn_complete").and_then(Value::as_bool),
+            Some(false)
+        );
+
+        let RpcOutput::Event { event_name, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("tool activity event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_TOOL_ACTIVITY_EVENT);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::from("After tool"))),
+        )))
+        .unwrap();
+
+        let RpcOutput::Event { payload, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("next assistant message started event")
+        else {
+            panic!("expected event");
+        };
+        let next_message_id = payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .expect("next assistant message id");
+        assert_ne!(next_message_id, first_message_id);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2172,6 +2172,7 @@ struct NativeAcpClient {
     message_ids: Arc<Mutex<HashMap<MessageStreamKey, String>>>,
     thinking_ids: Arc<Mutex<HashMap<String, String>>>,
     permission_waiters: Arc<Mutex<HashMap<String, oneshot::Sender<RequestPermissionOutcome>>>>,
+    suppressed_status_tool_calls: Arc<Mutex<HashSet<String>>>,
     tool_diffs: ToolDiffState,
     agent_writes: AgentWriteTracker,
     terminal_output: Arc<Mutex<HashMap<String, String>>>,
@@ -2435,16 +2436,26 @@ impl NativeAcpClient {
             .ok()
             .and_then(|mut ids| ids.remove(&Self::message_stream_key(session_id, role)));
         if let Some(message_id) = message_id {
-            self.emit(
-                AI_MESSAGE_COMPLETED_EVENT,
-                AiMessageCompletedPayload {
-                    session_id: session_id.to_string(),
-                    message_id,
-                    role: role.as_str().to_string(),
-                    turn_complete,
-                },
-            );
+            self.emit_text_message_completed(session_id, &message_id, role, turn_complete);
         }
+    }
+
+    fn emit_text_message_completed(
+        &self,
+        session_id: &str,
+        message_id: &str,
+        role: MessageRole,
+        turn_complete: bool,
+    ) {
+        self.emit(
+            AI_MESSAGE_COMPLETED_EVENT,
+            AiMessageCompletedPayload {
+                session_id: session_id.to_string(),
+                message_id: message_id.to_string(),
+                role: role.as_str().to_string(),
+                turn_complete,
+            },
+        );
     }
 
     fn begin_message(&self, session_id: &str) -> String {
@@ -2457,6 +2468,19 @@ impl NativeAcpClient {
 
     fn end_message(&self, session_id: &str) {
         self.end_text_message(session_id, MessageRole::Assistant, true);
+    }
+
+    fn complete_assistant_turn(&self, session_id: &str, fallback_message_id: &str) {
+        if self.current_message_id(session_id).is_some() {
+            self.end_message(session_id);
+        } else {
+            self.emit_text_message_completed(
+                session_id,
+                fallback_message_id,
+                MessageRole::Assistant,
+                true,
+            );
+        }
     }
 
     fn end_message_segment(&self, session_id: &str) {
@@ -2479,6 +2503,45 @@ impl NativeAcpClient {
         self.end_thinking(session_id);
         self.end_user_message(session_id);
         self.end_message_segment(session_id);
+    }
+
+    fn remember_suppressed_status_tool_call(&self, session_id: &str, tool_call_id: &str) {
+        if let Ok(mut ids) = self.suppressed_status_tool_calls.lock() {
+            ids.insert(call_state_key(session_id, tool_call_id));
+        }
+    }
+
+    fn forget_suppressed_status_tool_call(&self, session_id: &str, tool_call_id: &str) {
+        if let Ok(mut ids) = self.suppressed_status_tool_calls.lock() {
+            ids.remove(&call_state_key(session_id, tool_call_id));
+        }
+    }
+
+    fn has_suppressed_status_tool_call(&self, session_id: &str, tool_call_id: &str) -> bool {
+        self.suppressed_status_tool_calls
+            .lock()
+            .ok()
+            .map(|ids| ids.contains(&call_state_key(session_id, tool_call_id)))
+            .unwrap_or(false)
+    }
+
+    fn should_suppress_tool_call_update(&self, session_id: &str, update: &ToolCallUpdate) -> bool {
+        let tool_call_id = &update.tool_call_id.0;
+        if self.has_suppressed_status_tool_call(session_id, tool_call_id) {
+            if tool_call_update_is_terminal(update) {
+                self.forget_suppressed_status_tool_call(session_id, tool_call_id);
+            }
+            return true;
+        }
+
+        if should_suppress_status_tool_call_update(update) {
+            if !tool_call_update_is_terminal(update) {
+                self.remember_suppressed_status_tool_call(session_id, tool_call_id);
+            }
+            return true;
+        }
+
+        false
     }
 
     #[cfg(test)]
@@ -2890,6 +2953,7 @@ impl NativeAcpClient {
         let diffs = self
             .tool_diffs
             .normalized_diffs_for_tool_call(&session_id, &registered);
+        self.end_text_streams_before_activity(&session_id);
         self.emit(
             AI_TOOL_ACTIVITY_EVENT,
             map_tool_call(
@@ -2991,6 +3055,10 @@ impl NativeAcpClient {
             SessionUpdate::ToolCall(tool_call) => {
                 let tool_call = tool_call_with_merged_meta(tool_call, meta.as_ref());
                 if should_suppress_status_tool_call(&tool_call) {
+                    self.remember_suppressed_status_tool_call(
+                        &session_id,
+                        &tool_call.tool_call_id.0,
+                    );
                     return Ok(());
                 }
                 self.end_text_streams_before_activity(&session_id);
@@ -3005,7 +3073,7 @@ impl NativeAcpClient {
             }
             SessionUpdate::ToolCallUpdate(update) => {
                 let update = tool_call_update_with_merged_meta(update, meta.as_ref());
-                if should_suppress_status_tool_call_update(&update) {
+                if self.should_suppress_tool_call_update(&session_id, &update) {
                     return Ok(());
                 }
                 self.end_text_streams_before_activity(&session_id);
@@ -3371,6 +3439,7 @@ async fn run_acp_actor_inner(
         message_ids: Arc::new(Mutex::new(HashMap::new())),
         thinking_ids: Arc::new(Mutex::new(HashMap::new())),
         permission_waiters: Arc::new(Mutex::new(HashMap::new())),
+        suppressed_status_tool_calls: Arc::new(Mutex::new(HashSet::new())),
         tool_diffs,
         agent_writes,
         terminal_output: Arc::new(Mutex::new(HashMap::new())),
@@ -3596,17 +3665,7 @@ async fn handle_acp_command(
                     .map_err(|error| error.to_string());
                 client.end_thinking(&session_id);
                 client.end_user_message(&session_id);
-                if client.current_message_id(&session_id).is_none() {
-                    client.emit(
-                        AI_MESSAGE_STARTED_EVENT,
-                        AiMessageStartedPayload {
-                            session_id: session_id.clone(),
-                            message_id: message_id.clone(),
-                            role: MessageRole::Assistant.as_str().to_string(),
-                        },
-                    );
-                }
-                client.end_message(&session_id);
+                client.complete_assistant_turn(&session_id, &message_id);
                 if let Err(error) = &result {
                     client.emit(
                         AI_SESSION_ERROR_EVENT,
@@ -4445,6 +4504,13 @@ fn should_suppress_status_tool_call_update(update: &ToolCallUpdate) -> bool {
             .as_ref()
             .and_then(acp_event_type)
             .is_some_and(|event_type| event_type == "status")
+}
+
+fn tool_call_update_is_terminal(update: &ToolCallUpdate) -> bool {
+    matches!(
+        update.fields.status.as_ref(),
+        Some(ToolCallStatus::Completed | ToolCallStatus::Failed)
+    )
 }
 
 fn raw_string_field(raw: Option<&Value>, keys: &[&str]) -> Option<String> {
@@ -7232,6 +7298,7 @@ mod tests {
             message_ids: Arc::new(Mutex::new(HashMap::new())),
             thinking_ids: Arc::new(Mutex::new(HashMap::new())),
             permission_waiters: Arc::new(Mutex::new(HashMap::new())),
+            suppressed_status_tool_calls: Arc::new(Mutex::new(HashSet::new())),
             tool_diffs: ToolDiffState::default(),
             agent_writes: AgentWriteTracker::default(),
             terminal_output: Arc::new(Mutex::new(HashMap::new())),
@@ -10502,6 +10569,54 @@ mod tests {
     }
 
     #[test]
+    fn session_tool_call_suppresses_internal_status_update_without_title_after_suppressed_start() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::from(
+                "Before status",
+            ))),
+        )))
+        .unwrap();
+        while event_rx.try_recv().is_ok() {}
+
+        let tool_call = ToolCall::new(
+            ToolCallId::from("neverwrite:status:item:agent-msg-42"),
+            "Drafting response",
+        )
+        .kind(ToolKind::Other)
+        .status(ToolCallStatus::InProgress)
+        .meta(Meta::from_iter([(
+            ACP_STATUS_EVENT_TYPE_KEY.to_string(),
+            json!("status"),
+        )]));
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCall(tool_call),
+        )))
+        .unwrap();
+        assert!(event_rx.recv_timeout(StdDuration::from_millis(50)).is_err());
+        assert!(client.has_active_text_message("session-1", MessageRole::Assistant));
+
+        let update = ToolCallUpdate::new(
+            "neverwrite:status:item:agent-msg-42",
+            ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
+        );
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCallUpdate(update),
+        )))
+        .unwrap();
+
+        assert!(event_rx.recv_timeout(StdDuration::from_millis(50)).is_err());
+        assert!(client.has_active_text_message("session-1", MessageRole::Assistant));
+    }
+
+    #[test]
     fn session_tool_call_keeps_real_tool_with_suppressed_status_title() {
         let (event_tx, event_rx) = mpsc::channel();
         let client = test_client(event_tx);
@@ -10616,6 +10731,53 @@ mod tests {
             .and_then(Value::as_str)
             .expect("next assistant message id");
         assert_ne!(next_message_id, first_message_id);
+    }
+
+    #[test]
+    fn complete_assistant_turn_finishes_when_no_segment_is_active() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        let message_id = client.begin_message("session-1");
+        let _ = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("assistant message started event");
+
+        client.end_message_segment("session-1");
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("assistant segment completed event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_COMPLETED_EVENT);
+        assert_eq!(
+            payload.get("turn_complete").and_then(Value::as_bool),
+            Some(false)
+        );
+
+        client.complete_assistant_turn("session-1", &message_id);
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("turn completed event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_COMPLETED_EVENT);
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("turn_complete").and_then(Value::as_bool),
+            Some(true)
+        );
     }
 
     #[test]
@@ -10802,6 +10964,91 @@ mod tests {
         let (saw_tool_activity_diffs, saw_permission_diffs) = event_thread.join().unwrap();
         assert!(saw_tool_activity_diffs);
         assert!(saw_permission_diffs);
+    }
+
+    #[test]
+    fn permission_request_closes_active_assistant_segment_before_timeline_events() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::from(
+                "Before permission",
+            ))),
+        )))
+        .unwrap();
+        while event_rx.try_recv().is_ok() {}
+
+        let waiters = client.permission_waiters.clone();
+        let event_thread = std::thread::spawn(move || {
+            let mut event_names = Vec::new();
+            let mut completed_turn_complete = None;
+            let mut request_id = None;
+
+            for _ in 0..3 {
+                let event = event_rx
+                    .recv_timeout(StdDuration::from_secs(1))
+                    .expect("permission timeline event");
+                let RpcOutput::Event {
+                    event_name,
+                    payload,
+                } = event
+                else {
+                    continue;
+                };
+
+                if event_name == AI_MESSAGE_COMPLETED_EVENT {
+                    completed_turn_complete = payload.get("turn_complete").and_then(Value::as_bool);
+                }
+                if event_name == AI_PERMISSION_REQUEST_EVENT {
+                    request_id = payload
+                        .get("request_id")
+                        .and_then(Value::as_str)
+                        .map(ToString::to_string);
+                }
+                event_names.push(event_name);
+            }
+
+            let request_id = request_id.expect("permission request id");
+            let sender = waiters
+                .lock()
+                .unwrap()
+                .remove(&request_id)
+                .expect("permission waiter");
+            sender.send(RequestPermissionOutcome::Cancelled).unwrap();
+
+            (event_names, completed_turn_complete)
+        });
+
+        let request = RequestPermissionRequest::new(
+            "session-1",
+            ToolCallUpdate::new(
+                "tool-1",
+                ToolCallUpdateFields::new()
+                    .title("Write note.md".to_string())
+                    .kind(ToolKind::Edit)
+                    .status(ToolCallStatus::Pending),
+            ),
+            vec![PermissionOption::new(
+                "allow",
+                "Allow",
+                PermissionOptionKind::AllowOnce,
+            )],
+        );
+        run_client_future(client.request_permission(request)).unwrap();
+
+        let (event_names, completed_turn_complete) = event_thread.join().unwrap();
+        assert_eq!(
+            event_names,
+            vec![
+                AI_MESSAGE_COMPLETED_EVENT,
+                AI_TOOL_ACTIVITY_EVENT,
+                AI_PERMISSION_REQUEST_EVENT,
+            ]
+        );
+        assert_eq!(completed_turn_complete, Some(false));
+        assert!(!client.has_active_text_message("session-1", MessageRole::Assistant));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2167,13 +2167,41 @@ impl AcpSessionHandle {
 struct NativeAcpClient {
     event_tx: Sender<RpcOutput>,
     session_state: Arc<Mutex<NativeAiInner>>,
-    message_ids: Arc<Mutex<HashMap<String, String>>>,
+    message_ids: Arc<Mutex<HashMap<MessageStreamKey, String>>>,
     thinking_ids: Arc<Mutex<HashMap<String, String>>>,
     permission_waiters: Arc<Mutex<HashMap<String, oneshot::Sender<RequestPermissionOutcome>>>>,
     tool_diffs: ToolDiffState,
     agent_writes: AgentWriteTracker,
     terminal_output: Arc<Mutex<HashMap<String, String>>>,
     terminal_exit: Arc<Mutex<HashMap<String, TerminalExitMeta>>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct MessageStreamKey {
+    session_id: String,
+    role: MessageRole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MessageRole {
+    User,
+    Assistant,
+}
+
+impl MessageRole {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::User => "user",
+            Self::Assistant => "assistant",
+        }
+    }
+
+    fn id_kind(self) -> &'static str {
+        match self {
+            Self::User => "user-message",
+            Self::Assistant => "message",
+        }
+    }
 }
 
 impl NativeAcpClient {
@@ -2365,43 +2393,83 @@ impl NativeAcpClient {
         )
     }
 
-    fn begin_message(&self, session_id: &str) -> String {
-        let message_id = self.next_message_id(session_id, "message");
+    fn message_stream_key(session_id: &str, role: MessageRole) -> MessageStreamKey {
+        MessageStreamKey {
+            session_id: session_id.to_string(),
+            role,
+        }
+    }
+
+    fn begin_text_message(&self, session_id: &str, role: MessageRole) -> String {
+        let message_id = self.next_message_id(session_id, role.id_kind());
         if let Ok(mut ids) = self.message_ids.lock() {
-            ids.insert(session_id.to_string(), message_id.clone());
+            ids.insert(
+                Self::message_stream_key(session_id, role),
+                message_id.clone(),
+            );
         }
         self.emit(
             AI_MESSAGE_STARTED_EVENT,
             AiMessageStartedPayload {
                 session_id: session_id.to_string(),
                 message_id: message_id.clone(),
+                role: role.as_str().to_string(),
             },
         );
         message_id
     }
 
-    fn current_message_id(&self, session_id: &str) -> Option<String> {
-        self.message_ids
-            .lock()
-            .ok()
-            .and_then(|ids| ids.get(session_id).cloned())
+    fn current_text_message_id(&self, session_id: &str, role: MessageRole) -> Option<String> {
+        self.message_ids.lock().ok().and_then(|ids| {
+            ids.get(&Self::message_stream_key(session_id, role))
+                .cloned()
+        })
     }
 
-    fn end_message(&self, session_id: &str) {
+    fn end_text_message(&self, session_id: &str, role: MessageRole) {
         let message_id = self
             .message_ids
             .lock()
             .ok()
-            .and_then(|mut ids| ids.remove(session_id));
+            .and_then(|mut ids| ids.remove(&Self::message_stream_key(session_id, role)));
         if let Some(message_id) = message_id {
             self.emit(
                 AI_MESSAGE_COMPLETED_EVENT,
                 AiMessageCompletedPayload {
                     session_id: session_id.to_string(),
                     message_id,
+                    role: role.as_str().to_string(),
                 },
             );
         }
+    }
+
+    fn begin_message(&self, session_id: &str) -> String {
+        self.begin_text_message(session_id, MessageRole::Assistant)
+    }
+
+    fn current_message_id(&self, session_id: &str) -> Option<String> {
+        self.current_text_message_id(session_id, MessageRole::Assistant)
+    }
+
+    fn end_message(&self, session_id: &str) {
+        self.end_text_message(session_id, MessageRole::Assistant);
+    }
+
+    fn begin_user_message(&self, session_id: &str) -> String {
+        self.begin_text_message(session_id, MessageRole::User)
+    }
+
+    fn current_user_message_id(&self, session_id: &str) -> Option<String> {
+        self.current_text_message_id(session_id, MessageRole::User)
+    }
+
+    fn end_user_message(&self, session_id: &str) {
+        self.end_text_message(session_id, MessageRole::User);
+    }
+
+    fn has_active_text_message(&self, session_id: &str, role: MessageRole) -> bool {
+        self.current_text_message_id(session_id, role).is_some()
     }
 
     fn begin_thinking(&self, session_id: &str) -> String {
@@ -2441,6 +2509,7 @@ impl NativeAcpClient {
 
     fn mark_session_idle(&self, session_id: &str) {
         self.end_thinking(session_id);
+        self.end_user_message(session_id);
         self.end_message(session_id);
 
         let session = self.session_state.lock().ok().and_then(|mut state| {
@@ -2456,6 +2525,7 @@ impl NativeAcpClient {
 
     fn mark_subagent_closed_by_parent(&self, session_id: &str) {
         self.end_thinking(session_id);
+        self.end_user_message(session_id);
         self.end_message(session_id);
 
         let session = self.session_state.lock().ok().and_then(|mut state| {
@@ -2852,11 +2922,31 @@ impl NativeAcpClient {
             return Ok(());
         }
         match args.update {
+            SessionUpdate::UserMessageChunk(ContentChunk {
+                content: ContentBlock::Text(text),
+                ..
+            }) => {
+                // User chunks come from the runtime, not the local composer, so they need
+                // their own stream state.
+                let message_id = self
+                    .current_user_message_id(&session_id)
+                    .unwrap_or_else(|| self.begin_user_message(&session_id));
+                self.emit(
+                    AI_MESSAGE_DELTA_EVENT,
+                    AiMessageDeltaPayload {
+                        session_id,
+                        message_id,
+                        delta: text.text,
+                        role: MessageRole::User.as_str().to_string(),
+                    },
+                );
+            }
             SessionUpdate::AgentMessageChunk(ContentChunk {
                 content: ContentBlock::Text(text),
                 ..
             }) => {
                 self.end_thinking(&session_id);
+                self.end_user_message(&session_id);
                 let message_id = self
                     .current_message_id(&session_id)
                     .unwrap_or_else(|| self.begin_message(&session_id));
@@ -2866,6 +2956,7 @@ impl NativeAcpClient {
                         session_id,
                         message_id,
                         delta: text.text,
+                        role: MessageRole::Assistant.as_str().to_string(),
                     },
                 );
             }
@@ -3480,12 +3571,14 @@ async fn handle_acp_command(
                     .map(|_| ())
                     .map_err(|error| error.to_string());
                 client.end_thinking(&session_id);
+                client.end_user_message(&session_id);
                 if client.current_message_id(&session_id).is_none() {
                     client.emit(
                         AI_MESSAGE_STARTED_EVENT,
                         AiMessageStartedPayload {
                             session_id: session_id.clone(),
                             message_id: message_id.clone(),
+                            role: MessageRole::Assistant.as_str().to_string(),
                         },
                     );
                 }
@@ -7512,6 +7605,15 @@ mod tests {
         )
     }
 
+    fn subagent_child_user_message_notification_fixture() -> SessionNotification {
+        SessionNotification::new(
+            CHILD_RUNTIME_SESSION_ID,
+            SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::from(
+                "Parent task for child agent",
+            ))),
+        )
+    }
+
     fn turn_lifecycle_notification_fixture(
         runtime_session_id: &str,
         turn_event_type: &str,
@@ -8049,6 +8151,10 @@ mod tests {
             payload.get("session_id").and_then(Value::as_str),
             Some(CHILD_RUNTIME_SESSION_ID)
         );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::Assistant.as_str())
+        );
 
         let event = event_rx
             .recv_timeout(StdDuration::from_millis(250))
@@ -8065,10 +8171,162 @@ mod tests {
             payload.get("session_id").and_then(Value::as_str),
             Some(CHILD_RUNTIME_SESSION_ID)
         );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::Assistant.as_str())
+        );
 
-        let message_ids = client.message_ids.lock().unwrap();
-        assert!(message_ids.contains_key(CHILD_RUNTIME_SESSION_ID));
-        assert!(!message_ids.contains_key(PARENT_RUNTIME_SESSION_ID));
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
+        assert!(!client.has_active_text_message(PARENT_RUNTIME_SESSION_ID, MessageRole::Assistant));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+    }
+
+    #[test]
+    fn child_user_message_chunks_emit_user_role_without_touching_assistant_state() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
+        insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, PARENT_RUNTIME_SESSION_ID);
+        let client = test_client_with_state(event_tx, session_state);
+
+        run_client_future(
+            client.session_notification(subagent_child_user_message_notification_fixture()),
+        )
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message started event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_STARTED_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::User.as_str())
+        );
+        let user_message_id = payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .expect("user message id")
+            .to_string();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message delta event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_DELTA_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(user_message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::User.as_str())
+        );
+        assert_eq!(
+            payload.get("delta").and_then(Value::as_str),
+            Some("Parent task for child agent")
+        );
+
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
+        assert!(!client.has_active_text_message(PARENT_RUNTIME_SESSION_ID, MessageRole::User));
+
+        run_client_future(
+            client.session_notification(subagent_child_message_notification_fixture()),
+        )
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child user message completed event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_COMPLETED_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(user_message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::User.as_str())
+        );
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child assistant message started event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_STARTED_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::Assistant.as_str())
+        );
+        let assistant_message_id = payload
+            .get("message_id")
+            .and_then(Value::as_str)
+            .expect("assistant message id")
+            .to_string();
+        assert_ne!(assistant_message_id, user_message_id);
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("child assistant message delta event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_MESSAGE_DELTA_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(CHILD_RUNTIME_SESSION_ID)
+        );
+        assert_eq!(
+            payload.get("message_id").and_then(Value::as_str),
+            Some(assistant_message_id.as_str())
+        );
+        assert_eq!(
+            payload.get("role").and_then(Value::as_str),
+            Some(MessageRole::Assistant.as_str())
+        );
+
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
+        assert!(!client.has_active_text_message(PARENT_RUNTIME_SESSION_ID, MessageRole::Assistant));
     }
 
     #[test]
@@ -8144,6 +8402,7 @@ mod tests {
                 .status = AiSessionStatus::Streaming;
         }
         let client = test_client_with_state(event_tx, Arc::clone(&session_state));
+        client.begin_user_message(CHILD_RUNTIME_SESSION_ID);
         client.begin_message(CHILD_RUNTIME_SESSION_ID);
         while event_rx.try_recv().is_ok() {}
 
@@ -8156,9 +8415,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut saw_message_completed = false;
+        let mut saw_user_message_completed = false;
+        let mut saw_assistant_message_completed = false;
         let mut saw_idle_update = false;
-        for _ in 0..2 {
+        for _ in 0..3 {
             let RpcOutput::Event {
                 event_name,
                 payload,
@@ -8172,7 +8432,14 @@ mod tests {
                 && payload.get("session_id").and_then(Value::as_str)
                     == Some(CHILD_RUNTIME_SESSION_ID)
             {
-                saw_message_completed = true;
+                if payload.get("role").and_then(Value::as_str) == Some(MessageRole::User.as_str()) {
+                    saw_user_message_completed = true;
+                }
+                if payload.get("role").and_then(Value::as_str)
+                    == Some(MessageRole::Assistant.as_str())
+                {
+                    saw_assistant_message_completed = true;
+                }
             }
             if event_name == AI_SESSION_UPDATED_EVENT
                 && payload.get("session_id").and_then(Value::as_str)
@@ -8183,13 +8450,11 @@ mod tests {
             }
         }
 
-        assert!(saw_message_completed);
+        assert!(saw_user_message_completed);
+        assert!(saw_assistant_message_completed);
         assert!(saw_idle_update);
-        assert!(!client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(CHILD_RUNTIME_SESSION_ID));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
     }
 
     #[test]
@@ -8226,11 +8491,7 @@ mod tests {
         .unwrap();
 
         assert!(event_rx.try_recv().is_err());
-        assert!(client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(CHILD_RUNTIME_SESSION_ID));
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
         let state = session_state.lock().unwrap();
         assert_eq!(
             state
@@ -8271,11 +8532,7 @@ mod tests {
         .unwrap();
 
         assert!(event_rx.try_recv().is_err());
-        assert!(client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(PARENT_RUNTIME_SESSION_ID));
+        assert!(client.has_active_text_message(PARENT_RUNTIME_SESSION_ID, MessageRole::Assistant));
         let state = session_state.lock().unwrap();
         assert_eq!(
             state
@@ -8306,11 +8563,7 @@ mod tests {
         )
         .unwrap();
         while event_rx.try_recv().is_ok() {}
-        assert!(client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(CHILD_RUNTIME_SESSION_ID));
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
 
         let close_meta = Meta::from_iter([
             (
@@ -8367,11 +8620,8 @@ mod tests {
 
         assert!(saw_message_completed);
         assert!(saw_closed_update);
-        assert!(!client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(CHILD_RUNTIME_SESSION_ID));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
+        assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
     }
 
     #[test]
@@ -8470,11 +8720,7 @@ mod tests {
             assert_eq!(event_name, AI_TOOL_ACTIVITY_EVENT);
         }
 
-        assert!(client
-            .message_ids
-            .lock()
-            .unwrap()
-            .contains_key(CHILD_RUNTIME_SESSION_ID));
+        assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
         let state = session_state.lock().unwrap();
         assert_eq!(
             state

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -3911,6 +3911,111 @@ describe("chatStore", () => {
         });
     });
 
+    it("does not duplicate a chunked local composer echo across flushes", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...session,
+                    messages: [
+                        {
+                            id: "local-user-1",
+                            role: "user",
+                            kind: "text",
+                            content: "Echo me exactly",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Echo me ",
+            role: "user",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "exactly",
+            role: "user",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageCompleted({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            role: "user",
+        });
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toMatchObject({
+            id: "local-user-1",
+            role: "user",
+            content: "Echo me exactly",
+        });
+    });
+
+    it("restores a suppressed runtime user echo when chunks diverge", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...session,
+                    messages: [
+                        {
+                            id: "local-user-1",
+                            role: "user",
+                            kind: "text",
+                            content: "Echo me exactly",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Echo me ",
+            role: "user",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "differently",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(messages.map((message) => message.content)).toEqual([
+            "Echo me exactly",
+            "Echo me differently",
+        ]);
+        expect(messages[1]).toMatchObject({
+            id: "runtime-user-1",
+            role: "user",
+            title: "User",
+            inProgress: true,
+        });
+    });
+
     it("shows parent-sent user chunks in child sessions without a local echo", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -3945,6 +3945,163 @@ describe("chatStore", () => {
         });
     });
 
+    it("keeps runtime text before immediate status and tool timeline events", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Parent task for child agent",
+            role: "user",
+        });
+        useChatStore.getState().applyStatusEvent({
+            session_id: activeSessionId,
+            event_id: "subagent-spawning-1",
+            kind: "subagent_lifecycle",
+            status: "in_progress",
+            title: "Spawning subagent",
+            detail: "Starting Pauli",
+            emphasis: "neutral",
+        });
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "subagent-pauli",
+            title: "Spawned Pauli",
+            kind: "subagent",
+            status: "completed",
+            summary: "Pauli is ready",
+        });
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "assistant-1",
+            delta: "Child response",
+            role: "assistant",
+        });
+        useChatStore.getState().applyStatusEvent({
+            session_id: activeSessionId,
+            event_id: "subagent-finished-1",
+            kind: "subagent_lifecycle",
+            status: "completed",
+            title: "Subagents finished",
+            detail: "All child agents completed",
+            emphasis: "neutral",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(
+            messages.map((message) => ({
+                id: message.id,
+                role: message.role,
+                kind: message.kind,
+                title: message.title,
+                content: message.content,
+            })),
+        ).toEqual([
+            {
+                id: "runtime-user-1",
+                role: "user",
+                kind: "text",
+                title: "User",
+                content: "Parent task for child agent",
+            },
+            {
+                id: "status:subagent-spawning-1",
+                role: "system",
+                kind: "status",
+                title: "Spawning subagent",
+                content: "Starting Pauli",
+            },
+            {
+                id: "tool:subagent-pauli",
+                role: "assistant",
+                kind: "tool",
+                title: "Spawned Pauli",
+                content: "Pauli is ready",
+            },
+            {
+                id: "assistant-1",
+                role: "assistant",
+                kind: "text",
+                title: "Assistant",
+                content: "Child response",
+            },
+            {
+                id: "status:subagent-finished-1",
+                role: "system",
+                kind: "status",
+                title: "Subagents finished",
+                content: "All child agents completed",
+            },
+        ]);
+    });
+
+    it("keeps assistant text segments around tool activity in runtime order", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "assistant-before-tool",
+            delta: "Before tool",
+            role: "assistant",
+        });
+        useChatStore.getState().applyMessageCompleted({
+            session_id: activeSessionId,
+            message_id: "assistant-before-tool",
+            role: "assistant",
+            turn_complete: false,
+        });
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-1",
+            title: "Read file",
+            kind: "read",
+            status: "completed",
+            summary: "README.md",
+        });
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "assistant-after-tool",
+            delta: "After tool",
+            role: "assistant",
+        });
+        flushDeltasSync();
+
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        expect(session.status).toBe("streaming");
+        expect(
+            session.messages.map((message) => ({
+                id: message.id,
+                kind: message.kind,
+                content: message.content,
+                inProgress: message.inProgress,
+            })),
+        ).toEqual([
+            {
+                id: "assistant-before-tool",
+                kind: "text",
+                content: "Before tool",
+                inProgress: false,
+            },
+            {
+                id: "tool:tool-1",
+                kind: "tool",
+                content: "README.md",
+                inProgress: undefined,
+            },
+            {
+                id: "assistant-after-tool",
+                kind: "text",
+                content: "After tool",
+                inProgress: true,
+            },
+        ]);
+    });
+
     it("loads a session from backend and promotes it to the top of the history", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -3776,6 +3776,175 @@ describe("chatStore", () => {
         ]);
     });
 
+    it("creates runtime user text messages from user-role deltas", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Parent task for child agent",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        const message =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages.at(-1);
+        expect(message).toMatchObject({
+            id: "runtime-user-1",
+            role: "user",
+            kind: "text",
+            content: "Parent task for child agent",
+            title: "User",
+            inProgress: true,
+        });
+    });
+
+    it("keeps user and assistant deltas separate in one flush", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Investigate this",
+            role: "user",
+        });
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "assistant-1",
+            delta: "On it",
+            role: "assistant",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(messages.map((message) => message.role)).toEqual([
+            "user",
+            "assistant",
+        ]);
+        expect(messages.map((message) => message.content)).toEqual([
+            "Investigate this",
+            "On it",
+        ]);
+    });
+
+    it("completes only the runtime user message for user-role completions", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Investigate this",
+            role: "user",
+        });
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "assistant-1",
+            delta: "On it",
+            role: "assistant",
+        });
+        flushDeltasSync();
+
+        useChatStore.getState().applyMessageCompleted({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            role: "user",
+        });
+
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        expect(session.status).toBe("streaming");
+        expect(
+            session.messages.find((message) => message.id === "runtime-user-1"),
+        ).toMatchObject({
+            role: "user",
+            inProgress: false,
+        });
+        expect(
+            session.messages.find((message) => message.id === "assistant-1"),
+        ).toMatchObject({
+            role: "assistant",
+            inProgress: true,
+        });
+    });
+
+    it("does not duplicate an exact local composer echo in the same session", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...session,
+                    messages: [
+                        {
+                            id: "local-user-1",
+                            role: "user",
+                            kind: "text",
+                            content: "Echo me exactly",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Echo me exactly",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toMatchObject({
+            id: "local-user-1",
+            role: "user",
+            content: "Echo me exactly",
+        });
+    });
+
+    it("shows parent-sent user chunks in child sessions without a local echo", async () => {
+        await useChatStore.getState().initialize();
+
+        const parentSession = useChatStore.getState().sessionsById[getActiveSessionId()]!;
+        const childSessionId = "child-session-1";
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [childSessionId]: cloneSessionForTest(parentSession, childSessionId, {
+                    parentSessionId: parentSession.sessionId,
+                }),
+            },
+            sessionOrder: [childSessionId, ...state.sessionOrder],
+        }));
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: childSessionId,
+            message_id: "runtime-user-1",
+            delta: "Parent task for child agent",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[childSessionId]?.messages ?? [];
+        expect(messages).toHaveLength(1);
+        expect(messages[0]).toMatchObject({
+            id: "runtime-user-1",
+            role: "user",
+            kind: "text",
+            content: "Parent task for child agent",
+        });
+    });
+
     it("loads a session from backend and promotes it to the top of the history", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -4016,6 +4016,82 @@ describe("chatStore", () => {
         });
     });
 
+    it("restores a divergent suppressed runtime user echo before later timeline events", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...session,
+                    messages: [
+                        {
+                            id: "local-user-1",
+                            role: "user",
+                            kind: "text",
+                            content: "Echo me exactly",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "Echo me ",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        useChatStore.getState().applyStatusEvent({
+            session_id: activeSessionId,
+            event_id: "after-first-runtime-user-chunk",
+            kind: "subagent_lifecycle",
+            status: "in_progress",
+            title: "Spawning subagent",
+            detail: "Starting Pauli",
+            emphasis: "neutral",
+        });
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: activeSessionId,
+            message_id: "runtime-user-1",
+            delta: "differently",
+            role: "user",
+        });
+        flushDeltasSync();
+
+        const messages =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages ?? [];
+        expect(
+            messages.map((message) => ({
+                id: message.id,
+                kind: message.kind,
+                content: message.content,
+            })),
+        ).toEqual([
+            {
+                id: "local-user-1",
+                kind: "text",
+                content: "Echo me exactly",
+            },
+            {
+                id: "runtime-user-1",
+                kind: "text",
+                content: "Echo me differently",
+            },
+            {
+                id: "status:after-first-runtime-user-chunk",
+                kind: "status",
+                content: "Starting Pauli",
+            },
+        ]);
+    });
+
     it("shows parent-sent user chunks in child sessions without a local echo", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -5835,13 +5835,15 @@ function messageDeltaBufferKey(
     return `${sessionId}:${role}:${messageId}`;
 }
 
+// Callers pass an already-normalized session so the transcript is not
+// re-normalized on every runtime user delta.
 function latestLocalUserEchoCandidate(
-    session: AIChatSession,
+    normalizedSession: AIChatSession,
     text: string,
 ): AIChatMessage | null {
-    const normalized = normalizeSessionTranscript(session);
-    for (let index = normalized.messages.length - 1; index >= 0; index -= 1) {
-        const message = normalized.messages[index];
+    const messages = normalizedSession.messages ?? [];
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+        const message = messages[index];
         if (message.role === "user" && message.kind === "text") {
             if (message.title === runtimeTextMessageTitle("user")) {
                 return null;
@@ -5852,14 +5854,14 @@ function latestLocalUserEchoCandidate(
     return null;
 }
 
+// Expects an already-normalized session (see latestLocalUserEchoCandidate).
 function createRuntimeUserEchoMessage(
-    session: AIChatSession,
+    normalizedSession: AIChatSession,
     payload: {
         message_id: string;
         text: string;
     },
 ) {
-    const normalizedSession = normalizeSessionTranscript(session);
     const existingMessage =
         normalizedSession.messagesById?.[payload.message_id] ?? null;
     const workCycleId =
@@ -5885,22 +5887,30 @@ function resolveSuppressedRuntimeUserEcho(
     session: AIChatSession,
     messageId: string,
 ) {
-    const key = messageDeltaBufferKey(session.sessionId, "user", messageId);
+    const normalizedSession = normalizeSessionTranscript(session);
+    const key = messageDeltaBufferKey(
+        normalizedSession.sessionId,
+        "user",
+        messageId,
+    );
     const suppressed = _suppressedRuntimeUserEchoByKey.get(key);
     if (!suppressed) {
-        return normalizeSessionTranscript(session);
+        return normalizedSession;
     }
 
     _suppressedRuntimeUserEchoByKey.delete(key);
-    const localEcho = latestLocalUserEchoCandidate(session, suppressed.text);
+    const localEcho = latestLocalUserEchoCandidate(
+        normalizedSession,
+        suppressed.text,
+    );
     if (
         localEcho?.id === suppressed.local_message_id &&
         localEcho.content === suppressed.text
     ) {
-        return normalizeSessionTranscript(session);
+        return normalizedSession;
     }
 
-    return createRuntimeUserEchoMessage(session, {
+    return createRuntimeUserEchoMessage(normalizedSession, {
         message_id: messageId,
         text: suppressed.text,
     });

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1286,6 +1286,7 @@ interface ChatStore {
         session_id: string;
         message_id: string;
         role?: AIChatRole;
+        turn_complete?: boolean;
     }) => void;
     applyThinkingStarted: (payload: {
         session_id: string;
@@ -6033,6 +6034,12 @@ function flushDeltasSync() {
     flushDeltas();
 }
 
+function flushDeltasBeforeTimelineInsert() {
+    // Text/thinking deltas are buffered, while tool/status/plan-like events are
+    // inserted synchronously. Flush first so messageOrder follows runtime order.
+    flushDeltasSync();
+}
+
 function clearBufferedDeltasForSession(sessionId: string) {
     for (const [key, value] of _deltaBuffer.messageDelta.entries()) {
         if (value.session_id === sessionId) {
@@ -8243,10 +8250,15 @@ export const useChatStore = create<ChatStore>((set, get) => {
             bufferMessageDelta(session_id, message_id, delta, messageRole);
         },
 
-        applyMessageCompleted: ({ session_id, message_id, role }) => {
+        applyMessageCompleted: ({
+            session_id,
+            message_id,
+            role,
+            turn_complete,
+        }) => {
             flushDeltasSync();
             const messageRole = normalizeRuntimeTextMessageRole(role);
-            if (messageRole === "user") {
+            if (messageRole === "user" || turn_complete === false) {
                 set((state) => {
                     const session = state.sessionsById[session_id];
                     if (!session) return state;
@@ -8415,6 +8427,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
             scheduleStaleStreamingCheck(payload.session_id);
             const eventTimestamp = Date.now();
             let workCycleId: string | null | undefined = null;
@@ -8556,6 +8569,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
             scheduleStaleStreamingCheck(payload.session_id);
             set((state) => {
                 const session = state.sessionsById[payload.session_id];
@@ -8582,6 +8596,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
             scheduleStaleStreamingCheck(payload.session_id);
             set((state) => {
                 const session = state.sessionsById[payload.session_id];
@@ -8622,6 +8637,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
             scheduleStaleStreamingCheck(payload.session_id);
             set((state) => {
                 const session = state.sessionsById[payload.session_id];
@@ -8687,6 +8703,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
             const eventTimestamp = Date.now();
             let workCycleId: string | null | undefined = null;
 
@@ -8775,6 +8792,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             if (shouldIgnoreLateActivityForSession(get(), payload.session_id)) {
                 return;
             }
+            flushDeltasBeforeTimelineInsert();
 
             set((state) => {
                 const session = state.sessionsById[payload.session_id];

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -167,6 +167,7 @@ import { checkClaudeCodeInstalled } from "../../terminal/claudeCodeTerminal";
 const AI_PREFS_KEY = "neverwrite.ai.preferences";
 const AI_RUNTIME_CACHE_KEY = "neverwrite.ai.runtime-catalog";
 type PersistedSessionHistorySummary = Omit<PersistedSessionHistory, "messages">;
+type RuntimeTextMessageRole = Extract<AIChatRole, "user" | "assistant">;
 let _persistedHistoryCacheVaultPath: string | null = null;
 let _persistedHistoryCacheBySessionId = new Map<
     string,
@@ -1273,15 +1274,18 @@ interface ChatStore {
     applyMessageStarted: (payload: {
         session_id: string;
         message_id: string;
+        role?: AIChatRole;
     }) => void;
     applyMessageDelta: (payload: {
         session_id: string;
         message_id: string;
         delta: string;
+        role?: AIChatRole;
     }) => void;
     applyMessageCompleted: (payload: {
         session_id: string;
         message_id: string;
+        role?: AIChatRole;
     }) => void;
     applyThinkingStarted: (payload: {
         session_id: string;
@@ -5782,7 +5786,15 @@ function planUpdateKeepsSessionStreaming(payload: AIPlanUpdatePayload) {
 // Delta buffering: accumulate rapid deltas and flush to Zustand on rAF
 // ---------------------------------------------------------------------------
 interface DeltaBuffer {
-    messageDelta: Map<string, { message_id: string; text: string }>;
+    messageDelta: Map<
+        string,
+        {
+            session_id: string;
+            message_id: string;
+            role: RuntimeTextMessageRole;
+            text: string;
+        }
+    >;
     thinkingDelta: Map<string, Map<string, string>>;
     flushTimeoutId: number | null;
 }
@@ -5792,6 +5804,114 @@ const _deltaBuffer: DeltaBuffer = {
     thinkingDelta: new Map(),
     flushTimeoutId: null,
 };
+
+function normalizeRuntimeTextMessageRole(
+    role?: AIChatRole | null,
+): RuntimeTextMessageRole {
+    return role === "user" ? "user" : "assistant";
+}
+
+function runtimeTextMessageTitle(role: RuntimeTextMessageRole) {
+    return role === "user" ? "User" : "Assistant";
+}
+
+function messageDeltaBufferKey(
+    sessionId: string,
+    role: RuntimeTextMessageRole,
+    messageId: string,
+) {
+    return `${sessionId}:${role}:${messageId}`;
+}
+
+function findMatchingUserTextMessageId(
+    session: AIChatSession,
+    text: string,
+): string | null {
+    const normalized = normalizeSessionTranscript(session);
+    for (let index = normalized.messages.length - 1; index >= 0; index -= 1) {
+        const message = normalized.messages[index];
+        if (message.role === "user" && message.kind === "text") {
+            return message.content === text ? message.id : null;
+        }
+    }
+    return null;
+}
+
+function appendRuntimeTextDelta(
+    session: AIChatSession,
+    payload: {
+        message_id: string;
+        role: RuntimeTextMessageRole;
+        text: string;
+    },
+) {
+    const normalizedSession = normalizeSessionTranscript(session);
+    const workCycleId =
+        normalizedSession.activeWorkCycleId ??
+        normalizedSession.visibleWorkCycleId ??
+        null;
+    const title = runtimeTextMessageTitle(payload.role);
+    const existingMessage =
+        normalizedSession.messagesById?.[payload.message_id] ?? null;
+
+    if (
+        existingMessage &&
+        existingMessage.role === payload.role &&
+        existingMessage.kind === "text"
+    ) {
+        return replaceSessionMessage(
+            normalizedSession,
+            payload.message_id,
+            (message) => ({
+                ...message,
+                content: message.content + payload.text,
+                title: message.title ?? title,
+                inProgress: true,
+            }),
+        );
+    }
+
+    if (payload.role === "user") {
+        const matchingUserMessageId = findMatchingUserTextMessageId(
+            normalizedSession,
+            payload.text,
+        );
+        if (matchingUserMessageId) {
+            return normalizedSession;
+        }
+    }
+
+    const lastMessageId = normalizedSession.messageOrder?.at(-1) ?? null;
+    const lastMsg = lastMessageId
+        ? normalizedSession.messagesById?.[lastMessageId]
+        : null;
+
+    if (
+        lastMsg &&
+        lastMsg.id === payload.message_id &&
+        lastMsg.role === payload.role &&
+        lastMsg.kind === "text" &&
+        lastMsg.inProgress
+    ) {
+        return appendToMessageContent(
+            normalizedSession,
+            lastMsg.id,
+            payload.text,
+        );
+    }
+
+    const idTaken = existingMessage != null;
+    return appendSessionMessage(normalizedSession, {
+        id: idTaken ? `${payload.message_id}:${Date.now()}` : payload.message_id,
+        role: payload.role,
+        kind: "text",
+        content: payload.text,
+        workCycleId,
+        title,
+        timestamp: Date.now(),
+        inProgress: true,
+    });
+}
 
 function flushDeltas() {
     _deltaBuffer.flushTimeoutId = null;
@@ -5809,50 +5929,20 @@ function flushDeltas() {
         let changed = false;
 
         // Apply message deltas
-        for (const [sessionId, { message_id, text }] of msgEntries) {
-            const session = sessionsById[sessionId];
+        for (const { session_id, message_id, role, text } of msgEntries.values()) {
+            const session = sessionsById[session_id];
             if (!session) continue;
-            const normalizedSession = normalizeSessionTranscript(session);
-            const workCycleId =
-                normalizedSession.activeWorkCycleId ??
-                normalizedSession.visibleWorkCycleId ??
-                null;
-            const lastMessageId =
-                normalizedSession.messageOrder?.at(-1) ?? null;
-            const lastMsg = lastMessageId
-                ? normalizedSession.messagesById?.[lastMessageId]
-                : null;
+            const nextSession = appendRuntimeTextDelta(session, {
+                message_id,
+                role,
+                text,
+            });
 
-            let nextSession: AIChatSession;
-            if (
-                lastMsg &&
-                lastMsg.role === "assistant" &&
-                lastMsg.kind === "text" &&
-                lastMsg.inProgress
-            ) {
-                nextSession = appendToMessageContent(
-                    normalizedSession,
-                    lastMsg.id,
-                    text,
-                );
-            } else {
-                const idTaken =
-                    normalizedSession.messagesById?.[message_id] != null;
-                nextSession = appendSessionMessage(normalizedSession, {
-                    id: idTaken ? `${message_id}:${Date.now()}` : message_id,
-                    role: "assistant" as const,
-                    kind: "text" as const,
-                    content: text,
-                    workCycleId,
-                    title: "Assistant",
-                    timestamp: Date.now(),
-                    inProgress: true,
-                });
-            }
+            if (nextSession === session) continue;
 
             sessionsById = {
                 ...sessionsById,
-                [sessionId]: nextSession,
+                [session_id]: nextSession,
             };
             changed = true;
         }
@@ -5903,12 +5993,19 @@ function bufferMessageDelta(
     session_id: string,
     message_id: string,
     delta: string,
+    role: RuntimeTextMessageRole,
 ) {
-    const existing = _deltaBuffer.messageDelta.get(session_id);
+    const key = messageDeltaBufferKey(session_id, role, message_id);
+    const existing = _deltaBuffer.messageDelta.get(key);
     if (existing) {
         existing.text += delta;
     } else {
-        _deltaBuffer.messageDelta.set(session_id, { message_id, text: delta });
+        _deltaBuffer.messageDelta.set(key, {
+            session_id,
+            message_id,
+            role,
+            text: delta,
+        });
     }
     scheduleDeltaFlush();
 }
@@ -5937,7 +6034,11 @@ function flushDeltasSync() {
 }
 
 function clearBufferedDeltasForSession(sessionId: string) {
-    _deltaBuffer.messageDelta.delete(sessionId);
+    for (const [key, value] of _deltaBuffer.messageDelta.entries()) {
+        if (value.session_id === sessionId) {
+            _deltaBuffer.messageDelta.delete(key);
+        }
+    }
     _deltaBuffer.thinkingDelta.delete(sessionId);
 
     if (
@@ -8121,10 +8222,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
             });
         },
 
-        applyMessageDelta: ({ session_id, message_id, delta }) => {
+        applyMessageDelta: ({ session_id, message_id, delta, role }) => {
             if (shouldIgnoreLateActivityForSession(get(), session_id)) {
                 return;
             }
+            const messageRole = normalizeRuntimeTextMessageRole(role);
             scheduleStaleStreamingCheck(session_id);
             set((state) => {
                 const session = state.sessionsById[session_id];
@@ -8138,12 +8240,34 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     },
                 };
             });
-            bufferMessageDelta(session_id, message_id, delta);
+            bufferMessageDelta(session_id, message_id, delta, messageRole);
         },
 
-        applyMessageCompleted: ({ session_id }) => {
-            clearStaleStreamingCheck(session_id);
+        applyMessageCompleted: ({ session_id, message_id, role }) => {
             flushDeltasSync();
+            const messageRole = normalizeRuntimeTextMessageRole(role);
+            if (messageRole === "user") {
+                set((state) => {
+                    const session = state.sessionsById[session_id];
+                    if (!session) return state;
+                    const nextSession = setMessageInProgressState(
+                        session,
+                        message_id,
+                        false,
+                    );
+                    if (nextSession === session) return state;
+                    return {
+                        sessionsById: {
+                            ...state.sessionsById,
+                            [session_id]: nextSession,
+                        },
+                    };
+                });
+                persistCurrentSession(session_id);
+                return;
+            }
+
+            clearStaleStreamingCheck(session_id);
             const completedAt = Date.now();
             set((state) => {
                 const session = state.sessionsById[session_id];

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -5800,11 +5800,22 @@ interface DeltaBuffer {
     flushTimeoutId: number | null;
 }
 
+interface SuppressedRuntimeUserEcho {
+    session_id: string;
+    message_id: string;
+    text: string;
+    local_message_id: string;
+}
+
 const _deltaBuffer: DeltaBuffer = {
     messageDelta: new Map(),
     thinkingDelta: new Map(),
     flushTimeoutId: null,
 };
+const _suppressedRuntimeUserEchoByKey = new Map<
+    string,
+    SuppressedRuntimeUserEcho
+>();
 
 function normalizeRuntimeTextMessageRole(
     role?: AIChatRole | null,
@@ -5824,18 +5835,75 @@ function messageDeltaBufferKey(
     return `${sessionId}:${role}:${messageId}`;
 }
 
-function findMatchingUserTextMessageId(
+function latestLocalUserEchoCandidate(
     session: AIChatSession,
     text: string,
-): string | null {
+): AIChatMessage | null {
     const normalized = normalizeSessionTranscript(session);
     for (let index = normalized.messages.length - 1; index >= 0; index -= 1) {
         const message = normalized.messages[index];
         if (message.role === "user" && message.kind === "text") {
-            return message.content === text ? message.id : null;
+            if (message.title === runtimeTextMessageTitle("user")) {
+                return null;
+            }
+            return message.content.startsWith(text) ? message : null;
         }
     }
     return null;
+}
+
+function createRuntimeUserEchoMessage(
+    session: AIChatSession,
+    payload: {
+        message_id: string;
+        text: string;
+    },
+) {
+    const normalizedSession = normalizeSessionTranscript(session);
+    const existingMessage =
+        normalizedSession.messagesById?.[payload.message_id] ?? null;
+    const workCycleId =
+        normalizedSession.activeWorkCycleId ??
+        normalizedSession.visibleWorkCycleId ??
+        null;
+
+    return appendSessionMessage(normalizedSession, {
+        id: existingMessage
+            ? `${payload.message_id}:${Date.now()}`
+            : payload.message_id,
+        role: "user",
+        kind: "text",
+        content: payload.text,
+        workCycleId,
+        title: runtimeTextMessageTitle("user"),
+        timestamp: Date.now(),
+        inProgress: true,
+    });
+}
+
+function resolveSuppressedRuntimeUserEcho(
+    session: AIChatSession,
+    messageId: string,
+) {
+    const key = messageDeltaBufferKey(session.sessionId, "user", messageId);
+    const suppressed = _suppressedRuntimeUserEchoByKey.get(key);
+    if (!suppressed) {
+        return normalizeSessionTranscript(session);
+    }
+
+    _suppressedRuntimeUserEchoByKey.delete(key);
+    const localEcho = latestLocalUserEchoCandidate(session, suppressed.text);
+    if (
+        localEcho?.id === suppressed.local_message_id &&
+        localEcho.content === suppressed.text
+    ) {
+        return normalizeSessionTranscript(session);
+    }
+
+    return createRuntimeUserEchoMessage(session, {
+        message_id: messageId,
+        text: suppressed.text,
+    });
 }
 
 function appendRuntimeTextDelta(
@@ -5854,12 +5922,18 @@ function appendRuntimeTextDelta(
     const title = runtimeTextMessageTitle(payload.role);
     const existingMessage =
         normalizedSession.messagesById?.[payload.message_id] ?? null;
+    const bufferKey = messageDeltaBufferKey(
+        normalizedSession.sessionId,
+        payload.role,
+        payload.message_id,
+    );
 
     if (
         existingMessage &&
         existingMessage.role === payload.role &&
         existingMessage.kind === "text"
     ) {
+        _suppressedRuntimeUserEchoByKey.delete(bufferKey);
         return replaceSessionMessage(
             normalizedSession,
             payload.message_id,
@@ -5873,12 +5947,28 @@ function appendRuntimeTextDelta(
     }
 
     if (payload.role === "user") {
-        const matchingUserMessageId = findMatchingUserTextMessageId(
+        const suppressed = _suppressedRuntimeUserEchoByKey.get(bufferKey);
+        const accumulatedText = `${suppressed?.text ?? ""}${payload.text}`;
+        const localEcho = latestLocalUserEchoCandidate(
             normalizedSession,
-            payload.text,
+            accumulatedText,
         );
-        if (matchingUserMessageId) {
+        if (localEcho) {
+            _suppressedRuntimeUserEchoByKey.set(bufferKey, {
+                session_id: normalizedSession.sessionId,
+                message_id: payload.message_id,
+                text: accumulatedText,
+                local_message_id: localEcho.id,
+            });
             return normalizedSession;
+        }
+
+        if (suppressed) {
+            _suppressedRuntimeUserEchoByKey.delete(bufferKey);
+            return createRuntimeUserEchoMessage(normalizedSession, {
+                message_id: payload.message_id,
+                text: accumulatedText,
+            });
         }
     }
 
@@ -6044,6 +6134,11 @@ function clearBufferedDeltasForSession(sessionId: string) {
     for (const [key, value] of _deltaBuffer.messageDelta.entries()) {
         if (value.session_id === sessionId) {
             _deltaBuffer.messageDelta.delete(key);
+        }
+    }
+    for (const [key, value] of _suppressedRuntimeUserEchoByKey.entries()) {
+        if (value.session_id === sessionId) {
+            _suppressedRuntimeUserEchoByKey.delete(key);
         }
     }
     _deltaBuffer.thinkingDelta.delete(sessionId);
@@ -8262,8 +8357,15 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 set((state) => {
                     const session = state.sessionsById[session_id];
                     if (!session) return state;
+                    const baseSession =
+                        messageRole === "user"
+                            ? resolveSuppressedRuntimeUserEcho(
+                                  session,
+                                  message_id,
+                              )
+                            : session;
                     const nextSession = setMessageInProgressState(
-                        session,
+                        baseSession,
                         message_id,
                         false,
                     );
@@ -11910,6 +12012,13 @@ export function resetChatStore() {
     _queueDrainLocks.clear();
     _pendingStopBySessionId.clear();
     _pendingSessionPersistence.clear();
+    _deltaBuffer.messageDelta.clear();
+    _deltaBuffer.thinkingDelta.clear();
+    _suppressedRuntimeUserEchoByKey.clear();
+    if (_deltaBuffer.flushTimeoutId !== null) {
+        window.clearTimeout(_deltaBuffer.flushTimeoutId);
+        _deltaBuffer.flushTimeoutId = null;
+    }
     clearTrackedPersistedReconciliationTimers();
     _sessionPersistenceFlushScheduled = false;
     _sessionPersistenceEpoch += 1;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1757,6 +1757,28 @@ function appendSessionMessage(session: AIChatSession, message: AIChatMessage) {
     };
 }
 
+function insertSessionMessageAfter(
+    session: AIChatSession,
+    message: AIChatMessage,
+    afterMessageId: string | null,
+) {
+    const normalized = ensurePersistedTranscriptWindowAnchor(
+        normalizeSessionTranscript(session),
+    );
+    const anchorIndex =
+        afterMessageId != null
+            ? normalized.messageIndexById?.[afterMessageId]
+            : null;
+
+    if (anchorIndex == null) {
+        return appendSessionMessage(normalized, message);
+    }
+
+    const nextMessages = normalized.messages.slice();
+    nextMessages.splice(anchorIndex + 1, 0, message);
+    return replaceSessionTranscript(normalized, nextMessages);
+}
+
 function upsertSessionMessage(
     session: AIChatSession,
     message: AIChatMessage,
@@ -5805,6 +5827,7 @@ interface SuppressedRuntimeUserEcho {
     message_id: string;
     text: string;
     local_message_id: string;
+    insert_after_message_id: string | null;
 }
 
 const _deltaBuffer: DeltaBuffer = {
@@ -5860,6 +5883,7 @@ function createRuntimeUserEchoMessage(
     payload: {
         message_id: string;
         text: string;
+        insert_after_message_id?: string | null;
     },
 ) {
     const existingMessage =
@@ -5869,7 +5893,7 @@ function createRuntimeUserEchoMessage(
         normalizedSession.visibleWorkCycleId ??
         null;
 
-    return appendSessionMessage(normalizedSession, {
+    const message: AIChatMessage = {
         id: existingMessage
             ? `${payload.message_id}:${Date.now()}`
             : payload.message_id,
@@ -5880,7 +5904,17 @@ function createRuntimeUserEchoMessage(
         title: runtimeTextMessageTitle("user"),
         timestamp: Date.now(),
         inProgress: true,
-    });
+    };
+
+    if (payload.insert_after_message_id !== undefined) {
+        return insertSessionMessageAfter(
+            normalizedSession,
+            message,
+            payload.insert_after_message_id,
+        );
+    }
+
+    return appendSessionMessage(normalizedSession, message);
 }
 
 function resolveSuppressedRuntimeUserEcho(
@@ -5913,6 +5947,7 @@ function resolveSuppressedRuntimeUserEcho(
     return createRuntimeUserEchoMessage(normalizedSession, {
         message_id: messageId,
         text: suppressed.text,
+        insert_after_message_id: suppressed.insert_after_message_id,
     });
 }
 
@@ -5969,6 +6004,8 @@ function appendRuntimeTextDelta(
                 message_id: payload.message_id,
                 text: accumulatedText,
                 local_message_id: localEcho.id,
+                insert_after_message_id:
+                    normalizedSession.messageOrder?.at(-1) ?? null,
             });
             return normalizedSession;
         }
@@ -5978,6 +6015,7 @@ function appendRuntimeTextDelta(
             return createRuntimeUserEchoMessage(normalizedSession, {
                 message_id: payload.message_id,
                 text: accumulatedText,
+                insert_after_message_id: suppressed.insert_after_message_id,
             });
         }
     }

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -8158,6 +8158,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
         applySessionError: ({ session_id, message: rawMessage }) => {
             if (session_id) clearStaleStreamingCheck(session_id);
+            // The error message is appended to the timeline synchronously, so
+            // flush buffered text/thinking deltas first to keep messageOrder in
+            // runtime order (matches the other timeline-inserting handlers).
+            flushDeltasBeforeTimelineInsert();
             set((state) => {
                 const sessionRuntimeId = session_id
                     ? state.sessionsById[session_id]?.runtimeId

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -499,6 +499,7 @@ export interface AIMessageCompletedPayload {
     session_id: string;
     message_id: string;
     role?: AIChatRole;
+    turn_complete?: boolean;
 }
 
 export interface AIToolActivityPayload {

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -485,17 +485,20 @@ export interface AISessionErrorPayload {
 export interface AIMessageStartedPayload {
     session_id: string;
     message_id: string;
+    role?: AIChatRole;
 }
 
 export interface AIMessageDeltaPayload {
     session_id: string;
     message_id: string;
     delta: string;
+    role?: AIChatRole;
 }
 
 export interface AIMessageCompletedPayload {
     session_id: string;
     message_id: string;
+    role?: AIChatRole;
 }
 
 export interface AIToolActivityPayload {

--- a/crates/ai/src/events.rs
+++ b/crates/ai/src/events.rs
@@ -72,6 +72,7 @@ pub struct AiMessageCompletedPayload {
     pub session_id: String,
     pub message_id: String,
     pub role: String,
+    pub turn_complete: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/ai/src/events.rs
+++ b/crates/ai/src/events.rs
@@ -56,6 +56,7 @@ pub struct AiTokenUsagePayload {
 pub struct AiMessageStartedPayload {
     pub session_id: String,
     pub message_id: String,
+    pub role: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -63,12 +64,14 @@ pub struct AiMessageDeltaPayload {
     pub session_id: String,
     pub message_id: String,
     pub delta: String,
+    pub role: String,
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub struct AiMessageCompletedPayload {
     pub session_id: String,
     pub message_id: String,
+    pub role: String,
 }
 
 #[derive(Debug, Clone, Serialize)]


### PR DESCRIPTION
## Summary

- preserve runtime user/assistant roles through streamed message events
- segment assistant/user text around tools, permissions, plans, status, and errors so timeline order stays stable
- suppress internal drafting status updates without disturbing active text streams
- avoid duplicate local user echoes when runtime user chunks arrive in pieces

## Root Cause

Runtime text and thinking deltas are buffered, while tools, permissions, status, and errors are inserted into the chat timeline synchronously. Some handlers were not flushing or closing active text segments before inserting timeline events, so message order and in-progress state could drift under fast or interleaved runtime updates.

## Impact

This keeps subagent/user-message rendering stable, prevents stuck streaming turns when a tool-producing turn has no final text segment, and avoids duplicate prompt echoes in child/runtime sessions.

## Validation

- `cargo test -p neverwrite-native-backend`
- `npm test -- src/features/ai/store/chatStore.test.ts`
- `npm run build`