### PR TITLE
Center outline heading on jump with a landing flash

### DIFF
--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -124,6 +124,7 @@ import {
     getEditorFontFamily,
     getEditorHorizontalInset,
 } from "./editorExtensions";
+import { flashLine } from "./extensions/livePreviewHelpers";
 import { registerVimExCommands } from "./extensions/vimCommands";
 import { mergeViewCompartment } from "./extensions/mergeViewDiff";
 import { syncMergeViewForPaths } from "./mergeViewSync";
@@ -3677,10 +3678,16 @@ export function Editor({
             0,
             Math.min(pendingSelectionReveal.head, docLen),
         );
+        // Center the heading in the viewport instead of nudging it to the
+        // nearest edge (the default `scrollIntoView: true`), so the selected
+        // outline entry lands in the middle of the screen. Near the end of the
+        // document CodeMirror scrolls as far as it can ("as centered as
+        // possible"). A brief line flash marks where the jump landed.
         view.dispatch({
             selection: { anchor: clampedAnchor, head: clampedHead },
-            scrollIntoView: true,
+            effects: EditorView.scrollIntoView(clampedAnchor, { y: "center" }),
         });
+        flashLine(view, clampedAnchor);
         view.focus();
         clearPendingSelectionReveal();
     }, [activeTab, pendingSelectionReveal, clearPendingSelectionReveal]);

--- a/apps/desktop/src/features/editor/extensions/livePreview.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreview.ts
@@ -6,8 +6,8 @@ import {
     linkReferenceField,
     footnoteNumberField,
     findFootnoteDefinition,
-    flashFootnoteDefEffect,
-    footnoteDefFlashField,
+    flashLine,
+    lineFlashField,
 } from "./livePreviewHelpers";
 import { dispatchOpenYouTubeModal } from "../youtube";
 import { openVaultEmbedTarget } from "../embedNavigation";
@@ -259,9 +259,6 @@ function activateTaskLine(taskLine: HTMLElement, view: EditorView) {
     );
 }
 
-// How long the destination definition stays highlighted after a jump.
-const FOOTNOTE_FLASH_MS = 1200;
-
 /**
  * Resolves the footnote reference whose rendered number is under the pointer,
  * by geometric containment. Only currently-rendered (collapsed) references have
@@ -294,16 +291,9 @@ function jumpToFootnoteDefinition(view: EditorView, id: string): boolean {
     if (!definition) return false;
 
     view.dispatch({
-        effects: [
-            EditorView.scrollIntoView(definition.from, { y: "center" }),
-            flashFootnoteDefEffect.of(definition),
-        ],
+        effects: EditorView.scrollIntoView(definition.from, { y: "center" }),
     });
-    // Clear the highlight once it has played; guard against a torn-down view.
-    window.setTimeout(() => {
-        if (!view.dom.isConnected) return;
-        view.dispatch({ effects: flashFootnoteDefEffect.of(null) });
-    }, FOOTNOTE_FLASH_MS);
+    flashLine(view, definition.from);
     return true;
 }
 
@@ -617,7 +607,7 @@ export function livePreviewExtension(
     return [
         linkReferenceField,
         footnoteNumberField,
-        footnoteDefFlashField,
+        lineFlashField,
         createInlineLivePreviewPlugin(),
         createLeadingContentCollapseField(),
         createCodeBlockLivePreviewExtension(),

--- a/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts
@@ -527,33 +527,37 @@ export function findFootnoteDefinition(
     return null;
 }
 
-/** Effect: flash a jumped-to footnote definition line (a range, or null to clear). */
-export const flashFootnoteDefEffect = StateEffect.define<{
+/** How long a jump target stays highlighted after a flash. */
+export const LINE_FLASH_MS = 1200;
+
+/** Effect: flash a jumped-to line (a range, or null to clear). */
+export const flashLineEffect = StateEffect.define<{
     from: number;
     to: number;
 } | null>();
 
-const footnoteDefFlashMark = Decoration.line({
-    class: "cm-lp-footnote-def-flash",
+const lineFlashMark = Decoration.line({
+    class: "cm-lp-line-flash",
 });
 
 /**
- * Holds the transient highlight shown on the footnote definition a reference
- * jumped to, so the destination is obvious even when it was already on screen.
+ * Holds the transient highlight shown on a line a jump landed on, so the
+ * destination is obvious even when it was already on screen. Shared by the
+ * footnote-reference jump and the outline heading jump.
  */
-export const footnoteDefFlashField = StateField.define<DecorationSet>({
+export const lineFlashField = StateField.define<DecorationSet>({
     create() {
         return Decoration.none;
     },
     update(deco, transaction) {
         deco = deco.map(transaction.changes);
         for (const effect of transaction.effects) {
-            if (!effect.is(flashFootnoteDefEffect)) continue;
+            if (!effect.is(flashLineEffect)) continue;
             deco =
                 effect.value === null
                     ? Decoration.none
                     : Decoration.set(
-                          footnoteDefFlashMark.range(
+                          lineFlashMark.range(
                               transaction.state.doc.lineAt(effect.value.from)
                                   .from,
                           ),
@@ -563,6 +567,21 @@ export const footnoteDefFlashField = StateField.define<DecorationSet>({
     },
     provide: (field) => EditorView.decorations.from(field),
 });
+
+/**
+ * Flashes the line containing `pos`, then clears it after a short delay.
+ * Guards against a torn-down view. Used to mark where a jump landed.
+ */
+export function flashLine(view: EditorView, pos: number): void {
+    const line = view.state.doc.lineAt(pos);
+    view.dispatch({
+        effects: flashLineEffect.of({ from: line.from, to: line.to }),
+    });
+    window.setTimeout(() => {
+        if (!view.dom.isConnected) return;
+        view.dispatch({ effects: flashLineEffect.of(null) });
+    }, LINE_FLASH_MS);
+}
 
 export function findAncestor(
     node: SyntaxNode | null,

--- a/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewInline.test.ts
@@ -17,8 +17,8 @@ import {
     linkReferenceField,
     footnoteNumberField,
     findFootnoteDefinition,
-    flashFootnoteDefEffect,
-    footnoteDefFlashField,
+    flashLineEffect,
+    lineFlashField,
 } from "./livePreviewHelpers";
 import {
     createInlineLivePreviewPlugin,
@@ -986,34 +986,34 @@ describe("createInlineLivePreviewPlugin", () => {
         expect(findFootnoteDefinition(state, "missing")).toBeNull();
     });
 
-    it("flashes the jumped-to definition line then clears it", () => {
+    it("flashes the jumped-to line then clears it", () => {
         const doc = "x\n[^note]: def";
         const initial = EditorState.create({
             doc,
-            extensions: [footnoteDefFlashField],
+            extensions: [lineFlashField],
         });
         const defLine = initial.doc.line(2);
 
         const flashed = initial.update({
-            effects: flashFootnoteDefEffect.of({
+            effects: flashLineEffect.of({
                 from: defLine.from,
                 to: defLine.to,
             }),
         }).state;
         const ranges: number[] = [];
         flashed
-            .field(footnoteDefFlashField)
+            .field(lineFlashField)
             .between(0, flashed.doc.length, (from) => {
                 ranges.push(from);
             });
         expect(ranges).toEqual([defLine.from]);
 
         const cleared = flashed.update({
-            effects: flashFootnoteDefEffect.of(null),
+            effects: flashLineEffect.of(null),
         }).state;
         let count = 0;
         cleared
-            .field(footnoteDefFlashField)
+            .field(lineFlashField)
             .between(0, cleared.doc.length, () => {
                 count++;
             });

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -391,16 +391,16 @@ export const livePreviewTheme = EditorView.baseTheme({
         fontWeight: "600",
         marginRight: "6px",
     },
-    // Brief highlight on the definition a reference just jumped to.
-    "@keyframes cm-lp-footnote-flash": {
+    // Brief highlight on a line a jump just landed on (footnote def, outline heading).
+    "@keyframes cm-lp-line-flash": {
         from: {
             backgroundColor:
                 "color-mix(in srgb, var(--accent) 32%, transparent)",
         },
         to: { backgroundColor: "transparent" },
     },
-    ".cm-lp-footnote-def-flash": {
-        animation: "cm-lp-footnote-flash 1.1s ease-out",
+    ".cm-lp-line-flash": {
+        animation: "cm-lp-line-flash 1.1s ease-out",
         borderRadius: "4px",
     },
     ".cm-lp-callout": {


### PR DESCRIPTION
## What

Clicking an entry in the **Outline** now scrolls the matching heading to the **center of the editor**, instead of nudging it to the nearest viewport edge (the previous `scrollIntoView: true` used `"nearest"` alignment). Near the end of the document it scrolls as centered as it can.

A brief **line flash** marks where the jump landed — the same effect the footnote-reference jump already used.

## How

- `Editor.tsx`: the `pendingSelectionReveal` effect (the outline jump path, shared by the row click and the "Jump to Heading" context-menu entry) now dispatches `EditorView.scrollIntoView(anchor, { y: "center" })` + `flashLine(view, anchor)`.
- Generalized the footnote highlight into a reusable line flash, since the flash is not footnote-specific:
  - `flashFootnoteDefEffect` -> `flashLineEffect`
  - `footnoteDefFlashField` -> `lineFlashField`
  - `cm-lp-footnote-def-flash` -> `cm-lp-line-flash`
  - new shared `flashLine(view, pos)` helper (dispatch + timed clear, `LINE_FLASH_MS`)
- The footnote jump now delegates to `flashLine`, so both jumps share one flash implementation.

## Notes

- Centers **every** click, even when the heading was already visible (intended: the selected section always lands in the middle).
- The flash is only visible in **live preview** mode (where `lineFlashField` is loaded); in source mode the centering still works and the flash effect is a harmless no-op.

## Verification

- `tsc --noEmit`: clean
- `eslint` (touched files): clean
- `vitest`: 125/125 (includes the renamed line-flash test)