### PR TITLE
Fix hook dependency warnings in AI review

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -2172,7 +2172,6 @@ function ChangeReviewPanel({
     onPermissionResponse?: (requestId: string, optionId?: string) => void;
     readOnly?: boolean;
 }) {
-    const messageDiffs = message.diffs ?? [];
     const messageReviewDiffs = message.reviewDiffs;
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const trackedFiles = useChatStore((state) =>
@@ -2181,8 +2180,12 @@ function ChangeReviewPanel({
     const diffs = useMemo(
         () =>
             messageReviewDiffs ??
-            deriveChatChangeReviewDiffs(messageDiffs, trackedFiles, vaultPath),
-        [messageDiffs, messageReviewDiffs, trackedFiles, vaultPath],
+            deriveChatChangeReviewDiffs(
+                message.diffs ?? [],
+                trackedFiles,
+                vaultPath,
+            ),
+        [message.diffs, messageReviewDiffs, trackedFiles, vaultPath],
     );
     const editDiffZoom = useChatStore((state) => state.editDiffZoom);
     const setEditDiffZoom = useChatStore((state) => state.setEditDiffZoom);

--- a/apps/desktop/src/features/ai/components/AIReviewView.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.tsx
@@ -306,7 +306,6 @@ function ReviewContent({ tab }: { tab: ReviewTab }) {
         },
         [
             expansion.expandedKeys,
-            persistedState?.scrollTop,
             tab.sessionId,
             vaultPath,
         ],


### PR DESCRIPTION
## Summary

- Stabilize chat change review diff memoization when a message has no `diffs` payload.
- Remove an unused persisted scroll dependency from the AI review view persistence callback.

## Root Cause

`message.diffs ?? []` created a fresh fallback array on each render, which made the hook dependency unstable. `persistedState?.scrollTop` was also listed as a dependency for a callback that reads scroll state from arguments and refs instead.

## Validation

- `npm run lint`
- `npm run test -- src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/components/AIReviewView.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/reviewTabPersistence.test.ts`
- `npm run test -- src/features/ai/diff/reviewDiff.test.ts src/features/ai/diff/editedFilesPresentationModel.test.ts src/features/ai/diff/chatChangeReviewModel.test.ts src/features/ai/diff/reviewProjection.test.ts src/features/ai/diff/reviewProjectionIndex.test.ts src/features/ai/diff/lineMap.test.ts src/features/ai/store/editedFilesBufferModel.test.ts src/features/ai/store/actionLogModel.test.ts src/features/ai/store/actionLogRustEngine.test.ts src/features/ai/store/actionLogRustEngineFallback.test.ts src/features/ai/components/EditedFilesBufferPanel.test.tsx src/features/ai/components/editedFilesPresentation.test.tsx src/features/ai/components/useEditedFilesReviewExpansion.test.tsx`

Closes #211