### PR TITLE
Add active line highlight setting

### DIFF
--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -18,6 +18,7 @@ export interface Settings {
     editorAutosaveDelayMs: number; // 50–5000
     editorContentWidth: number; // 600–1200
     lineWrapping: boolean;
+    editorActiveLineHighlight: boolean;
     justifyText: boolean;
     livePreviewEnabled: boolean;
     inlineReviewEnabled: boolean;
@@ -175,6 +176,7 @@ const defaults: Settings = {
     editorAutosaveDelayMs: 300,
     editorContentWidth: 940,
     lineWrapping: true,
+    editorActiveLineHighlight: true,
     justifyText: false,
     livePreviewEnabled: true,
     inlineReviewEnabled: true,
@@ -420,6 +422,9 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
                 1200,
             ),
             lineWrapping: parsed.state.lineWrapping ?? defaults.lineWrapping,
+            editorActiveLineHighlight:
+                parsed.state.editorActiveLineHighlight ??
+                defaults.editorActiveLineHighlight,
             justifyText: parsed.state.justifyText ?? defaults.justifyText,
             livePreviewEnabled:
                 parsed.state.livePreviewEnabled ?? defaults.livePreviewEnabled,
@@ -543,6 +548,7 @@ function pickSettings(state: SettingsStore): Settings {
         editorAutosaveDelayMs: state.editorAutosaveDelayMs,
         editorContentWidth: state.editorContentWidth,
         lineWrapping: state.lineWrapping,
+        editorActiveLineHighlight: state.editorActiveLineHighlight,
         justifyText: state.justifyText,
         livePreviewEnabled: state.livePreviewEnabled,
         inlineReviewEnabled: state.inlineReviewEnabled,

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -108,6 +108,7 @@ import {
     livePreviewCompartment,
     alignmentCompartment,
     wrappingCompartment,
+    activeLineCompartment,
     tabSizeCompartment,
     spellcheckCompartment,
     spellcheckDecorationsCompartment,
@@ -118,6 +119,7 @@ import {
     getLivePreviewExtension,
     getAlignmentExtension,
     getWrappingExtension,
+    getActiveLineExtension,
     getSpellcheckExtension,
     getVimExtension,
     getLineNumberExtension,
@@ -476,6 +478,9 @@ export function Editor({
     );
     const editorContentWidth = useSettingsStore((s) => s.editorContentWidth);
     const lineWrapping = useSettingsStore((s) => s.lineWrapping);
+    const editorActiveLineHighlight = useSettingsStore(
+        (s) => s.editorActiveLineHighlight,
+    );
     const justifyText = useSettingsStore((s) => s.justifyText);
     const livePreviewEnabled = useSettingsStore((s) => s.livePreviewEnabled);
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
@@ -2328,6 +2333,12 @@ export function Editor({
                             useSettingsStore.getState().lineWrapping,
                         ),
                     ),
+                    activeLineCompartment.of(
+                        getActiveLineExtension(
+                            useSettingsStore.getState()
+                                .editorActiveLineHighlight,
+                        ),
+                    ),
                     drawSelection(),
                     alignmentCompartment.of(
                         getAlignmentExtension(
@@ -3057,6 +3068,11 @@ export function Editor({
                             settings.vimRelativeLineNumbers,
                         ),
                     ),
+                    activeLineCompartment.reconfigure(
+                        getActiveLineExtension(
+                            settings.editorActiveLineHighlight,
+                        ),
+                    ),
                 ],
             });
         }
@@ -3612,6 +3628,9 @@ export function Editor({
                 wrappingCompartment.reconfigure(
                     getWrappingExtension(lineWrapping),
                 ),
+                activeLineCompartment.reconfigure(
+                    getActiveLineExtension(editorActiveLineHighlight),
+                ),
                 tabSizeCompartment.reconfigure([
                     EditorState.tabSize.of(tabSize),
                     indentUnit.of(" ".repeat(tabSize)),
@@ -3628,6 +3647,7 @@ export function Editor({
     }, [
         justifyText,
         lineWrapping,
+        editorActiveLineHighlight,
         tabSize,
         vimModeEnabled,
         vimRelativeLineNumbers,

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -30,6 +30,7 @@ import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
     baseTheme,
+    getActiveLineExtension,
     getEditorFontFamily,
     getEditorHorizontalInset,
     getSyntaxExtension,
@@ -98,6 +99,7 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
     const viewRef = useRef<EditorView | null>(null);
     const syntaxCompartmentRef = useRef(new Compartment());
     const wrappingCompartmentRef = useRef(new Compartment());
+    const activeLineCompartmentRef = useRef(new Compartment());
     const languageCompartmentRef = useRef(new Compartment());
     const loadRequestRef = useRef(0);
     const contextMenuCleanupRef = useRef<(() => void) | null>(null);
@@ -115,6 +117,9 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
     );
     const editorContentWidth = useSettingsStore((s) => s.editorContentWidth);
     const lineWrapping = useSettingsStore((s) => s.lineWrapping);
+    const editorActiveLineHighlight = useSettingsStore(
+        (s) => s.editorActiveLineHighlight,
+    );
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const sessionsById = useChatStore((state) => state.sessionsById);
@@ -332,6 +337,9 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
                     wrappingCompartmentRef.current.of(
                         getWrappingExtension(lineWrapping),
                     ),
+                    activeLineCompartmentRef.current.of(
+                        getActiveLineExtension(editorActiveLineHighlight),
+                    ),
                     drawSelection(),
                     EditorView.editorAttributes.of({
                         "data-live-preview": "false",
@@ -432,6 +440,7 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
     }, [
         handleLocalContentChange,
         handleEditorContextMenu,
+        editorActiveLineHighlight,
         lineWrapping,
         syncCurrentSelection,
         tab,
@@ -451,11 +460,16 @@ export function FileTextTabView({ paneId }: FileTextTabViewProps) {
         }
 
         view.dispatch({
-            effects: wrappingCompartmentRef.current.reconfigure(
-                getWrappingExtension(lineWrapping),
-            ),
+            effects: [
+                wrappingCompartmentRef.current.reconfigure(
+                    getWrappingExtension(lineWrapping),
+                ),
+                activeLineCompartmentRef.current.reconfigure(
+                    getActiveLineExtension(editorActiveLineHighlight),
+                ),
+            ],
         });
-    }, [lineWrapping]);
+    }, [editorActiveLineHighlight, lineWrapping]);
 
     useEffect(() => {
         const view = viewRef.current;

--- a/apps/desktop/src/features/editor/editorExtensions.ts
+++ b/apps/desktop/src/features/editor/editorExtensions.ts
@@ -5,9 +5,11 @@ import {
     ViewPlugin,
     gutter,
     GutterMarker,
+    highlightActiveLine,
+    highlightActiveLineGutter,
     lineNumbers,
 } from "@codemirror/view";
-import { Compartment, RangeSetBuilder } from "@codemirror/state";
+import { Compartment, RangeSetBuilder, type Extension } from "@codemirror/state";
 import { syntaxTree, syntaxHighlighting } from "@codemirror/language";
 import { buildSyntaxHighlightStyle } from "./extensions/syntaxTheme";
 import type {
@@ -157,6 +159,8 @@ export const livePreviewCompartment = new Compartment();
 export const alignmentCompartment = new Compartment();
 // Compartment for line wrapping
 export const wrappingCompartment = new Compartment();
+// Compartment for the cursor line highlight
+export const activeLineCompartment = new Compartment();
 // Compartment for tab size
 export const tabSizeCompartment = new Compartment();
 // Compartment for spellcheck attributes
@@ -169,6 +173,10 @@ export const grammarDecorationsCompartment = new Compartment();
 export const vimCompartment = new Compartment();
 // Compartment for the line-number gutter (absolute vs. vim relative numbering)
 export const lineNumberCompartment = new Compartment();
+
+export function getActiveLineExtension(enabled: boolean): Extension {
+    return enabled ? [highlightActiveLine(), highlightActiveLineGutter()] : [];
+}
 
 const sourceHeadingDecoration = Decoration.mark({
     class: "cm-source-heading",

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -1098,6 +1098,7 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         editorAutosaveDelayMs,
         editorContentWidth,
         lineWrapping,
+        editorActiveLineHighlight,
         justifyText,
         tabSize,
         vimModeEnabled,
@@ -1130,6 +1131,12 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         "Formatting",
         [
             ["Line wrapping", "Wrap long lines to fit the editor width."],
+            [
+                "Highlight active line",
+                "Highlight the line containing the cursor.",
+                "current line",
+                "cursor line",
+            ],
             [
                 "Justify text",
                 "Distribute wrapped lines evenly across the editor width.",
@@ -1239,6 +1246,21 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                     <Toggle
                         value={lineWrapping}
                         onChange={(v) => setSetting("lineWrapping", v)}
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Formatting"
+                label="Highlight active line"
+                description="Highlight the line containing the cursor."
+                keywords={["current line", "cursor line"]}
+                control={
+                    <Toggle
+                        value={editorActiveLineHighlight}
+                        onChange={(v) =>
+                            setSetting("editorActiveLineHighlight", v)
+                        }
                     />
                 }
             />

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -71,6 +71,7 @@ the same Settings stores.
 | Editor / Typography | `editorLineHeight` | Per-vault | `175` | `neverwrite:settings:<vault-path>` | Percentage, clamped to `120..220`. |
 | Editor / Typography | `editorAutosaveDelayMs` | Per-vault | `300` | `neverwrite:settings:<vault-path>` | Clamped to `50..5000`. |
 | Editor / Formatting | `lineWrapping` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Used by editor and review surfaces. |
+| Editor / Formatting | `editorActiveLineHighlight` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Controls the CodeMirror active-line highlight in note and text-file editors. |
 | Editor / Formatting | `justifyText` | Per-vault | `false` | `neverwrite:settings:<vault-path>` | Only meaningful when wrapping is enabled. |
 | Editor / Formatting | `livePreviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Controls source vs live-preview editor mode; also exposed through quick actions outside the Settings panel. |
 | Editor / Formatting | `tabSize` | Per-vault | `2` | `neverwrite:settings:<vault-path>` | Normalized to `2` or `4`. |
@@ -243,4 +244,4 @@ when they are persisted or visible in Settings:
 - Review anchors, resolved hunk positions, and transient review synchronization
   state.
 
-Last updated: June 1, 2026.
+Last updated: June 17, 2026.


### PR DESCRIPTION
## Summary

Adds a new per-vault Editor setting for highlighting the active CodeMirror line.

## Changes

- Adds `editorActiveLineHighlight` to desktop settings with a default of `true`.
- Wires CodeMirror `highlightActiveLine()` and `highlightActiveLineGutter()` through a reconfigurable compartment.
- Adds the Settings > Editor > Formatting toggle.
- Applies the preference to both note editors and text-file editors.
- Documents the setting scope/default in `docs/settings-scope.md`.

## Validation

- `npm --prefix apps/desktop run build`
- `npm --prefix apps/desktop run lint`