### PR TITLE
Update GitHub Actions to Node 24 runtime majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Linux system dependencies
         run: |
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -96,15 +96,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm

--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -33,10 +33,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: npm
@@ -143,10 +143,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: npm
@@ -219,10 +219,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
                   cache: npm

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -78,7 +78,7 @@ jobs:
                   EOF
 
             - name: Upload release body artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: release-body-${{ steps.meta.outputs.tag }}
                   path: release-body.md
@@ -370,21 +370,21 @@ jobs:
                     --install
 
             - name: Upload release asset artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: release-assets-${{ matrix.target }}
                   path: ${{ runner.temp }}/release-assets
                   if-no-files-found: error
 
             - name: Upload target metadata artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: release-target-metadata-${{ matrix.target }}
                   path: ${{ runner.temp }}/target-metadata/${{ matrix.target }}.json
                   if-no-files-found: error
 
             - name: Upload target feed artifact
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: release-target-feeds-${{ matrix.target }}
                   path: ${{ runner.temp }}/release-assets/feeds
@@ -501,7 +501,7 @@ jobs:
                   cp "$firefox_zip" "$RUNNER_TEMP/web-clipper-assets/NeverWrite-Web-Clipper-${{ needs.prepare.outputs.tag }}-firefox-mv3.zip"
 
             - name: Upload browser extension release assets
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: release-assets-web-clipper
                   path: ${{ runner.temp }}/web-clipper-assets
@@ -551,20 +551,20 @@ jobs:
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Download release body
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   name: release-body-${{ needs.prepare.outputs.tag }}
                   path: .artifacts/release-body
 
             - name: Download staged release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   pattern: release-assets-*
                   path: .artifacts/release-assets
                   merge-multiple: true
 
             - name: Download target metadata
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   pattern: release-target-metadata-*
                   path: .artifacts/release-targets
@@ -623,21 +623,21 @@ jobs:
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Download target metadata
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   pattern: release-target-metadata-*
                   path: .artifacts/release-targets
                   merge-multiple: true
 
             - name: Download target feeds
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   pattern: release-target-feeds-*
                   path: .artifacts/feeds
                   merge-multiple: true
 
             - name: Download staged release assets
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@v8
               with:
                   pattern: release-assets-*
                   path: .artifacts/release-assets
@@ -710,14 +710,14 @@ jobs:
                   EOF
 
             - name: Upload platform validation pack
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: platform-validation-pack-${{ needs.prepare.outputs.tag }}
                   path: dist/platform-validation/${{ needs.prepare.outputs.tag }}
                   if-no-files-found: error
 
             - name: Upload release asset size report
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               with:
                   name: electron-release-asset-sizes-${{ needs.prepare.outputs.tag }}
                   path: dist/release-asset-sizes/${{ needs.prepare.outputs.tag }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -33,13 +33,13 @@ jobs:
             pages_base_url: ${{ steps.meta.outputs.pages_base_url }}
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
@@ -125,12 +125,12 @@ jobs:
                       node_dist: linux-arm64
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
@@ -396,17 +396,17 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ env.RELEASE_TAG }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@v6
               with:
                   version: 10.33.0
 
@@ -545,7 +545,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}
@@ -617,7 +617,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
                   ref: ${{ env.RELEASE_TAG }}

--- a/.github/workflows/validate-release-metadata.yml
+++ b/.github/workflows/validate-release-metadata.yml
@@ -62,10 +62,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v6
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@v6
               with:
                   node-version: 22
 


### PR DESCRIPTION
Closes #193

## Summary

- Updates GitHub Actions that were still on Node.js 20 action-runtime majors.
- Keeps the project command runtime on `node-version: 22`.
- Leaves `Swatinem/rust-cache@v2` unchanged because its action metadata already declares Node.js 24.

## Changes

- `actions/checkout@v4` -> `actions/checkout@v6`
- `actions/setup-node@v4` -> `actions/setup-node@v6`
- `pnpm/action-setup@v4` -> `pnpm/action-setup@v6`
- `actions/upload-artifact@v4` -> `actions/upload-artifact@v7`
- `actions/download-artifact@v4` -> `actions/download-artifact@v8`

## Validation

- `rg -n "actions/(checkout|setup-node|upload-artifact|download-artifact)@v4|pnpm/action-setup@v4" .github/workflows` returned no matches.
- `rg -n -i "node20|node 20|node\\.js 20|ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION|FORCE_JAVASCRIPT_ACTIONS_TO_NODE24" .github/workflows` returned no matches.
- `rg -n "@v4" .github/workflows` returned no matches.
- Verified target action tags declare `node24`: `actions/checkout@v6`, `actions/setup-node@v6`, `actions/upload-artifact@v7`, `actions/download-artifact@v8`, `pnpm/action-setup@v6`, and `Swatinem/rust-cache@v2`.
- Reviewed release artifact names, patterns, paths, `merge-multiple`, and `if-no-files-found` settings in `release-desktop.yml`.
- `git diff --check HEAD~2..HEAD` passed.

`actionlint` was not available locally, so workflow syntax validation should rely on GitHub Actions for this PR.