### PR TITLE
Prepare 0.3.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,27 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.3.5] - 2026-06-17
+
+### Added
+
+- Added native image attachments to the AI composer, including paste/drop support, provider-aware limits, validation feedback, ACP image prompt blocks for capable providers, timeline rendering, chat history/export persistence, and opening sent images in app tabs.
+- Added a Settings toggle for editor active line highlighting.
+
+### Changed
+
+- Polished Markdown live preview footnotes so named references render as sequential superscript numbers with matching definition badges while keeping raw labels editable.
+- Centered outline and footnote jump destinations in the editor and added a brief landing flash so navigation targets are easier to locate.
+- Flattened pane header action buttons with a simpler divider treatment.
+
+### Fixed
+
+- Fixed live preview footnote navigation so clicking a footnote reference scrolls to off-screen definitions reliably without moving the caret unless the number itself is clicked.
+- Fixed adjacent live preview footnote references so they keep a stable superscript baseline and remain legible when citations are abutting.
+- Fixed live preview block refreshes after parser updates so embedded preview blocks stay in sync with Markdown edits.
+- Fixed window dragging from the docked sidebar header band after sidebar collapse and expand transitions.
+- Fixed queued AI image edits so pasted image attachments are not duplicated.
+
 ## [0.3.4] - 2026-06-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.4",
+            "version": "0.3.5",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.4",
+    "version": "0.3.5",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.4",
+    "version": "0.3.5",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {

--- a/release/apt/README.md
+++ b/release/apt/README.md
@@ -50,13 +50,13 @@ Release
 Release.gpg
 Packages
 Packages.gz
-NeverWrite-0.3.4-amd64.deb
-NeverWrite-0.3.4-arm64.deb
+NeverWrite-0.3.5-amd64.deb
+NeverWrite-0.3.5-arm64.deb
 ```
 
 The `.deb` binary packages stay on GitHub Releases with the other release
 assets. The `Filename` field in each `Packages` stanza is the release asset file
-name, for example `NeverWrite-0.3.4-amd64.deb`. APT resolves it relative to the
+name, for example `NeverWrite-0.3.5-amd64.deb`. APT resolves it relative to the
 configured `latest/download` release URL.
 
 GitHub Pages only publishes the install helper files:


### PR DESCRIPTION
## Summary

- Add the 0.3.5 changelog entry from the post-0.3.4 release history.
- Align desktop, native backend, lockfile, and Web Clipper package versions to 0.3.5.
- Refresh the APT release asset examples for the 0.3.5 package names.

## Validation

- `cargo check -p neverwrite-native-backend`
- `cargo check --locked -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.3.5`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`

## Notes

No release tag has been created or pushed yet.