### PR TITLE
Harden web clipper dependency audit

### DIFF
--- a/apps/web-clipper/pnpm-lock.yaml
+++ b/apps/web-clipper/pnpm-lock.yaml
@@ -6,7 +6,9 @@ settings:
 
 overrides:
   node-notifier>uuid: 11.1.1
+  shell-quote: 1.8.4
   web-ext-run>tmp: 0.2.6
+  ws: ^8.20.1
 
 importers:
 
@@ -1883,8 +1885,9 @@ packages:
   setimmediate@1.0.5:
     resolution: {integrity: sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==}
 
-  shell-quote@1.7.3:
-    resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
+    engines: {node: '>= 0.4'}
 
   shellwords@0.1.1:
     resolution: {integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==}
@@ -2270,8 +2273,8 @@ packages:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3269,7 +3272,7 @@ snapshots:
   fx-runner@1.4.0:
     dependencies:
       commander: 2.9.0
-      shell-quote: 1.7.3
+      shell-quote: 1.8.4
       spawn-sync: 1.0.15
       when: 3.7.7
       which: 1.2.4
@@ -3429,7 +3432,7 @@ snapshots:
       whatwg-encoding: 3.1.1
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
-      ws: 8.20.0
+      ws: 8.21.0
       xml-name-validator: 5.0.0
     transitivePeerDependencies:
       - bufferutil
@@ -3950,7 +3953,7 @@ snapshots:
 
   setimmediate@1.0.5: {}
 
-  shell-quote@1.7.3: {}
+  shell-quote@1.8.4: {}
 
   shellwords@0.1.1: {}
 
@@ -4312,7 +4315,7 @@ snapshots:
       string-width: 7.2.0
       strip-ansi: 7.2.0
 
-  ws@8.20.0: {}
+  ws@8.21.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/apps/web-clipper/pnpm-workspace.yaml
+++ b/apps/web-clipper/pnpm-workspace.yaml
@@ -3,4 +3,6 @@ packages:
 
 overrides:
     node-notifier>uuid: 11.1.1
+    shell-quote: 1.8.4
     web-ext-run>tmp: 0.2.6
+    ws: ^8.20.1


### PR DESCRIPTION
## Summary

- Add pnpm workspace overrides for `shell-quote` and `ws` in the web clipper workspace.
- Regenerate the web clipper lockfile so `shell-quote` resolves to `1.8.4` and `ws` resolves to `8.21.0`.
- Preserve the existing dependency overrides for `node-notifier>uuid` and `web-ext-run>tmp`.

## Why

Dependabot reported a critical advisory for `shell-quote` through the web clipper tooling chain (`wxt > web-ext-run > fx-runner > shell-quote`). A local audit also reported a moderate `ws` advisory through `jsdom`. Both are development/test/build dependencies, but they keep the workspace audit failing and should be cleared during hardening.

## Validation

- `pnpm audit --prod=false`
- `pnpm why shell-quote`
- `pnpm why ws`
- `pnpm install --frozen-lockfile`
- `pnpm run check`
- `git diff --check`

Result: audit is clean, `shell-quote` resolves to `1.8.4`, `ws` resolves to `8.21.0`, and the web clipper compile/tests/build passed.