### PR TITLE
Add Escape shortcut to stop the focused agent

### DIFF
--- a/apps/desktop/src/app/shortcuts/format.test.ts
+++ b/apps/desktop/src/app/shortcuts/format.test.ts
@@ -19,6 +19,12 @@ describe("shortcut registry formatting", () => {
         expect(formatShortcutAction("new_agent", "windows")).toBe(
             "Ctrl+Shift+N",
         );
+        expect(formatShortcutAction("stop_active_agent", "macos")).toBe(
+            "Escape",
+        );
+        expect(formatShortcutAction("stop_active_agent", "windows")).toBe(
+            "Escape",
+        );
         expect(formatShortcutAction("new_terminal", "macos")).toBe("⌘R");
         expect(formatShortcutAction("new_terminal", "windows")).toBe("Ctrl+R");
         expect(formatShortcutAction("zoom_in", "macos")).toBe("⌘=");
@@ -65,6 +71,13 @@ describe("shortcut registry formatting", () => {
                 shortcut: "Ctrl+Shift+N",
             },
         );
+        expect(
+            entries.find((entry) => entry.id === "stop_active_agent"),
+        ).toMatchObject({
+            label: "Stop active agent",
+            category: "AI",
+            shortcut: "Escape",
+        });
         expect(
             entries.find((entry) => entry.id === "new_terminal"),
         ).toMatchObject({

--- a/apps/desktop/src/app/shortcuts/registry.ts
+++ b/apps/desktop/src/app/shortcuts/registry.ts
@@ -15,6 +15,7 @@ export type ShortcutActionId =
     | "open_vault"
     | "new_note"
     | "new_agent"
+    | "stop_active_agent"
     | "new_terminal"
     | "new_tab"
     | "close_tab"
@@ -122,6 +123,15 @@ const shortcutDefinitions = [
         bindings: {
             macos: [{ key: "n", modifiers: ["meta", "shift"] }],
             windows: [{ key: "n", modifiers: ["ctrl", "shift"] }],
+        },
+    },
+    {
+        id: "stop_active_agent",
+        label: "Stop active agent",
+        category: "AI",
+        bindings: {
+            macos: [{ key: "Escape" }],
+            windows: [{ key: "Escape" }],
         },
     },
     {
@@ -440,6 +450,7 @@ export const SHORTCUT_SETTINGS_ORDER: ShortcutActionId[] = [
     "open_vault",
     "new_note",
     "new_agent",
+    "stop_active_agent",
     "new_terminal",
     "new_tab",
     "reopen_closed_tab",

--- a/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
@@ -116,8 +116,13 @@ describe("ContextMenu scroll-to-close behaviour", () => {
     it("closes on Escape key", () => {
         const onClose = vi.fn();
         renderMenu(onClose);
-        fireEvent.keyDown(document, { key: "Escape" });
+        const event = new KeyboardEvent("keydown", {
+            key: "Escape",
+            cancelable: true,
+        });
+        document.dispatchEvent(event);
         expect(onClose).toHaveBeenCalled();
+        expect(event.defaultPrevented).toBe(true);
     });
 
     it("closes on mousedown outside the menu", () => {

--- a/apps/desktop/src/components/context-menu/ContextMenu.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.tsx
@@ -115,7 +115,10 @@ export function ContextMenu<T>({
             }
         };
         const handleKey = (event: KeyboardEvent) => {
-            if (event.key === "Escape") onClose();
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
         };
         const handleScroll = (event: Event) => {
             const target = event.target;

--- a/apps/desktop/src/features/ai/chatTurnStatus.test.ts
+++ b/apps/desktop/src/features/ai/chatTurnStatus.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import type { AIChatSessionStatus } from "./types";
+import { isCancellableChatTurnStatus } from "./chatTurnStatus";
+
+describe("isCancellableChatTurnStatus", () => {
+    it("matches chat turn statuses that can be stopped", () => {
+        const cancellableStatuses: AIChatSessionStatus[] = [
+            "streaming",
+            "waiting_permission",
+            "waiting_user_input",
+        ];
+        const nonCancellableStatuses: Array<
+            AIChatSessionStatus | null | undefined
+        > = ["idle", "review_required", "error", null, undefined];
+
+        for (const status of cancellableStatuses) {
+            expect(isCancellableChatTurnStatus(status)).toBe(true);
+        }
+
+        for (const status of nonCancellableStatuses) {
+            expect(isCancellableChatTurnStatus(status)).toBe(false);
+        }
+    });
+});

--- a/apps/desktop/src/features/ai/chatTurnStatus.ts
+++ b/apps/desktop/src/features/ai/chatTurnStatus.ts
@@ -1,0 +1,11 @@
+import type { AIChatSessionStatus } from "./types";
+
+export function isCancellableChatTurnStatus(
+    status: AIChatSessionStatus | null | undefined,
+): boolean {
+    return (
+        status === "streaming" ||
+        status === "waiting_permission" ||
+        status === "waiting_user_input"
+    );
+}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -544,6 +544,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                             if (event.key === "Enter") {
                                 commitTitleEdit();
                             } else if (event.key === "Escape") {
+                                event.preventDefault();
                                 cancelEditing();
                             }
                         }}

--- a/apps/desktop/src/features/ai/components/HistorySessionCard.tsx
+++ b/apps/desktop/src/features/ai/components/HistorySessionCard.tsx
@@ -206,6 +206,7 @@ export function HistorySessionCard({
                                 if (e.key === "Enter") {
                                     commitEdit();
                                 } else if (e.key === "Escape") {
+                                    e.preventDefault();
                                     cancelEdit();
                                 }
                             }}

--- a/apps/desktop/src/features/ai/components/HistorySessionList.tsx
+++ b/apps/desktop/src/features/ai/components/HistorySessionList.tsx
@@ -145,6 +145,7 @@ export function HistorySessionList({
                 void runContentSearch(search);
             }
             if (e.key === "Escape") {
+                e.preventDefault();
                 clearSearch();
             }
         },

--- a/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
+++ b/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
@@ -363,6 +363,7 @@ export function HistoryTranscriptViewer({
                             }
                             onKeyDown={(event) => {
                                 if (event.key === "Escape") {
+                                    event.preventDefault();
                                     setSearchQuery("");
                                     setSearchOpen(false);
                                 } else if (

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -144,6 +144,7 @@ import {
     type QueuedChatMessage,
     type QueuedChatMessageStatus,
 } from "../types";
+import { isCancellableChatTurnStatus } from "../chatTurnStatus";
 import {
     getLastTranscriptMessage,
     getSessionTranscriptLength,
@@ -3214,11 +3215,7 @@ async function replaceEmptySessionForAdditionalRoots(
 }
 
 function isSessionBusy(session: AIChatSession) {
-    return (
-        session.status === "streaming" ||
-        session.status === "waiting_permission" ||
-        session.status === "waiting_user_input"
-    );
+    return isCancellableChatTurnStatus(session.status);
 }
 
 function cleanupQueuedMessagesBySessionId(

--- a/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
+++ b/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
@@ -812,8 +812,10 @@ export function BookmarksPanel() {
                                     onKeyDown={(e) => {
                                         if (e.key === "Enter")
                                             confirmCreateFolder();
-                                        if (e.key === "Escape")
+                                        if (e.key === "Escape") {
+                                            e.preventDefault();
                                             cancelCreateFolder();
+                                        }
                                     }}
                                     onBlur={confirmCreateFolder}
                                     placeholder="Folder name…"
@@ -905,8 +907,10 @@ export function BookmarksPanel() {
                                                         e.stopPropagation();
                                                         if (e.key === "Enter")
                                                             confirmRename();
-                                                        if (e.key === "Escape")
+                                                        if (e.key === "Escape") {
+                                                            e.preventDefault();
                                                             cancelRename();
+                                                        }
                                                     }}
                                                     onBlur={confirmRename}
                                                     className="flex-1 bg-transparent outline-none"

--- a/apps/desktop/src/features/editor/FloatingSelectionToolbar.tsx
+++ b/apps/desktop/src/features/editor/FloatingSelectionToolbar.tsx
@@ -195,7 +195,10 @@ export function FloatingSelectionToolbar({
         };
 
         const handleKey = (event: KeyboardEvent) => {
-            if (event.key === "Escape") onClose();
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
         };
 
         document.addEventListener("mousedown", handleDown);

--- a/apps/desktop/src/features/editor/FrontmatterPanel.tsx
+++ b/apps/desktop/src/features/editor/FrontmatterPanel.tsx
@@ -362,7 +362,10 @@ function DateField({
             }
         };
         const handleKey = (event: KeyboardEvent) => {
-            if (event.key === "Escape") setOpen(false);
+            if (event.key === "Escape") {
+                event.preventDefault();
+                setOpen(false);
+            }
         };
         document.addEventListener("mousedown", handleDown);
         document.addEventListener("keydown", handleKey);

--- a/apps/desktop/src/features/editor/LinkContextMenu.tsx
+++ b/apps/desktop/src/features/editor/LinkContextMenu.tsx
@@ -43,7 +43,10 @@ export function LinkContextMenu({
             }
         };
         const handleKey = (event: KeyboardEvent) => {
-            if (event.key === "Escape") onClose();
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
         };
         const handleScroll = (event: Event) => {
             const target = event.target;

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.test.tsx
@@ -9,7 +9,7 @@ import {
     setVaultEntries,
 } from "../../test/test-utils";
 import { publishWindowTabDropZone } from "../../app/detachedWindows";
-import { useEditorStore } from "../../app/store/editorStore";
+import { useEditorStore, type ChatTab } from "../../app/store/editorStore";
 import { CLEAR_FILE_TREE_SELECTION_EVENT } from "../../app/utils/navigation";
 import {
     createInitialLayout,
@@ -17,12 +17,18 @@ import {
 } from "../../app/store/workspaceLayoutTree";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { FILE_TREE_NOTE_DRAG_EVENT } from "../ai/dragEvents";
+import {
+    resetChatStore,
+    useChatStore,
+} from "../ai/store/chatStore";
+import type { AIChatSession, AIChatSessionStatus } from "../ai/types";
 import { MultiPaneWorkspace } from "./MultiPaneWorkspace";
 import { CROSS_PANE_TAB_DROP_PREVIEW_EVENT } from "./workspaceTabDropPreview";
 
 const innerPositionMock = vi.fn();
 const scaleFactorMock = vi.fn();
 const onDragDropEventMock = vi.fn();
+const originalStopStreaming = useChatStore.getState().stopStreaming;
 
 vi.mock("../../app/detachedWindows", () => ({
     getCurrentWindowLabel: vi.fn(() => "main"),
@@ -76,7 +82,64 @@ describe("MultiPaneWorkspace", () => {
         );
     }
 
+    function createChatTab(sessionId: string): ChatTab {
+        return {
+            id: `tab-${sessionId}`,
+            kind: "ai-chat",
+            sessionId,
+            title: sessionId,
+        };
+    }
+
+    function createChatSession(
+        sessionId: string,
+        status: AIChatSessionStatus,
+    ): AIChatSession {
+        return {
+            sessionId,
+            status,
+        } as AIChatSession;
+    }
+
+    function setPaneChatSession(
+        paneId: string,
+        sessionId: string,
+        status: AIChatSessionStatus,
+    ) {
+        const tab = createChatTab(sessionId);
+        useEditorStore.setState((state) => ({
+            panes: state.panes.map((pane) =>
+                pane.id === paneId
+                    ? {
+                          ...pane,
+                          tabs: [tab],
+                          tabIds: [tab.id],
+                          activeTabId: tab.id,
+                      }
+                    : pane,
+            ),
+        }));
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [sessionId]: createChatSession(sessionId, status),
+            },
+            sessionOrder: [
+                ...state.sessionOrder.filter((id) => id !== sessionId),
+                sessionId,
+            ],
+        }));
+    }
+
+    function installStopStreamingMock() {
+        const stopStreaming = vi.fn(async (_sessionId?: string) => {});
+        useChatStore.setState({ stopStreaming });
+        return stopStreaming;
+    }
+
     beforeEach(() => {
+        resetChatStore();
+        useChatStore.setState({ stopStreaming: originalStopStreaming });
         const mockWindow = getMockCurrentWindow() as unknown as {
             innerPosition: typeof innerPositionMock;
             scaleFactor: typeof scaleFactorMock;
@@ -250,6 +313,78 @@ describe("MultiPaneWorkspace", () => {
             );
         }
     });
+
+    it.each<AIChatSessionStatus>([
+        "streaming",
+        "waiting_permission",
+        "waiting_user_input",
+    ])("stops the focused chat when Escape is pressed in %s", (status) => {
+        setPaneChatSession("primary", "session-primary", status);
+        const stopStreaming = installStopStreamingMock();
+        renderComponent(<MultiPaneWorkspace />);
+
+        fireEvent.keyDown(window, { key: "Escape" });
+
+        expect(stopStreaming).toHaveBeenCalledTimes(1);
+        expect(stopStreaming).toHaveBeenCalledWith("session-primary");
+    });
+
+    it("does not stop a chat in another pane", () => {
+        setPaneChatSession("primary", "session-primary", "streaming");
+        setPaneChatSession("secondary", "session-secondary", "streaming");
+        useEditorStore.setState({ focusedPaneId: "primary" });
+        const stopStreaming = installStopStreamingMock();
+        renderComponent(<MultiPaneWorkspace />);
+
+        fireEvent.keyDown(window, { key: "Escape" });
+
+        expect(stopStreaming).toHaveBeenCalledTimes(1);
+        expect(stopStreaming).toHaveBeenCalledWith("session-primary");
+        expect(stopStreaming).not.toHaveBeenCalledWith("session-secondary");
+    });
+
+    it("does not stop the focused chat when Escape was already prevented", () => {
+        setPaneChatSession("primary", "session-primary", "streaming");
+        const stopStreaming = installStopStreamingMock();
+        renderComponent(<MultiPaneWorkspace />);
+        const event = new KeyboardEvent("keydown", {
+            key: "Escape",
+            cancelable: true,
+        });
+        event.preventDefault();
+
+        window.dispatchEvent(event);
+
+        expect(stopStreaming).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ["metaKey", { metaKey: true }],
+        ["ctrlKey", { ctrlKey: true }],
+        ["altKey", { altKey: true }],
+        ["shiftKey", { shiftKey: true }],
+    ])("does not stop the focused chat with %s", (_name, modifier) => {
+        setPaneChatSession("primary", "session-primary", "streaming");
+        const stopStreaming = installStopStreamingMock();
+        renderComponent(<MultiPaneWorkspace />);
+
+        fireEvent.keyDown(window, { key: "Escape", ...modifier });
+
+        expect(stopStreaming).not.toHaveBeenCalled();
+    });
+
+    it.each<AIChatSessionStatus>(["idle", "review_required", "error"])(
+        "does not stop a focused chat in %s",
+        (status) => {
+            setPaneChatSession("primary", "session-primary", status);
+            const stopStreaming = installStopStreamingMock();
+            renderComponent(<MultiPaneWorkspace />);
+
+            fireEvent.keyDown(window, { key: "Escape" });
+
+            expect(stopStreaming).not.toHaveBeenCalled();
+        },
+    );
 
     it("opens a dragged vault file in the pane under the pointer", async () => {
         setVaultEntries([

--- a/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
+++ b/apps/desktop/src/features/editor/MultiPaneWorkspace.tsx
@@ -15,6 +15,8 @@ import {
 } from "../../app/detachedWindows";
 import { clearFileTreeSelection } from "../../app/utils/navigation";
 import {
+    isChatTab,
+    selectEditorPaneActiveTab,
     selectFocusedPaneId,
     selectLeafPaneIds,
     useEditorStore,
@@ -31,7 +33,10 @@ import {
     AGENT_SIDEBAR_DRAG_EVENT,
     type AgentSidebarDragDetail,
 } from "../ai/agentSidebarDragEvents";
+import { isCancellableChatTurnStatus } from "../ai/chatTurnStatus";
 import { openOrMoveChatSessionAtDropTarget } from "../ai/chatPaneMovement";
+import { useChatStore } from "../ai/store/chatStore";
+import type { AIChatSessionStatus } from "../ai/types";
 import { WorkspaceSplitContainer } from "./WorkspaceSplitContainer";
 import {
     getWorkspaceFileDropPaneId,
@@ -48,6 +53,11 @@ import {
 } from "./workspaceTabDropPreview";
 
 const AGENT_SIDEBAR_DROP_SOURCE_PANE_ID = "__agents-sidebar__";
+
+interface ActiveAgentStopTarget {
+    sessionId: string | null;
+    status: AIChatSessionStatus | null;
+}
 
 function resolveFileTreeFolderAtPoint(x: number, y: number): string | null {
     const els = document.elementsFromPoint(x, y);
@@ -240,6 +250,18 @@ export function MultiPaneWorkspace() {
     const leafPaneIds = useEditorStore(useShallow(selectLeafPaneIds));
     const layoutTree = useEditorStore((state) => state.layoutTree);
     const focusedPaneId = useEditorStore(selectFocusedPaneId);
+    const activeChatSessionId = useEditorStore((state) => {
+        const activeTab = selectEditorPaneActiveTab(
+            state,
+            selectFocusedPaneId(state),
+        );
+        return activeTab && isChatTab(activeTab) ? activeTab.sessionId : null;
+    });
+    const activeChatSessionStatus = useChatStore((state) =>
+        activeChatSessionId
+            ? (state.sessionsById[activeChatSessionId]?.status ?? null)
+            : null,
+    );
     const refreshVaultStructure = useVaultStore(
         (state) => state.refreshStructure,
     );
@@ -249,7 +271,47 @@ export function MultiPaneWorkspace() {
     const [externalFileDropPaneId, setExternalFileDropPaneId] = useState<
         string | null
     >(null);
+    const activeAgentStopRef = useRef<ActiveAgentStopTarget>({
+        sessionId: null,
+        status: null,
+    });
     const visiblePaneCount = Math.max(1, leafPaneIds.length);
+
+    useEffect(() => {
+        activeAgentStopRef.current = {
+            sessionId: activeChatSessionId,
+            status: activeChatSessionStatus,
+        };
+    }, [activeChatSessionId, activeChatSessionStatus]);
+
+    useEffect(() => {
+        const handleKeyDown = (event: KeyboardEvent) => {
+            if (event.defaultPrevented || event.key !== "Escape") {
+                return;
+            }
+
+            if (
+                event.metaKey ||
+                event.ctrlKey ||
+                event.altKey ||
+                event.shiftKey
+            ) {
+                return;
+            }
+
+            const { sessionId, status } = activeAgentStopRef.current;
+            if (!sessionId || !isCancellableChatTurnStatus(status)) {
+                return;
+            }
+
+            event.preventDefault();
+            event.stopPropagation();
+            void useChatStore.getState().stopStreaming(sessionId);
+        };
+
+        window.addEventListener("keydown", handleKeyDown);
+        return () => window.removeEventListener("keydown", handleKeyDown);
+    }, []);
 
     useLayoutEffect(() => {
         const label = getCurrentWindowLabel();

--- a/apps/desktop/src/features/graph/GraphContextMenu.tsx
+++ b/apps/desktop/src/features/graph/GraphContextMenu.tsx
@@ -38,7 +38,10 @@ export function GraphContextMenu({
             }
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
         };
         window.addEventListener("mousedown", handleClick);
         window.addEventListener("keydown", handleKey);

--- a/apps/desktop/src/features/notes/LinksPanel.tsx
+++ b/apps/desktop/src/features/notes/LinksPanel.tsx
@@ -203,7 +203,10 @@ function BacklinksContextMenu({
             }
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
         };
         document.addEventListener("mousedown", handleDown);
         document.addEventListener("keydown", handleKey);
@@ -304,7 +307,10 @@ function OutgoingLinksContextMenu({
             }
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") onClose();
+            if (e.key === "Escape") {
+                e.preventDefault();
+                onClose();
+            }
         };
         document.addEventListener("mousedown", handleDown);
         document.addEventListener("keydown", handleKey);

--- a/apps/desktop/src/features/search/QueryBuilder.tsx
+++ b/apps/desktop/src/features/search/QueryBuilder.tsx
@@ -162,7 +162,10 @@ export function Dropdown<T extends string>({
             }
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setOpen(false);
+            if (e.key === "Escape") {
+                e.preventDefault();
+                setOpen(false);
+            }
         };
 
         document.addEventListener("mousedown", handleDown);

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -428,6 +428,8 @@ describe("SettingsPanel", () => {
         expect(screen.getByText("Ctrl+Shift+0")).toBeInTheDocument();
         expect(screen.getByText("Add Selection to Chat")).toBeInTheDocument();
         expect(screen.getByText("Ctrl+L")).toBeInTheDocument();
+        expect(screen.getByText("Stop active agent")).toBeInTheDocument();
+        expect(screen.getByText("Escape")).toBeInTheDocument();
     });
 
     it("hides the inline close button in standalone Windows settings", () => {

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -243,7 +243,10 @@ function SelectField<T extends string | number | null>({
             setOpen(false);
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") setOpen(false);
+            if (e.key === "Escape") {
+                e.preventDefault();
+                setOpen(false);
+            }
         };
         const handleResize = () => setOpen(false);
         document.addEventListener("mousedown", handleDown);
@@ -463,6 +466,7 @@ function NumberStepper({
                         inputRef.current?.blur();
                     }
                     if (e.key === "Escape") {
+                        e.preventDefault();
                         setLocal(String(value));
                         setIsEditing(false);
                         inputRef.current?.blur();
@@ -4685,7 +4689,10 @@ export function SettingsPanel({
 
     useEffect(() => {
         const onKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") handleClose();
+            if (e.key === "Escape") {
+                e.preventDefault();
+                handleClose();
+            }
         };
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -1083,6 +1083,7 @@ const FlatTreeRowView = memo(
                                     }
                                 }
                                 if (event.key === "Escape") {
+                                    event.preventDefault();
                                     onRenameCancel();
                                 }
                             }}
@@ -1213,7 +1214,10 @@ const FlatTreeRowView = memo(
                         }
                         onKeyDown={(event) => {
                             if (event.key === "Enter") onCreateConfirm();
-                            if (event.key === "Escape") onCreateCancel();
+                            if (event.key === "Escape") {
+                                event.preventDefault();
+                                onCreateCancel();
+                            }
                         }}
                         onBlur={onCreateConfirm}
                         placeholder={
@@ -1342,6 +1346,7 @@ const FlatTreeRowView = memo(
                                     }
                                 }
                                 if (event.key === "Escape") {
+                                    event.preventDefault();
                                     onRenameCancel();
                                 }
                             }}
@@ -1467,7 +1472,10 @@ const FlatTreeRowView = memo(
                                 if (value) onRenameNoteConfirm(note, value);
                                 else onRenameCancel();
                             }
-                            if (e.key === "Escape") onRenameCancel();
+                            if (e.key === "Escape") {
+                                e.preventDefault();
+                                onRenameCancel();
+                            }
                         }}
                         onBlur={() => {
                             const value =
@@ -1877,7 +1885,10 @@ function MoveDestinationPicker({
             }
         };
         const handleKey = (event: KeyboardEvent) => {
-            if (event.key === "Escape") onClose();
+            if (event.key === "Escape") {
+                event.preventDefault();
+                onClose();
+            }
         };
 
         document.addEventListener("mousedown", handleDown);

--- a/apps/desktop/src/features/vault/VaultSwitcher.tsx
+++ b/apps/desktop/src/features/vault/VaultSwitcher.tsx
@@ -53,7 +53,10 @@ export function VaultSwitcher({
             }
         };
         const handleKey = (e: KeyboardEvent) => {
-            if (e.key === "Escape") closeSwitcher();
+            if (e.key === "Escape") {
+                e.preventDefault();
+                closeSwitcher();
+            }
         };
         document.addEventListener("mousedown", handleDown);
         document.addEventListener("keydown", handleKey);


### PR DESCRIPTION
## Summary

Adds an `Escape` shortcut that stops the active AI turn in the focused workspace pane, reusing the existing `stopStreaming` cancellation flow.

## What changed

- Extracted a shared `isCancellableChatTurnStatus` helper for streaming, permission, and user-input waits.
- Added a workspace-level `Escape` listener that targets only the active chat tab in the focused pane.
- Covered focused-pane behavior, prevented events, modifier keys, cancellable states, and non-cancellable states.
- Added `Stop active agent` as an informational shortcut reference in Settings > Shortcuts.

## Validation

- `./node_modules/.bin/vitest run src/features/editor/MultiPaneWorkspace.test.tsx src/features/ai/store/chatStore.test.ts src/app/shortcuts/format.test.ts src/features/settings/SettingsPanel.test.tsx`
- `./node_modules/.bin/eslint src/features/editor/MultiPaneWorkspace.tsx src/features/editor/MultiPaneWorkspace.test.tsx src/features/ai/chatTurnStatus.ts src/features/ai/chatTurnStatus.test.ts src/features/ai/store/chatStore.ts src/app/shortcuts/registry.ts src/app/shortcuts/format.test.ts src/features/settings/SettingsPanel.test.tsx`
- `git diff --check main...HEAD`

Note: `./node_modules/.bin/tsc -b --pretty false` currently fails in an unrelated pre-existing `chatStore.test.ts` block around `sentAttachments?.filter(...)`, outside this PR diff.
