### PR TITLE
Refresh live preview blocks after parser updates

### DIFF
--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
+import { forceParsing } from "@codemirror/language";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
@@ -80,6 +81,38 @@ describe("code block live preview", () => {
                 line.classList.contains("cm-lp-block-gap-hidden"),
             ),
         ).toBe(true);
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("renders tables when the markdown parser finishes after editor creation", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const filler = "plain text ".repeat(420);
+        const table = ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+        const doc = `${filler}\n\n${table}`;
+        const tableEnd = doc.length;
+        const state = EditorState.create({
+            doc,
+            selection: EditorSelection.cursor(0),
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                livePreviewExtension(null, {
+                    resolveWikilink: () => false,
+                    navigateWikilink: () => {},
+                    getNoteLinkTarget: () => null,
+                    openLinkContextMenu: () => {},
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent });
+
+        expect(view.dom.querySelector(".cm-lp-table-widget")).toBeNull();
+        expect(forceParsing(view, tableEnd, 100)).toBe(true);
+        expect(view.dom.querySelector(".cm-lp-table-widget")).not.toBeNull();
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -1228,13 +1228,23 @@ function needsBlockRebuild(tr: Transaction): boolean {
     );
 }
 
+function needsSyntaxBackedBlockRebuild(tr: Transaction): boolean {
+    // CodeMirror may finish markdown parsing in a background language-state
+    // transaction with no document or selection change. Syntax-backed widgets
+    // must rebuild when new nodes become available.
+    if (!tr.docChanged && syntaxTree(tr.startState) !== syntaxTree(tr.state)) {
+        return true;
+    }
+    return needsBlockRebuild(tr);
+}
+
 export function createCodeBlockLivePreviewExtension() {
     return StateField.define<DecorationSet>({
         create(state) {
             return buildCodeBlockDecorations(state);
         },
         update(decorations, transaction) {
-            if (!needsBlockRebuild(transaction)) {
+            if (!needsSyntaxBackedBlockRebuild(transaction)) {
                 return transaction.docChanged
                     ? decorations.map(transaction.changes)
                     : decorations;
@@ -2294,7 +2304,7 @@ export function createImageLivePreviewExtension(vaultRoot: string | null) {
             return buildBlockDecorations(state, vaultRoot);
         },
         update(decorations, transaction) {
-            if (!needsBlockRebuild(transaction)) {
+            if (!needsSyntaxBackedBlockRebuild(transaction)) {
                 return transaction.docChanged
                     ? decorations.map(transaction.changes)
                     : decorations;
@@ -2315,7 +2325,7 @@ export function createTableLivePreviewExtension(
             return buildTableDecorations(state, interactions);
         },
         update(decorations, transaction) {
-            if (!needsBlockRebuild(transaction)) {
+            if (!needsSyntaxBackedBlockRebuild(transaction)) {
                 return transaction.docChanged
                     ? decorations.map(transaction.changes)
                     : decorations;


### PR DESCRIPTION
## Summary
- Rebuild syntax-backed Live Preview block decorations when CodeMirror advances the markdown syntax tree without a document or selection change.
- Cover the delayed-table parse case with a regression test.

## Root Cause
Tables are built from `syntaxTree(state)`, but the table decoration field skipped parser-only language-state transactions. A first click changed selection and forced the rebuild, making the table appear late.

## Validation
- `npm test -- src/features/editor/extensions/livePreviewBlocks.test.ts`

Fixes #226