### PR TITLE
Constrain chat content width

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -14,6 +14,7 @@ import {
 import { FILE_TREE_NOTE_DRAG_EVENT } from "../dragEvents";
 import type { AIAvailableCommand, AIComposerPart } from "../types";
 import { AIChatComposer } from "./AIChatComposer";
+import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { getChatPillMetrics } from "./chatPillMetrics";
 
@@ -42,8 +43,10 @@ function renderComposer({
     availableCommands = [],
     isStopping = false,
     hasPendingSubmitAfterStop = false,
+    expanded = false,
     onMentionAttach = vi.fn(),
     onFolderAttach = vi.fn(),
+    onToggleExpanded = vi.fn(),
     onSubmit = () => {},
     onStop = () => {},
 }: {
@@ -57,12 +60,14 @@ function renderComposer({
     availableCommands?: AIAvailableCommand[];
     isStopping?: boolean;
     hasPendingSubmitAfterStop?: boolean;
+    expanded?: boolean;
     onMentionAttach?: (note: {
         id: string;
         title: string;
         path: string;
     }) => void;
     onFolderAttach?: (folderPath: string, name: string) => void;
+    onToggleExpanded?: () => void;
     onSubmit?: () => void;
     onStop?: () => void;
 } = {}) {
@@ -88,6 +93,8 @@ function renderComposer({
             availableCommands={availableCommands}
             isStopping={isStopping}
             hasPendingSubmitAfterStop={hasPendingSubmitAfterStop}
+            expanded={expanded}
+            onToggleExpanded={onToggleExpanded}
             onChange={onChange}
             onMentionAttach={onMentionAttach}
             onFolderAttach={onFolderAttach}
@@ -112,6 +119,40 @@ function setCaret(node: Node, offset: number) {
 }
 
 describe("AIChatComposer mention picker", () => {
+    it("keeps the composer shell full-width while capping the inner content", () => {
+        renderComposer();
+
+        const shell = screen.getByTestId("chat-composer-shell");
+        const contentColumn = screen.getByTestId(
+            "chat-composer-content-column",
+        );
+
+        expect(shell).toContainElement(contentColumn);
+        expect(shell).not.toHaveStyle({
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+        });
+        expect(contentColumn).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
+        });
+    });
+
+    it("keeps the capped composer content flexible while expanded", () => {
+        renderComposer({ expanded: true });
+
+        const contentColumn = screen.getByTestId(
+            "chat-composer-content-column",
+        );
+
+        expect(contentColumn).toHaveClass("flex-1");
+        expect(contentColumn).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
+        });
+    });
+
     it("lets regular composer pills show their full label", () => {
         expect(getComposerPillLayoutStyle(getChatPillMetrics(14))).toMatchObject(
             {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -53,6 +53,7 @@ import {
     shouldIncludeVaultEntryInFileScope,
     isTextLikeVaultEntry,
 } from "../../../app/utils/vaultEntries";
+import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 
 const MIN_COMPOSER_HEIGHT = 64;
 const MAX_COMPOSER_HEIGHT = 480;
@@ -1674,6 +1675,10 @@ export function AIChatComposer({
         document.body.classList.remove("resizing-composer");
         resizeSession.current = null;
     };
+    const contentColumnClassName =
+        expanded || customHeight != null
+            ? "relative flex h-full min-h-0 min-w-0 flex-1 flex-col"
+            : "relative flex min-w-0 flex-col";
 
     return (
         <div
@@ -1688,10 +1693,16 @@ export function AIChatComposer({
         >
             {contextBar ? (
                 <div className={expanded ? "px-2 pb-1.5" : "px-3 pb-1.5"}>
-                    {contextBar}
+                    <div
+                        className="min-w-0"
+                        style={AI_CHAT_CONTENT_COLUMN_STYLE}
+                    >
+                        {contextBar}
+                    </div>
                 </div>
             ) : null}
             <div
+                data-testid="chat-composer-shell"
                 className={
                     expanded
                         ? "relative flex h-full min-h-0 flex-1 flex-col"
@@ -1711,99 +1722,108 @@ export function AIChatComposer({
                         : { height: customHeight }),
                 }}
             >
-                {!expanded && (
-                    <div
-                        ref={resizeHandleRef}
-                        onPointerDown={onResizeDown}
-                        onPointerMove={onResizeMove}
-                        onPointerUp={onResizeUp}
-                        onPointerCancel={onResizeUp}
-                        className="group absolute left-0 right-0 flex cursor-row-resize items-center justify-center touch-none"
-                        style={{
-                            top: -4,
-                            height: 9,
-                            zIndex: 2,
-                        }}
-                    >
-                        <div
-                            className="rounded-full transition-colors duration-150"
-                            style={{
-                                width: 32,
-                                height: 3,
-                                backgroundColor: "var(--border)",
-                            }}
-                        />
-                    </div>
-                )}
-                <button
-                    type="button"
-                    tabIndex={-1}
-                    onClick={onToggleExpanded}
-                    onMouseDown={(e) => e.preventDefault()}
-                    onMouseEnter={(e) => {
-                        e.currentTarget.style.backgroundColor =
-                            "color-mix(in srgb, var(--bg-tertiary) 80%, transparent)";
-                        e.currentTarget.style.color = "var(--text-primary)";
-                        e.currentTarget.style.opacity = "1";
-                    }}
-                    onMouseLeave={(e) => {
-                        e.currentTarget.style.backgroundColor = "transparent";
-                        e.currentTarget.style.color = "var(--text-secondary)";
-                        e.currentTarget.style.opacity = "0.45";
-                    }}
-                    className="absolute right-2 top-2 flex items-center justify-center rounded"
-                    style={{
-                        width: 22,
-                        height: 22,
-                        color: "var(--text-secondary)",
-                        backgroundColor: "transparent",
-                        border: "none",
-                        opacity: 0.45,
-                        outline: "none",
-                        zIndex: 1,
-                        transition:
-                            "background-color 100ms ease, color 100ms ease, opacity 100ms ease",
-                    }}
-                    title={expanded ? "Collapse composer" : "Expand composer"}
-                    aria-label={
-                        expanded ? "Collapse composer" : "Expand composer"
-                    }
+                <div
+                    className={contentColumnClassName}
+                    data-testid="chat-composer-content-column"
+                    style={AI_CHAT_CONTENT_COLUMN_STYLE}
                 >
-                    {expanded ? (
-                        <svg
-                            width="13"
-                            height="13"
-                            viewBox="0 0 14 14"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.6"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
+                    {!expanded && (
+                        <div
+                            ref={resizeHandleRef}
+                            onPointerDown={onResizeDown}
+                            onPointerMove={onResizeMove}
+                            onPointerUp={onResizeUp}
+                            onPointerCancel={onResizeUp}
+                            className="group absolute left-0 right-0 flex cursor-row-resize items-center justify-center touch-none"
+                            style={{
+                                top: -4,
+                                height: 9,
+                                zIndex: 2,
+                            }}
                         >
-                            {/* Collapse: inner brackets at (5,5) and (9,9)
-                                with diagonals out to the outer corners — reads
-                                as arrows pulling inward toward the centre. */}
-                            <path d="M5 1V5H1M9 13V9H13M5 5L1 1M9 9L13 13" />
-                        </svg>
-                    ) : (
-                        <svg
-                            width="13"
-                            height="13"
-                            viewBox="0 0 14 14"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.6"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        >
-                            {/* Expand: outer brackets at the corners with
-                                diagonals pushing outward — arrows reaching
-                                toward the corners. */}
-                            <path d="M9 1h4v4M5 13H1V9M13 1l-5 5M1 13l5-5" />
-                        </svg>
+                            <div
+                                className="rounded-full transition-colors duration-150"
+                                style={{
+                                    width: 32,
+                                    height: 3,
+                                    backgroundColor: "var(--border)",
+                                }}
+                            />
+                        </div>
                     )}
-                </button>
-                {isEmpty && (
+                    <button
+                        type="button"
+                        tabIndex={-1}
+                        onClick={onToggleExpanded}
+                        onMouseDown={(e) => e.preventDefault()}
+                        onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor =
+                                "color-mix(in srgb, var(--bg-tertiary) 80%, transparent)";
+                            e.currentTarget.style.color = "var(--text-primary)";
+                            e.currentTarget.style.opacity = "1";
+                        }}
+                        onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor =
+                                "transparent";
+                            e.currentTarget.style.color =
+                                "var(--text-secondary)";
+                            e.currentTarget.style.opacity = "0.45";
+                        }}
+                        className="absolute right-2 top-2 flex items-center justify-center rounded"
+                        style={{
+                            width: 22,
+                            height: 22,
+                            color: "var(--text-secondary)",
+                            backgroundColor: "transparent",
+                            border: "none",
+                            opacity: 0.45,
+                            outline: "none",
+                            zIndex: 1,
+                            transition:
+                                "background-color 100ms ease, color 100ms ease, opacity 100ms ease",
+                        }}
+                        title={
+                            expanded ? "Collapse composer" : "Expand composer"
+                        }
+                        aria-label={
+                            expanded ? "Collapse composer" : "Expand composer"
+                        }
+                    >
+                        {expanded ? (
+                            <svg
+                                width="13"
+                                height="13"
+                                viewBox="0 0 14 14"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="1.6"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            >
+                                {/* Collapse: inner brackets at (5,5) and (9,9)
+                                    with diagonals out to the outer corners — reads
+                                    as arrows pulling inward toward the centre. */}
+                                <path d="M5 1V5H1M9 13V9H13M5 5L1 1M9 9L13 13" />
+                            </svg>
+                        ) : (
+                            <svg
+                                width="13"
+                                height="13"
+                                viewBox="0 0 14 14"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="1.6"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            >
+                                {/* Expand: outer brackets at the corners with
+                                    diagonals pushing outward — arrows reaching
+                                    toward the corners. */}
+                                <path d="M9 1h4v4M5 13H1V9M13 1l-5 5M1 13l5-5" />
+                            </svg>
+                        )}
+                    </button>
+                    {isEmpty && (
                     <div
                         className="pointer-events-none absolute left-3.5 top-2.5"
                         style={{
@@ -1824,16 +1844,16 @@ export function AIChatComposer({
                                 ? "Set up a provider in Settings → AI providers"
                                 : `Message ${runtimeName} — @ to include context, / for commands`)}
                     </div>
-                )}
-                <div
-                    ref={bindComposerRef}
-                    contentEditable={!disabled}
-                    suppressContentEditableWarning
-                    role="textbox"
-                    aria-label={AI_MESSAGE_LABEL}
-                    autoCorrect="off"
-                    autoCapitalize="off"
-                    spellCheck={false}
+                    )}
+                    <div
+                        ref={bindComposerRef}
+                        contentEditable={!disabled}
+                        suppressContentEditableWarning
+                        role="textbox"
+                        aria-label={AI_MESSAGE_LABEL}
+                        autoCorrect="off"
+                        autoCapitalize="off"
+                        spellCheck={false}
                     onContextMenu={(event) => {
                         event.preventDefault();
                         const composer = composerRef.current;
@@ -2308,6 +2328,7 @@ export function AIChatComposer({
                     />
                 )}
                 {bottomAccent}
+                </div>
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -86,6 +86,22 @@ function getScrollContainer(root: HTMLElement) {
     return container!;
 }
 
+function getMessageColumn(root: HTMLElement) {
+    const column = root.querySelector(
+        '[data-selectable="true"]',
+    ) as HTMLDivElement | null;
+    expect(column).not.toBeNull();
+    return column!;
+}
+
+function expectSharedChatContentColumn(element: HTMLElement) {
+    expect(element).toHaveStyle({
+        width: "100%",
+        maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+        marginInline: "auto",
+    });
+}
+
 describe("AIChatMessageList streaming run indicator", () => {
     afterEach(() => {
         vi.useRealTimers();
@@ -195,14 +211,10 @@ describe("AIChatMessageList streaming run indicator", () => {
             />,
         );
 
-        const messageColumn = view.container.querySelector(
-            '[data-selectable="true"]',
-        );
+        const messageColumn = getMessageColumn(view.container);
 
+        expectSharedChatContentColumn(messageColumn);
         expect(messageColumn).toHaveStyle({
-            width: "100%",
-            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
-            marginInline: "auto",
             fontFamily:
                 '"American Typewriter", "Courier Prime", "Courier New", "Nimbus Mono PS", monospace',
         });
@@ -218,16 +230,60 @@ describe("AIChatMessageList streaming run indicator", () => {
         );
 
         const scrollContainer = getScrollContainer(view.container);
-        const messageColumn = view.container.querySelector(
-            '[data-selectable="true"]',
-        );
+        const messageColumn = getMessageColumn(view.container);
 
         expect(scrollContainer).toHaveClass("flex-1");
-        expect(messageColumn).toHaveStyle({
-            width: "100%",
-            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
-            marginInline: "auto",
+        expectSharedChatContentColumn(messageColumn);
+    });
+
+    it.each([
+        ["narrow", 320],
+        ["wide", 1200],
+    ])(
+        "keeps the shared transcript column responsive in a %s panel",
+        (_label, width) => {
+            const view = renderComponent(
+                <AIChatMessageList
+                    sessionId={`session-${width}`}
+                    messages={createMessages()}
+                    status="idle"
+                />,
+            );
+            const scrollContainer = getScrollContainer(view.container);
+            configureScrollableViewport(scrollContainer, 320, { width });
+
+            expect(scrollContainer.clientWidth).toBe(width);
+            expectSharedChatContentColumn(getMessageColumn(view.container));
+        },
+    );
+
+    it("keeps the shared transcript column during width-change scroll anchoring", () => {
+        let width = 1200;
+        const messages = createLongTranscript(80);
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-resize-column"
+                messages={messages}
+                status="idle"
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer, 320, {
+            getWidth: () => width,
         });
+
+        act(() => {
+            scrollContainer.scrollTop = 2_400;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        width = 360;
+        act(() => {
+            window.dispatchEvent(new Event("resize"));
+        });
+
+        expect(scrollContainer.clientWidth).toBe(360);
+        expectSharedChatContentColumn(getMessageColumn(view.container));
     });
 
     it("keeps empty new chats top-aligned", () => {
@@ -616,11 +672,9 @@ describe("AIChatMessageList streaming run indicator", () => {
         );
 
         expect(screen.getAllByText("Implement")).toHaveLength(1);
-        expect(screen.getByTestId("chat-pinned-plan-column")).toHaveStyle({
-            width: "100%",
-            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
-            marginInline: "auto",
-        });
+        expectSharedChatContentColumn(
+            screen.getByTestId("chat-pinned-plan-column"),
+        );
         expect(
             view.container.querySelector('[aria-label="Dismiss plan banner"]'),
         ).not.toBeNull();

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -5,6 +5,7 @@ import type { AIChatMessage } from "../types";
 import { AIChatMessageList } from "./AIChatMessageList";
 import { resetChatMessageListViewState } from "./chatMessageListViewState";
 import { resetChatRowUiStore } from "../store/chatRowUiStore";
+import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 
 function createMessages(): AIChatMessage[] {
     return [
@@ -199,8 +200,33 @@ describe("AIChatMessageList streaming run indicator", () => {
         );
 
         expect(messageColumn).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
             fontFamily:
                 '"American Typewriter", "Courier Prime", "Courier New", "Nimbus Mono PS", monospace',
+        });
+    });
+
+    it("constrains the transcript content while keeping the scroll container full-width", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-column"
+                messages={createMessages()}
+                status="idle"
+            />,
+        );
+
+        const scrollContainer = getScrollContainer(view.container);
+        const messageColumn = view.container.querySelector(
+            '[data-selectable="true"]',
+        );
+
+        expect(scrollContainer).toHaveClass("flex-1");
+        expect(messageColumn).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
         });
     });
 
@@ -590,6 +616,11 @@ describe("AIChatMessageList streaming run indicator", () => {
         );
 
         expect(screen.getAllByText("Implement")).toHaveLength(1);
+        expect(screen.getByTestId("chat-pinned-plan-column")).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
+        });
         expect(
             view.container.querySelector('[aria-label="Dismiss plan banner"]'),
         ).not.toBeNull();

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -30,6 +30,7 @@ import {
     useChatRowUiStore,
 } from "../store/chatRowUiStore";
 import { useChatStore } from "../store/chatStore";
+import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 
 interface AIChatMessageListProps {
     sessionId?: string | null;
@@ -655,20 +656,26 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                             "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
                     }}
                 >
-                    <PlanMessage
-                        sessionId={sessionId}
-                        message={visiblePinnedPlan}
-                        pillMetrics={pillMetrics}
-                        onDismiss={() =>
-                            dismissPinnedPlan(
-                                rowUiSessionId,
-                                visiblePinnedPlan.id,
-                                {
-                                    pinnedPlanDismissed: true,
-                                },
-                            )
-                        }
-                    />
+                    <div
+                        className="min-w-0"
+                        data-testid="chat-pinned-plan-column"
+                        style={AI_CHAT_CONTENT_COLUMN_STYLE}
+                    >
+                        <PlanMessage
+                            sessionId={sessionId}
+                            message={visiblePinnedPlan}
+                            pillMetrics={pillMetrics}
+                            onDismiss={() =>
+                                dismissPinnedPlan(
+                                    rowUiSessionId,
+                                    visiblePinnedPlan.id,
+                                    {
+                                        pinnedPlanDismissed: true,
+                                    },
+                                )
+                            }
+                        />
+                    </div>
                 </div>
             )}
             <div
@@ -682,6 +689,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                     className="min-w-0"
                     data-selectable="true"
                     style={{
+                        ...AI_CHAT_CONTENT_COLUMN_STYLE,
                         fontSize: chatFontSize,
                         fontFamily: getEditorFontFamily(chatFontFamily),
                     }}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -6,13 +6,27 @@ import { renderComponent } from "../../../test/test-utils";
 import { resetChatStore, useChatStore } from "../store/chatStore";
 import type { AIChatSession } from "../types";
 import { AIChatSessionView } from "./AIChatSessionView";
+import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 
 vi.mock("./AIChatMessageList", () => ({
     AIChatMessageList: () => <div data-testid="chat-message-list" />,
 }));
 
 vi.mock("./AIChatComposer", () => ({
-    AIChatComposer: () => <div data-testid="chat-composer" />,
+    AIChatComposer: ({
+        expanded,
+        onToggleExpanded,
+    }: {
+        expanded?: boolean;
+        onToggleExpanded?: () => void;
+    }) => (
+        <button
+            type="button"
+            data-testid="chat-composer"
+            data-expanded={String(Boolean(expanded))}
+            onClick={onToggleExpanded}
+        />
+    ),
 }));
 
 vi.mock("./AIChatContextBar", () => ({
@@ -62,6 +76,34 @@ function createSession(sessionId: string, title: string): AIChatSession {
     };
 }
 
+function setupWorkspaceSession(sessionId = "session-a") {
+    useChatStore.setState((state) => ({
+        ...state,
+        sessionsById: {
+            [sessionId]: createSession(sessionId, "Workspace chat"),
+        },
+        activeSessionId: sessionId,
+    }));
+    useEditorStore.getState().openChat(sessionId, {
+        title: "Workspace chat",
+        paneId: "primary",
+    });
+}
+
+function expectColumnAncestor(testId: string) {
+    const element = screen.getByTestId(testId);
+    const column = element.closest('[data-testid="chat-content-column"]');
+
+    expect(column).not.toBeNull();
+    expect(column).toHaveStyle({
+        width: "100%",
+        maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+        marginInline: "auto",
+    });
+
+    return column as HTMLElement;
+}
+
 describe("AIChatSessionView", () => {
     beforeEach(() => {
         resetChatStore();
@@ -77,17 +119,7 @@ describe("AIChatSessionView", () => {
     });
 
     it("renames the workspace chat from the local header title on double click", async () => {
-        useChatStore.setState((state) => ({
-            ...state,
-            sessionsById: {
-                "session-a": createSession("session-a", "Workspace chat"),
-            },
-            activeSessionId: "session-a",
-        }));
-        useEditorStore.getState().openChat("session-a", {
-            title: "Workspace chat",
-            paneId: "primary",
-        });
+        setupWorkspaceSession();
 
         renderComponent(<AIChatSessionView paneId="primary" />);
 
@@ -109,6 +141,7 @@ describe("AIChatSessionView", () => {
     });
 
     it("removes expired screenshots from the composer", async () => {
+        setupWorkspaceSession();
         useChatStore.setState((state) => ({
             ...state,
             sessionsById: {
@@ -131,10 +164,6 @@ describe("AIChatSessionView", () => {
                 ],
             },
         }));
-        useEditorStore.getState().openChat("session-a", {
-            title: "Workspace chat",
-            paneId: "primary",
-        });
 
         renderComponent(<AIChatSessionView paneId="primary" />);
 
@@ -143,5 +172,29 @@ describe("AIChatSessionView", () => {
                 useChatStore.getState().composerPartsBySessionId["session-a"],
             ).toEqual([{ id: "text-1", type: "text", text: "Review  please" }]);
         });
+    });
+
+    it("aligns lower chat panels and the composer to the shared content column", () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        expectColumnAncestor("edited-files-panel");
+        expectColumnAncestor("queued-messages-panel");
+        expectColumnAncestor("chat-composer");
+    });
+
+    it("keeps the composer column flexible while the composer is expanded", () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        fireEvent.click(screen.getByTestId("chat-composer"));
+
+        expect(screen.getByTestId("chat-composer")).toHaveAttribute(
+            "data-expanded",
+            "true",
+        );
+        expect(expectColumnAncestor("chat-composer")).toHaveClass("flex-1");
     });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -174,17 +174,21 @@ describe("AIChatSessionView", () => {
         });
     });
 
-    it("aligns lower chat panels and the composer to the shared content column", () => {
+    it("aligns lower chat panels to the shared content column", () => {
         setupWorkspaceSession();
 
         renderComponent(<AIChatSessionView paneId="primary" />);
 
         expectColumnAncestor("edited-files-panel");
         expectColumnAncestor("queued-messages-panel");
-        expectColumnAncestor("chat-composer");
+        expect(
+            screen
+                .getByTestId("chat-composer")
+                .closest('[data-testid="chat-content-column"]'),
+        ).toBeNull();
     });
 
-    it("keeps the composer column flexible while the composer is expanded", () => {
+    it("keeps the composer flexible while it is expanded", () => {
         setupWorkspaceSession();
 
         renderComponent(<AIChatSessionView paneId="primary" />);
@@ -195,6 +199,5 @@ describe("AIChatSessionView", () => {
             "data-expanded",
             "true",
         );
-        expect(expectColumnAncestor("chat-composer")).toHaveClass("flex-1");
     });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -9,7 +9,14 @@
  * All session data is read reactively from chatStore, which is the single
  * source of truth regardless of where the UI renders.
  */
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type ReactNode,
+} from "react";
 import { open as runtimeOpen } from "@neverwrite/runtime";
 import { useShallow } from "zustand/react/shallow";
 import {
@@ -37,6 +44,7 @@ import { QueuedMessagesPanel } from "./QueuedMessagesPanel";
 import { AIChatRuntimeBanner } from "./AIChatRuntimeBanner";
 import { AIDiscardedRootsBanner } from "./AIDiscardedRootsBanner";
 import { useInlineRename } from "./useInlineRename";
+import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 import {
     appendFileAttachmentPart,
     appendScreenshotPart,
@@ -59,6 +67,28 @@ const IDLE_CONNECTION: AIRuntimeConnectionState = {
     status: "idle",
     message: null,
 };
+
+function ChatContentColumn({
+    children,
+    fill = false,
+}: {
+    children: ReactNode;
+    fill?: boolean;
+}) {
+    return (
+        <div
+            className={
+                fill
+                    ? "flex min-h-0 min-w-0 flex-1 flex-col"
+                    : "min-w-0"
+            }
+            data-testid="chat-content-column"
+            style={AI_CHAT_CONTENT_COLUMN_STYLE}
+        >
+            {children}
+        </div>
+    );
+}
 
 interface AIChatSessionViewProps {
     paneId?: string;
@@ -555,7 +585,9 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 />
             )}
 
-            <EditedFilesBufferPanel sessionId={sessionId} />
+            <ChatContentColumn>
+                <EditedFilesBufferPanel sessionId={sessionId} />
+            </ChatContentColumn>
 
             <div
                 className={
@@ -564,171 +596,190 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                         : "pt-2"
                 }
             >
-                <QueuedMessagesPanel
-                    items={queuedMessages}
-                    editingItem={queuedMessageEdit?.item ?? null}
-                    onCancel={(messageId) => {
-                        chatActions.removeQueuedMessage(sessionId, messageId);
-                    }}
-                    onClearAll={() => {
-                        chatActions.clearSessionQueue(sessionId);
-                    }}
-                    onEdit={(messageId) => {
-                        chatActions.editQueuedMessage(sessionId, messageId);
-                    }}
-                    onSendNow={(messageId) => {
-                        void chatActions.sendQueuedMessageNow(
-                            sessionId,
-                            messageId,
-                        );
-                    }}
-                    onCancelEdit={() => {
-                        chatActions.cancelQueuedMessageEdit(sessionId);
-                    }}
-                />
-                <AIChatComposer
-                    key={sessionId}
-                    sessionId={sessionId}
-                    parts={composerParts}
-                    notes={noteOptions}
-                    files={fileOptions}
-                    status={session?.status ?? "idle"}
-                    runtimeName={runtimeLabel}
-                    runtimeId={session?.runtimeId}
-                    requireCmdEnterToSend={requireCmdEnterToSend}
-                    composerFontSize={composerFontSize}
-                    composerFontFamily={composerFontFamily}
-                    availableCommands={session?.availableCommands}
-                    isStopping={Boolean(interruptedTurnState?.isStopping)}
-                    hasPendingSubmitAfterStop={Boolean(
-                        interruptedTurnState?.pendingManualSend,
-                    )}
-                    expanded={composerExpanded}
-                    onToggleExpanded={() => setComposerExpanded((v) => !v)}
-                    disabled={
-                        !session ||
-                        isClosedSubagent ||
-                        isPendingSessionCreation ||
-                        activeConnection.status === "loading" ||
-                        Boolean(session.isResumingSession)
-                    }
-                    placeholderText={
-                        isClosedSubagent
-                            ? "This subagent was closed by its parent thread."
-                            : isPendingSessionCreation
-                              ? pendingSessionError
-                                  ? "Agent unavailable"
-                                  : "Loading agent"
-                            : undefined
-                    }
-                    contextBar={
-                        <AIChatContextBar
-                            attachments={[
-                                ...(session?.attachments ?? [])
-                                    .filter(
-                                        (a) =>
-                                            !composerParts.some(
-                                                (p) =>
-                                                    (p.type === "mention" &&
-                                                        p.noteId ===
-                                                            a.noteId) ||
-                                                    (p.type ===
-                                                        "file_mention" &&
-                                                        a.type === "file" &&
-                                                        a.path === p.path) ||
-                                                    (p.type ===
-                                                        "folder_mention" &&
-                                                        a.type === "folder" &&
-                                                        p.folderPath ===
-                                                            a.noteId),
-                                            ),
-                                    )
-                                    .map((attachment) => ({
-                                        id: attachment.id,
-                                        noteId: attachment.noteId,
-                                        label: attachment.label,
-                                        path: attachment.path,
-                                        removable: true,
-                                        type: attachment.type,
-                                        status: attachment.status,
-                                        errorMessage: attachment.errorMessage,
-                                    })),
-                            ]}
-                            onRemoveAttachment={handleRemoveAttachment}
-                            onClearAll={handleClearAttachments}
-                        />
-                    }
-                    bottomAccent={
-                        contextUsageBarEnabled ? (
-                            <AIChatContextUsageBar
-                                usage={tokenUsage}
-                                cornerRadius={composerExpanded ? 9 : 11}
+                <ChatContentColumn>
+                    <QueuedMessagesPanel
+                        items={queuedMessages}
+                        editingItem={queuedMessageEdit?.item ?? null}
+                        onCancel={(messageId) => {
+                            chatActions.removeQueuedMessage(
+                                sessionId,
+                                messageId,
+                            );
+                        }}
+                        onClearAll={() => {
+                            chatActions.clearSessionQueue(sessionId);
+                        }}
+                        onEdit={(messageId) => {
+                            chatActions.editQueuedMessage(sessionId, messageId);
+                        }}
+                        onSendNow={(messageId) => {
+                            void chatActions.sendQueuedMessageNow(
+                                sessionId,
+                                messageId,
+                            );
+                        }}
+                        onCancelEdit={() => {
+                            chatActions.cancelQueuedMessageEdit(sessionId);
+                        }}
+                    />
+                </ChatContentColumn>
+                <ChatContentColumn fill={composerExpanded}>
+                    <AIChatComposer
+                        key={sessionId}
+                        sessionId={sessionId}
+                        parts={composerParts}
+                        notes={noteOptions}
+                        files={fileOptions}
+                        status={session?.status ?? "idle"}
+                        runtimeName={runtimeLabel}
+                        runtimeId={session?.runtimeId}
+                        requireCmdEnterToSend={requireCmdEnterToSend}
+                        composerFontSize={composerFontSize}
+                        composerFontFamily={composerFontFamily}
+                        availableCommands={session?.availableCommands}
+                        isStopping={Boolean(interruptedTurnState?.isStopping)}
+                        hasPendingSubmitAfterStop={Boolean(
+                            interruptedTurnState?.pendingManualSend,
+                        )}
+                        expanded={composerExpanded}
+                        onToggleExpanded={() => setComposerExpanded((v) => !v)}
+                        disabled={
+                            !session ||
+                            isClosedSubagent ||
+                            isPendingSessionCreation ||
+                            activeConnection.status === "loading" ||
+                            Boolean(session.isResumingSession)
+                        }
+                        placeholderText={
+                            isClosedSubagent
+                                ? "This subagent was closed by its parent thread."
+                                : isPendingSessionCreation
+                                  ? pendingSessionError
+                                      ? "Agent unavailable"
+                                      : "Loading agent"
+                                  : undefined
+                        }
+                        contextBar={
+                            <AIChatContextBar
+                                attachments={[
+                                    ...(session?.attachments ?? [])
+                                        .filter(
+                                            (a) =>
+                                                !composerParts.some(
+                                                    (p) =>
+                                                        (p.type ===
+                                                            "mention" &&
+                                                            p.noteId ===
+                                                                a.noteId) ||
+                                                        (p.type ===
+                                                            "file_mention" &&
+                                                            a.type === "file" &&
+                                                            a.path === p.path) ||
+                                                        (p.type ===
+                                                            "folder_mention" &&
+                                                            a.type ===
+                                                                "folder" &&
+                                                            p.folderPath ===
+                                                                a.noteId),
+                                                ),
+                                        )
+                                        .map((attachment) => ({
+                                            id: attachment.id,
+                                            noteId: attachment.noteId,
+                                            label: attachment.label,
+                                            path: attachment.path,
+                                            removable: true,
+                                            type: attachment.type,
+                                            status: attachment.status,
+                                            errorMessage:
+                                                attachment.errorMessage,
+                                        })),
+                                ]}
+                                onRemoveAttachment={handleRemoveAttachment}
+                                onClearAll={handleClearAttachments}
                             />
-                        ) : null
-                    }
-                    footer={
-                        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                            {!isPendingSessionCreation && (
-                                <AIChatAgentControls
-                                    disabled={agentControlsDisabled}
-                                    runtimeId={session?.runtimeId}
-                                    modelId={session?.modelId ?? ""}
-                                    modeId={session?.modeId ?? ""}
-                                    effortsByModel={
-                                        session?.effortsByModel ?? {}
-                                    }
-                                    models={agentCatalog.models}
-                                    modes={agentCatalog.modes}
-                                    configOptions={agentCatalog.configOptions}
-                                    onModelChange={(modelId) => {
-                                        void chatActions.setModel(
-                                            modelId,
-                                            sessionId,
-                                        );
-                                    }}
-                                    onModeChange={(modeId) => {
-                                        void chatActions.setMode(
-                                            modeId,
-                                            sessionId,
-                                        );
-                                    }}
-                                    onConfigOptionChange={(optionId, value) => {
-                                        void chatActions.setConfigOption(
+                        }
+                        bottomAccent={
+                            contextUsageBarEnabled ? (
+                                <AIChatContextUsageBar
+                                    usage={tokenUsage}
+                                    cornerRadius={composerExpanded ? 9 : 11}
+                                />
+                            ) : null
+                        }
+                        footer={
+                            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                {!isPendingSessionCreation && (
+                                    <AIChatAgentControls
+                                        disabled={agentControlsDisabled}
+                                        runtimeId={session?.runtimeId}
+                                        modelId={session?.modelId ?? ""}
+                                        modeId={session?.modeId ?? ""}
+                                        effortsByModel={
+                                            session?.effortsByModel ?? {}
+                                        }
+                                        models={agentCatalog.models}
+                                        modes={agentCatalog.modes}
+                                        configOptions={
+                                            agentCatalog.configOptions
+                                        }
+                                        onModelChange={(modelId) => {
+                                            void chatActions.setModel(
+                                                modelId,
+                                                sessionId,
+                                            );
+                                        }}
+                                        onModeChange={(modeId) => {
+                                            void chatActions.setMode(
+                                                modeId,
+                                                sessionId,
+                                            );
+                                        }}
+                                        onConfigOptionChange={(
                                             optionId,
                                             value,
-                                            sessionId,
-                                        );
-                                    }}
-                                />
-                            )}
-                        </div>
-                    }
-                    onChange={(parts) => {
-                        chatActions.setComposerParts(parts, sessionId);
-                    }}
-                    onAttachFile={handleAttachFile}
-                    onPasteImage={handlePasteImage}
-                    onFocus={() => {
-                        if (!sessionId) return;
-                        chatActions.markSessionFocused(sessionId);
-                    }}
-                    onMentionAttach={(note) => {
-                        chatActions.attachNote(note, sessionId);
-                    }}
-                    onFileMentionAttach={(file) => {
-                        chatActions.attachVaultFile(file, sessionId);
-                    }}
-                    onFolderAttach={(folderPath, name) => {
-                        chatActions.attachFolder(folderPath, name, sessionId);
-                    }}
-                    onSubmit={() => {
-                        setComposerExpanded(false);
-                        void chatActions.sendMessage(sessionId);
-                    }}
-                    onStop={() => {
-                        void chatActions.stopStreaming(sessionId);
-                    }}
-                />
+                                        ) => {
+                                            void chatActions.setConfigOption(
+                                                optionId,
+                                                value,
+                                                sessionId,
+                                            );
+                                        }}
+                                    />
+                                )}
+                            </div>
+                        }
+                        onChange={(parts) => {
+                            chatActions.setComposerParts(parts, sessionId);
+                        }}
+                        onAttachFile={handleAttachFile}
+                        onPasteImage={handlePasteImage}
+                        onFocus={() => {
+                            if (!sessionId) return;
+                            chatActions.markSessionFocused(sessionId);
+                        }}
+                        onMentionAttach={(note) => {
+                            chatActions.attachNote(note, sessionId);
+                        }}
+                        onFileMentionAttach={(file) => {
+                            chatActions.attachVaultFile(file, sessionId);
+                        }}
+                        onFolderAttach={(folderPath, name) => {
+                            chatActions.attachFolder(
+                                folderPath,
+                                name,
+                                sessionId,
+                            );
+                        }}
+                        onSubmit={() => {
+                            setComposerExpanded(false);
+                            void chatActions.sendMessage(sessionId);
+                        }}
+                        onStop={() => {
+                            void chatActions.stopStreaming(sessionId);
+                        }}
+                    />
+                </ChatContentColumn>
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -70,18 +70,12 @@ const IDLE_CONNECTION: AIRuntimeConnectionState = {
 
 function ChatContentColumn({
     children,
-    fill = false,
 }: {
     children: ReactNode;
-    fill?: boolean;
 }) {
     return (
         <div
-            className={
-                fill
-                    ? "flex min-h-0 min-w-0 flex-1 flex-col"
-                    : "min-w-0"
-            }
+            className="min-w-0"
             data-testid="chat-content-column"
             style={AI_CHAT_CONTENT_COLUMN_STYLE}
         >
@@ -623,163 +617,149 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                         }}
                     />
                 </ChatContentColumn>
-                <ChatContentColumn fill={composerExpanded}>
-                    <AIChatComposer
-                        key={sessionId}
-                        sessionId={sessionId}
-                        parts={composerParts}
-                        notes={noteOptions}
-                        files={fileOptions}
-                        status={session?.status ?? "idle"}
-                        runtimeName={runtimeLabel}
-                        runtimeId={session?.runtimeId}
-                        requireCmdEnterToSend={requireCmdEnterToSend}
-                        composerFontSize={composerFontSize}
-                        composerFontFamily={composerFontFamily}
-                        availableCommands={session?.availableCommands}
-                        isStopping={Boolean(interruptedTurnState?.isStopping)}
-                        hasPendingSubmitAfterStop={Boolean(
-                            interruptedTurnState?.pendingManualSend,
-                        )}
-                        expanded={composerExpanded}
-                        onToggleExpanded={() => setComposerExpanded((v) => !v)}
-                        disabled={
-                            !session ||
-                            isClosedSubagent ||
-                            isPendingSessionCreation ||
-                            activeConnection.status === "loading" ||
-                            Boolean(session.isResumingSession)
-                        }
-                        placeholderText={
-                            isClosedSubagent
-                                ? "This subagent was closed by its parent thread."
-                                : isPendingSessionCreation
-                                  ? pendingSessionError
-                                      ? "Agent unavailable"
-                                      : "Loading agent"
-                                  : undefined
-                        }
-                        contextBar={
-                            <AIChatContextBar
-                                attachments={[
-                                    ...(session?.attachments ?? [])
-                                        .filter(
-                                            (a) =>
-                                                !composerParts.some(
-                                                    (p) =>
-                                                        (p.type ===
-                                                            "mention" &&
-                                                            p.noteId ===
-                                                                a.noteId) ||
-                                                        (p.type ===
-                                                            "file_mention" &&
-                                                            a.type === "file" &&
-                                                            a.path === p.path) ||
-                                                        (p.type ===
-                                                            "folder_mention" &&
-                                                            a.type ===
-                                                                "folder" &&
-                                                            p.folderPath ===
-                                                                a.noteId),
-                                                ),
-                                        )
-                                        .map((attachment) => ({
-                                            id: attachment.id,
-                                            noteId: attachment.noteId,
-                                            label: attachment.label,
-                                            path: attachment.path,
-                                            removable: true,
-                                            type: attachment.type,
-                                            status: attachment.status,
-                                            errorMessage:
-                                                attachment.errorMessage,
-                                        })),
-                                ]}
-                                onRemoveAttachment={handleRemoveAttachment}
-                                onClearAll={handleClearAttachments}
+                <AIChatComposer
+                    key={sessionId}
+                    sessionId={sessionId}
+                    parts={composerParts}
+                    notes={noteOptions}
+                    files={fileOptions}
+                    status={session?.status ?? "idle"}
+                    runtimeName={runtimeLabel}
+                    runtimeId={session?.runtimeId}
+                    requireCmdEnterToSend={requireCmdEnterToSend}
+                    composerFontSize={composerFontSize}
+                    composerFontFamily={composerFontFamily}
+                    availableCommands={session?.availableCommands}
+                    isStopping={Boolean(interruptedTurnState?.isStopping)}
+                    hasPendingSubmitAfterStop={Boolean(
+                        interruptedTurnState?.pendingManualSend,
+                    )}
+                    expanded={composerExpanded}
+                    onToggleExpanded={() => setComposerExpanded((v) => !v)}
+                    disabled={
+                        !session ||
+                        isClosedSubagent ||
+                        isPendingSessionCreation ||
+                        activeConnection.status === "loading" ||
+                        Boolean(session.isResumingSession)
+                    }
+                    placeholderText={
+                        isClosedSubagent
+                            ? "This subagent was closed by its parent thread."
+                            : isPendingSessionCreation
+                              ? pendingSessionError
+                                  ? "Agent unavailable"
+                                  : "Loading agent"
+                              : undefined
+                    }
+                    contextBar={
+                        <AIChatContextBar
+                            attachments={[
+                                ...(session?.attachments ?? [])
+                                    .filter(
+                                        (a) =>
+                                            !composerParts.some(
+                                                (p) =>
+                                                    (p.type === "mention" &&
+                                                        p.noteId ===
+                                                            a.noteId) ||
+                                                    (p.type ===
+                                                        "file_mention" &&
+                                                        a.type === "file" &&
+                                                        a.path === p.path) ||
+                                                    (p.type ===
+                                                        "folder_mention" &&
+                                                        a.type === "folder" &&
+                                                        p.folderPath ===
+                                                            a.noteId),
+                                            ),
+                                    )
+                                    .map((attachment) => ({
+                                        id: attachment.id,
+                                        noteId: attachment.noteId,
+                                        label: attachment.label,
+                                        path: attachment.path,
+                                        removable: true,
+                                        type: attachment.type,
+                                        status: attachment.status,
+                                        errorMessage: attachment.errorMessage,
+                                    })),
+                            ]}
+                            onRemoveAttachment={handleRemoveAttachment}
+                            onClearAll={handleClearAttachments}
+                        />
+                    }
+                    bottomAccent={
+                        contextUsageBarEnabled ? (
+                            <AIChatContextUsageBar
+                                usage={tokenUsage}
+                                cornerRadius={composerExpanded ? 9 : 11}
                             />
-                        }
-                        bottomAccent={
-                            contextUsageBarEnabled ? (
-                                <AIChatContextUsageBar
-                                    usage={tokenUsage}
-                                    cornerRadius={composerExpanded ? 9 : 11}
-                                />
-                            ) : null
-                        }
-                        footer={
-                            <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                                {!isPendingSessionCreation && (
-                                    <AIChatAgentControls
-                                        disabled={agentControlsDisabled}
-                                        runtimeId={session?.runtimeId}
-                                        modelId={session?.modelId ?? ""}
-                                        modeId={session?.modeId ?? ""}
-                                        effortsByModel={
-                                            session?.effortsByModel ?? {}
-                                        }
-                                        models={agentCatalog.models}
-                                        modes={agentCatalog.modes}
-                                        configOptions={
-                                            agentCatalog.configOptions
-                                        }
-                                        onModelChange={(modelId) => {
-                                            void chatActions.setModel(
-                                                modelId,
-                                                sessionId,
-                                            );
-                                        }}
-                                        onModeChange={(modeId) => {
-                                            void chatActions.setMode(
-                                                modeId,
-                                                sessionId,
-                                            );
-                                        }}
-                                        onConfigOptionChange={(
+                        ) : null
+                    }
+                    footer={
+                        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                            {!isPendingSessionCreation && (
+                                <AIChatAgentControls
+                                    disabled={agentControlsDisabled}
+                                    runtimeId={session?.runtimeId}
+                                    modelId={session?.modelId ?? ""}
+                                    modeId={session?.modeId ?? ""}
+                                    effortsByModel={
+                                        session?.effortsByModel ?? {}
+                                    }
+                                    models={agentCatalog.models}
+                                    modes={agentCatalog.modes}
+                                    configOptions={agentCatalog.configOptions}
+                                    onModelChange={(modelId) => {
+                                        void chatActions.setModel(
+                                            modelId,
+                                            sessionId,
+                                        );
+                                    }}
+                                    onModeChange={(modeId) => {
+                                        void chatActions.setMode(
+                                            modeId,
+                                            sessionId,
+                                        );
+                                    }}
+                                    onConfigOptionChange={(optionId, value) => {
+                                        void chatActions.setConfigOption(
                                             optionId,
                                             value,
-                                        ) => {
-                                            void chatActions.setConfigOption(
-                                                optionId,
-                                                value,
-                                                sessionId,
-                                            );
-                                        }}
-                                    />
-                                )}
-                            </div>
-                        }
-                        onChange={(parts) => {
-                            chatActions.setComposerParts(parts, sessionId);
-                        }}
-                        onAttachFile={handleAttachFile}
-                        onPasteImage={handlePasteImage}
-                        onFocus={() => {
-                            if (!sessionId) return;
-                            chatActions.markSessionFocused(sessionId);
-                        }}
-                        onMentionAttach={(note) => {
-                            chatActions.attachNote(note, sessionId);
-                        }}
-                        onFileMentionAttach={(file) => {
-                            chatActions.attachVaultFile(file, sessionId);
-                        }}
-                        onFolderAttach={(folderPath, name) => {
-                            chatActions.attachFolder(
-                                folderPath,
-                                name,
-                                sessionId,
-                            );
-                        }}
-                        onSubmit={() => {
-                            setComposerExpanded(false);
-                            void chatActions.sendMessage(sessionId);
-                        }}
-                        onStop={() => {
-                            void chatActions.stopStreaming(sessionId);
-                        }}
-                    />
-                </ChatContentColumn>
+                                            sessionId,
+                                        );
+                                    }}
+                                />
+                            )}
+                        </div>
+                    }
+                    onChange={(parts) => {
+                        chatActions.setComposerParts(parts, sessionId);
+                    }}
+                    onAttachFile={handleAttachFile}
+                    onPasteImage={handlePasteImage}
+                    onFocus={() => {
+                        if (!sessionId) return;
+                        chatActions.markSessionFocused(sessionId);
+                    }}
+                    onMentionAttach={(note) => {
+                        chatActions.attachNote(note, sessionId);
+                    }}
+                    onFileMentionAttach={(file) => {
+                        chatActions.attachVaultFile(file, sessionId);
+                    }}
+                    onFolderAttach={(folderPath, name) => {
+                        chatActions.attachFolder(folderPath, name, sessionId);
+                    }}
+                    onSubmit={() => {
+                        setComposerExpanded(false);
+                        void chatActions.sendMessage(sessionId);
+                    }}
+                    onStop={() => {
+                        void chatActions.stopStreaming(sessionId);
+                    }}
+                />
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.test.tsx
+++ b/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.test.tsx
@@ -1,13 +1,11 @@
-import { act, waitFor } from "@testing-library/react";
+import { act, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../../test/test-utils";
 import { resetChatStore, useChatStore } from "../store/chatStore";
 import type { AIChatSession } from "../types";
+import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
+import { resetChatMessageListViewState } from "./chatMessageListViewState";
 import { HistoryTranscriptViewer } from "./HistoryTranscriptViewer";
-
-vi.mock("./AIChatMessageList", () => ({
-    AIChatMessageList: () => <div data-testid="history-message-list" />,
-}));
 
 function createEmptyPersistedSession(
     sessionId: string,
@@ -40,6 +38,7 @@ function createEmptyPersistedSession(
 describe("HistoryTranscriptViewer", () => {
     beforeEach(() => {
         resetChatStore();
+        resetChatMessageListViewState();
     });
 
     it("does not reload an empty history session when only the session object identity changes", async () => {
@@ -81,5 +80,45 @@ describe("HistoryTranscriptViewer", () => {
         });
 
         expect(ensureSessionTranscriptLoaded).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the history transcript through the shared capped message column", () => {
+        const session = createEmptyPersistedSession("history-column", {
+            messages: [
+                {
+                    id: "history-column-message",
+                    role: "assistant",
+                    kind: "text",
+                    content: "Persisted transcript content",
+                    timestamp: 10,
+                },
+            ],
+        });
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [],
+            ensureSessionTranscriptLoaded: vi.fn().mockResolvedValue(true),
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+        }));
+
+        const view = renderComponent(
+            <HistoryTranscriptViewer historySessionId={session.sessionId} />,
+        );
+        const messageColumn = view.container.querySelector(
+            '[data-selectable="true"]',
+        );
+
+        expect(
+            screen.getByText("Persisted transcript content"),
+        ).toBeInTheDocument();
+        expect(messageColumn).not.toBeNull();
+        expect(messageColumn).toHaveStyle({
+            width: "100%",
+            maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
+            marginInline: "auto",
+        });
     });
 });

--- a/apps/desktop/src/features/ai/components/chatContentLayout.ts
+++ b/apps/desktop/src/features/ai/components/chatContentLayout.ts
@@ -1,0 +1,9 @@
+import type { CSSProperties } from "react";
+
+export const AI_CHAT_CONTENT_MAX_WIDTH_PX = 740;
+
+export const AI_CHAT_CONTENT_COLUMN_STYLE = {
+    width: "100%",
+    maxWidth: AI_CHAT_CONTENT_MAX_WIDTH_PX,
+    marginInline: "auto",
+} satisfies CSSProperties;


### PR DESCRIPTION
## Summary

- Add a shared chat content width token and apply it to the active transcript, pinned plan, history transcript, edit/queue strips, and composer content.
- Keep scroll containers and the composer shell full-width while capping the readable content column at 740px.
- Add focused regression coverage for narrow/wide panes, history inheritance, scroll anchoring, pinned plan layout, lower action panels, and composer shell/content behavior.

## Why

Wide chat panes were making messages and related controls harder to scan. This keeps the readable parts of chat aligned in a narrower column, while preserving the full-width composer background so the bottom area still feels like part of the pane.

## Validation

- `./node_modules/.bin/eslint src/features/ai/components/AIChatComposer.tsx src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatSessionView.tsx src/features/ai/components/AIChatSessionView.test.tsx`
- `./node_modules/.bin/vitest run src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/AIChatMessageList.test.tsx src/features/ai/components/HistoryTranscriptViewer.test.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`