### PR TITLE
Add native image attachments to the AI composer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,6 +1759,7 @@ version = "0.3.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",
+ "base64",
  "keyring",
  "neverwrite-ai",
  "neverwrite-diff",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
 acp12 = { package = "agent-client-protocol-legacy", path = "../../../vendor/acp12/agent-client-protocol", features = ["unstable"] }
+base64 = "0.22.1"
 keyring = { version = "3.6.3", features = ["apple-native", "windows-native", "linux-native-async-persistent", "async-io", "crypto-rust"] }
 neverwrite-diff = { path = "../../../crates/diff" }
 neverwrite-ai = { path = "../../../crates/ai" }

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -69,6 +69,10 @@ const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
 const AGENT_WRITE_ORIGIN_WINDOW: Duration = Duration::from_secs(15);
 const MAX_TERMINAL_SUMMARY_CHARS: usize = 8_000;
 const MAX_NATIVE_IMAGE_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
+const CONSERVATIVE_NATIVE_BASE64_IMAGE_ATTACHMENT_BYTES: u64 = 5 * 1024 * 1024;
+const CONSERVATIVE_NATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES: u64 =
+    (CONSERVATIVE_NATIVE_BASE64_IMAGE_ATTACHMENT_BYTES / 4) * 3;
+const GROK_NATIVE_IMAGE_ATTACHMENT_BYTES: u64 = 20 * 1024 * 1024;
 const MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE: usize = 12;
 const ACP_STATUS_EVENT_TYPE_KEY: &str = "neverwriteEventType";
 const ACP_STATUS_KIND_KEY: &str = "neverwriteStatusKind";
@@ -1660,6 +1664,7 @@ impl NativeAi {
                 managed.vault_root.as_deref(),
                 &managed.additional_roots,
                 handle.prompt_capabilities(),
+                Some(managed.session.runtime_id.as_str()),
             )?;
             managed.session.status = AiSessionStatus::Streaming;
             touch_session(&mut state, &session_id);
@@ -8313,8 +8318,10 @@ fn build_prompt_with_attachments(
     attachments: &[AiAttachmentInput],
     vault_root: Option<&Path>,
     additional_roots: &[PathBuf],
+    runtime_id: Option<&str>,
 ) -> Result<String, String> {
-    validate_image_attachment_policy(attachments)?;
+    let image_limits = native_image_attachment_limits_for_runtime(runtime_id);
+    validate_image_attachment_policy(attachments, &image_limits)?;
 
     let mut context_parts = Vec::new();
     for attachment in attachments {
@@ -8395,13 +8402,21 @@ fn build_prompt_blocks_with_attachments(
     vault_root: Option<&Path>,
     additional_roots: &[PathBuf],
     capabilities: AcpPromptCapabilities,
+    runtime_id: Option<&str>,
 ) -> Result<Vec<ContentBlock>, String> {
     if !capabilities.embedded_context && !capabilities.image {
-        return build_prompt_with_attachments(content, attachments, vault_root, additional_roots)
-            .map(|content| vec![ContentBlock::from(content)]);
+        return build_prompt_with_attachments(
+            content,
+            attachments,
+            vault_root,
+            additional_roots,
+            runtime_id,
+        )
+        .map(|content| vec![ContentBlock::from(content)]);
     }
 
-    validate_image_attachment_policy(attachments)?;
+    let image_limits = native_image_attachment_limits_for_runtime(runtime_id);
+    validate_image_attachment_policy(attachments, &image_limits)?;
 
     let mut blocks = Vec::new();
     let mut text_context_parts = Vec::new();
@@ -8469,6 +8484,7 @@ fn build_prompt_blocks_with_attachments(
                         vault_root,
                         additional_roots,
                         capabilities,
+                        &image_limits,
                     )?;
                 }
             }
@@ -8537,14 +8553,76 @@ fn embedded_text_resource_block(
     ))
 }
 
-fn is_supported_native_image_mime(mime: &str) -> bool {
-    matches!(
-        mime,
-        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
-    )
+#[derive(Debug, Clone, Copy)]
+struct NativeImageAttachmentLimits {
+    runtime_label: &'static str,
+    max_bytes: u64,
+    max_images_per_message: usize,
+    allowed_mime_types: &'static [&'static str],
 }
 
-fn validate_image_attachment_policy(attachments: &[AiAttachmentInput]) -> Result<(), String> {
+const DEFAULT_NATIVE_IMAGE_MIME_TYPES: &[&str] =
+    &["image/png", "image/jpeg", "image/gif", "image/webp"];
+const CONSERVATIVE_NATIVE_IMAGE_MIME_TYPES: &[&str] = &["image/png", "image/jpeg", "image/webp"];
+const GROK_NATIVE_IMAGE_MIME_TYPES: &[&str] = &["image/png", "image/jpeg"];
+
+fn native_image_attachment_limits_for_runtime(
+    runtime_id: Option<&str>,
+) -> NativeImageAttachmentLimits {
+    match runtime_id {
+        Some(CODEX_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "Codex",
+            max_bytes: MAX_NATIVE_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: DEFAULT_NATIVE_IMAGE_MIME_TYPES,
+        },
+        Some(CLAUDE_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "Claude",
+            max_bytes: CONSERVATIVE_NATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: DEFAULT_NATIVE_IMAGE_MIME_TYPES,
+        },
+        Some(GEMINI_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "Gemini",
+            max_bytes: MAX_NATIVE_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: CONSERVATIVE_NATIVE_IMAGE_MIME_TYPES,
+        },
+        Some(GROK_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "Grok",
+            max_bytes: GROK_NATIVE_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: GROK_NATIVE_IMAGE_MIME_TYPES,
+        },
+        Some(KILO_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "Kilo",
+            max_bytes: CONSERVATIVE_NATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: CONSERVATIVE_NATIVE_IMAGE_MIME_TYPES,
+        },
+        Some(OPENCODE_RUNTIME_ID) => NativeImageAttachmentLimits {
+            runtime_label: "OpenCode",
+            max_bytes: CONSERVATIVE_NATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: CONSERVATIVE_NATIVE_IMAGE_MIME_TYPES,
+        },
+        _ => NativeImageAttachmentLimits {
+            runtime_label: "this provider",
+            max_bytes: MAX_NATIVE_IMAGE_ATTACHMENT_BYTES,
+            max_images_per_message: MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE,
+            allowed_mime_types: DEFAULT_NATIVE_IMAGE_MIME_TYPES,
+        },
+    }
+}
+
+fn is_supported_native_image_mime(mime: &str, limits: &NativeImageAttachmentLimits) -> bool {
+    limits.allowed_mime_types.contains(&mime)
+}
+
+fn validate_image_attachment_policy(
+    attachments: &[AiAttachmentInput],
+    limits: &NativeImageAttachmentLimits,
+) -> Result<(), String> {
     let mut image_count = 0;
 
     for attachment in attachments {
@@ -8560,15 +8638,18 @@ fn validate_image_attachment_policy(attachments: &[AiAttachmentInput]) -> Result
         }
 
         image_count += 1;
-        if !is_supported_native_image_mime(mime) {
-            return Err(format!("Unsupported image attachment type: {}.", mime));
+        if !is_supported_native_image_mime(mime, limits) {
+            return Err(format!(
+                "Unsupported image attachment type for {}: {}.",
+                limits.runtime_label, mime
+            ));
         }
     }
 
-    if image_count > MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE {
+    if image_count > limits.max_images_per_message {
         return Err(format!(
-            "Too many image attachments: {} exceeds the {} image limit.",
-            image_count, MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE
+            "Too many image attachments for {}: {} exceeds the {} image limit.",
+            limits.runtime_label, image_count, limits.max_images_per_message
         ));
     }
 
@@ -8583,6 +8664,7 @@ fn append_file_attachment_blocks(
     vault_root: Option<&Path>,
     additional_roots: &[PathBuf],
     capabilities: AcpPromptCapabilities,
+    image_limits: &NativeImageAttachmentLimits,
 ) -> Result<(), String> {
     let path = allowed_attachment_path(file_path, vault_root, additional_roots)?;
     let mime = attachment
@@ -8624,10 +8706,10 @@ fn append_file_attachment_blocks(
     } else if mime.starts_with("image/") {
         let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
         if capabilities.image {
-            if size > MAX_NATIVE_IMAGE_ATTACHMENT_BYTES {
+            if size > image_limits.max_bytes {
                 return Err(format!(
-                    "Image attachment is too large: {} exceeds the {} byte limit.",
-                    rel_path, MAX_NATIVE_IMAGE_ATTACHMENT_BYTES
+                    "Image attachment is too large for {}: {} exceeds the {} byte limit.",
+                    image_limits.runtime_label, rel_path, image_limits.max_bytes
                 ));
             }
             match std::fs::read(&path) {
@@ -13265,6 +13347,7 @@ mod tests {
             }],
             Some(vault.path()),
             &[],
+            None,
         )
         .expect_err("outside attachment should be blocked");
 
@@ -13296,6 +13379,7 @@ mod tests {
                 image: false,
                 embedded_context: true,
             },
+            None,
         )
         .unwrap();
 
@@ -13349,6 +13433,7 @@ mod tests {
                 image: false,
                 embedded_context: false,
             },
+            None,
         )
         .unwrap();
 
@@ -13389,6 +13474,7 @@ mod tests {
                 image: true,
                 embedded_context: false,
             },
+            None,
         )
         .unwrap();
 
@@ -13435,6 +13521,7 @@ mod tests {
                 image: false,
                 embedded_context: true,
             },
+            None,
         )
         .unwrap();
 
@@ -13478,6 +13565,7 @@ mod tests {
                 image: true,
                 embedded_context: true,
             },
+            None,
         )
         .expect_err("outside native image attachment should be blocked");
 
@@ -13512,10 +13600,81 @@ mod tests {
                 image: true,
                 embedded_context: true,
             },
+            None,
         )
         .expect_err("oversized native image attachment should be blocked");
 
         assert!(error.contains("Image attachment is too large"));
+    }
+
+    #[test]
+    fn prompt_blocks_apply_claude_native_image_size_limit() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("claude-huge.png");
+        let file = fs::File::create(&image_path).unwrap();
+        file.set_len(CONSERVATIVE_NATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES + 1)
+            .unwrap();
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Huge Screenshot".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+            Some(CLAUDE_RUNTIME_ID),
+        )
+        .expect_err("Claude native image limit should be provider-aware");
+
+        assert!(error.contains("Image attachment is too large for Claude"));
+    }
+
+    #[test]
+    fn prompt_blocks_apply_grok_native_image_mime_policy() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("image.webp");
+        fs::write(&image_path, [0_u8, 1, 2, 3]).unwrap();
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "WebP".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/webp".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+            Some(GROK_RUNTIME_ID),
+        )
+        .expect_err("Grok native image MIME policy should be provider-aware");
+
+        assert!(error.contains("Unsupported image attachment type for Grok"));
     }
 
     #[test]
@@ -13545,6 +13704,7 @@ mod tests {
                 image: true,
                 embedded_context: true,
             },
+            None,
         )
         .expect_err("unsupported native image type should be blocked");
 
@@ -13583,6 +13743,7 @@ mod tests {
                 image: true,
                 embedded_context: true,
             },
+            None,
         )
         .expect_err("too many native image attachments should be blocked");
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -69,6 +69,7 @@ const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
 const AGENT_WRITE_ORIGIN_WINDOW: Duration = Duration::from_secs(15);
 const MAX_TERMINAL_SUMMARY_CHARS: usize = 8_000;
 const MAX_NATIVE_IMAGE_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
+const MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE: usize = 12;
 const ACP_STATUS_EVENT_TYPE_KEY: &str = "neverwriteEventType";
 const ACP_STATUS_KIND_KEY: &str = "neverwriteStatusKind";
 const ACP_STATUS_EMPHASIS_KEY: &str = "neverwriteStatusEmphasis";
@@ -8313,6 +8314,8 @@ fn build_prompt_with_attachments(
     vault_root: Option<&Path>,
     additional_roots: &[PathBuf],
 ) -> Result<String, String> {
+    validate_image_attachment_policy(attachments)?;
+
     let mut context_parts = Vec::new();
     for attachment in attachments {
         if let Some(content) = attachment.content.as_deref() {
@@ -8397,6 +8400,8 @@ fn build_prompt_blocks_with_attachments(
         return build_prompt_with_attachments(content, attachments, vault_root, additional_roots)
             .map(|content| vec![ContentBlock::from(content)]);
     }
+
+    validate_image_attachment_policy(attachments)?;
 
     let mut blocks = Vec::new();
     let mut text_context_parts = Vec::new();
@@ -8530,6 +8535,44 @@ fn embedded_text_resource_block(
             TextResourceContents::new(text.to_string(), uri).mime_type(mime_type),
         ),
     ))
+}
+
+fn is_supported_native_image_mime(mime: &str) -> bool {
+    matches!(
+        mime,
+        "image/png" | "image/jpeg" | "image/gif" | "image/webp"
+    )
+}
+
+fn validate_image_attachment_policy(attachments: &[AiAttachmentInput]) -> Result<(), String> {
+    let mut image_count = 0;
+
+    for attachment in attachments {
+        if attachment.attachment_type.as_deref() != Some("file") {
+            continue;
+        }
+
+        let Some(mime) = attachment.mime_type.as_deref() else {
+            continue;
+        };
+        if !mime.starts_with("image/") {
+            continue;
+        }
+
+        image_count += 1;
+        if !is_supported_native_image_mime(mime) {
+            return Err(format!("Unsupported image attachment type: {}.", mime));
+        }
+    }
+
+    if image_count > MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE {
+        return Err(format!(
+            "Too many image attachments: {} exceeds the {} image limit.",
+            image_count, MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE
+        ));
+    }
+
+    Ok(())
 }
 
 fn append_file_attachment_blocks(
@@ -13473,6 +13516,77 @@ mod tests {
         .expect_err("oversized native image attachment should be blocked");
 
         assert!(error.contains("Image attachment is too large"));
+    }
+
+    #[test]
+    fn prompt_blocks_reject_unsupported_image_attachment_type() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("vector.svg");
+        fs::write(&image_path, "<svg />").unwrap();
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Vector".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/svg+xml".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+        )
+        .expect_err("unsupported native image type should be blocked");
+
+        assert!(error.contains("Unsupported image attachment type"));
+        assert!(error.contains("image/svg+xml"));
+    }
+
+    #[test]
+    fn prompt_blocks_reject_too_many_image_attachments() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let mut attachments = Vec::new();
+        for index in 0..=MAX_NATIVE_IMAGE_ATTACHMENTS_PER_MESSAGE {
+            let image_path = vault.path().join(format!("shot-{index}.png"));
+            fs::write(&image_path, [0_u8, 1, 2, 3]).unwrap();
+            attachments.push(AiAttachmentInput {
+                label: format!("Screenshot {index}"),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            });
+        }
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe these images",
+            &attachments,
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+        )
+        .expect_err("too many native image attachments should be blocked");
+
+        assert!(error.contains("Too many image attachments"));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -16,9 +16,9 @@ use agent_client_protocol::schema::{
     ElicitationAction, ElicitationCapabilities, ElicitationContentValue,
     ElicitationFormCapabilities, ElicitationMode, ElicitationPropertySchema, ElicitationScope,
     ElicitationUrlCapabilities, EmbeddedResource, EmbeddedResourceResource, FileSystemCapabilities,
-    Implementation, InitializeRequest, InitializeResponse, LogoutRequest, Meta, MultiSelectItems,
-    NewSessionRequest, PermissionOption, PermissionOptionKind, Plan, PlanEntryPriority,
-    PlanEntryStatus, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
+    ImageContent, Implementation, InitializeRequest, InitializeResponse, LogoutRequest, Meta,
+    MultiSelectItems, NewSessionRequest, PermissionOption, PermissionOptionKind, Plan,
+    PlanEntryPriority, PlanEntryStatus, PromptRequest, ProtocolVersion, RequestPermissionOutcome,
     RequestPermissionRequest, RequestPermissionResponse, ResumeSessionRequest,
     SelectedPermissionOutcome, SessionConfigKind, SessionConfigOption, SessionConfigOptionCategory,
     SessionConfigSelectOption, SessionConfigSelectOptions, SessionId, SessionModeState,
@@ -26,6 +26,7 @@ use agent_client_protocol::schema::{
     TextResourceContents, ToolCall, ToolCallContent, ToolCallStatus, ToolCallUpdate, ToolKind,
 };
 use agent_client_protocol::{Agent, ByteStreams, Client, ConnectionTo};
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use neverwrite_ai::{
     AiAuthMethod, AiConfigOption, AiConfigOptionCategory, AiConfigSelectOption, AiFileDiffPayload,
     AiImageGenerationPayload, AiMessageCompletedPayload, AiMessageDeltaPayload,
@@ -8391,7 +8392,7 @@ fn build_prompt_blocks_with_attachments(
     additional_roots: &[PathBuf],
     capabilities: AcpPromptCapabilities,
 ) -> Result<Vec<ContentBlock>, String> {
-    if !capabilities.embedded_context {
+    if !capabilities.embedded_context && !capabilities.image {
         return build_prompt_with_attachments(content, attachments, vault_root, additional_roots)
             .map(|content| vec![ContentBlock::from(content)]);
     }
@@ -8401,11 +8402,23 @@ fn build_prompt_blocks_with_attachments(
 
     for attachment in attachments {
         if let Some(content) = attachment.content.as_deref() {
-            blocks.push(embedded_text_resource_block(
-                content,
-                attachment_resource_uri(attachment, "selection"),
-                text_attachment_mime(attachment),
-            ));
+            if capabilities.embedded_context {
+                blocks.push(embedded_text_resource_block(
+                    content,
+                    attachment_resource_uri(attachment, "selection"),
+                    text_attachment_mime(attachment),
+                ));
+            } else {
+                let tag = if attachment.attachment_type.as_deref() == Some("selection") {
+                    "attached_selection"
+                } else {
+                    "attached_note"
+                };
+                text_context_parts.push(format!(
+                    "<{tag} name=\"{}\">\n{}\n</{tag}>",
+                    attachment.label, content
+                ));
+            }
             continue;
         }
 
@@ -8421,11 +8434,19 @@ fn build_prompt_blocks_with_attachments(
             }
             Some("audio") => {
                 if let Some(transcription) = attachment.transcription.as_deref() {
-                    blocks.push(embedded_text_resource_block(
-                        transcription,
-                        attachment_resource_uri(attachment, "audio"),
-                        Some("text/plain".to_string()),
-                    ));
+                    if capabilities.embedded_context {
+                        blocks.push(embedded_text_resource_block(
+                            transcription,
+                            attachment_resource_uri(attachment, "audio"),
+                            Some("text/plain".to_string()),
+                        ));
+                    } else {
+                        let source = attachment.file_path.as_deref().unwrap_or("audio");
+                        text_context_parts.push(format!(
+                            "<attached_audio name=\"{}\" source=\"{}\">\n[Transcription]\n{}\n</attached_audio>",
+                            attachment.label, source, transcription
+                        ));
+                    }
                 }
             }
             Some("file") => {
@@ -8441,29 +8462,47 @@ fn build_prompt_blocks_with_attachments(
                         file_path,
                         vault_root,
                         additional_roots,
+                        capabilities,
                     )?;
                 }
             }
             _ => {
                 if let Some(path) = attachment.path.as_deref() {
                     let path = allowed_attachment_path(path, vault_root, additional_roots)?;
-                    match std::fs::read_to_string(&path) {
-                        Ok(file_content) => blocks.push(embedded_text_resource_block(
-                            &file_content,
-                            path_resource_uri(&path, attachment),
-                            text_attachment_mime(attachment),
-                        )),
-                        Err(error) => text_context_parts.push(format!(
-                            "<attached_note name=\"{}\">\n[Error reading note: {}]\n</attached_note>",
-                            attachment.label, error
-                        )),
+                    if capabilities.embedded_context {
+                        match std::fs::read_to_string(&path) {
+                            Ok(file_content) => blocks.push(embedded_text_resource_block(
+                                &file_content,
+                                path_resource_uri(&path, attachment),
+                                text_attachment_mime(attachment),
+                            )),
+                            Err(error) => text_context_parts.push(format!(
+                                "<attached_note name=\"{}\">\n[Error reading note: {}]\n</attached_note>",
+                                attachment.label, error
+                            )),
+                        }
+                    } else {
+                        match std::fs::read_to_string(&path) {
+                            Ok(file_content) => text_context_parts.push(format!(
+                                "<attached_note name=\"{}\">\n{}\n</attached_note>",
+                                attachment.label, file_content
+                            )),
+                            Err(error) => text_context_parts.push(format!(
+                                "<attached_note name=\"{}\">\n[Error reading note: {}]\n</attached_note>",
+                                attachment.label, error
+                            )),
+                        }
                     }
                 }
             }
         }
     }
 
-    let prompt_text = prompt_without_embedded_attachment_references(content, attachments);
+    let prompt_text = if capabilities.embedded_context {
+        prompt_without_embedded_attachment_references(content, attachments)
+    } else {
+        content.to_string()
+    };
     let prompt_text = if text_context_parts.is_empty() {
         prompt_text
     } else if prompt_text.is_empty() {
@@ -8499,6 +8538,7 @@ fn append_file_attachment_blocks(
     file_path: &str,
     vault_root: Option<&Path>,
     additional_roots: &[PathBuf],
+    capabilities: AcpPromptCapabilities,
 ) -> Result<(), String> {
     let path = allowed_attachment_path(file_path, vault_root, additional_roots)?;
     let mime = attachment
@@ -8513,23 +8553,49 @@ fn append_file_attachment_blocks(
             attachment.label, rel_path
         ));
     } else if mime.starts_with("text/") || mime == "application/json" {
-        match std::fs::read_to_string(&path) {
-            Ok(text) => blocks.push(embedded_text_resource_block(
-                &text,
-                path_resource_uri(&path, attachment),
-                Some(mime.to_string()),
-            )),
-            Err(error) => text_context_parts.push(format!(
-                "<attached_file name=\"{}\" type=\"{}\">\n[Error reading file: {}]\n</attached_file>",
-                attachment.label, mime, error
-            )),
+        if capabilities.embedded_context {
+            match std::fs::read_to_string(&path) {
+                Ok(text) => blocks.push(embedded_text_resource_block(
+                    &text,
+                    path_resource_uri(&path, attachment),
+                    Some(mime.to_string()),
+                )),
+                Err(error) => text_context_parts.push(format!(
+                    "<attached_file name=\"{}\" type=\"{}\">\n[Error reading file: {}]\n</attached_file>",
+                    attachment.label, mime, error
+                )),
+            }
+        } else {
+            match std::fs::read_to_string(&path) {
+                Ok(text) => text_context_parts.push(format!(
+                    "<attached_file name=\"{}\" type=\"{}\">\n{}\n</attached_file>",
+                    attachment.label, mime, text
+                )),
+                Err(error) => text_context_parts.push(format!(
+                    "<attached_file name=\"{}\" type=\"{}\">\n[Error reading file: {}]\n</attached_file>",
+                    attachment.label, mime, error
+                )),
+            }
         }
     } else if mime.starts_with("image/") {
         let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
-        text_context_parts.push(format!(
-            "<attached_image name=\"{}\" type=\"{}\" path=\"{}\" size=\"{}\" />",
-            attachment.label, mime, rel_path, size
-        ));
+        if capabilities.image {
+            match std::fs::read(&path) {
+                Ok(bytes) => blocks.push(ContentBlock::Image(
+                    ImageContent::new(BASE64_STANDARD.encode(bytes), mime.to_string())
+                        .uri(path_resource_uri(&path, attachment)),
+                )),
+                Err(error) => text_context_parts.push(format!(
+                    "<attached_image name=\"{}\" type=\"{}\" path=\"{}\" size=\"{}\">\n[Error reading image: {}]\n</attached_image>",
+                    attachment.label, mime, rel_path, size, error
+                )),
+            }
+        } else {
+            text_context_parts.push(format!(
+                "<attached_image name=\"{}\" type=\"{}\" path=\"{}\" size=\"{}\" />",
+                attachment.label, mime, rel_path, size
+            ));
+        }
     } else {
         let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
         text_context_parts.push(format!(
@@ -13244,6 +13310,128 @@ mod tests {
             }
             other => panic!("expected fallback text prompt, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn prompt_blocks_send_image_attachment_as_native_block() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("screenshot.png");
+        fs::write(&image_path, [0_u8, 1, 2, 3]).unwrap();
+
+        let blocks = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Screenshot".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: false,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(blocks.len(), 2);
+        let expected_uri = format!("file://{}", image_path.canonicalize().unwrap().display());
+        match &blocks[0] {
+            ContentBlock::Image(image) => {
+                assert_eq!(image.data, "AAECAw==");
+                assert_eq!(image.mime_type, "image/png");
+                assert_eq!(image.uri.as_deref(), Some(expected_uri.as_str()));
+            }
+            other => panic!("expected native image block, got {other:?}"),
+        }
+        match &blocks[1] {
+            ContentBlock::Text(text) => assert_eq!(text.text, "describe this image"),
+            other => panic!("expected text prompt, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_blocks_keep_image_attachment_fallback_without_image_capability() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("screenshot.png");
+        fs::write(&image_path, [0_u8, 1, 2, 3]).unwrap();
+
+        let blocks = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Screenshot".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: false,
+                embedded_context: true,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(blocks.len(), 1);
+        match &blocks[0] {
+            ContentBlock::Text(text) => {
+                assert!(text.text.contains("<attached_image"));
+                assert!(text.text.contains("type=\"image/png\""));
+                assert!(text.text.contains("path=\"screenshot.png\""));
+                assert!(text.text.contains("describe this image"));
+            }
+            other => panic!("expected textual image fallback, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn prompt_blocks_reject_native_image_attachment_outside_allowed_roots() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        let image_path = outside.path().join("secret.png");
+        fs::write(&image_path, [0_u8, 1, 2, 3]).unwrap();
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Secret Screenshot".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+        )
+        .expect_err("outside native image attachment should be blocked");
+
+        assert!(error.contains("outside the vault"));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -68,6 +68,7 @@ const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
     "Inherited XAI_API_KEY looks invalid. Update the environment variable to reconnect Grok.";
 const AGENT_WRITE_ORIGIN_WINDOW: Duration = Duration::from_secs(15);
 const MAX_TERMINAL_SUMMARY_CHARS: usize = 8_000;
+const MAX_NATIVE_IMAGE_ATTACHMENT_BYTES: u64 = 10 * 1024 * 1024;
 const ACP_STATUS_EVENT_TYPE_KEY: &str = "neverwriteEventType";
 const ACP_STATUS_KIND_KEY: &str = "neverwriteStatusKind";
 const ACP_STATUS_EMPHASIS_KEY: &str = "neverwriteStatusEmphasis";
@@ -8580,6 +8581,12 @@ fn append_file_attachment_blocks(
     } else if mime.starts_with("image/") {
         let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
         if capabilities.image {
+            if size > MAX_NATIVE_IMAGE_ATTACHMENT_BYTES {
+                return Err(format!(
+                    "Image attachment is too large: {} exceeds the {} byte limit.",
+                    rel_path, MAX_NATIVE_IMAGE_ATTACHMENT_BYTES
+                ));
+            }
             match std::fs::read(&path) {
                 Ok(bytes) => blocks.push(ContentBlock::Image(
                     ImageContent::new(BASE64_STANDARD.encode(bytes), mime.to_string())
@@ -13432,6 +13439,40 @@ mod tests {
         .expect_err("outside native image attachment should be blocked");
 
         assert!(error.contains("outside the vault"));
+    }
+
+    #[test]
+    fn prompt_blocks_reject_native_image_attachment_above_size_limit() {
+        let vault = tempfile::tempdir().unwrap();
+        let vault_root = vault.path().canonicalize().unwrap();
+        let image_path = vault.path().join("huge.png");
+        let file = fs::File::create(&image_path).unwrap();
+        file.set_len(MAX_NATIVE_IMAGE_ATTACHMENT_BYTES + 1).unwrap();
+
+        let error = build_prompt_blocks_with_attachments(
+            "describe this image",
+            &[AiAttachmentInput {
+                label: "Huge Screenshot".to_string(),
+                path: None,
+                content: None,
+                attachment_type: Some("file".to_string()),
+                note_id: None,
+                file_path: Some(image_path.display().to_string()),
+                mime_type: Some("image/png".to_string()),
+                transcription: None,
+                start_line: None,
+                end_line: None,
+            }],
+            Some(vault_root.as_path()),
+            &[],
+            AcpPromptCapabilities {
+                image: true,
+                embedded_context: true,
+            },
+        )
+        .expect_err("oversized native image attachment should be blocked");
+
+        assert!(error.contains("Image attachment is too large"));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -875,6 +875,7 @@ struct AcpSessionHandle {
 
 #[derive(Debug, Clone, Copy, Default)]
 struct AcpPromptCapabilities {
+    image: bool,
     embedded_context: bool,
 }
 
@@ -3657,6 +3658,10 @@ fn prompt_capabilities_from_initialize_response(
     initialize_response: &InitializeResponse,
 ) -> AcpPromptCapabilities {
     AcpPromptCapabilities {
+        image: initialize_response
+            .agent_capabilities
+            .prompt_capabilities
+            .image,
         embedded_context: initialize_response
             .agent_capabilities
             .prompt_capabilities
@@ -13172,6 +13177,7 @@ mod tests {
             None,
             &[],
             AcpPromptCapabilities {
+                image: false,
                 embedded_context: true,
             },
         )
@@ -13224,6 +13230,7 @@ mod tests {
             None,
             &[],
             AcpPromptCapabilities {
+                image: false,
                 embedded_context: false,
             },
         )
@@ -16016,6 +16023,22 @@ mod tests {
             &response,
             "xai.api_key"
         ));
+    }
+
+    #[test]
+    fn acp_prompt_capabilities_copy_image_support_from_initialize_response() {
+        let response = InitializeResponse::new(ProtocolVersion::LATEST).agent_capabilities(
+            agent_client_protocol::schema::AgentCapabilities::new().prompt_capabilities(
+                agent_client_protocol::schema::PromptCapabilities::new()
+                    .image(true)
+                    .embedded_context(true),
+            ),
+        );
+
+        let capabilities = prompt_capabilities_from_initialize_response(&response);
+
+        assert!(capabilities.image);
+        assert!(capabilities.embedded_context);
     }
 
     #[test]

--- a/apps/desktop/src/features/ai/chatExport.test.ts
+++ b/apps/desktop/src/features/ai/chatExport.test.ts
@@ -90,4 +90,41 @@ describe("chatExport", () => {
         expect(markdown).toContain("### Assistant");
         expect(markdown).toContain("Respuesta");
     });
+
+    it("includes per-message attachments in the exported transcript", () => {
+        const session = createSession("session-a", "Visual review", {
+            messages: [
+                {
+                    id: "session-a-user",
+                    role: "user",
+                    kind: "text",
+                    content: "Inspect this screenshot",
+                    timestamp: Date.UTC(2026, 2, 10, 15, 0, 0),
+                    attachments: [
+                        {
+                            id: "attachment-image",
+                            type: "file",
+                            noteId: null,
+                            label: "Screenshot 10:32",
+                            path: null,
+                            filePath: "/vault/assets/chat/screenshot.png",
+                            mimeType: "image/png",
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const markdown = buildChatExportMarkdown(
+            session,
+            runtimes,
+            new Date(Date.UTC(2026, 2, 10, 15, 5, 0)),
+        );
+
+        expect(markdown).toContain("Inspect this screenshot");
+        expect(markdown).toContain("Attachments:");
+        expect(markdown).toContain(
+            "- File: Screenshot 10:32 (/vault/assets/chat/screenshot.png)",
+        );
+    });
 });

--- a/apps/desktop/src/features/ai/chatExport.ts
+++ b/apps/desktop/src/features/ai/chatExport.ts
@@ -2,7 +2,12 @@ import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import type { NoteDto } from "../../app/store/vaultStore";
 import { getSessionRuntimeName, getSessionTitle } from "./sessionPresentation";
 import { getSessionTranscriptMessages } from "./transcriptModel";
-import type { AIChatMessage, AIChatSession, AIRuntimeOption } from "./types";
+import type {
+    AIChatAttachment,
+    AIChatMessage,
+    AIChatSession,
+    AIRuntimeOption,
+} from "./types";
 
 interface SavedNoteDetail {
     title: string;
@@ -110,9 +115,7 @@ function formatMessageContent(message: AIChatMessage) {
     return content;
 }
 
-function formatAttachmentLine(
-    sessionAttachment: AIChatSession["attachments"][number],
-) {
+function formatAttachmentLine(sessionAttachment: AIChatAttachment) {
     const typeLabel =
         sessionAttachment.type === "folder"
             ? "Folder"
@@ -122,7 +125,11 @@ function formatAttachmentLine(
                 ? "Selection"
                 : "Note";
 
-    const detail = sessionAttachment.path ?? sessionAttachment.noteId ?? "";
+    const detail =
+        sessionAttachment.path ??
+        sessionAttachment.filePath ??
+        sessionAttachment.noteId ??
+        "";
     return detail
         ? `- ${typeLabel}: ${sessionAttachment.label} (${detail})`
         : `- ${typeLabel}: ${sessionAttachment.label}`;
@@ -188,6 +195,12 @@ export function buildChatExportMarkdown(
         lines.push(`_${formatIsoTimestamp(message.timestamp)}_`);
         lines.push("");
         lines.push(formatMessageContent(message));
+        if (message.attachments && message.attachments.length > 0) {
+            lines.push("", "Attachments:");
+            message.attachments.forEach((attachment) => {
+                lines.push(formatAttachmentLine(attachment));
+            });
+        }
     });
 
     return `${lines.join("\n")}\n`;

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -13,7 +13,10 @@ import {
 } from "../../../test/test-utils";
 import { FILE_TREE_NOTE_DRAG_EVENT } from "../dragEvents";
 import type { AIAvailableCommand, AIComposerPart } from "../types";
-import { MAX_IMAGE_ATTACHMENTS_PER_MESSAGE } from "../imageAttachments";
+import {
+    MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+    MAX_IMAGE_ATTACHMENT_BYTES,
+} from "../imageAttachments";
 import { AIChatComposer } from "./AIChatComposer";
 import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
@@ -375,6 +378,38 @@ describe("AIChatComposer mention picker", () => {
         expect(onChange).not.toHaveBeenCalled();
     });
 
+    it("rejects oversized image files from file-tree attach when size metadata is available", async () => {
+        const { onChange, onImageAttachmentValidationFailure } = renderComposer();
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "attach",
+                        x: 0,
+                        y: 0,
+                        notes: [],
+                        files: [
+                            {
+                                filePath: "/vault/assets/huge.png",
+                                fileName: "huge.png",
+                                mimeType: "image/png",
+                                sizeBytes: MAX_IMAGE_ATTACHMENT_BYTES + 1,
+                            },
+                        ],
+                    },
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
+                "too_large",
+            );
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
     it("rejects file-tree image attachments above the per-message count", async () => {
         const parts = Array.from(
             { length: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE },
@@ -454,6 +489,54 @@ describe("AIChatComposer mention picker", () => {
         await waitFor(() => {
             expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
                 "unsupported_type",
+            );
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("rejects oversized native file drops when the vault entry size is known", async () => {
+        setVaultEntries([
+            buildVaultFileEntry("assets/huge.png", {
+                mimeType: "image/png",
+                size: MAX_IMAGE_ATTACHMENT_BYTES + 1,
+                isImageLike: true,
+            }),
+        ]);
+        let dragHandler:
+            | ((event: {
+                  payload: {
+                      type: string;
+                      position?: { x: number; y: number };
+                      paths?: string[];
+                  };
+              }) => void)
+            | null = null;
+        vi.mocked(getCurrentWebview().onDragDropEvent).mockImplementation(
+            async (handler) => {
+                dragHandler = handler as typeof dragHandler;
+                return () => {};
+            },
+        );
+
+        const { onChange, onImageAttachmentValidationFailure } = renderComposer();
+
+        await waitFor(() => {
+            expect(dragHandler).not.toBeNull();
+        });
+
+        act(() => {
+            dragHandler?.({
+                payload: {
+                    type: "drop",
+                    position: { x: 0, y: 0 },
+                    paths: ["/vault/assets/huge.png"],
+                },
+            });
+        });
+
+        await waitFor(() => {
+            expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
+                "too_large",
             );
         });
         expect(onChange).not.toHaveBeenCalled();

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import { invoke } from "@neverwrite/runtime";
+import { getCurrentWebview, invoke } from "@neverwrite/runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import type { EditorFontFamily } from "../../../app/store/settingsStore";
@@ -13,6 +13,7 @@ import {
 } from "../../../test/test-utils";
 import { FILE_TREE_NOTE_DRAG_EVENT } from "../dragEvents";
 import type { AIAvailableCommand, AIComposerPart } from "../types";
+import { MAX_IMAGE_ATTACHMENTS_PER_MESSAGE } from "../imageAttachments";
 import { AIChatComposer } from "./AIChatComposer";
 import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
@@ -47,6 +48,7 @@ function renderComposer({
     onMentionAttach = vi.fn(),
     onFolderAttach = vi.fn(),
     onToggleExpanded = vi.fn(),
+    onImageAttachmentValidationFailure = vi.fn(),
     onSubmit = () => {},
     onStop = () => {},
 }: {
@@ -68,6 +70,7 @@ function renderComposer({
     }) => void;
     onFolderAttach?: (folderPath: string, name: string) => void;
     onToggleExpanded?: () => void;
+    onImageAttachmentValidationFailure?: (reason: string) => void;
     onSubmit?: () => void;
     onStop?: () => void;
 } = {}) {
@@ -98,6 +101,9 @@ function renderComposer({
             onChange={onChange}
             onMentionAttach={onMentionAttach}
             onFolderAttach={onFolderAttach}
+            onImageAttachmentValidationFailure={
+                onImageAttachmentValidationFailure
+            }
             onSubmit={onSubmit}
             onStop={onStop}
         />,
@@ -106,7 +112,15 @@ function renderComposer({
     const composer = screen.getByRole("textbox", {
         name: "Message NeverWrite",
     });
-    return { composer, onChange, onFolderAttach, onMentionAttach, onSubmit, onStop };
+    return {
+        composer,
+        onChange,
+        onFolderAttach,
+        onMentionAttach,
+        onImageAttachmentValidationFailure,
+        onSubmit,
+        onStop,
+    };
 }
 
 function setCaret(node: Node, offset: number) {
@@ -328,6 +342,121 @@ describe("AIChatComposer mention picker", () => {
             "research",
         );
         expect(onMentionAttach).toHaveBeenCalledTimes(1);
+    });
+
+    it("rejects unsupported image files from file-tree attach", async () => {
+        const { onChange, onImageAttachmentValidationFailure } = renderComposer();
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "attach",
+                        x: 0,
+                        y: 0,
+                        notes: [],
+                        files: [
+                            {
+                                filePath: "/vault/assets/vector.svg",
+                                fileName: "vector.svg",
+                                mimeType: "image/svg+xml",
+                            },
+                        ],
+                    },
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
+                "unsupported_type",
+            );
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("rejects file-tree image attachments above the per-message count", async () => {
+        const parts = Array.from(
+            { length: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE },
+            (_, index): AIComposerPart => ({
+                id: `shot-${index}`,
+                type: "screenshot",
+                filePath: `/vault/assets/chat/shot-${index}.png`,
+                mimeType: "image/png",
+                label: `Screenshot ${index}`,
+            }),
+        );
+        const { onChange, onImageAttachmentValidationFailure } = renderComposer({
+            parts,
+        });
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "attach",
+                        x: 0,
+                        y: 0,
+                        notes: [],
+                        files: [
+                            {
+                                filePath: "/vault/assets/extra.png",
+                                fileName: "extra.png",
+                                mimeType: "image/png",
+                            },
+                        ],
+                    },
+                }),
+            );
+        });
+
+        await waitFor(() => {
+            expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
+                "too_many",
+            );
+        });
+        expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("rejects unsupported image files from native file drop", async () => {
+        let dragHandler:
+            | ((event: {
+                  payload: {
+                      type: string;
+                      position?: { x: number; y: number };
+                      paths?: string[];
+                  };
+              }) => void)
+            | null = null;
+        vi.mocked(getCurrentWebview().onDragDropEvent).mockImplementation(
+            async (handler) => {
+                dragHandler = handler as typeof dragHandler;
+                return () => {};
+            },
+        );
+
+        const { onChange, onImageAttachmentValidationFailure } = renderComposer();
+
+        await waitFor(() => {
+            expect(dragHandler).not.toBeNull();
+        });
+
+        act(() => {
+            dragHandler?.({
+                payload: {
+                    type: "drop",
+                    position: { x: 0, y: 0 },
+                    paths: ["/vault/assets/vector.svg"],
+                },
+            });
+        });
+
+        await waitFor(() => {
+            expect(onImageAttachmentValidationFailure).toHaveBeenCalledWith(
+                "unsupported_type",
+            );
+        });
+        expect(onChange).not.toHaveBeenCalled();
     });
 
     it("opens the @ picker when the caret is inside a text node", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -54,6 +54,10 @@ import {
     isTextLikeVaultEntry,
 } from "../../../app/utils/vaultEntries";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import {
+    type ImageAttachmentValidationFailure,
+    validateNewImageAttachmentReference,
+} from "../imageAttachments";
 
 const MIN_COMPOSER_HEIGHT = 64;
 const MAX_COMPOSER_HEIGHT = 480;
@@ -88,6 +92,9 @@ interface AIChatComposerProps {
     onToggleExpanded?: () => void;
     onAttachFile?: () => void;
     onPasteImage?: (file: File) => void;
+    onImageAttachmentValidationFailure?: (
+        reason: ImageAttachmentValidationFailure,
+    ) => void;
     onFocus?: () => void;
     onSubmit: () => void;
     onStop: () => void;
@@ -613,6 +620,27 @@ function selectAllComposerContent(root: HTMLDivElement) {
     selection.addRange(range);
 }
 
+function appendValidatedFileAttachmentPart(
+    parts: AIComposerPart[],
+    file: { filePath: string; mimeType: string; label: string },
+    onImageAttachmentValidationFailure?: (
+        reason: ImageAttachmentValidationFailure,
+    ) => void,
+) {
+    if (file.mimeType.startsWith("image/")) {
+        const validation = validateNewImageAttachmentReference(
+            { mimeType: file.mimeType },
+            parts,
+        );
+        if (!validation.ok) {
+            onImageAttachmentValidationFailure?.(validation.reason);
+            return parts;
+        }
+    }
+
+    return appendFileAttachmentPart(parts, file);
+}
+
 function syncComposerDom(
     root: HTMLDivElement,
     parts: AIComposerPart[],
@@ -1045,6 +1073,7 @@ export function AIChatComposer({
     onFolderAttach,
     onToggleExpanded,
     onPasteImage,
+    onImageAttachmentValidationFailure,
     onFocus,
     onSubmit,
     onStop,
@@ -1197,6 +1226,9 @@ export function AIChatComposer({
     const onMentionAttachRef = useRef(onMentionAttach);
     const onFileMentionAttachRef = useRef(onFileMentionAttach);
     const onFolderAttachRef = useRef(onFolderAttach);
+    const onImageAttachmentValidationFailureRef = useRef(
+        onImageAttachmentValidationFailure,
+    );
 
     useEffect(() => {
         partsRef.current = parts;
@@ -1204,7 +1236,16 @@ export function AIChatComposer({
         onMentionAttachRef.current = onMentionAttach;
         onFileMentionAttachRef.current = onFileMentionAttach;
         onFolderAttachRef.current = onFolderAttach;
-    }, [onChange, onFileMentionAttach, onFolderAttach, onMentionAttach, parts]);
+        onImageAttachmentValidationFailureRef.current =
+            onImageAttachmentValidationFailure;
+    }, [
+        onChange,
+        onFileMentionAttach,
+        onFolderAttach,
+        onImageAttachmentValidationFailure,
+        onMentionAttach,
+        parts,
+    ]);
 
     const syncFromDom = () => {
         const composer = composerRef.current;
@@ -1489,13 +1530,20 @@ export function AIChatComposer({
                 // File drop (PDFs, etc.) — inline pills
                 if (detail.files && detail.files.length > 0) {
                     for (const file of detail.files) {
-                        current = appendFileAttachmentPart(current, {
-                            filePath: file.filePath,
-                            mimeType: file.mimeType,
-                            label: file.fileName,
-                        });
+                        const next = appendValidatedFileAttachmentPart(
+                            current,
+                            {
+                                filePath: file.filePath,
+                                mimeType: file.mimeType,
+                                label: file.fileName,
+                            },
+                            onImageAttachmentValidationFailureRef.current,
+                        );
+                        if (next !== current) {
+                            didAttach = true;
+                            current = next;
+                        }
                     }
-                    didAttach = true;
                 }
 
                 // Notes drop
@@ -1586,6 +1634,7 @@ export function AIChatComposer({
                         md: "text/markdown",
                     };
                     let currentParts = partsRef.current;
+                    let didAttach = false;
                     for (const filePath of paths) {
                         const fileName = filePath.split("/").pop() ?? "file";
                         const dotIdx = fileName.lastIndexOf(".");
@@ -1600,11 +1649,12 @@ export function AIChatComposer({
                                 filePath,
                                 fileName,
                             );
+                            didAttach = true;
                         } else {
                             const ext = fileName
                                 .slice(dotIdx + 1)
                                 .toLowerCase();
-                            currentParts = appendFileAttachmentPart(
+                            const nextParts = appendValidatedFileAttachmentPart(
                                 currentParts,
                                 {
                                     filePath,
@@ -1613,9 +1663,15 @@ export function AIChatComposer({
                                         "application/octet-stream",
                                     label: fileName,
                                 },
+                                onImageAttachmentValidationFailureRef.current,
                             );
+                            if (nextParts !== currentParts) {
+                                didAttach = true;
+                                currentParts = nextParts;
+                            }
                         }
                     }
+                    if (!didAttach) return;
                     onChangeRef.current(currentParts);
                     focusComposerAtEnd();
                     return;

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -623,6 +623,7 @@ function selectAllComposerContent(root: HTMLDivElement) {
 function appendValidatedFileAttachmentPart(
     parts: AIComposerPart[],
     file: { filePath: string; mimeType: string; label: string },
+    runtimeId?: string | null,
     onImageAttachmentValidationFailure?: (
         reason: ImageAttachmentValidationFailure,
     ) => void,
@@ -631,6 +632,7 @@ function appendValidatedFileAttachmentPart(
         const validation = validateNewImageAttachmentReference(
             { mimeType: file.mimeType },
             parts,
+            runtimeId,
         );
         if (!validation.ok) {
             onImageAttachmentValidationFailure?.(validation.reason);
@@ -1226,12 +1228,14 @@ export function AIChatComposer({
     const onMentionAttachRef = useRef(onMentionAttach);
     const onFileMentionAttachRef = useRef(onFileMentionAttach);
     const onFolderAttachRef = useRef(onFolderAttach);
+    const runtimeIdRef = useRef(runtimeId);
     const onImageAttachmentValidationFailureRef = useRef(
         onImageAttachmentValidationFailure,
     );
 
     useEffect(() => {
         partsRef.current = parts;
+        runtimeIdRef.current = runtimeId;
         onChangeRef.current = onChange;
         onMentionAttachRef.current = onMentionAttach;
         onFileMentionAttachRef.current = onFileMentionAttach;
@@ -1245,6 +1249,7 @@ export function AIChatComposer({
         onImageAttachmentValidationFailure,
         onMentionAttach,
         parts,
+        runtimeId,
     ]);
 
     const syncFromDom = () => {
@@ -1537,6 +1542,7 @@ export function AIChatComposer({
                                 mimeType: file.mimeType,
                                 label: file.fileName,
                             },
+                            runtimeIdRef.current,
                             onImageAttachmentValidationFailureRef.current,
                         );
                         if (next !== current) {
@@ -1663,6 +1669,7 @@ export function AIChatComposer({
                                         "application/octet-stream",
                                     label: fileName,
                                 },
+                                runtimeIdRef.current,
                                 onImageAttachmentValidationFailureRef.current,
                             );
                             if (nextParts !== currentParts) {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -622,7 +622,12 @@ function selectAllComposerContent(root: HTMLDivElement) {
 
 function appendValidatedFileAttachmentPart(
     parts: AIComposerPart[],
-    file: { filePath: string; mimeType: string; label: string },
+    file: {
+        filePath: string;
+        mimeType: string;
+        label: string;
+        sizeBytes?: number | null;
+    },
     runtimeId?: string | null,
     onImageAttachmentValidationFailure?: (
         reason: ImageAttachmentValidationFailure,
@@ -630,7 +635,7 @@ function appendValidatedFileAttachmentPart(
 ) {
     if (file.mimeType.startsWith("image/")) {
         const validation = validateNewImageAttachmentReference(
-            { mimeType: file.mimeType },
+            { mimeType: file.mimeType, sizeBytes: file.sizeBytes },
             parts,
             runtimeId,
         );
@@ -641,6 +646,17 @@ function appendValidatedFileAttachmentPart(
     }
 
     return appendFileAttachmentPart(parts, file);
+}
+
+function normalizeAttachmentLookupPath(path: string) {
+    return path.replace(/\\/g, "/");
+}
+
+function getKnownFileSizeBytes(
+    filePath: string,
+    fileSizeByPath: Map<string, number>,
+) {
+    return fileSizeByPath.get(normalizeAttachmentLookupPath(filePath)) ?? null;
 }
 
 function syncComposerDom(
@@ -1090,6 +1106,7 @@ export function AIChatComposer({
     const fallbackEntries = useVaultStore((state) => state.entries);
     const composerRef = useRef<HTMLDivElement>(null);
     const shellRef = useRef<HTMLDivElement>(null);
+    const fileSizeByPathRef = useRef<Map<string, number>>(new Map());
     const [composerElement, setComposerElement] =
         useState<HTMLDivElement | null>(null);
     const [mentionState, setMentionState] =
@@ -1159,6 +1176,14 @@ export function AIChatComposer({
         fileTreeContentMode,
         fileTreeExtensionFilter,
     ]);
+    useEffect(() => {
+        const next = new Map<string, number>();
+        for (const entry of fallbackEntries) {
+            if (typeof entry.size !== "number") continue;
+            next.set(normalizeAttachmentLookupPath(entry.path), entry.size);
+        }
+        fileSizeByPathRef.current = next;
+    }, [fallbackEntries]);
     const pillMetrics = useMemo(
         () => getChatPillMetrics(composerFontSize),
         [composerFontSize],
@@ -1541,6 +1566,12 @@ export function AIChatComposer({
                                 filePath: file.filePath,
                                 mimeType: file.mimeType,
                                 label: file.fileName,
+                                sizeBytes:
+                                    file.sizeBytes ??
+                                    getKnownFileSizeBytes(
+                                        file.filePath,
+                                        fileSizeByPathRef.current,
+                                    ),
                             },
                             runtimeIdRef.current,
                             onImageAttachmentValidationFailureRef.current,
@@ -1668,6 +1699,10 @@ export function AIChatComposer({
                                         mimeMap[ext] ??
                                         "application/octet-stream",
                                     label: fileName,
+                                    sizeBytes: getKnownFileSizeBytes(
+                                        filePath,
+                                        fileSizeByPathRef.current,
+                                    ),
                                 },
                                 runtimeIdRef.current,
                                 onImageAttachmentValidationFailureRef.current,

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -74,6 +74,10 @@ beforeEach(() => {
     localStorage.clear();
     resetChatStore();
     useSettingsStore.setState({ lineWrapping: true });
+    useEditorStore.setState({
+        tabs: [],
+        activeTabId: null,
+    });
 });
 
 describe("AIChatMessageItem errors", () => {
@@ -240,7 +244,18 @@ describe("AIChatMessageItem user image attachments", () => {
             screen.getByRole("button", { name: "Reveal in Finder" }),
         );
 
-        expect(openPath).toHaveBeenCalledWith(filePath);
+        expect(openPath).not.toHaveBeenCalledWith(filePath);
+        expect(useEditorStore.getState().tabs).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                relativePath: "assets/chat/screenshot.png",
+                title: "screenshot.png",
+                path: filePath,
+                mimeType: "image/png",
+                viewer: "image",
+                content: "",
+            }),
+        ]);
         expect(revealItemInDir).toHaveBeenCalledWith(filePath);
     });
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -3,6 +3,7 @@ import { invoke, openPath, revealItemInDir } from "@neverwrite/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
+import { useVaultStore } from "../../../app/store/vaultStore";
 import {
     renderComponent,
     setEditorTabs,
@@ -202,6 +203,110 @@ describe("AIChatMessageItem generated images", () => {
 
         expect(openPath).toHaveBeenCalledWith(imagePath);
         expect(revealItemInDir).toHaveBeenCalledWith(imagePath);
+    });
+});
+
+describe("AIChatMessageItem user image attachments", () => {
+    it("renders image attachments below user text", () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        const filePath = "/vault/assets/chat/screenshot.png";
+
+        renderMessage({
+            id: "user:with-image",
+            role: "user",
+            kind: "text",
+            content: "Inspect this",
+            timestamp: Date.now(),
+            attachments: [
+                {
+                    id: "attachment:image",
+                    type: "file",
+                    noteId: null,
+                    label: "Screenshot 10:32",
+                    path: null,
+                    filePath,
+                    mimeType: "image/png",
+                },
+            ],
+        });
+
+        const image = screen.getByRole("img", { name: "Screenshot 10:32" });
+        expect(image.getAttribute("src")).toContain(
+            "neverwrite-file://localhost/vault/",
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Open" }));
+        fireEvent.click(
+            screen.getByRole("button", { name: "Reveal in Finder" }),
+        );
+
+        expect(openPath).toHaveBeenCalledWith(filePath);
+        expect(revealItemInDir).toHaveBeenCalledWith(filePath);
+    });
+
+    it("does not render attachment thumbnails when user text has no attachments", () => {
+        renderMessage({
+            id: "user:plain",
+            role: "user",
+            kind: "text",
+            content: "No files here",
+            timestamp: Date.now(),
+        });
+
+        expect(screen.queryByRole("img")).not.toBeInTheDocument();
+        expect(screen.queryByText("Image unavailable")).not.toBeInTheDocument();
+    });
+
+    it("does not render non-image attachments as thumbnails", () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        renderMessage({
+            id: "user:with-file",
+            role: "user",
+            kind: "text",
+            content: "Read this file",
+            timestamp: Date.now(),
+            attachments: [
+                {
+                    id: "attachment:file",
+                    type: "file",
+                    noteId: null,
+                    label: "guide.md",
+                    path: null,
+                    filePath: "/vault/docs/guide.md",
+                    mimeType: "text/markdown",
+                },
+            ],
+        });
+
+        expect(screen.queryByRole("img")).not.toBeInTheDocument();
+        expect(screen.queryByText("guide.md")).not.toBeInTheDocument();
+    });
+
+    it("shows a compact unavailable state for image paths outside the active vault", () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        renderMessage({
+            id: "user:external-image",
+            role: "user",
+            kind: "text",
+            content: "Inspect this",
+            timestamp: Date.now(),
+            attachments: [
+                {
+                    id: "attachment:external-image",
+                    type: "file",
+                    noteId: null,
+                    label: "external.png",
+                    path: null,
+                    filePath: "/outside/external.png",
+                    mimeType: "image/png",
+                },
+            ],
+        });
+
+        expect(screen.getByText("Image unavailable")).toBeInTheDocument();
+        expect(screen.queryByRole("img")).not.toBeInTheDocument();
     });
 });
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -48,8 +48,10 @@ import {
     openAiEditedFileByAbsolutePath,
 } from "../chatFileNavigation";
 import { openChatSessionInWorkspace } from "../chatPaneMovement";
+import { useEditorStore } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
+import { toVaultRelativePath } from "../../../app/utils/vaultPaths";
 import {
     buildCodexGeneratedImagePreviewUrl,
     buildVaultPreviewUrlFromAbsolutePath,
@@ -93,12 +95,27 @@ function UserMessageAttachmentThumbnail({
     const previewUrl = buildVaultPreviewUrlFromAbsolutePath(filePath, vaultPath);
     const unavailable = !previewUrl || loadFailed;
     const label = attachment.label || fileNameFromPath(filePath);
+    const fileName = fileNameFromPath(filePath);
 
     const copyPath = () => {
         void navigator.clipboard?.writeText(filePath).then(() => {
             setCopied(true);
             window.setTimeout(() => setCopied(false), 1200);
         });
+    };
+
+    const openInApp = () => {
+        const relativePath = toVaultRelativePath(filePath, vaultPath);
+        if (!relativePath) return;
+        useEditorStore.getState().openFile(
+            relativePath,
+            fileName,
+            filePath,
+            "",
+            attachment.mimeType ?? "image/*",
+            "image",
+            { contentTruncated: false },
+        );
     };
 
     return (
@@ -171,7 +188,7 @@ function UserMessageAttachmentThumbnail({
                 <div className="flex flex-wrap items-center gap-1.5">
                     <ImageActionButton
                         icon="open"
-                        onClick={() => void openPath(filePath)}
+                        onClick={openInApp}
                     >
                         Open
                     </ImageActionButton>

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -13,6 +13,7 @@ import {
     type ContextMenuState,
 } from "../../../components/context-menu/ContextMenu";
 import type {
+    AIChatAttachment,
     AIChatMessage,
     AIChatSession,
     AIFileDiff,
@@ -49,7 +50,10 @@ import {
 import { openChatSessionInWorkspace } from "../chatPaneMovement";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
-import { buildCodexGeneratedImagePreviewUrl } from "../../../app/utils/filePreviewUrl";
+import {
+    buildCodexGeneratedImagePreviewUrl,
+    buildVaultPreviewUrlFromAbsolutePath,
+} from "../../../app/utils/filePreviewUrl";
 import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 
 interface UserMentionContextMenuPayload {
@@ -60,6 +64,155 @@ interface UserMentionContextMenuPayload {
 
 interface ToolTargetContextMenuPayload {
     target: string;
+}
+
+function isImageFileAttachment(attachment: AIChatAttachment) {
+    return (
+        attachment.type === "file" &&
+        Boolean(attachment.filePath) &&
+        attachment.mimeType?.startsWith("image/") === true
+    );
+}
+
+function fileNameFromPath(path: string) {
+    return path.split(/[\\/]/).filter(Boolean).at(-1) ?? path;
+}
+
+function UserMessageAttachmentThumbnail({
+    attachment,
+    vaultPath,
+}: {
+    attachment: AIChatAttachment;
+    vaultPath: string | null;
+}) {
+    const [loadFailed, setLoadFailed] = useState(false);
+    const [copied, setCopied] = useState(false);
+    const filePath = attachment.filePath;
+    if (!filePath) return null;
+
+    const previewUrl = buildVaultPreviewUrlFromAbsolutePath(filePath, vaultPath);
+    const unavailable = !previewUrl || loadFailed;
+    const label = attachment.label || fileNameFromPath(filePath);
+
+    const copyPath = () => {
+        void navigator.clipboard?.writeText(filePath).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1200);
+        });
+    };
+
+    return (
+        <div
+            className="flex min-w-0 items-stretch overflow-hidden rounded-md"
+            style={{
+                border: "1px solid color-mix(in srgb, var(--border) 82%, transparent)",
+                backgroundColor:
+                    "color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-tertiary))",
+            }}
+        >
+            <div
+                className="flex h-20 w-28 shrink-0 items-center justify-center overflow-hidden"
+                style={{
+                    backgroundColor: "var(--bg-primary)",
+                    borderRight: "1px solid var(--border)",
+                }}
+            >
+                {unavailable ? (
+                    <div
+                        className="px-2 text-center font-medium"
+                        style={{
+                            color: "var(--text-secondary)",
+                            fontSize: "0.74em",
+                            lineHeight: 1.2,
+                        }}
+                    >
+                        Image unavailable
+                    </div>
+                ) : (
+                    <img
+                        src={previewUrl}
+                        alt={label}
+                        title={filePath}
+                        className="block h-full w-full"
+                        draggable={false}
+                        loading="lazy"
+                        decoding="async"
+                        onError={() => setLoadFailed(true)}
+                        style={{ objectFit: "cover" }}
+                    />
+                )}
+            </div>
+
+            <div className="flex min-w-0 flex-1 flex-col justify-between gap-2 px-2.5 py-2">
+                <div className="min-w-0">
+                    <div
+                        className="truncate font-medium"
+                        title={filePath}
+                        style={{
+                            color: "var(--text-primary)",
+                            fontSize: "0.82em",
+                        }}
+                    >
+                        {label}
+                    </div>
+                    <div
+                        className="truncate"
+                        title={attachment.mimeType ?? undefined}
+                        style={{
+                            color: "var(--text-secondary)",
+                            fontSize: "0.72em",
+                            opacity: 0.82,
+                        }}
+                    >
+                        {attachment.mimeType ?? "image"}
+                    </div>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-1.5">
+                    <ImageActionButton
+                        icon="open"
+                        onClick={() => void openPath(filePath)}
+                    >
+                        Open
+                    </ImageActionButton>
+                    <ImageActionButton
+                        icon="reveal"
+                        onClick={() => void revealItemInDir(filePath)}
+                    >
+                        Reveal in Finder
+                    </ImageActionButton>
+                    <ImageActionButton
+                        icon={copied ? "check" : "copy"}
+                        onClick={copyPath}
+                    >
+                        {copied ? "Copied" : "Copy Path"}
+                    </ImageActionButton>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function UserMessageAttachments({
+    attachments,
+}: {
+    attachments?: AIChatAttachment[];
+}) {
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+    const imageAttachments = (attachments ?? []).filter(isImageFileAttachment);
+    if (imageAttachments.length === 0) return null;
+
+    return (
+        <div className="mt-2 flex max-w-full flex-col gap-1.5">
+            {imageAttachments.map((attachment) => (
+                <UserMessageAttachmentThumbnail
+                    key={attachment.id}
+                    attachment={attachment}
+                    vaultPath={vaultPath}
+                />
+            ))}
+        </div>
+    );
 }
 
 /** Parse @mentions and @fetch in serialized user messages into styled pills. */
@@ -279,6 +432,7 @@ function UserTextMessage({
                     });
                 },
             )}
+            <UserMessageAttachments attachments={message.attachments} />
             {contextMenu ? (
                 <ContextMenu
                     menu={contextMenu}

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -1467,23 +1467,31 @@ function ImageActionButton({
     icon: ImageActionIcon;
 }) {
     const [hovered, setHovered] = useState(false);
+    const [pressed, setPressed] = useState(false);
     return (
         <button
             type="button"
-            className="inline-flex items-center justify-center gap-1.5 rounded-md px-2 py-1 font-medium leading-none transition-colors"
+            className="inline-flex items-center justify-center gap-1.5 rounded-md px-2 py-1 font-medium leading-none transition-[background-color,border-color,color,transform] duration-150 ease-out active:scale-95"
             onClick={onClick}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
+            onPointerDown={() => setPressed(true)}
+            onPointerUp={() => setPressed(false)}
+            onPointerLeave={() => setPressed(false)}
+            onPointerCancel={() => setPressed(false)}
+            onBlur={() => setPressed(false)}
             style={{
-                color: hovered
+                color: hovered || pressed
                     ? "var(--text-primary)"
                     : "var(--text-secondary)",
                 border: `1px solid color-mix(in srgb, var(--border) ${
-                    hovered ? "100%" : "70%"
+                    hovered || pressed ? "100%" : "70%"
                 }, transparent)`,
-                backgroundColor: hovered
-                    ? "color-mix(in srgb, var(--text-primary) 6%, var(--bg-secondary))"
-                    : "transparent",
+                backgroundColor: pressed
+                    ? "color-mix(in srgb, var(--text-primary) 10%, var(--bg-secondary))"
+                    : hovered
+                      ? "color-mix(in srgb, var(--text-primary) 6%, var(--bg-secondary))"
+                      : "transparent",
                 fontSize: "0.74em",
             }}
         >

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -1470,7 +1470,7 @@ function ImageActionButton({
     return (
         <button
             type="button"
-            className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 font-medium transition-colors"
+            className="inline-flex items-center justify-center gap-1.5 rounded-md px-2 py-1 font-medium leading-none transition-colors"
             onClick={onClick}
             onMouseEnter={() => setHovered(true)}
             onMouseLeave={() => setHovered(false)}
@@ -1488,7 +1488,7 @@ function ImageActionButton({
             }}
         >
             <ImageActionGlyph icon={icon} />
-            {children}
+            <span className="leading-none">{children}</span>
         </button>
     );
 }

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -377,4 +377,67 @@ describe("AIChatSessionView", () => {
             "Codex supports up to 12 images per message",
         );
     });
+
+    it("removes a pasted image file when the final attachment validation loses a race", async () => {
+        setupWorkspaceSession();
+        invokeMock.mockImplementation(async (command) => {
+            if (command === "save_vault_binary_file") {
+                useChatStore.setState((state) => ({
+                    ...state,
+                    composerPartsBySessionId: {
+                        "session-a": Array.from(
+                            { length: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE },
+                            (_, index) => ({
+                                id: `shot-${index}`,
+                                type: "screenshot" as const,
+                                filePath: `/vault/assets/chat/shot-${index}.png`,
+                                mimeType: "image/png",
+                                label: `Screenshot ${index}`,
+                            }),
+                        ),
+                    },
+                }));
+                return {
+                    path: "/vault/assets/chat/pasted-image.png",
+                    relative_path: "assets/chat/pasted-image.png",
+                    file_name: "pasted-image.png",
+                    mime_type: "image/png",
+                };
+            }
+            if (command === "move_vault_entry_to_trash") {
+                return undefined;
+            }
+            if (command === "list_vault_entries") {
+                return [];
+            }
+            return undefined;
+        });
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        fireEvent.click(screen.getByTestId("paste-image"));
+
+        const file = {
+            size: 128,
+            type: "image/png",
+            arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(4)),
+        } as unknown as File;
+
+        await act(async () => {
+            await (composerMockState.onPasteImage?.(file) as unknown as
+                | Promise<void>
+                | void);
+        });
+
+        expect(invokeMock).toHaveBeenCalledWith(
+            "move_vault_entry_to_trash",
+            expect.objectContaining({
+                relativePath: "assets/chat/pasted-image.png",
+            }),
+        );
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Codex supports up to 12 images per message",
+        );
+        expect(
+            useChatStore.getState().composerPartsBySessionId["session-a"],
+        ).toHaveLength(MAX_IMAGE_ATTACHMENTS_PER_MESSAGE);
+    });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -201,6 +201,71 @@ describe("AIChatSessionView", () => {
         });
     });
 
+    it("keeps sent timeline image attachments when composer screenshots expire", async () => {
+        setupWorkspaceSession();
+        const sentAttachments = [
+            {
+                id: "sent-image",
+                type: "file" as const,
+                noteId: null,
+                label: "old.png",
+                path: null,
+                filePath: "/vault/assets/chat/old.png",
+                mimeType: "image/png",
+            },
+        ];
+
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                "session-a": {
+                    ...createSession("session-a", "Workspace chat"),
+                    messages: [
+                        {
+                            id: "sent-message",
+                            role: "user",
+                            kind: "text",
+                            content: "See attached image",
+                            timestamp: 10,
+                            attachments: sentAttachments,
+                        },
+                    ],
+                },
+            },
+            activeSessionId: "session-a",
+            screenshotRetentionSeconds: 60,
+            composerPartsBySessionId: {
+                "session-a": [
+                    {
+                        id: "draft-shot",
+                        type: "screenshot",
+                        filePath: "/vault/assets/chat/draft-old.png",
+                        mimeType: "image/png",
+                        label: "Screenshot 10:42 hrs",
+                        createdAt: Date.now() - 61_000,
+                    },
+                ],
+            },
+        }));
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        await waitFor(() => {
+            expect(
+                useChatStore.getState().composerPartsBySessionId["session-a"],
+            ).toHaveLength(1);
+            expect(
+                useChatStore.getState().composerPartsBySessionId["session-a"]?.some(
+                    (part) => part.type === "screenshot",
+                ),
+            ).toBe(false);
+        });
+        expect(
+            useChatStore.getState().sessionsById["session-a"]?.messages[0]
+                ?.attachments,
+        ).toEqual(sentAttachments);
+    });
+
     it("aligns lower chat panels to the shared content column", () => {
         setupWorkspaceSession();
 

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -311,7 +311,7 @@ describe("AIChatSessionView", () => {
         });
 
         expect(screen.getByRole("status")).toHaveTextContent(
-            "Image is too large",
+            "Codex supports images up to 10 MB",
         );
         expect(invokeMock).not.toHaveBeenCalledWith(
             "save_vault_binary_file",
@@ -374,7 +374,7 @@ describe("AIChatSessionView", () => {
         });
 
         expect(screen.getByRole("status")).toHaveTextContent(
-            "Too many images attached",
+            "Codex supports up to 12 images per message",
         );
     });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -1,12 +1,24 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { invoke } from "@neverwrite/runtime";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { renderComponent } from "../../../test/test-utils";
 import { resetChatStore, useChatStore } from "../store/chatStore";
 import type { AIChatSession } from "../types";
+import {
+    MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+    MAX_IMAGE_ATTACHMENT_BYTES,
+} from "../imageAttachments";
 import { AIChatSessionView } from "./AIChatSessionView";
 import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
+
+const composerMockState = vi.hoisted(() => ({
+    onPasteImage: undefined as ((file: File) => void) | undefined,
+}));
+
+const invokeMock = vi.mocked(invoke);
 
 vi.mock("./AIChatMessageList", () => ({
     AIChatMessageList: () => <div data-testid="chat-message-list" />,
@@ -15,17 +27,31 @@ vi.mock("./AIChatMessageList", () => ({
 vi.mock("./AIChatComposer", () => ({
     AIChatComposer: ({
         expanded,
+        footer,
         onToggleExpanded,
+        onPasteImage,
     }: {
         expanded?: boolean;
+        footer?: ReactNode;
         onToggleExpanded?: () => void;
+        onPasteImage?: (file: File) => void;
     }) => (
-        <button
-            type="button"
-            data-testid="chat-composer"
-            data-expanded={String(Boolean(expanded))}
-            onClick={onToggleExpanded}
-        />
+        <div>
+            <button
+                type="button"
+                data-testid="chat-composer"
+                data-expanded={String(Boolean(expanded))}
+                onClick={onToggleExpanded}
+            />
+            <div data-testid="chat-composer-footer">{footer}</div>
+            <button
+                type="button"
+                data-testid="paste-image"
+                onClick={() => {
+                    composerMockState.onPasteImage = onPasteImage;
+                }}
+            />
+        </div>
     ),
 }));
 
@@ -107,6 +133,7 @@ function expectColumnAncestor(testId: string) {
 describe("AIChatSessionView", () => {
     beforeEach(() => {
         resetChatStore();
+        composerMockState.onPasteImage = undefined;
         useVaultStore.setState({
             vaultPath: "/vault",
             notes: [],
@@ -198,6 +225,91 @@ describe("AIChatSessionView", () => {
         expect(screen.getByTestId("chat-composer")).toHaveAttribute(
             "data-expanded",
             "true",
+        );
+    });
+
+    it("shows visible feedback when a pasted image is too large", async () => {
+        setupWorkspaceSession();
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        fireEvent.click(screen.getByTestId("paste-image"));
+
+        const oversizedFile = {
+            size: MAX_IMAGE_ATTACHMENT_BYTES + 1,
+            type: "image/png",
+            arrayBuffer: vi.fn(),
+        } as unknown as File;
+
+        await act(async () => {
+            await (composerMockState.onPasteImage?.(oversizedFile) as unknown as
+                | Promise<void>
+                | void);
+        });
+
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Image is too large",
+        );
+        expect(invokeMock).not.toHaveBeenCalledWith(
+            "save_vault_binary_file",
+            expect.anything(),
+        );
+    });
+
+    it("shows visible feedback for unsupported pasted image types", async () => {
+        setupWorkspaceSession();
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        fireEvent.click(screen.getByTestId("paste-image"));
+
+        const unsupportedFile = {
+            size: 128,
+            type: "image/tiff",
+            arrayBuffer: vi.fn(),
+        } as unknown as File;
+
+        await act(async () => {
+            await (composerMockState.onPasteImage?.(
+                unsupportedFile,
+            ) as unknown as Promise<void> | void);
+        });
+
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Unsupported image type",
+        );
+    });
+
+    it("shows visible feedback when the composer already has too many images", async () => {
+        setupWorkspaceSession();
+        useChatStore.setState((state) => ({
+            ...state,
+            composerPartsBySessionId: {
+                "session-a": Array.from(
+                    { length: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE },
+                    (_, index) => ({
+                        id: `shot-${index}`,
+                        type: "screenshot" as const,
+                        filePath: `/vault/assets/chat/shot-${index}.png`,
+                        mimeType: "image/png",
+                        label: `Screenshot ${index}`,
+                    }),
+                ),
+            },
+        }));
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        fireEvent.click(screen.getByTestId("paste-image"));
+
+        const file = {
+            size: 128,
+            type: "image/png",
+            arrayBuffer: vi.fn(),
+        } as unknown as File;
+
+        await act(async () => {
+            await (composerMockState.onPasteImage?.(file) as unknown as
+                | Promise<void>
+                | void);
+        });
+
+        expect(screen.getByRole("status")).toHaveTextContent(
+            "Too many images attached",
         );
     });
 });

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -794,6 +794,11 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     }}
                     onAttachFile={handleAttachFile}
                     onPasteImage={handlePasteImage}
+                    onImageAttachmentValidationFailure={(reason) => {
+                        setImageAttachmentNotice(
+                            imageAttachmentValidationMessage(reason),
+                        );
+                    }}
                     onFocus={() => {
                         if (!sessionId) return;
                         chatActions.markSessionFocused(sessionId);

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -320,10 +320,15 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
             const currentParts =
                 useChatStore.getState().composerPartsBySessionId[sessionId] ??
                 createEmptyComposerParts();
-            const validation = validateNewImageAttachment(file, currentParts);
+            const runtimeId = session?.runtimeId ?? null;
+            const validation = validateNewImageAttachment(
+                file,
+                currentParts,
+                runtimeId,
+            );
             if (!validation.ok) {
                 setImageAttachmentNotice(
-                    imageAttachmentValidationMessage(validation.reason),
+                    imageAttachmentValidationMessage(validation.reason, runtimeId),
                 );
                 return;
             }
@@ -358,6 +363,20 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     useChatStore.getState().composerPartsBySessionId[
                         sessionId
                     ] ?? createEmptyComposerParts();
+                const latestValidation = validateNewImageAttachment(
+                    file,
+                    latestParts,
+                    runtimeId,
+                );
+                if (!latestValidation.ok) {
+                    setImageAttachmentNotice(
+                        imageAttachmentValidationMessage(
+                            latestValidation.reason,
+                            runtimeId,
+                        ),
+                    );
+                    return;
+                }
                 chatActions.setComposerParts(
                     appendScreenshotPart(latestParts, {
                         filePath: saved.path,
@@ -373,7 +392,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 setImageAttachmentNotice("Image could not be attached");
             }
         },
-        [chatActions, refreshEntries, sessionId],
+        [chatActions, refreshEntries, session?.runtimeId, sessionId],
     );
 
     useEffect(() => {
@@ -795,8 +814,9 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     onAttachFile={handleAttachFile}
                     onPasteImage={handlePasteImage}
                     onImageAttachmentValidationFailure={(reason) => {
+                        const runtimeId = session?.runtimeId ?? null;
                         setImageAttachmentNotice(
-                            imageAttachmentValidationMessage(reason),
+                            imageAttachmentValidationMessage(reason, runtimeId),
                         );
                     }}
                     onFocus={() => {

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -26,7 +26,10 @@ import {
     useEditorStore,
 } from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
-import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
+import {
+    isTextLikeVaultEntry,
+    moveVaultEntryToTrash,
+} from "../../../app/utils/vaultEntries";
 import { vaultInvoke } from "../../../app/utils/vaultInvoke";
 import {
     type AIComposerPart,
@@ -357,7 +360,6 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     fileName,
                     bytes,
                 });
-                await refreshEntries();
                 const timeLabel = `Screenshot ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")} hrs`;
                 const latestParts =
                     useChatStore.getState().composerPartsBySessionId[
@@ -369,6 +371,15 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     runtimeId,
                 );
                 if (!latestValidation.ok) {
+                    await moveVaultEntryToTrash(saved.relative_path).catch(
+                        (cleanupError) => {
+                            console.error(
+                                "[chat] Failed to remove rejected pasted image:",
+                                cleanupError,
+                            );
+                        },
+                    );
+                    await refreshEntries();
                     setImageAttachmentNotice(
                         imageAttachmentValidationMessage(
                             latestValidation.reason,
@@ -377,6 +388,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     );
                     return;
                 }
+                await refreshEntries();
                 chatActions.setComposerParts(
                     appendScreenshotPart(latestParts, {
                         filePath: saved.path,

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -56,6 +56,11 @@ import {
     pruneExpiredScreenshotParts,
 } from "../screenshotRetention";
 import {
+    getImageAttachmentExtension,
+    imageAttachmentValidationMessage,
+    validateNewImageAttachment,
+} from "../imageAttachments";
+import {
     findSessionForHistorySelection,
     getSessionTitle,
     getSessionTitleText,
@@ -90,6 +95,9 @@ interface AIChatSessionViewProps {
 
 export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
     const [composerExpanded, setComposerExpanded] = useState(false);
+    const [imageAttachmentNotice, setImageAttachmentNotice] = useState<
+        string | null
+    >(null);
 
     // Resolve sessionId from the active ChatTab in this pane
     const sessionId = useEditorStore((state) => {
@@ -309,19 +317,20 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
     const handlePasteImage = useCallback(
         async (file: File) => {
             if (!sessionId) return;
-            const MAX_SIZE = 25 * 1024 * 1024;
-            if (file.size > MAX_SIZE) return;
+            const currentParts =
+                useChatStore.getState().composerPartsBySessionId[sessionId] ??
+                createEmptyComposerParts();
+            const validation = validateNewImageAttachment(file, currentParts);
+            if (!validation.ok) {
+                setImageAttachmentNotice(
+                    imageAttachmentValidationMessage(validation.reason),
+                );
+                return;
+            }
             try {
                 const buffer = await file.arrayBuffer();
                 const bytes = Array.from(new Uint8Array(buffer));
-                const ext =
-                    file.type === "image/jpeg"
-                        ? "jpg"
-                        : file.type === "image/gif"
-                          ? "gif"
-                          : file.type === "image/webp"
-                            ? "webp"
-                            : "png";
+                const ext = getImageAttachmentExtension(file.type);
                 const now = new Date();
                 const ts = [
                     now.getFullYear(),
@@ -345,12 +354,12 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 });
                 await refreshEntries();
                 const timeLabel = `Screenshot ${String(now.getHours()).padStart(2, "0")}:${String(now.getMinutes()).padStart(2, "0")} hrs`;
-                const currentParts =
+                const latestParts =
                     useChatStore.getState().composerPartsBySessionId[
                         sessionId
                     ] ?? createEmptyComposerParts();
                 chatActions.setComposerParts(
-                    appendScreenshotPart(currentParts, {
+                    appendScreenshotPart(latestParts, {
                         filePath: saved.path,
                         mimeType: saved.mime_type ?? file.type,
                         label: timeLabel,
@@ -358,12 +367,22 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     }),
                     sessionId,
                 );
+                setImageAttachmentNotice(null);
             } catch (error) {
                 console.error("[chat] Failed to save pasted image:", error);
+                setImageAttachmentNotice("Image could not be attached");
             }
         },
         [chatActions, refreshEntries, sessionId],
     );
+
+    useEffect(() => {
+        if (!imageAttachmentNotice) return;
+        const timer = window.setTimeout(() => {
+            setImageAttachmentNotice(null);
+        }, 3500);
+        return () => window.clearTimeout(timer);
+    }, [imageAttachmentNotice]);
 
     useEffect(() => {
         if (!sessionId || screenshotRetentionSeconds <= 0) return;
@@ -717,6 +736,21 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                     }
                     footer={
                         <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                            {imageAttachmentNotice ? (
+                                <div
+                                    role="status"
+                                    aria-live="polite"
+                                    className="rounded-md px-2 py-1 text-xs font-medium"
+                                    style={{
+                                        color: "#f87171",
+                                        backgroundColor:
+                                            "color-mix(in srgb, #ef4444 8%, transparent)",
+                                        border: "1px solid color-mix(in srgb, #ef4444 24%, var(--border))",
+                                    }}
+                                >
+                                    {imageAttachmentNotice}
+                                </div>
+                            ) : null}
                             {!isPendingSessionCreation && (
                                 <AIChatAgentControls
                                     disabled={agentControlsDisabled}

--- a/apps/desktop/src/features/ai/composerParts.test.ts
+++ b/apps/desktop/src/features/ai/composerParts.test.ts
@@ -43,7 +43,18 @@ describe("serializeComposerPartsForAI", () => {
                 mimeType: "text/markdown",
                 label: "guide.md",
             },
-            { id: "text-5", type: "text", text: " and " },
+        ];
+
+        expect(serializeComposerParts(parts)).toBe(
+            "Review [@Spec] and [@📁 docs] plus [@Lines 10-12] with [📎 guide.md]",
+        );
+        expect(serializeComposerPartsForAI(parts)).toBe(
+            "Review /vault/notes/spec.md and /vault/docs plus /vault/notes/spec.md:10-12 with /vault/docs/guide.md",
+        );
+    });
+
+    it("omits image attachments from the prompt because they are sent separately", () => {
+        const parts: AIComposerPart[] = [
             {
                 id: "shot-1",
                 type: "screenshot",
@@ -51,14 +62,22 @@ describe("serializeComposerPartsForAI", () => {
                 mimeType: "image/png",
                 label: "Screenshot 10:42 hrs",
             },
+            { id: "text-1", type: "text", text: " what do you see" },
+            {
+                id: "file-image",
+                type: "file_attachment",
+                filePath: "/vault/assets/chat/frame.webp",
+                mimeType: "image/webp",
+                label: "frame.webp",
+            },
+            { id: "text-2", type: "text", text: "?" },
         ];
 
-        expect(serializeComposerParts(parts)).toBe(
-            "Review [@Spec] and [@📁 docs] plus [@Lines 10-12] with [📎 guide.md] and [Screenshot 10:42 hrs]",
-        );
-        expect(serializeComposerPartsForAI(parts)).toBe(
-            "Review /vault/notes/spec.md and /vault/docs plus /vault/notes/spec.md:10-12 with /vault/docs/guide.md and /vault/assets/chat/screenshot.png",
-        );
+        expect(
+            serializeComposerPartsForAI(parts, {
+                vaultPath: "/vault",
+            }).trim(),
+        ).toBe("what do you see?");
     });
 
     it("resolves relative paths against the vault root before sending to the agent", () => {

--- a/apps/desktop/src/features/ai/composerParts.ts
+++ b/apps/desktop/src/features/ai/composerParts.ts
@@ -164,10 +164,11 @@ export function serializeComposerPartsForAI(
                 return normalizePathForAI(part.path, options);
             if (part.type === "selection_mention")
                 return `${normalizePathForAI(part.path, options)}:${part.startLine}-${part.endLine}`;
-            if (part.type === "screenshot")
+            if (part.type === "screenshot") return "";
+            if (part.type === "file_attachment") {
+                if (part.mimeType.startsWith("image/")) return "";
                 return normalizePathForAI(part.filePath, options);
-            if (part.type === "file_attachment")
-                return normalizePathForAI(part.filePath, options);
+            }
             return "";
         })
         .join("");

--- a/apps/desktop/src/features/ai/dragEvents.ts
+++ b/apps/desktop/src/features/ai/dragEvents.ts
@@ -16,6 +16,7 @@ export interface FileTreeDraggedFile {
     filePath: string;
     fileName: string;
     mimeType: string;
+    sizeBytes?: number | null;
 }
 
 export interface FileTreeDraggedFolder {

--- a/apps/desktop/src/features/ai/imageAttachments.test.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.test.ts
@@ -4,6 +4,7 @@ import {
     MAX_IMAGE_ATTACHMENT_BYTES,
     MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
     countComposerImageAttachments,
+    getImageAttachmentLimits,
     getImageAttachmentExtension,
     imageAttachmentValidationMessage,
     validateNewImageAttachment,
@@ -66,6 +67,42 @@ describe("imageAttachments", () => {
         expect(imageAttachmentValidationMessage("too_large")).toBe(
             "Image is too large",
         );
+    });
+
+    it("applies conservative base64-backed limits for Claude", () => {
+        const claudeLimits = getImageAttachmentLimits("claude-acp");
+
+        expect(claudeLimits.maxBytes).toBeLessThan(MAX_IMAGE_ATTACHMENT_BYTES);
+        expect(
+            validateNewImageAttachment(
+                { size: claudeLimits.maxBytes + 1, type: "image/png" },
+                [],
+                "claude-acp",
+            ),
+        ).toEqual({ ok: false, reason: "too_large" });
+        expect(imageAttachmentValidationMessage("too_large", "claude-acp")).toBe(
+            "Claude supports images up to 3.8 MB",
+        );
+    });
+
+    it("uses Grok-specific image size and MIME limits", () => {
+        const grokLimits = getImageAttachmentLimits("grok-acp");
+
+        expect(grokLimits.maxBytes).toBe(20 * 1024 * 1024);
+        expect(
+            validateNewImageAttachment(
+                { size: MAX_IMAGE_ATTACHMENT_BYTES + 1, type: "image/png" },
+                [],
+                "grok-acp",
+            ),
+        ).toEqual({ ok: true });
+        expect(
+            validateNewImageAttachment(
+                { size: 42, type: "image/webp" },
+                [],
+                "grok-acp",
+            ),
+        ).toEqual({ ok: false, reason: "unsupported_type" });
     });
 
     it("rejects messages that already have the maximum image count", () => {

--- a/apps/desktop/src/features/ai/imageAttachments.test.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.test.ts
@@ -7,6 +7,7 @@ import {
     getImageAttachmentExtension,
     imageAttachmentValidationMessage,
     validateNewImageAttachment,
+    validateNewImageAttachmentReference,
 } from "./imageAttachments";
 
 function imagePart(id: string): AIComposerPart {
@@ -82,6 +83,22 @@ describe("imageAttachments", () => {
         expect(imageAttachmentValidationMessage("too_many")).toBe(
             "Too many images attached",
         );
+    });
+
+    it("validates existing image file references without a byte size", () => {
+        expect(
+            validateNewImageAttachmentReference(
+                { mimeType: "image/svg+xml" },
+                [],
+            ),
+        ).toEqual({ ok: false, reason: "unsupported_type" });
+
+        expect(
+            validateNewImageAttachmentReference(
+                { mimeType: "image/png" },
+                [imagePart("shot")],
+            ),
+        ).toEqual({ ok: true });
     });
 
     it("maps supported image MIME types to persisted file extensions", () => {

--- a/apps/desktop/src/features/ai/imageAttachments.test.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.test.ts
@@ -138,6 +138,18 @@ describe("imageAttachments", () => {
         ).toEqual({ ok: true });
     });
 
+    it("rejects existing image file references when known byte size exceeds the limit", () => {
+        expect(
+            validateNewImageAttachmentReference(
+                {
+                    mimeType: "image/png",
+                    sizeBytes: MAX_IMAGE_ATTACHMENT_BYTES + 1,
+                },
+                [],
+            ),
+        ).toEqual({ ok: false, reason: "too_large" });
+    });
+
     it("maps supported image MIME types to persisted file extensions", () => {
         expect(getImageAttachmentExtension("image/jpeg")).toBe("jpg");
         expect(getImageAttachmentExtension("image/gif")).toBe("gif");

--- a/apps/desktop/src/features/ai/imageAttachments.test.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import type { AIComposerPart } from "./types";
+import {
+    MAX_IMAGE_ATTACHMENT_BYTES,
+    MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+    countComposerImageAttachments,
+    getImageAttachmentExtension,
+    imageAttachmentValidationMessage,
+    validateNewImageAttachment,
+} from "./imageAttachments";
+
+function imagePart(id: string): AIComposerPart {
+    return {
+        id,
+        type: "screenshot",
+        filePath: `/vault/assets/chat/${id}.png`,
+        mimeType: "image/png",
+        label: id,
+    };
+}
+
+describe("imageAttachments", () => {
+    it("counts screenshots and image file attachments as image attachments", () => {
+        expect(
+            countComposerImageAttachments([
+                { id: "text", type: "text", text: "hello" },
+                imagePart("shot"),
+                {
+                    id: "file-image",
+                    type: "file_attachment",
+                    filePath: "/vault/assets/photo.webp",
+                    mimeType: "image/webp",
+                    label: "photo.webp",
+                },
+                {
+                    id: "file-text",
+                    type: "file_attachment",
+                    filePath: "/vault/docs/guide.md",
+                    mimeType: "text/markdown",
+                    label: "guide.md",
+                },
+            ]),
+        ).toBe(2);
+    });
+
+    it("rejects unsupported image MIME types", () => {
+        expect(
+            validateNewImageAttachment(
+                { size: 42, type: "image/tiff" },
+                [],
+            ),
+        ).toEqual({ ok: false, reason: "unsupported_type" });
+        expect(imageAttachmentValidationMessage("unsupported_type")).toBe(
+            "Unsupported image type",
+        );
+    });
+
+    it("rejects images above the per-image byte limit", () => {
+        expect(
+            validateNewImageAttachment(
+                { size: MAX_IMAGE_ATTACHMENT_BYTES + 1, type: "image/png" },
+                [],
+            ),
+        ).toEqual({ ok: false, reason: "too_large" });
+        expect(imageAttachmentValidationMessage("too_large")).toBe(
+            "Image is too large",
+        );
+    });
+
+    it("rejects messages that already have the maximum image count", () => {
+        const parts = Array.from(
+            { length: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE },
+            (_, index) => imagePart(`shot-${index}`),
+        );
+
+        expect(
+            validateNewImageAttachment(
+                { size: 42, type: "image/png" },
+                parts,
+            ),
+        ).toEqual({ ok: false, reason: "too_many" });
+        expect(imageAttachmentValidationMessage("too_many")).toBe(
+            "Too many images attached",
+        );
+    });
+
+    it("maps supported image MIME types to persisted file extensions", () => {
+        expect(getImageAttachmentExtension("image/jpeg")).toBe("jpg");
+        expect(getImageAttachmentExtension("image/gif")).toBe("gif");
+        expect(getImageAttachmentExtension("image/webp")).toBe("webp");
+        expect(getImageAttachmentExtension("image/png")).toBe("png");
+    });
+});

--- a/apps/desktop/src/features/ai/imageAttachments.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.ts
@@ -143,7 +143,10 @@ export function validateNewImageAttachment(
 }
 
 export function validateNewImageAttachmentReference(
-    attachment: { mimeType: string | null | undefined },
+    attachment: {
+        mimeType: string | null | undefined;
+        sizeBytes?: number | null;
+    },
     currentParts: AIComposerPart[],
     runtimeId?: string | null,
 ): { ok: true } | { ok: false; reason: ImageAttachmentValidationFailure } {
@@ -151,6 +154,13 @@ export function validateNewImageAttachmentReference(
 
     if (!isAllowedImageAttachmentMimeType(attachment.mimeType, runtimeId)) {
         return { ok: false, reason: "unsupported_type" };
+    }
+
+    if (
+        typeof attachment.sizeBytes === "number" &&
+        attachment.sizeBytes > limits.maxBytes
+    ) {
+        return { ok: false, reason: "too_large" };
     }
 
     if (countComposerImageAttachments(currentParts) >= limits.maxImagesPerMessage) {

--- a/apps/desktop/src/features/ai/imageAttachments.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.ts
@@ -2,6 +2,11 @@ import type { AIComposerPart } from "./types";
 
 export const MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
 export const MAX_IMAGE_ATTACHMENTS_PER_MESSAGE = 12;
+const GROK_IMAGE_ATTACHMENT_BYTES = 20 * 1024 * 1024;
+const CONSERVATIVE_BASE64_IMAGE_ATTACHMENT_BYTES = 5 * 1024 * 1024;
+const CONSERVATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES =
+    Math.floor(CONSERVATIVE_BASE64_IMAGE_ATTACHMENT_BYTES / 4) * 3;
+
 export const ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES = [
     "image/png",
     "image/jpeg",
@@ -9,18 +14,92 @@ export const ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES = [
     "image/webp",
 ] as const;
 
+const CONSERVATIVE_IMAGE_ATTACHMENT_MIME_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+] as const;
+
+const GROK_IMAGE_ATTACHMENT_MIME_TYPES = ["image/png", "image/jpeg"] as const;
+
+export interface ImageAttachmentLimits {
+    runtimeLabel: string;
+    maxBytes: number;
+    maxImagesPerMessage: number;
+    allowedMimeTypes: readonly string[];
+}
+
 export type ImageAttachmentValidationFailure =
     | "too_large"
     | "too_many"
     | "unsupported_type";
 
-const ALLOWED_IMAGE_ATTACHMENT_MIME_TYPE_SET = new Set<string>(
-    ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
-);
+const DEFAULT_IMAGE_ATTACHMENT_LIMITS: ImageAttachmentLimits = {
+    runtimeLabel: "this provider",
+    maxBytes: MAX_IMAGE_ATTACHMENT_BYTES,
+    maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+    allowedMimeTypes: ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
+};
 
-export function isAllowedImageAttachmentMimeType(mimeType: string | null | undefined) {
+const RUNTIME_IMAGE_ATTACHMENT_LIMITS: Record<string, ImageAttachmentLimits> = {
+    "codex-acp": {
+        runtimeLabel: "Codex",
+        maxBytes: MAX_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "claude-acp": {
+        runtimeLabel: "Claude",
+        maxBytes: CONSERVATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "claude-code-terminal": {
+        runtimeLabel: "Claude Code",
+        maxBytes: CONSERVATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "gemini-acp": {
+        runtimeLabel: "Gemini",
+        maxBytes: MAX_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: CONSERVATIVE_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "grok-acp": {
+        runtimeLabel: "Grok",
+        maxBytes: GROK_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: GROK_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "kilo-acp": {
+        runtimeLabel: "Kilo",
+        maxBytes: CONSERVATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: CONSERVATIVE_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+    "opencode-acp": {
+        runtimeLabel: "OpenCode",
+        maxBytes: CONSERVATIVE_BASE64_RAW_IMAGE_ATTACHMENT_BYTES,
+        maxImagesPerMessage: MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
+        allowedMimeTypes: CONSERVATIVE_IMAGE_ATTACHMENT_MIME_TYPES,
+    },
+};
+
+export function getImageAttachmentLimits(
+    runtimeId?: string | null,
+): ImageAttachmentLimits {
+    if (!runtimeId) return DEFAULT_IMAGE_ATTACHMENT_LIMITS;
+    return RUNTIME_IMAGE_ATTACHMENT_LIMITS[runtimeId] ?? DEFAULT_IMAGE_ATTACHMENT_LIMITS;
+}
+
+export function isAllowedImageAttachmentMimeType(
+    mimeType: string | null | undefined,
+    runtimeId?: string | null,
+) {
+    const limits = getImageAttachmentLimits(runtimeId);
     return Boolean(
-        mimeType && ALLOWED_IMAGE_ATTACHMENT_MIME_TYPE_SET.has(mimeType),
+        mimeType && limits.allowedMimeTypes.includes(mimeType),
     );
 }
 
@@ -44,16 +123,19 @@ export function getImageAttachmentExtension(mimeType: string | null | undefined)
 export function validateNewImageAttachment(
     file: Pick<File, "size" | "type">,
     currentParts: AIComposerPart[],
+    runtimeId?: string | null,
 ): { ok: true } | { ok: false; reason: ImageAttachmentValidationFailure } {
-    if (!isAllowedImageAttachmentMimeType(file.type)) {
+    const limits = getImageAttachmentLimits(runtimeId);
+
+    if (!isAllowedImageAttachmentMimeType(file.type, runtimeId)) {
         return { ok: false, reason: "unsupported_type" };
     }
 
-    if (file.size > MAX_IMAGE_ATTACHMENT_BYTES) {
+    if (file.size > limits.maxBytes) {
         return { ok: false, reason: "too_large" };
     }
 
-    if (countComposerImageAttachments(currentParts) >= MAX_IMAGE_ATTACHMENTS_PER_MESSAGE) {
+    if (countComposerImageAttachments(currentParts) >= limits.maxImagesPerMessage) {
         return { ok: false, reason: "too_many" };
     }
 
@@ -63,22 +145,42 @@ export function validateNewImageAttachment(
 export function validateNewImageAttachmentReference(
     attachment: { mimeType: string | null | undefined },
     currentParts: AIComposerPart[],
+    runtimeId?: string | null,
 ): { ok: true } | { ok: false; reason: ImageAttachmentValidationFailure } {
-    if (!isAllowedImageAttachmentMimeType(attachment.mimeType)) {
+    const limits = getImageAttachmentLimits(runtimeId);
+
+    if (!isAllowedImageAttachmentMimeType(attachment.mimeType, runtimeId)) {
         return { ok: false, reason: "unsupported_type" };
     }
 
-    if (countComposerImageAttachments(currentParts) >= MAX_IMAGE_ATTACHMENTS_PER_MESSAGE) {
+    if (countComposerImageAttachments(currentParts) >= limits.maxImagesPerMessage) {
         return { ok: false, reason: "too_many" };
     }
 
     return { ok: true };
 }
 
+function formatAttachmentBytes(bytes: number) {
+    const mib = bytes / (1024 * 1024);
+    return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
+}
+
 export function imageAttachmentValidationMessage(
     reason: ImageAttachmentValidationFailure,
+    runtimeId?: string | null,
 ) {
-    if (reason === "too_large") return "Image is too large";
-    if (reason === "too_many") return "Too many images attached";
-    return "Unsupported image type";
+    const limits = getImageAttachmentLimits(runtimeId);
+    if (!runtimeId) {
+        if (reason === "too_large") return "Image is too large";
+        if (reason === "too_many") return "Too many images attached";
+        return "Unsupported image type";
+    }
+
+    if (reason === "too_large") {
+        return `${limits.runtimeLabel} supports images up to ${formatAttachmentBytes(limits.maxBytes)}`;
+    }
+    if (reason === "too_many") {
+        return `${limits.runtimeLabel} supports up to ${limits.maxImagesPerMessage} images per message`;
+    }
+    return `Unsupported image type for ${limits.runtimeLabel}`;
 }

--- a/apps/desktop/src/features/ai/imageAttachments.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.ts
@@ -1,0 +1,69 @@
+import type { AIComposerPart } from "./types";
+
+export const MAX_IMAGE_ATTACHMENT_BYTES = 10 * 1024 * 1024;
+export const MAX_IMAGE_ATTACHMENTS_PER_MESSAGE = 12;
+export const ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES = [
+    "image/png",
+    "image/jpeg",
+    "image/gif",
+    "image/webp",
+] as const;
+
+export type ImageAttachmentValidationFailure =
+    | "too_large"
+    | "too_many"
+    | "unsupported_type";
+
+const ALLOWED_IMAGE_ATTACHMENT_MIME_TYPE_SET = new Set<string>(
+    ALLOWED_IMAGE_ATTACHMENT_MIME_TYPES,
+);
+
+export function isAllowedImageAttachmentMimeType(mimeType: string | null | undefined) {
+    return Boolean(
+        mimeType && ALLOWED_IMAGE_ATTACHMENT_MIME_TYPE_SET.has(mimeType),
+    );
+}
+
+export function countComposerImageAttachments(parts: AIComposerPart[]) {
+    return parts.filter((part) => {
+        if (part.type === "screenshot") return true;
+        return (
+            part.type === "file_attachment" &&
+            part.mimeType.startsWith("image/")
+        );
+    }).length;
+}
+
+export function getImageAttachmentExtension(mimeType: string | null | undefined) {
+    if (mimeType === "image/jpeg") return "jpg";
+    if (mimeType === "image/gif") return "gif";
+    if (mimeType === "image/webp") return "webp";
+    return "png";
+}
+
+export function validateNewImageAttachment(
+    file: Pick<File, "size" | "type">,
+    currentParts: AIComposerPart[],
+): { ok: true } | { ok: false; reason: ImageAttachmentValidationFailure } {
+    if (!isAllowedImageAttachmentMimeType(file.type)) {
+        return { ok: false, reason: "unsupported_type" };
+    }
+
+    if (file.size > MAX_IMAGE_ATTACHMENT_BYTES) {
+        return { ok: false, reason: "too_large" };
+    }
+
+    if (countComposerImageAttachments(currentParts) >= MAX_IMAGE_ATTACHMENTS_PER_MESSAGE) {
+        return { ok: false, reason: "too_many" };
+    }
+
+    return { ok: true };
+}
+
+export function imageAttachmentValidationMessage(
+    reason: ImageAttachmentValidationFailure,
+) {
+    if (reason === "too_large") return "Image is too large";
+    if (reason === "too_many") return "Too many images attached";
+    return "Unsupported image type";
+}

--- a/apps/desktop/src/features/ai/imageAttachments.ts
+++ b/apps/desktop/src/features/ai/imageAttachments.ts
@@ -60,6 +60,21 @@ export function validateNewImageAttachment(
     return { ok: true };
 }
 
+export function validateNewImageAttachmentReference(
+    attachment: { mimeType: string | null | undefined },
+    currentParts: AIComposerPart[],
+): { ok: true } | { ok: false; reason: ImageAttachmentValidationFailure } {
+    if (!isAllowedImageAttachmentMimeType(attachment.mimeType)) {
+        return { ok: false, reason: "unsupported_type" };
+    }
+
+    if (countComposerImageAttachments(currentParts) >= MAX_IMAGE_ATTACHMENTS_PER_MESSAGE) {
+        return { ok: false, reason: "too_many" };
+    }
+
+    return { ok: true };
+}
+
 export function imageAttachmentValidationMessage(
     reason: ImageAttachmentValidationFailure,
 ) {

--- a/apps/desktop/src/features/ai/screenshotRetention.ts
+++ b/apps/desktop/src/features/ai/screenshotRetention.ts
@@ -70,6 +70,8 @@ export function pruneExpiredScreenshotParts(
     retentionSeconds: number,
     now = Date.now(),
 ): AIComposerPart[] {
+    // Draft-only cleanup: sent timeline message attachments are AIChatMessage data,
+    // not composer parts, and must never be routed through this helper.
     if (retentionSeconds <= 0) return parts;
 
     const retentionMs = retentionSeconds * 1000;

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1465,6 +1465,105 @@ describe("chatStore", () => {
         });
     });
 
+    it("carries queued screenshot attachments into the sent user message", async () => {
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_send_message") {
+                return {
+                    ...sessionPayload,
+                    status: "streaming",
+                    session_id:
+                        typeof args === "object" &&
+                        args !== null &&
+                        "sessionId" in args &&
+                        typeof args.sessionId === "string"
+                            ? args.sessionId
+                            : sessionPayload.session_id,
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    status: "streaming",
+                    attachments: [],
+                },
+            },
+        }));
+        useChatStore.getState().setComposerParts([
+            { id: "text-1", type: "text", text: "Inspect " },
+            {
+                id: "screenshot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:32",
+                createdAt: 123,
+            },
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        const queuedMessage =
+            useChatStore.getState().queuedMessagesBySessionId[
+                activeSessionId
+            ]?.[0];
+        expect(queuedMessage?.attachments).toEqual([
+            expect.objectContaining({
+                type: "file",
+                noteId: null,
+                label: "Screenshot 10:32",
+                path: null,
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+            }),
+        ]);
+
+        useChatStore.getState().applyMessageCompleted({
+            session_id: activeSessionId,
+            message_id: "assistant-1",
+        });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        expect(
+            invokeMock.mock.calls.some(
+                ([command, payload]) =>
+                    command === "ai_send_message" &&
+                    typeof payload === "object" &&
+                    payload !== null &&
+                    "attachments" in payload &&
+                    Array.isArray(payload.attachments) &&
+                    payload.attachments.some(
+                        (attachment) =>
+                            attachment.filePath ===
+                                "/vault/assets/chat/screenshot.png" &&
+                            attachment.mimeType === "image/png",
+                    ),
+            ),
+        ).toBe(true);
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById[activeSessionId]?.messages.some(
+                    (message) =>
+                        message.role === "user" &&
+                        message.attachments?.some(
+                            (attachment) =>
+                                attachment.filePath ===
+                                    "/vault/assets/chat/screenshot.png" &&
+                                attachment.mimeType === "image/png",
+                        ),
+                ),
+        ).toBe(true);
+    });
+
     it("does not synthesize legacy auto-context attachments when sending a plain composer message", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1367,6 +1367,7 @@ describe("chatStore", () => {
             useChatStore.getState().queuedMessagesBySessionId[
                 activeSessionId
             ]?.[0];
+        expect(queuedMessage?.prompt).toBe("Inspect");
         expect(queuedMessage?.attachments).toEqual([
             expect.objectContaining({
                 type: "file",
@@ -1409,6 +1410,7 @@ describe("chatStore", () => {
             useChatStore.getState().queuedMessagesBySessionId[
                 activeSessionId
             ]?.[0];
+        expect(queuedMessage?.prompt).toBe("Inspect");
         expect(queuedMessage?.attachments).toEqual([
             expect.objectContaining({
                 type: "file",
@@ -1419,6 +1421,48 @@ describe("chatStore", () => {
                 mimeType: "image/jpeg",
             }),
         ]);
+    });
+
+    it("allows image-only composer messages without echoing the image path into the prompt", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    status: "waiting_permission",
+                    attachments: [],
+                },
+            },
+        }));
+        useChatStore.getState().setComposerParts([
+            {
+                id: "screenshot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:32",
+                createdAt: 123,
+            },
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        const queuedMessage =
+            useChatStore.getState().queuedMessagesBySessionId[
+                activeSessionId
+            ]?.[0];
+        expect(queuedMessage).toMatchObject({
+            content: "[Screenshot 10:32]",
+            prompt: "",
+            attachments: [
+                expect.objectContaining({
+                    filePath: "/vault/assets/chat/screenshot.png",
+                    mimeType: "image/png",
+                }),
+            ],
+        });
     });
 
     it("copies pasted screenshot attachments onto the optimistic user message", async () => {
@@ -1515,6 +1559,7 @@ describe("chatStore", () => {
             useChatStore.getState().queuedMessagesBySessionId[
                 activeSessionId
             ]?.[0];
+        expect(queuedMessage?.prompt).toBe("Inspect");
         expect(queuedMessage?.attachments).toEqual([
             expect.objectContaining({
                 type: "file",
@@ -1538,6 +1583,8 @@ describe("chatStore", () => {
                     command === "ai_send_message" &&
                     typeof payload === "object" &&
                     payload !== null &&
+                    "content" in payload &&
+                    payload.content === "Inspect" &&
                     "attachments" in payload &&
                     Array.isArray(payload.attachments) &&
                     payload.attachments.some(

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1421,6 +1421,50 @@ describe("chatStore", () => {
         ]);
     });
 
+    it("copies pasted screenshot attachments onto the optimistic user message", async () => {
+        await useChatStore.getState().initialize();
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_send_message") {
+                return {
+                    ...sessionPayload,
+                    status: "streaming",
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+        useChatStore.getState().setComposerParts([
+            { id: "text-1", type: "text", text: "Inspect " },
+            {
+                id: "screenshot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:32",
+                createdAt: 123,
+            },
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        const activeSessionId = getActiveSessionId();
+        const userMessage =
+            useChatStore.getState().sessionsById[activeSessionId]?.messages[0];
+        expect(userMessage).toMatchObject({
+            role: "user",
+            attachments: [
+                expect.objectContaining({
+                    type: "file",
+                    noteId: null,
+                    label: "Screenshot 10:32",
+                    path: null,
+                    filePath: "/vault/assets/chat/screenshot.png",
+                    mimeType: "image/png",
+                }),
+            ],
+        });
+    });
+
     it("does not synthesize legacy auto-context attachments when sending a plain composer message", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",
@@ -3011,6 +3055,18 @@ describe("chatStore", () => {
                             kind: "text",
                             content: "Recovered from disk",
                             timestamp: 10,
+                            attachments: [
+                                {
+                                    id: "attachment-1",
+                                    type: "file",
+                                    noteId: null,
+                                    label: "Screenshot",
+                                    path: null,
+                                    filePath:
+                                        "/vault/assets/chat/screenshot.png",
+                                    mimeType: "image/png",
+                                },
+                            ],
                         },
                         {
                             id: "m2",
@@ -3052,6 +3108,13 @@ describe("chatStore", () => {
         expect(sessionAfter.messages.map((message) => message.id)).toEqual([
             "m1",
             "m2",
+        ]);
+        expect(sessionAfter.messages[0]?.attachments).toEqual([
+            expect.objectContaining({
+                type: "file",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+            }),
         ]);
     });
 
@@ -13853,6 +13916,81 @@ describe("chatStore", () => {
         expect(historyPayload?.history).not.toHaveProperty(
             "visibleWorkCycleId",
         );
+    });
+
+    it("persists user message attachments in session history", async () => {
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [],
+        });
+
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    messages: [
+                        {
+                            id: "user-with-screenshot",
+                            role: "user",
+                            kind: "text",
+                            content: "Inspect this screenshot",
+                            timestamp: 10,
+                            attachments: [
+                                {
+                                    id: "attachment-1",
+                                    type: "file",
+                                    noteId: null,
+                                    label: "Screenshot",
+                                    path: null,
+                                    filePath:
+                                        "/vault/assets/chat/screenshot.png",
+                                    mimeType: "image/png",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
+        }));
+
+        useChatStore.getState().applySessionError({
+            session_id: activeSessionId,
+            message: "Trigger persistence",
+        });
+        await Promise.resolve();
+
+        const historyCall = invokeMock.mock.calls.find(
+            ([command]) => command === "ai_save_session_history",
+        );
+        expect(historyCall).toBeTruthy();
+
+        const historyPayload =
+            typeof historyCall?.[1] === "object" && historyCall[1] !== null
+                ? (historyCall[1] as {
+                      history?: {
+                          messages?: Array<{
+                              id?: string;
+                              attachments?: AIChatAttachment[];
+                          }>;
+                      };
+                  })
+                : null;
+
+        expect(
+            historyPayload?.history?.messages?.find(
+                (message) => message.id === "user-with-screenshot",
+            )?.attachments,
+        ).toEqual([
+            expect.objectContaining({
+                type: "file",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+            }),
+        ]);
     });
 
     it("coalesces repeated history persistence requests in the same microtask", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7131,6 +7131,83 @@ describe("chatStore", () => {
         ).toBe(true);
     });
 
+    it("does not duplicate image attachments when saving an edited queued screenshot message", async () => {
+        let sentAttachments: AIChatAttachment[] | null = null;
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_send_message") {
+                sentAttachments =
+                    typeof args === "object" &&
+                    args !== null &&
+                    "attachments" in args &&
+                    Array.isArray(args.attachments)
+                        ? (args.attachments as AIChatAttachment[])
+                        : null;
+                return {
+                    ...sessionPayload,
+                    status: "streaming" as const,
+                };
+            }
+
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const screenshotPart: AIComposerPart = {
+            id: "screenshot-1",
+            type: "screenshot",
+            filePath: "/vault/assets/chat/screenshot.png",
+            mimeType: "image/png",
+            label: "Screenshot 10:32",
+            createdAt: 123,
+        };
+        const queuedAttachment: AIChatAttachment = {
+            id: "queued-image",
+            type: "file",
+            noteId: null,
+            label: "Screenshot 10:32",
+            path: null,
+            filePath: "/vault/assets/chat/screenshot.png",
+            mimeType: "image/png",
+            status: "ready",
+        };
+
+        useChatStore
+            .getState()
+            .enqueueMessage(
+                activeSessionId,
+                createQueuedMessage("queued-image", "Inspect this", {
+                    content: "Inspect this [Screenshot 10:32]",
+                    prompt: "Inspect this",
+                    composerParts: [
+                        { id: "text-1", type: "text", text: "Inspect this " },
+                        screenshotPart,
+                    ],
+                    attachments: [queuedAttachment],
+                }),
+            );
+
+        useChatStore
+            .getState()
+            .editQueuedMessage(activeSessionId, "queued-image");
+        useChatStore.getState().setComposerParts([
+            { id: "text-2", type: "text", text: "Inspect this again " },
+            screenshotPart,
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        expect(
+            sentAttachments?.filter(
+                (attachment) =>
+                    attachment.filePath ===
+                        "/vault/assets/chat/screenshot.png" &&
+                    attachment.mimeType === "image/png",
+            ),
+        ).toHaveLength(1);
+    });
+
     it("drops stale queued copies of an edited message when sending it immediately", async () => {
         invokeMock.mockImplementation(async (command, args) => {
             if (command === "ai_send_message") {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1336,6 +1336,91 @@ describe("chatStore", () => {
         });
     });
 
+    it("normalizes pasted screenshot parts into file attachments", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    status: "waiting_permission",
+                    attachments: [],
+                },
+            },
+        }));
+        useChatStore.getState().setComposerParts([
+            { id: "text-1", type: "text", text: "Inspect " },
+            {
+                id: "screenshot-1",
+                type: "screenshot",
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+                label: "Screenshot 10:32",
+                createdAt: 123,
+            },
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        const queuedMessage =
+            useChatStore.getState().queuedMessagesBySessionId[
+                activeSessionId
+            ]?.[0];
+        expect(queuedMessage?.attachments).toEqual([
+            expect.objectContaining({
+                type: "file",
+                noteId: null,
+                label: "Screenshot 10:32",
+                path: null,
+                filePath: "/vault/assets/chat/screenshot.png",
+                mimeType: "image/png",
+            }),
+        ]);
+    });
+
+    it("normalizes image file attachment parts into the same file attachment shape", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    status: "waiting_permission",
+                    attachments: [],
+                },
+            },
+        }));
+        useChatStore.getState().setComposerParts([
+            { id: "text-1", type: "text", text: "Inspect " },
+            {
+                id: "file-1",
+                type: "file_attachment",
+                filePath: "/vault/assets/chat/frame.jpg",
+                mimeType: "image/jpeg",
+                label: "frame.jpg",
+            },
+        ]);
+
+        await useChatStore.getState().sendMessage();
+
+        const queuedMessage =
+            useChatStore.getState().queuedMessagesBySessionId[
+                activeSessionId
+            ]?.[0];
+        expect(queuedMessage?.attachments).toEqual([
+            expect.objectContaining({
+                type: "file",
+                noteId: null,
+                label: "frame.jpg",
+                path: null,
+                filePath: "/vault/assets/chat/frame.jpg",
+                mimeType: "image/jpeg",
+            }),
+        ]);
+    });
+
     it("does not synthesize legacy auto-context attachments when sending a plain composer message", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2567,6 +2567,25 @@ function cloneComposerParts(parts: AIComposerPart[]): AIComposerPart[] {
     return parts.map(cloneComposerPart);
 }
 
+type ComposerFileBackedPart = Extract<
+    AIComposerPart,
+    { type: "screenshot" } | { type: "file_attachment" }
+>;
+
+function composerFilePartToAttachment(
+    part: ComposerFileBackedPart,
+): AIChatAttachment {
+    return {
+        id: crypto.randomUUID(),
+        type: "file",
+        noteId: null,
+        label: part.label,
+        path: null,
+        filePath: part.filePath,
+        mimeType: part.mimeType,
+    };
+}
+
 function normalizeComparablePath(path: string) {
     return normalizeVaultPath(path).replace(/\/+$/, "");
 }
@@ -2873,30 +2892,14 @@ function buildQueuedMessage(
             (p): p is Extract<AIComposerPart, { type: "screenshot" }> =>
                 p.type === "screenshot",
         )
-        .map((p) => ({
-            id: crypto.randomUUID(),
-            type: "file" as const,
-            noteId: null,
-            label: p.label,
-            path: null,
-            filePath: p.filePath,
-            mimeType: p.mimeType,
-        }));
+        .map(composerFilePartToAttachment);
 
     const fileAttachments: AIChatAttachment[] = composerPartsSnapshot
         .filter(
             (p): p is Extract<AIComposerPart, { type: "file_attachment" }> =>
                 p.type === "file_attachment",
         )
-        .map((p) => ({
-            id: crypto.randomUUID(),
-            type: "file" as const,
-            noteId: null,
-            label: p.label,
-            path: null,
-            filePath: p.filePath,
-            mimeType: p.mimeType,
-        }));
+        .map(composerFilePartToAttachment);
 
     const attachments = [
         ...session.attachments,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2874,9 +2874,6 @@ function buildQueuedMessage(
     const prompt = serializeComposerPartsForAI(composerPartsSnapshot, {
         vaultPath: useVaultStore.getState().vaultPath,
     }).trim();
-    if (!content || !prompt) {
-        return null;
-    }
 
     const selectionAttachments: AIChatAttachment[] = composerPartsSnapshot
         .filter(
@@ -2914,6 +2911,10 @@ function buildQueuedMessage(
         ...screenshotAttachments,
         ...fileAttachments,
     ].map(cloneAttachment);
+
+    if (!content || (!prompt && attachments.length === 0)) {
+        return null;
+    }
 
     return {
         id: crypto.randomUUID(),

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2559,6 +2559,13 @@ function cloneAttachment(attachment: AIChatAttachment): AIChatAttachment {
     return { ...attachment };
 }
 
+function cloneMessageAttachments(
+    attachments?: AIChatAttachment[] | null,
+): AIChatAttachment[] | undefined {
+    if (!attachments?.length) return undefined;
+    return attachments.map(cloneAttachment);
+}
+
 function cloneComposerPart(part: AIComposerPart): AIComposerPart {
     return { ...part };
 }
@@ -5990,6 +5997,7 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
             kind: m.kind,
             content: m.content,
             timestamp: m.timestamp,
+            attachments: cloneMessageAttachments(m.attachments),
             title: m.title,
             meta: m.meta,
             permission_request_id: m.permissionRequestId,
@@ -6681,6 +6689,7 @@ function restoreMessagesFromHistory(
                 kind: m.kind as AIChatMessageKind,
                 content: m.content,
                 timestamp: m.timestamp,
+                attachments: cloneMessageAttachments(m.attachments),
                 title: m.title,
                 meta: m.meta,
                 permissionRequestId: m.permission_request_id,
@@ -7349,6 +7358,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     ...createTextMessage("user", currentItem.content),
                     id: userMessageId,
                     workCycleId: nextSession.activeWorkCycleId,
+                    attachments: cloneMessageAttachments(currentItem.attachments),
                 };
 
                 return {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2597,6 +2597,53 @@ function normalizeComparablePath(path: string) {
     return normalizeVaultPath(path).replace(/\/+$/, "");
 }
 
+function isComposerOwnedQueuedAttachment(
+    attachment: AIChatAttachment,
+    composerParts: AIComposerPart[],
+) {
+    if (attachment.type === "selection") {
+        if (!attachment.path) return false;
+        const attachmentPath = normalizeComparablePath(attachment.path);
+        return composerParts.some(
+            (part) =>
+                part.type === "selection_mention" &&
+                normalizeComparablePath(part.path) === attachmentPath &&
+                part.startLine === attachment.startLine &&
+                part.endLine === attachment.endLine,
+        );
+    }
+
+    if (attachment.type !== "file" || attachment.path || !attachment.filePath) {
+        return false;
+    }
+
+    const attachmentPath = normalizeComparablePath(attachment.filePath);
+    return composerParts.some(
+        (part) =>
+            (part.type === "screenshot" ||
+                part.type === "file_attachment") &&
+            normalizeComparablePath(part.filePath) === attachmentPath &&
+            (!attachment.mimeType || part.mimeType === attachment.mimeType),
+    );
+}
+
+function getQueuedMessageContextAttachments(
+    queuedItem: QueuedChatMessage,
+): AIChatAttachment[] {
+    // Queue items store the final send payload. When reopening one for editing,
+    // keep only session-level context here; composer-owned attachments are
+    // reconstructed from composerParts on save.
+    return queuedItem.attachments
+        .filter(
+            (attachment) =>
+                !isComposerOwnedQueuedAttachment(
+                    attachment,
+                    queuedItem.composerParts,
+                ),
+        )
+        .map(cloneAttachment);
+}
+
 function isPathInsideRoot(path: string, root: string) {
     const normalizedPath = normalizeComparablePath(path);
     const normalizedRoot = normalizeVaultRoot(root);
@@ -10417,7 +10464,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                         [sessionId]: {
                             ...session,
                             attachments:
-                                queuedItem.attachments.map(cloneAttachment),
+                                getQueuedMessageContextAttachments(queuedItem),
                         },
                     },
                     composerPartsBySessionId: {

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -352,6 +352,7 @@ export interface AIChatMessage {
     content: string;
     timestamp: number;
     workCycleId?: string | null;
+    attachments?: AIChatAttachment[];
     title?: string;
     inProgress?: boolean;
     meta?: Record<string, string | number | boolean | null>;
@@ -707,6 +708,7 @@ export interface PersistedMessage {
     kind: string;
     content: string;
     timestamp: number;
+    attachments?: AIChatAttachment[];
     title?: string;
     meta?: Record<string, string | number | boolean | null>;
     permission_request_id?: string;

--- a/apps/desktop/src/features/editor/tabDragAttachments.ts
+++ b/apps/desktop/src/features/editor/tabDragAttachments.ts
@@ -36,11 +36,16 @@ function buildDraggedFiles(tab: Tab): FileTreeDraggedFile[] | null {
     }
 
     if (isFileTab(tab)) {
+        const mimeType = tab.mimeType ?? "application/octet-stream";
         return [
             {
                 filePath: tab.path,
                 fileName: getPathBaseName(tab.path) || tab.title,
-                mimeType: tab.mimeType ?? "application/octet-stream",
+                mimeType,
+                ...(mimeType.startsWith("image/") &&
+                typeof tab.sizeBytes === "number"
+                    ? { sizeBytes: tab.sizeBytes }
+                    : {}),
             },
         ];
     }

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -544,13 +544,16 @@ function getAbsoluteVaultPath(vaultPath: string | null, path: string) {
 }
 
 function getDraggedVaultFile(entry: VaultEntryDto) {
+    const mimeType =
+        entry.kind === "pdf"
+            ? "application/pdf"
+            : (entry.mime_type ?? "application/octet-stream");
+
     return {
         filePath: entry.path,
         fileName: entry.file_name,
-        mimeType:
-            entry.kind === "pdf"
-                ? "application/pdf"
-                : (entry.mime_type ?? "application/octet-stream"),
+        mimeType,
+        ...(mimeType.startsWith("image/") ? { sizeBytes: entry.size } : {}),
     };
 }
 

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -29,6 +29,8 @@ pub struct PersistedMessage {
     pub kind: String,
     pub content: String,
     pub timestamp: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub attachments: Option<serde_json::Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1704,6 +1706,17 @@ mod tests {
                     kind: "text".to_string(),
                     content: "Hello".to_string(),
                     timestamp: 10,
+                    attachments: Some(serde_json::json!([
+                        {
+                            "id": "attachment:image",
+                            "type": "file",
+                            "noteId": null,
+                            "label": "Screenshot 10:32",
+                            "path": null,
+                            "filePath": "/vault/assets/chat/screenshot.png",
+                            "mimeType": "image/png"
+                        }
+                    ])),
                     title: None,
                     meta: None,
                     permission_request_id: None,
@@ -1725,6 +1738,7 @@ mod tests {
                     kind: "text".to_string(),
                     content: "Assistant reply".to_string(),
                     timestamp: 20,
+                    attachments: None,
                     title: None,
                     meta: None,
                     permission_request_id: None,
@@ -2007,6 +2021,24 @@ mod tests {
     }
 
     #[test]
+    fn preserves_message_attachments_in_lazy_transcript() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        let expected_attachments = history.messages[0].attachments.clone();
+
+        save_session_history(&dir, &history).expect("history should persist");
+
+        let page =
+            load_session_history_page(&dir, "session-1", 0, 1).expect("history page should load");
+        assert_eq!(page.messages[0].attachments, expected_attachments);
+
+        let histories = load_all_session_histories(&dir, true).expect("full history should load");
+        assert_eq!(histories[0].messages[0].attachments, expected_attachments);
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
     fn preserves_parent_session_id_in_lazy_metadata() {
         let dir = make_temp_dir();
         let mut history = sample_history_with_session_id("child-session");
@@ -2185,6 +2217,7 @@ mod tests {
                     kind: "text".to_string(),
                     content: "Assistant reply (edited)".to_string(),
                     timestamp: 20,
+                    attachments: None,
                     title: None,
                     meta: None,
                     permission_request_id: None,
@@ -2206,6 +2239,7 @@ mod tests {
                     kind: "plan".to_string(),
                     content: "Next step".to_string(),
                     timestamp: 30,
+                    attachments: None,
                     title: Some("Plan".to_string()),
                     meta: None,
                     permission_request_id: None,
@@ -2414,6 +2448,7 @@ mod tests {
             kind: "text".to_string(),
             content: "Assistant reply (edited)".to_string(),
             timestamp: 20,
+            attachments: None,
             title: Some("Reply".to_string()),
             meta: Some(serde_json::json!({
                 "status": "completed",
@@ -2437,6 +2472,7 @@ mod tests {
             kind: "permission".to_string(),
             content: "Edit watcher.rs".to_string(),
             timestamp: 30,
+            attachments: None,
             title: Some("Permission request".to_string()),
             meta: Some(serde_json::json!({
                 "status": "pending",
@@ -2486,6 +2522,7 @@ mod tests {
             kind: "user_input_request".to_string(),
             content: "Need confirmation".to_string(),
             timestamp: 40,
+            attachments: None,
             title: Some("Input requested".to_string()),
             meta: Some(serde_json::json!({
                 "status": "pending",
@@ -2517,6 +2554,7 @@ mod tests {
             kind: "plan".to_string(),
             content: "Confirm restore".to_string(),
             timestamp: 50,
+            attachments: None,
             title: Some("Plan".to_string()),
             meta: None,
             permission_request_id: None,

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -86,7 +86,7 @@ the same Settings stores.
 | AI / Chat | `historyRetentionDays` | Global preference, applied to current vault histories | `0` | `neverwrite.ai.preferences` | `0` means forever; pruning operates on the currently open vault's `.neverwrite/sessions/`. |
 | AI / Composer | `requireCmdEnterToSend` | Global | `false` | `neverwrite.ai.preferences` | Changes Enter behavior in the AI composer. |
 | AI / Composer | `contextUsageBarEnabled` | Global | `true` | `neverwrite.ai.preferences` | Shows or hides composer context usage. |
-| AI / Composer | `screenshotRetentionSeconds` | Global | `0` | `neverwrite.ai.preferences` | `0` means forever. |
+| AI / Composer | `screenshotRetentionSeconds` | Global | `1800` | `neverwrite.ai.preferences` | `1800` means 30 minutes. `0` means forever. This draft-only cleanup removes expired pasted screenshots from the composer, not image attachments already copied onto sent timeline messages. |
 | AI / Composer | `composerFontFamily` | Global | `system` | `neverwrite.ai.preferences` | Validated with editor font-family normalization. |
 | AI / Composer | `composerFontSize` | Global | `14` | `neverwrite.ai.preferences` | Composer input font size. |
 | AI Providers | `defaultRuntimeId` | Global | Runtime-dependent | `neverwrite.ai.preferences` | Preferred runtime for new chats. |


### PR DESCRIPTION
## Summary

- Adds ACP image prompt capability tracking and sends supported `image/*` attachments as native `ContentBlock::Image` blocks.
- Persists user-message image attachments, restores them from chat history, and renders compact timeline thumbnails with in-app image opening actions.
- Normalizes pasted screenshots and image file attachments into the same message attachment shape.
- Adds provider-aware image limits, visible composer feedback, backend validation, and fallback text for runtimes without native image support.
- Prevents duplicated image path echoes in prompts and preserves attachments through lazy transcript persistence.

## Why

Pasted screenshots previously lived mostly as composer/file references. The model could receive a path or fallback text instead of the actual image, and the chat timeline could lose image metadata after restart. This brings the composer flow closer to a native multimodal attachment model while keeping files persisted locally in the vault.

## Validation

- `npm test -- src/features/ai/composerParts.test.ts src/features/ai/store/chatStore.test.ts`
- `npm test -- src/features/ai/components/AIChatMessageItem.test.tsx`
- `npm test -- src/features/ai/store/chatStore.test.ts src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/chatExport.test.ts`
- `npm test -- src/features/ai/imageAttachments.test.ts src/features/ai/components/AIChatSessionView.test.tsx`
- `npm test -- src/features/ai/screenshotRetention.test.ts src/features/ai/components/AIChatSessionView.test.tsx src/features/settings/SettingsPanel.test.tsx`
- `npx tsc -b`
- `npm run lint`
- `cargo test prompt_blocks`
- `cargo test -p neverwrite-ai persistence::tests::`
