### PR TITLE
Tidy footnotes in markdown live preview (#196)

### DIFF
--- a/apps/desktop/e2e/harness/main.ts
+++ b/apps/desktop/e2e/harness/main.ts
@@ -2,7 +2,10 @@ import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { drawSelection, EditorView } from "@codemirror/view";
 
-import { linkReferenceField } from "../../src/features/editor/extensions/livePreviewHelpers";
+import {
+    linkReferenceField,
+    footnoteNumberField,
+} from "../../src/features/editor/extensions/livePreviewHelpers";
 import { createInlineLivePreviewPlugin } from "../../src/features/editor/extensions/livePreviewInline";
 import { livePreviewTheme } from "../../src/features/editor/extensions/livePreviewTheme";
 
@@ -41,6 +44,7 @@ window.mountEditor = ({ doc, selection }: MountOptions) => {
             extensions: [
                 markdown({ base: markdownLanguage }),
                 linkReferenceField,
+                footnoteNumberField,
                 createInlineLivePreviewPlugin(),
                 livePreviewTheme,
                 // The real editor (src/features/editor/Editor.tsx,

--- a/apps/desktop/src/features/editor/extensions/livePreview.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreview.ts
@@ -5,7 +5,12 @@ import {
     resolveLinkHref,
     linkReferenceField,
     footnoteNumberField,
+    findFootnoteDefinition,
+    footnoteRefAt,
+    flashFootnoteDefEffect,
+    footnoteDefFlashField,
 } from "./livePreviewHelpers";
+import { selectionTouchesRange } from "./selectionActivity";
 import { dispatchOpenYouTubeModal } from "../youtube";
 import { openVaultEmbedTarget } from "../embedNavigation";
 import {
@@ -256,9 +261,35 @@ function activateTaskLine(taskLine: HTMLElement, view: EditorView) {
     );
 }
 
+// How long the destination definition stays highlighted after a jump.
+const FOOTNOTE_FLASH_MS = 1200;
+
+/**
+ * Jumps to a footnote definition by resolving its position from the document
+ * text (the live preview virtualizes the DOM, so the definition is usually not
+ * rendered) and scrolling there via CodeMirror, with a brief highlight so the
+ * landing spot is obvious even when it was already on screen.
+ */
+function jumpToFootnoteDefinition(view: EditorView, id: string): boolean {
+    const definition = findFootnoteDefinition(view.state, id);
+    if (!definition) return false;
+
+    view.dispatch({
+        effects: [
+            EditorView.scrollIntoView(definition.from, { y: "center" }),
+            flashFootnoteDefEffect.of(definition),
+        ],
+    });
+    // Clear the highlight once it has played; guard against a torn-down view.
+    window.setTimeout(() => {
+        if (!view.dom.isConnected) return;
+        view.dispatch({ effects: flashFootnoteDefEffect.of(null) });
+    }, FOOTNOTE_FLASH_MS);
+    return true;
+}
+
 function activateInteractivePreview(
     target: HTMLElement,
-    view: EditorView,
     interactions: TableInteractionHandlers,
 ) {
     const embedWidget = target.closest(
@@ -328,20 +359,6 @@ function activateInteractivePreview(
                 isEmail: false,
             }) ?? liveLink.dataset.href,
         );
-        return true;
-    }
-
-    const footnoteRef = target.closest(
-        ".cm-lp-footnote-ref",
-    ) as HTMLElement | null;
-    if (footnoteRef?.dataset.footnoteId) {
-        const definition = view.dom.querySelector<HTMLElement>(
-            `.cm-lp-footnote-def[data-footnote-id="${CSS.escape(
-                footnoteRef.dataset.footnoteId,
-            )}"]`,
-        );
-        if (!definition) return false;
-        definition.scrollIntoView({ block: "nearest" });
         return true;
     }
 
@@ -436,6 +453,29 @@ export function livePreviewExtension(
     const clickHandler = EditorView.domEventHandlers({
         mousedown(event: MouseEvent, view: EditorView) {
             const target = event.target as HTMLElement;
+
+            // A footnote reference renders as a tiny superscript widget flanked
+            // by CM widget buffers, so the click target is unreliable and a
+            // plain mousedown would drop the caret inside it (revealing the raw
+            // `[^id]`). Resolve the reference by document position instead and
+            // jump straight to its definition, unless it is already revealed for
+            // editing.
+            const pos = view.posAtCoords({
+                x: event.clientX,
+                y: event.clientY,
+            });
+            if (pos !== null) {
+                const ref = footnoteRefAt(view.state, pos);
+                if (
+                    ref &&
+                    !selectionTouchesRange(view.state, ref.from, ref.to) &&
+                    jumpToFootnoteDefinition(view, ref.id)
+                ) {
+                    event.preventDefault();
+                    return true;
+                }
+            }
+
             const taskLine = getTaskLinePointerTarget(
                 target,
                 event.clientX,
@@ -484,7 +524,7 @@ export function livePreviewExtension(
                 return true;
             }
 
-            if (!activateInteractivePreview(target, view, interactions)) {
+            if (!activateInteractivePreview(target, interactions)) {
                 return false;
             }
 
@@ -518,11 +558,24 @@ export function livePreviewExtension(
                 return true;
             }
 
+            // Keyboard activation has a reliable focused target, so resolve the
+            // footnote from the DOM here (the pointer path resolves by position).
+            const footnoteRef = target.closest(
+                ".cm-lp-footnote-ref",
+            ) as HTMLElement | null;
+            if (footnoteRef?.dataset.footnoteId) {
+                event.preventDefault();
+                return jumpToFootnoteDefinition(
+                    view,
+                    footnoteRef.dataset.footnoteId,
+                );
+            }
+
             if (!target.closest(KEYBOARD_INTERACTIVE_PREVIEW_SELECTOR)) {
                 return false;
             }
 
-            if (!activateInteractivePreview(target, view, interactions)) {
+            if (!activateInteractivePreview(target, interactions)) {
                 return false;
             }
 
@@ -550,6 +603,7 @@ export function livePreviewExtension(
     return [
         linkReferenceField,
         footnoteNumberField,
+        footnoteDefFlashField,
         createInlineLivePreviewPlugin(),
         createLeadingContentCollapseField(),
         createCodeBlockLivePreviewExtension(),

--- a/apps/desktop/src/features/editor/extensions/livePreview.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreview.ts
@@ -6,11 +6,9 @@ import {
     linkReferenceField,
     footnoteNumberField,
     findFootnoteDefinition,
-    footnoteRefAt,
     flashFootnoteDefEffect,
     footnoteDefFlashField,
 } from "./livePreviewHelpers";
-import { selectionTouchesRange } from "./selectionActivity";
 import { dispatchOpenYouTubeModal } from "../youtube";
 import { openVaultEmbedTarget } from "../embedNavigation";
 import {
@@ -265,6 +263,27 @@ function activateTaskLine(taskLine: HTMLElement, view: EditorView) {
 const FOOTNOTE_FLASH_MS = 1200;
 
 /**
+ * Resolves the footnote reference whose rendered number is under the pointer,
+ * by geometric containment. Only currently-rendered (collapsed) references have
+ * a `.cm-lp-footnote-ref` element, so a reference revealed for editing is
+ * naturally skipped and the click falls through to normal caret placement.
+ */
+function footnoteRefIdAtPoint(
+    view: EditorView,
+    x: number,
+    y: number,
+): string | null {
+    const refs = view.dom.querySelectorAll<HTMLElement>(".cm-lp-footnote-ref");
+    for (const el of refs) {
+        const r = el.getBoundingClientRect();
+        if (x >= r.left && x <= r.right && y >= r.top && y <= r.bottom) {
+            return el.dataset.footnoteId ?? null;
+        }
+    }
+    return null;
+}
+
+/**
  * Jumps to a footnote definition by resolving its position from the document
  * text (the live preview virtualizes the DOM, so the definition is usually not
  * rendered) and scrolling there via CodeMirror, with a brief highlight so the
@@ -454,26 +473,21 @@ export function livePreviewExtension(
         mousedown(event: MouseEvent, view: EditorView) {
             const target = event.target as HTMLElement;
 
-            // A footnote reference renders as a tiny superscript widget flanked
-            // by CM widget buffers, so the click target is unreliable and a
-            // plain mousedown would drop the caret inside it (revealing the raw
-            // `[^id]`). Resolve the reference by document position instead and
-            // jump straight to its definition, unless it is already revealed for
-            // editing.
-            const pos = view.posAtCoords({
-                x: event.clientX,
-                y: event.clientY,
-            });
-            if (pos !== null) {
-                const ref = footnoteRefAt(view.state, pos);
-                if (
-                    ref &&
-                    !selectionTouchesRange(view.state, ref.from, ref.to) &&
-                    jumpToFootnoteDefinition(view, ref.id)
-                ) {
-                    event.preventDefault();
-                    return true;
-                }
+            // A footnote reference renders as a tiny raised superscript number;
+            // a plain mousedown would drop the caret inside the token (revealing
+            // the raw `[^id]`). Jump to its definition instead — but only when
+            // the pointer is geometrically on the number. `posAtCoords` is wrong
+            // here: at the superscript's raised height the only content is the
+            // number, so clicking the empty space to its right (to keep writing)
+            // still maps back onto the token.
+            const footnoteId = footnoteRefIdAtPoint(
+                view,
+                event.clientX,
+                event.clientY,
+            );
+            if (footnoteId && jumpToFootnoteDefinition(view, footnoteId)) {
+                event.preventDefault();
+                return true;
             }
 
             const taskLine = getTaskLinePointerTarget(

--- a/apps/desktop/src/features/editor/extensions/livePreview.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreview.ts
@@ -1,7 +1,11 @@
 import { EditorView } from "@codemirror/view";
 import { openUrl } from "@neverwrite/runtime";
 
-import { resolveLinkHref, linkReferenceField } from "./livePreviewHelpers";
+import {
+    resolveLinkHref,
+    linkReferenceField,
+    footnoteNumberField,
+} from "./livePreviewHelpers";
 import { dispatchOpenYouTubeModal } from "../youtube";
 import { openVaultEmbedTarget } from "../embedNavigation";
 import {
@@ -545,6 +549,7 @@ export function livePreviewExtension(
 
     return [
         linkReferenceField,
+        footnoteNumberField,
         createInlineLivePreviewPlugin(),
         createLeadingContentCollapseField(),
         createCodeBlockLivePreviewExtension(),

--- a/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
@@ -410,6 +410,97 @@ export const linkReferenceField = StateField.define<LinkReferenceMap>({
     },
 });
 
+// ---------------------------------------------------------------------------
+// Footnote numbering
+// ---------------------------------------------------------------------------
+
+/** Maps a footnote id to the compact number shown in the live preview. */
+export type FootnoteNumberMap = Map<string, number>;
+
+// Footnote token: [^id]. The id cannot contain whitespace or ']'.
+const FOOTNOTE_TOKEN_RE = /\[\^([^\]\s]+)\]/g;
+
+/**
+ * Assigns every footnote a compact, stable display number so the live preview
+ * can render `[^descriptive-label]` as a tidy superscript index instead of the
+ * raw label (which reads as noise — see issue #196).
+ *
+ * Numbering matches the reader's mental model used by Pandoc/Obsidian/GitHub:
+ * footnotes are numbered by the order their *references* first appear in the
+ * document. `[^id]:` definition markers are skipped while scanning references;
+ * a footnote that is only ever defined (never referenced) is then appended so
+ * it still receives a stable number.
+ */
+export function buildFootnoteNumberIndex(state: EditorState): FootnoteNumberMap {
+    const numbers: FootnoteNumberMap = new Map();
+    const text = state.doc.toString();
+    const definedOnly: string[] = [];
+    let next = 1;
+
+    FOOTNOTE_TOKEN_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = FOOTNOTE_TOKEN_RE.exec(text)) !== null) {
+        const id = match[1];
+        const lineStart = text.lastIndexOf("\n", match.index - 1) + 1;
+        // A definition marker is `[^id]:` at the start of its line. Defer those
+        // so references drive the numbering order.
+        const isDefinition =
+            text[match.index + match[0].length] === ":" &&
+            text.slice(lineStart, match.index).trim() === "";
+        if (isDefinition) {
+            definedOnly.push(id);
+            continue;
+        }
+        if (!numbers.has(id)) numbers.set(id, next++);
+    }
+
+    for (const id of definedOnly) {
+        if (!numbers.has(id)) numbers.set(id, next++);
+    }
+
+    return numbers;
+}
+
+// Characters that can change footnote markers: [ ^ ] :
+const FOOTNOTE_SIGNIFICANT = /(?:[\]:^]|\[)/;
+
+function footnoteNumbersNeedRebuild(transaction: Transaction): boolean {
+    if (!transaction.docChanged) return false;
+    let dominated = true;
+    transaction.changes.iterChangedRanges((fromA, toA, fromB, toB) => {
+        if (!dominated) return;
+        if (
+            toA > fromA &&
+            FOOTNOTE_SIGNIFICANT.test(
+                transaction.startState.doc.sliceString(fromA, toA),
+            )
+        ) {
+            dominated = false;
+            return;
+        }
+        if (
+            toB > fromB &&
+            FOOTNOTE_SIGNIFICANT.test(
+                transaction.state.doc.sliceString(fromB, toB),
+            )
+        ) {
+            dominated = false;
+        }
+    });
+    return !dominated;
+}
+
+/** StateField caching footnote display numbers, rebuilt only when markers change. */
+export const footnoteNumberField = StateField.define<FootnoteNumberMap>({
+    create(state) {
+        return buildFootnoteNumberIndex(state);
+    },
+    update(numbers, transaction) {
+        if (!footnoteNumbersNeedRebuild(transaction)) return numbers;
+        return buildFootnoteNumberIndex(transaction.state);
+    },
+});
+
 export function findAncestor(
     node: SyntaxNode | null,
     name: string,

--- a/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
@@ -1,7 +1,8 @@
-import { Decoration } from "@codemirror/view";
+import { Decoration, type DecorationSet, EditorView } from "@codemirror/view";
 import {
     type EditorState,
     type Transaction,
+    StateEffect,
     StateField,
 } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
@@ -499,6 +500,99 @@ export const footnoteNumberField = StateField.define<FootnoteNumberMap>({
         if (!footnoteNumbersNeedRebuild(transaction)) return numbers;
         return buildFootnoteNumberIndex(transaction.state);
     },
+});
+
+// Footnote definition marker at the start of a line: `[^id]:`.
+const FOOTNOTE_DEF_LINE_RE = /^\[\^([^\]\s]+)\]:/gm;
+
+/**
+ * Resolves the definition line for a footnote id by scanning the document text.
+ * The live preview virtualizes the DOM, so the definition is usually not
+ * rendered when a reference is clicked — resolving the position from the text
+ * lets us jump to it regardless of what is currently on screen.
+ */
+export function findFootnoteDefinition(
+    state: EditorState,
+    id: string,
+): { from: number; to: number } | null {
+    const text = state.doc.toString();
+    FOOTNOTE_DEF_LINE_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = FOOTNOTE_DEF_LINE_RE.exec(text)) !== null) {
+        if (match[1] === id) {
+            const line = state.doc.lineAt(match.index);
+            return { from: line.from, to: line.to };
+        }
+    }
+    return null;
+}
+
+// Footnote reference token, scanned within a single line.
+const FOOTNOTE_REF_AT_RE = /\[\^([^\]\s]+)\]/g;
+
+/**
+ * Returns the footnote reference covering a document position, if any. Pointer
+ * hits resolve to a position rather than a DOM node — the reference renders as a
+ * tiny superscript widget flanked by CM widget buffers, so the click target is
+ * unreliable, but the position is not. Definition markers (`[^id]:` at the start
+ * of a line) are excluded.
+ */
+export function footnoteRefAt(
+    state: EditorState,
+    pos: number,
+): { id: string; from: number; to: number } | null {
+    const line = state.doc.lineAt(pos);
+    const offset = pos - line.from;
+    FOOTNOTE_REF_AT_RE.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = FOOTNOTE_REF_AT_RE.exec(line.text)) !== null) {
+        const start = match.index;
+        const end = start + match[0].length;
+        const isDefinition =
+            line.text.slice(0, start).trim() === "" && line.text[end] === ":";
+        if (isDefinition) continue;
+        if (offset >= start && offset <= end) {
+            return { id: match[1], from: line.from + start, to: line.from + end };
+        }
+    }
+    return null;
+}
+
+/** Effect: flash a jumped-to footnote definition line (a range, or null to clear). */
+export const flashFootnoteDefEffect = StateEffect.define<{
+    from: number;
+    to: number;
+} | null>();
+
+const footnoteDefFlashMark = Decoration.line({
+    class: "cm-lp-footnote-def-flash",
+});
+
+/**
+ * Holds the transient highlight shown on the footnote definition a reference
+ * jumped to, so the destination is obvious even when it was already on screen.
+ */
+export const footnoteDefFlashField = StateField.define<DecorationSet>({
+    create() {
+        return Decoration.none;
+    },
+    update(deco, transaction) {
+        deco = deco.map(transaction.changes);
+        for (const effect of transaction.effects) {
+            if (!effect.is(flashFootnoteDefEffect)) continue;
+            deco =
+                effect.value === null
+                    ? Decoration.none
+                    : Decoration.set(
+                          footnoteDefFlashMark.range(
+                              transaction.state.doc.lineAt(effect.value.from)
+                                  .from,
+                          ),
+                      );
+        }
+        return deco;
+    },
+    provide: (field) => EditorView.decorations.from(field),
 });
 
 export function findAncestor(

--- a/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
@@ -527,37 +527,6 @@ export function findFootnoteDefinition(
     return null;
 }
 
-// Footnote reference token, scanned within a single line.
-const FOOTNOTE_REF_AT_RE = /\[\^([^\]\s]+)\]/g;
-
-/**
- * Returns the footnote reference covering a document position, if any. Pointer
- * hits resolve to a position rather than a DOM node — the reference renders as a
- * tiny superscript widget flanked by CM widget buffers, so the click target is
- * unreliable, but the position is not. Definition markers (`[^id]:` at the start
- * of a line) are excluded.
- */
-export function footnoteRefAt(
-    state: EditorState,
-    pos: number,
-): { id: string; from: number; to: number } | null {
-    const line = state.doc.lineAt(pos);
-    const offset = pos - line.from;
-    FOOTNOTE_REF_AT_RE.lastIndex = 0;
-    let match: RegExpExecArray | null;
-    while ((match = FOOTNOTE_REF_AT_RE.exec(line.text)) !== null) {
-        const start = match.index;
-        const end = start + match[0].length;
-        const isDefinition =
-            line.text.slice(0, start).trim() === "" && line.text[end] === ":";
-        if (isDefinition) continue;
-        if (offset >= start && offset <= end) {
-            return { id: match[1], from: line.from + start, to: line.from + end };
-        }
-    }
-    return null;
-}
-
 /** Effect: flash a jumped-to footnote definition line (a range, or null to clear). */
 export const flashFootnoteDefEffect = StateEffect.define<{
     from: number;

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
@@ -13,7 +13,7 @@ vi.mock("../../../app/utils/perfInstrumentation", () => ({
 }));
 
 import { perfMeasure } from "../../../app/utils/perfInstrumentation";
-import { linkReferenceField } from "./livePreviewHelpers";
+import { linkReferenceField, footnoteNumberField } from "./livePreviewHelpers";
 import {
     createInlineLivePreviewPlugin,
     createLeadingContentCollapseField,
@@ -124,6 +124,7 @@ function createView(
         extensions: [
             markdown({ base: markdownLanguage }),
             linkReferenceField,
+            footnoteNumberField,
             plugin,
         ],
     });
@@ -879,6 +880,49 @@ describe("createInlineLivePreviewPlugin", () => {
         expect(hasHiddenRange(decorations, 5, 6, "cm-lp-hidden-inline")).toBe(
             true,
         );
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("renders footnote references as sequential numbers", () => {
+        const doc = "x [^alpha] y [^beta]\n\n[^alpha]: A\n[^beta]: B";
+        const { plugin, parent, view } = createView(
+            doc,
+            EditorSelection.cursor(doc.length),
+        );
+
+        const instance = view.plugin(plugin);
+        expect(instance).not.toBeNull();
+
+        const widgetTextAt = (from: number, to: number) => {
+            let text: string | null = null;
+            instance!.decorations.between(from, to, (dFrom, dTo, deco) => {
+                const widget = (deco.spec as { widget?: { toDOM(): HTMLElement } })
+                    .widget;
+                if (dFrom === from && dTo === to && widget) {
+                    text = widget.toDOM().textContent;
+                    return false;
+                }
+            });
+            return text;
+        };
+
+        // `[^alpha]` -> 1, `[^beta]` -> 2 (numbered by reference order).
+        // Content ranges exclude the `[^` ... `]` delimiters.
+        expect(widgetTextAt(4, 9)).toBe("1");
+        expect(widgetTextAt(15, 19)).toBe("2");
+
+        // The matching definition lines carry the same number for correlation.
+        const decorations = collectDecorations(view, plugin);
+        const alphaDef = decorations.find(
+            (deco) => deco.attributes["data-footnote-id"] === "alpha",
+        );
+        expect(alphaDef?.attributes["data-footnote-number"]).toBe("1");
+        const betaDef = decorations.find(
+            (deco) => deco.attributes["data-footnote-id"] === "beta",
+        );
+        expect(betaDef?.attributes["data-footnote-number"]).toBe("2");
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
@@ -17,7 +17,6 @@ import {
     linkReferenceField,
     footnoteNumberField,
     findFootnoteDefinition,
-    footnoteRefAt,
     flashFootnoteDefEffect,
     footnoteDefFlashField,
 } from "./livePreviewHelpers";
@@ -985,19 +984,6 @@ describe("createInlineLivePreviewPlugin", () => {
         expect(def).not.toBeNull();
         expect(state.doc.lineAt(def!.from).text).toBe("[^note]: The definition.");
         expect(findFootnoteDefinition(state, "missing")).toBeNull();
-    });
-
-    it("locates a footnote reference at a position, excluding definitions", () => {
-        const doc = "ab[^note]cd\n[^note]: def";
-        const state = EditorState.create({ doc });
-
-        // Inside the reference token resolves to its id and range.
-        expect(footnoteRefAt(state, 5)).toEqual({ id: "note", from: 2, to: 9 });
-        // Before the token: no match.
-        expect(footnoteRefAt(state, 0)).toBeNull();
-        // The identical token on the definition line is ignored.
-        const defPos = state.doc.line(2).from + 3;
-        expect(footnoteRefAt(state, defPos)).toBeNull();
     });
 
     it("flashes the jumped-to definition line then clears it", () => {

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
@@ -13,7 +13,14 @@ vi.mock("../../../app/utils/perfInstrumentation", () => ({
 }));
 
 import { perfMeasure } from "../../../app/utils/perfInstrumentation";
-import { linkReferenceField, footnoteNumberField } from "./livePreviewHelpers";
+import {
+    linkReferenceField,
+    footnoteNumberField,
+    findFootnoteDefinition,
+    footnoteRefAt,
+    flashFootnoteDefEffect,
+    footnoteDefFlashField,
+} from "./livePreviewHelpers";
 import {
     createInlineLivePreviewPlugin,
     createLeadingContentCollapseField,
@@ -966,6 +973,65 @@ describe("createInlineLivePreviewPlugin", () => {
 
         view.destroy();
         parent.remove();
+    });
+
+    it("resolves a footnote definition position from the document text", () => {
+        // The definition sits far below the reference and well outside any
+        // rendered viewport — resolution must come from the text, not the DOM.
+        const doc = `Body ref[^note] here.${"\nfiller".repeat(80)}\n\n[^note]: The definition.`;
+        const state = EditorState.create({ doc });
+
+        const def = findFootnoteDefinition(state, "note");
+        expect(def).not.toBeNull();
+        expect(state.doc.lineAt(def!.from).text).toBe("[^note]: The definition.");
+        expect(findFootnoteDefinition(state, "missing")).toBeNull();
+    });
+
+    it("locates a footnote reference at a position, excluding definitions", () => {
+        const doc = "ab[^note]cd\n[^note]: def";
+        const state = EditorState.create({ doc });
+
+        // Inside the reference token resolves to its id and range.
+        expect(footnoteRefAt(state, 5)).toEqual({ id: "note", from: 2, to: 9 });
+        // Before the token: no match.
+        expect(footnoteRefAt(state, 0)).toBeNull();
+        // The identical token on the definition line is ignored.
+        const defPos = state.doc.line(2).from + 3;
+        expect(footnoteRefAt(state, defPos)).toBeNull();
+    });
+
+    it("flashes the jumped-to definition line then clears it", () => {
+        const doc = "x\n[^note]: def";
+        const initial = EditorState.create({
+            doc,
+            extensions: [footnoteDefFlashField],
+        });
+        const defLine = initial.doc.line(2);
+
+        const flashed = initial.update({
+            effects: flashFootnoteDefEffect.of({
+                from: defLine.from,
+                to: defLine.to,
+            }),
+        }).state;
+        const ranges: number[] = [];
+        flashed
+            .field(footnoteDefFlashField)
+            .between(0, flashed.doc.length, (from) => {
+                ranges.push(from);
+            });
+        expect(ranges).toEqual([defLine.from]);
+
+        const cleared = flashed.update({
+            effects: flashFootnoteDefEffect.of(null),
+        }).state;
+        let count = 0;
+        cleared
+            .field(footnoteDefFlashField)
+            .between(0, cleared.doc.length, () => {
+                count++;
+            });
+        expect(count).toBe(0);
     });
 
     it("switches the active inline token when moving within the same line", () => {

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
@@ -928,6 +928,46 @@ describe("createInlineLivePreviewPlugin", () => {
         parent.remove();
     });
 
+    it("separates abutting footnote references with a comma", () => {
+        const doc = "[^a][^b]\n\n[^a]: A\n[^b]: B";
+        const { plugin, parent, view } = createView(
+            doc,
+            EditorSelection.cursor(doc.length),
+        );
+
+        const instance = view.plugin(plugin);
+        expect(instance).not.toBeNull();
+
+        const widgetTextAt = (from: number, to: number) => {
+            let text: string | null = null;
+            instance!.decorations.between(from, to, (dFrom, dTo, deco) => {
+                const widget = (deco.spec as { widget?: { toDOM(): HTMLElement } })
+                    .widget;
+                if (dFrom === from && dTo === to && widget) {
+                    text = widget.toDOM().textContent;
+                    return false;
+                }
+            });
+            return text;
+        };
+
+        // `[^a]` is directly followed by `[^b]`, so its number carries a comma;
+        // the trailing `[^b]` does not.
+        expect(widgetTextAt(2, 3)).toBe("1,");
+        expect(widgetTextAt(6, 7)).toBe("2");
+
+        // The parser pairs the two carets of `[^a][^b]` into a spurious
+        // Superscript node; it must not be styled (that 0.8em wrapper used to
+        // shrink and misalign the first reference).
+        const decorations = collectDecorations(view, plugin);
+        expect(findDecorationByClass(decorations, "cm-lp-superscript")).toBe(
+            undefined,
+        );
+
+        view.destroy();
+        parent.remove();
+    });
+
     it("switches the active inline token when moving within the same line", () => {
         const doc = "==bold== and ==mark==";
         const { plugin, parent, view } = createView(

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
@@ -207,8 +207,10 @@ class FootnoteRefWidget extends WidgetType {
         return ref;
     }
 
+    // Let pointer events reach the editor's domEventHandlers so a click can be
+    // resolved to the footnote and jumped to its definition.
     ignoreEvent() {
-        return true;
+        return false;
     }
 }
 

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
@@ -24,6 +24,8 @@ import {
     hideInactiveChildMarks,
     parseLinkChildren,
     linkReferenceField,
+    footnoteNumberField,
+    type FootnoteNumberMap,
     resolveLinkHref,
     findAncestor,
     hasDescendant,
@@ -107,6 +109,7 @@ interface BuildContext {
     blockRanges: Array<{ from: number; to: number }>;
     orderedListMarkerWidths: Map<string, string>;
     linkReferences: Map<string, { url: string; title: string | null }>;
+    footnoteNumbers: FootnoteNumberMap;
     vpFrom: number;
     vpTo: number;
     vpText: string;
@@ -151,6 +154,42 @@ class EmptyListCaretAnchorWidget extends WidgetType {
         span.className = "cm-lp-caret-anchor";
         span.setAttribute("aria-hidden", "true");
         return span;
+    }
+
+    ignoreEvent() {
+        return true;
+    }
+}
+
+/**
+ * Renders a footnote reference as a compact, clickable superscript number.
+ * The descriptive label stays in the document (and is revealed when the caret
+ * enters the token); only the *display* collapses to a tidy index.
+ */
+class FootnoteRefWidget extends WidgetType {
+    private id: string;
+    private label: string;
+
+    constructor(id: string, label: string) {
+        super();
+        this.id = id;
+        this.label = label;
+    }
+
+    eq(other: FootnoteRefWidget) {
+        return other.id === this.id && other.label === this.label;
+    }
+
+    toDOM() {
+        const ref = document.createElement("span");
+        ref.className = "cm-lp-footnote-ref";
+        ref.textContent = this.label;
+        ref.dataset.footnoteId = this.id;
+        ref.tabIndex = 0;
+        ref.setAttribute("role", "button");
+        // Powerusers keep descriptive labels; surface the raw id on hover.
+        ref.title = this.id;
+        return ref;
     }
 
     ignoreEvent() {
@@ -1441,8 +1480,17 @@ function applyFootnoteDefinitionDecorations(context: BuildContext) {
         const marker = `[^${label}]:`;
         const markerTo = line.from + marker.length;
 
+        // Surface the same number the references use so a numbered `[^1]` in the
+        // body maps to its definition. Rendered as a CSS ::before badge.
+        const number = context.footnoteNumbers.get(label);
+        const numberAttr =
+            number !== undefined
+                ? { "data-footnote-number": String(number) }
+                : undefined;
+
         addLineDecoration(context.lineDecos, line.from, "cm-lp-footnote-def", {
             "data-footnote-id": label,
+            ...numberAttr,
         });
         hideRange(context, line.from, markerTo);
         if (
@@ -1555,19 +1603,18 @@ function applyRichRegexRules(context: BuildContext) {
         registerRevealSensitiveRange(context, "range", absFrom, absTo);
 
         if (!selectionTouchesRange(context.state, absFrom, absTo)) {
+            const number = context.footnoteNumbers.get(id);
             hideRange(context, absFrom, contentFrom, hideInlineMark);
             hideRange(context, contentTo, absTo, hideInlineMark);
             pushDeco(
                 context,
                 contentFrom,
                 contentTo,
-                Decoration.mark({
-                    class: "cm-lp-footnote-ref",
-                    attributes: {
-                        "data-footnote-id": id,
-                        tabindex: "0",
-                        role: "button",
-                    },
+                Decoration.replace({
+                    widget: new FootnoteRefWidget(
+                        id,
+                        number !== undefined ? String(number) : id,
+                    ),
                 }),
             );
         }
@@ -1693,6 +1740,7 @@ function buildInlineDecorations(
         blockRanges: [],
         orderedListMarkerWidths: new Map<string, string>(),
         linkReferences: state.field(linkReferenceField),
+        footnoteNumbers: state.field(footnoteNumberField),
         vpFrom,
         vpTo,
         vpText: state.doc.sliceString(vpFrom, vpTo),

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.ts
@@ -169,26 +169,41 @@ class EmptyListCaretAnchorWidget extends WidgetType {
 class FootnoteRefWidget extends WidgetType {
     private id: string;
     private label: string;
+    // Directly-adjacent references ([^a][^b]) collapse to abutting numbers that
+    // read as one ("98" instead of "9, 8"); a trailing comma keeps them legible.
+    private trailingSeparator: boolean;
 
-    constructor(id: string, label: string) {
+    constructor(id: string, label: string, trailingSeparator: boolean) {
         super();
         this.id = id;
         this.label = label;
+        this.trailingSeparator = trailingSeparator;
     }
 
     eq(other: FootnoteRefWidget) {
-        return other.id === this.id && other.label === this.label;
+        return (
+            other.id === this.id &&
+            other.label === this.label &&
+            other.trailingSeparator === this.trailingSeparator
+        );
     }
 
     toDOM() {
         const ref = document.createElement("span");
         ref.className = "cm-lp-footnote-ref";
-        ref.textContent = this.label;
         ref.dataset.footnoteId = this.id;
         ref.tabIndex = 0;
         ref.setAttribute("role", "button");
         // Powerusers keep descriptive labels; surface the raw id on hover.
         ref.title = this.id;
+        ref.appendChild(document.createTextNode(this.label));
+        if (this.trailingSeparator) {
+            const sep = document.createElement("span");
+            sep.className = "cm-lp-footnote-sep";
+            sep.textContent = ",";
+            sep.setAttribute("aria-hidden", "true");
+            ref.appendChild(sep);
+        }
         return ref;
     }
 
@@ -710,13 +725,28 @@ function addLineClassForRange(
     }
 }
 
+// Pandoc super/subscript (`^x^`, `~x~`) cannot contain brackets. When the
+// markdown parser pairs the carets of two adjacent footnote references
+// (`[^a][^b]`) it emits a spurious Superscript node spanning `^a][^`; styling it
+// wraps the first footnote in a 0.8em span and throws off its alignment. Bracket
+// content means the node is not a real script and must not be decorated.
+function spansBracketSyntax(
+    node: LivePreviewNode,
+    context: BuildContext,
+): boolean {
+    const text = context.state.doc.sliceString(node.from, node.to);
+    return text.includes("[") || text.includes("]");
+}
+
 function createInlineFormattingRule(
     nodeName: string,
     mark: Decoration,
     markerName: string,
+    skipNode?: (node: LivePreviewNode, context: BuildContext) => boolean,
 ): NodeRule {
     return (node, context) => {
         if (node.name !== nodeName) return;
+        if (skipNode?.(node, context)) return;
         registerRevealSensitiveRange(
             context,
             "range-boundary",
@@ -1093,11 +1123,17 @@ const nodeRules: NodeRule[] = [
     createInlineFormattingRule("StrongEmphasis", boldMark, "EmphasisMark"),
     createInlineFormattingRule("Emphasis", italicMark, "EmphasisMark"),
     createInlineFormattingRule("InlineCode", inlineCodeMark, "CodeMark"),
-    createInlineFormattingRule("Subscript", subscriptMark, "SubscriptMark"),
+    createInlineFormattingRule(
+        "Subscript",
+        subscriptMark,
+        "SubscriptMark",
+        spansBracketSyntax,
+    ),
     createInlineFormattingRule(
         "Superscript",
         superscriptMark,
         "SuperscriptMark",
+        spansBracketSyntax,
     ),
     linkRule,
     horizontalRuleRule,
@@ -1604,6 +1640,13 @@ function applyRichRegexRules(context: BuildContext) {
 
         if (!selectionTouchesRange(context.state, absFrom, absTo)) {
             const number = context.footnoteNumbers.get(id);
+            // When the next character starts another reference ([^a][^b]) the
+            // numbers abut with no whitespace to separate them — add a comma so
+            // a run of citations stays legible.
+            const after = footnoteMatch.index + footnoteMatch[0].length;
+            const followedByRef =
+                context.vpText[after] === "[" &&
+                context.vpText[after + 1] === "^";
             hideRange(context, absFrom, contentFrom, hideInlineMark);
             hideRange(context, contentTo, absTo, hideInlineMark);
             pushDeco(
@@ -1614,6 +1657,7 @@ function applyRichRegexRules(context: BuildContext) {
                     widget: new FootnoteRefWidget(
                         id,
                         number !== undefined ? String(number) : id,
+                        followedByRef,
                     ),
                 }),
             );

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -350,10 +350,17 @@ export const livePreviewTheme = EditorView.baseTheme({
     ".cm-lp-task-line::selection, .cm-lp-task-line *::selection": {
         backgroundColor: "var(--selection-bg)",
     },
+    // Superscript via the MDN position pattern rather than `vertical-align:
+    // super`: each reference is a replace widget, and `super` resolves against
+    // the surrounding line box, so abutting refs (separated by zero-width hidden
+    // delimiter spans) landed at slightly different heights. A fixed `top`
+    // offset puts every reference — single or in a run — at the same height.
     ".cm-lp-footnote-ref": {
         fontSize: "0.72em",
-        verticalAlign: "super",
         lineHeight: "0",
+        position: "relative",
+        verticalAlign: "baseline",
+        top: "-0.5em",
         color: "var(--accent)",
         cursor: "pointer",
         fontWeight: "600",
@@ -362,6 +369,13 @@ export const livePreviewTheme = EditorView.baseTheme({
     ".cm-lp-footnote-ref:hover": {
         textDecoration: "underline",
         textUnderlineOffset: "0.2em",
+    },
+    // Comma between abutting references; muted and never underlined on hover.
+    ".cm-lp-footnote-sep": {
+        color: "var(--text-secondary)",
+        fontWeight: "400",
+        textDecoration: "none",
+        marginRight: "0.15em",
     },
     ".cm-lp-footnote-def": {
         color: "var(--text-secondary)",

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -391,6 +391,18 @@ export const livePreviewTheme = EditorView.baseTheme({
         fontWeight: "600",
         marginRight: "6px",
     },
+    // Brief highlight on the definition a reference just jumped to.
+    "@keyframes cm-lp-footnote-flash": {
+        from: {
+            backgroundColor:
+                "color-mix(in srgb, var(--accent) 32%, transparent)",
+        },
+        to: { backgroundColor: "transparent" },
+    },
+    ".cm-lp-footnote-def-flash": {
+        animation: "cm-lp-footnote-flash 1.1s ease-out",
+        borderRadius: "4px",
+    },
     ".cm-lp-callout": {
         borderLeft:
             "3px solid color-mix(in srgb, var(--accent) 42%, var(--border))",

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -353,10 +353,15 @@ export const livePreviewTheme = EditorView.baseTheme({
     ".cm-lp-footnote-ref": {
         fontSize: "0.72em",
         verticalAlign: "super",
+        lineHeight: "0",
         color: "var(--accent)",
         cursor: "pointer",
         fontWeight: "600",
-        marginLeft: "0.08em",
+        marginLeft: "0.1em",
+    },
+    ".cm-lp-footnote-ref:hover": {
+        textDecoration: "underline",
+        textUnderlineOffset: "0.2em",
     },
     ".cm-lp-footnote-def": {
         color: "var(--text-secondary)",
@@ -364,6 +369,13 @@ export const livePreviewTheme = EditorView.baseTheme({
         borderLeft:
             "2px solid color-mix(in srgb, var(--accent) 28%, var(--border))",
         marginLeft: "4px",
+    },
+    // Numbered badge that ties a definition back to its `[^n]` references.
+    ".cm-lp-footnote-def[data-footnote-number]::before": {
+        content: "attr(data-footnote-number) '.'",
+        color: "var(--accent)",
+        fontWeight: "600",
+        marginRight: "6px",
     },
     ".cm-lp-callout": {
         borderLeft:


### PR DESCRIPTION
Closes #196.

Footnote references rendered their raw label as superscript, which reads as noise in the live preview — especially with descriptive, named footnotes (`[^fomc-statement]`, `[^bls-cpi]`, …). This reworks how footnotes render and behave.

## What changed

**Sequential numbering.** References render as compact superscript numbers (`¹ ² ³`) instead of the raw label — the convention used by Pandoc/Obsidian/GitHub. Numbering is document-wide and stable across scrolling (`footnoteNumberField`), by order of first reference appearance. The raw `[^label]` is still revealed when the caret enters the token and shown on hover (`title`). Definitions get a matching numbered badge so `[^n]` in the body maps to its definition.

**Adjacent references.** Directly-abutting references (`[^a][^b]`) used to collapse into one unreadable number (`98`); they now get a muted comma separator (`9, 8`). References separated by real whitespace are left untouched.

**Alignment.** The markdown parser pairs the carets of two adjacent footnotes (`[^a][^b]`) into a spurious Pandoc-superscript node spanning `^a][^`; styling it wrapped the first reference in a `0.8em` span and pushed it off the superscript baseline. Super/subscript styling now skips nodes that span bracket characters (a real `^x^` / `~x~` never contains them). References also use the deterministic MDN superscript pattern (`position: relative; top`) so every one lands at the same height.

**Click-to-jump (was broken).** Clicking a reference did nothing: the handler looked the definition up in the virtualized DOM (so off-screen definitions were never found), and the widget's `ignoreEvent: true` swallowed the pointer event while the click dropped the caret into the token and revealed the raw `[^id]`. Now the definition position is resolved from the document text and scrolled to via CodeMirror, with a brief flash on the destination. The clicked reference is resolved by document position (the tiny superscript widget is flanked by CM widget buffers, so the DOM target is unreliable) and handled on `mousedown` so the caret never moves; the keyboard path resolves it from the focused element.

## Verification
- `vitest` editor extensions: 125 passing (new tests for numbering, adjacency/comma, the spurious-superscript guard, `findFootnoteDefinition`, `footnoteRefAt`, and the flash field).
- `tsc -b` and `eslint` clean.
- End-to-end checked in the real editor (Playwright + full live-preview extension): clicking a reference scrolls its off-screen definition into view, flashes it, and leaves the caret put.

## Behavior note
Clicking a footnote now jumps to its definition rather than placing the caret (consistent with other rendered widgets). To edit the label, move the caret into it with the keyboard.