### PR TITLE
Prepare 0.3.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,30 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.3.4] - 2026-06-16
+
+### Added
+
+- Added support for ACP form and URL elicitations so agents can request structured input, multi-select answers, skip/cancel decisions, and browser follow-up actions from the chat flow.
+- Added mixed ACP runtime compatibility so Claude can use the newer ACP stack while Gemini and Grok continue to run through legacy ACP sessions.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.44.0` and the vendored ACP bridge baseline to `0.16.0`.
+- Improved Grok model controls by preventing incompatible in-session model switches and explaining when a new Grok chat is required.
+- Reduced Gemini transcript noise by hiding topic-update activity from chat history.
+- Documented mixed ACP runtime compatibility, Claude ACP packaging checks, and related troubleshooting guidance.
+
+### Fixed
+
+- Fixed Gemini legacy sessions inheriting the wrong API-key authentication type.
+- Hardened ACP user-input and review-interaction handling so accept, decline, skip, cancel, retry, and multi-answer flows stay consistent.
+
+### Security
+
+- Updated desktop and Web Clipper dependency resolutions, including `vite`, `dompurify`, `form-data`, `js-yaml`, `tar`, and `tmp`.
+- Patched desktop Babel tooling and Web Clipper build tooling dependencies.
+
 ## [0.3.3] - 2026-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/README.md
+++ b/README.md
@@ -4,15 +4,7 @@
 <img width="2693" height="1211" alt="Captura de pantalla 2026-04-30 a las 5 03 43" src="https://github.com/user-attachments/assets/83968dc3-cfb9-41b5-ad99-bfea4305447b" />
 
 [Important note about Claude subscription usage in NeverWrite starting June 15, 2026](https://github.com/jsgrrchg/NeverWrite/discussions/83)
-
-Note: Thank you all for the support and contributions. NeverWrite is expanding toward broader ACP provider compatibility, and local LLM support is part of the roadmap before 1.0 is reached. If you use an ACP-compliant provider that is not supported yet, please open an issue so it can be prioritized. If you have experience with local LLM architecture, I would love your help designing how NeverWrite’s review layer should work for local models.
-
-AI tooling is moving quickly, and I have to be honest with myself, maintaining this app properly takes real time, testing, and provider subscriptions, something that can only be possible having a full time maintainer and proper funding. If NeverWrite is useful to you, GitHub Sponsors is now available and directly helps fund continued development and broader ACP compatibility work.
-
-You can also help by opening issues, sending PRs, testing edge cases, and especially sharing the project. I spend most of my time behind the editor fixing bugs, building new features, and thinking about how to improve and optimize it even more, so I need the kind of power only a community can give: feedback, testing, ideas, and word of mouth.
-
-The mission of NeverWrite is to become the number one alternative for a knowledge workspace prepared to endure this new agentic era that has just begun. Come along for the ride, we’re only getting started.
-
+  - Update: Claude delayed their decision, you can continue to use claude native integration inside NeverWrite. More info in the linked discussion.
 ----
 
 NeverWrite is a local-first knowledge workspace for people who need to handle workflows with multiple parallel agents and subagents. Built like a code editor, but for markdown. It has inline review changes, like Cursor and others. Please help me test it!

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.3",
+            "version": "0.3.4",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.3",
+    "version": "0.3.4",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.3",
+    "version": "0.3.4",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {

--- a/release/apt/README.md
+++ b/release/apt/README.md
@@ -50,13 +50,13 @@ Release
 Release.gpg
 Packages
 Packages.gz
-NeverWrite-0.3.3-amd64.deb
-NeverWrite-0.3.3-arm64.deb
+NeverWrite-0.3.4-amd64.deb
+NeverWrite-0.3.4-arm64.deb
 ```
 
 The `.deb` binary packages stay on GitHub Releases with the other release
 assets. The `Filename` field in each `Packages` stanza is the release asset file
-name, for example `NeverWrite-0.3.3-amd64.deb`. APT resolves it relative to the
+name, for example `NeverWrite-0.3.4-amd64.deb`. APT resolves it relative to the
 configured `latest/download` release URL.
 
 GitHub Pages only publishes the install helper files:


### PR DESCRIPTION
## Summary
- Prepare the 0.3.4 release metadata and changelog.
- Align desktop, native backend, Web Clipper, and lockfile versions.
- Refresh APT release asset examples for 0.3.4.
- Update the README Claude subscription note.

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.3.4
- cargo check --locked -p neverwrite-native-backend
- node --test scripts/release-metadata.test.mjs
- git diff --check