### PR TITLE
Prepare 0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,27 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.3.3] - 2026-06-07
+
+### Added
+
+- Added a native Grok ACP provider, including automatic detection for the official Grok CLI install path.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.42.0`.
+- Removed the Claude Code max-turns setting now that Claude Code manages turn limits internally.
+- Constrained the AI chat transcript, composer, and action panels to a shared readable width.
+- Top-aligned newly streamed chat messages so incoming responses stay easier to scan.
+
+### Fixed
+
+- Fixed dropped Excalidraw files so they open as maps instead of plain files.
+- Fixed AI chat links so raw URLs are clickable and external links open in the system browser.
+- Fixed runtime message timeline ordering so user messages, errors, and subagent activity stay in the correct transcript order.
+- Fixed hook dependency warnings in the AI review UI.
+- Fixed APT release asset publishing for Debian packages.
+
 ## [0.3.2] - 2026-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1713,7 +1713,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "agent-client-protocol",
  "keyring",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.2",
+            "version": "0.3.3",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.2",
+    "version": "0.3.3",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.2",
+    "version": "0.3.3",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {

--- a/release/apt/README.md
+++ b/release/apt/README.md
@@ -50,13 +50,13 @@ Release
 Release.gpg
 Packages
 Packages.gz
-NeverWrite-0.3.2-amd64.deb
-NeverWrite-0.3.2-arm64.deb
+NeverWrite-0.3.3-amd64.deb
+NeverWrite-0.3.3-arm64.deb
 ```
 
 The `.deb` binary packages stay on GitHub Releases with the other release
 assets. The `Filename` field in each `Packages` stanza is the release asset file
-name, for example `NeverWrite-0.3.2-amd64.deb`. APT resolves it relative to the
+name, for example `NeverWrite-0.3.3-amd64.deb`. APT resolves it relative to the
 configured `latest/download` release URL.
 
 GitHub Pages only publishes the install helper files:


### PR DESCRIPTION
## Summary
- Prepare NeverWrite 0.3.3 release metadata
- Add 0.3.3 changelog notes
- Align desktop, native backend, Web Clipper, lockfiles, and APT docs

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.3.3
- cargo check --locked -p neverwrite-native-backend
- node --test scripts/release-metadata.test.mjs
- node --test scripts/apt-repo.test.mjs
