### PR TITLE
Hide active line highlight when editor loses focus

### DIFF
--- a/apps/desktop/src/features/editor/editorExtensions.ts
+++ b/apps/desktop/src/features/editor/editorExtensions.ts
@@ -136,8 +136,11 @@ export const baseTheme = EditorView.theme({
             backgroundColor: "transparent",
         },
     ".cm-activeLine": {
-        backgroundColor: "color-mix(in srgb, var(--accent) 3.5%, transparent)",
+        backgroundColor: "transparent",
         borderRadius: "8px",
+    },
+    "&.cm-focused .cm-activeLine": {
+        backgroundColor: "color-mix(in srgb, var(--accent) 3.5%, transparent)",
     },
     ".cm-activeLineGutter": {
         backgroundColor: "transparent",


### PR DESCRIPTION
## Summary

Keeps CodeMirror's active-line state intact, but only paints the active-line background while the editor is focused.

## Why

The active line highlight added in `90f3a250` stayed visible after the note lost focus, which made it look like a selection was stuck. The underlying selection/cursor state should remain preserved for editor restore, undo, toolbar, agent selection, and inline review flows, so this fix is intentionally visual.

## Impact

- The active line remains highlighted while editing.
- The highlight disappears when the editor loses focus.
- Selection and review state are not collapsed or rewritten.

## Validation

- `npm --prefix apps/desktop test -- src/features/editor/Editor.test.tsx src/features/editor/FileTabView.test.tsx`