### PR TITLE
Fix drag selection visibility

### DIFF
--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -870,6 +870,9 @@ describe("Editor", () => {
         const rangeRectsSpy = vi
             .spyOn(Range.prototype, "getClientRects")
             .mockReturnValue([fakeRect] as unknown as DOMRectList);
+        const selectionLayer = view.dom.querySelector(".cm-selectionLayer");
+        expect(selectionLayer).toBeInstanceOf(HTMLElement);
+        (selectionLayer as HTMLElement).style.opacity = "0";
 
         await act(async () => {
             view.focus();
@@ -890,6 +893,7 @@ describe("Editor", () => {
         expect(
             screen.queryByRole("button", { name: "Heading 1" }),
         ).not.toBeInTheDocument();
+        expect((selectionLayer as HTMLElement).style.opacity).toBe("1");
 
         await act(async () => {
             fireEvent.mouseUp(document, { button: 0 });

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -1528,6 +1528,7 @@ export function Editor({
                 if (useEditorStore.getState().currentSelection !== null) {
                     useEditorStore.getState().clearCurrentSelection();
                 }
+                syncSelectionLayerVisibility(view);
                 setSelectionToolbar((prev) => (prev === null ? prev : null));
                 return;
             }


### PR DESCRIPTION
## Summary

Fixes the editor text-selection overlay staying hidden while the user is still dragging a selection.

## Root Cause

`196bb1e9` delayed the floating selection toolbar until mouse release by returning early from `updateSelectionToolbar` while a mouse selection is active. That early return also skipped `syncSelectionLayerVisibility(view)`, so CodeMirror's internal selection updated during drag, but `.cm-selectionLayer` remained at `opacity: 0` until `mouseup` ran the normal toolbar update path.

## Changes

- Keep the floating toolbar hidden during mouse-drag selection.
- Continue syncing the CodeMirror selection layer visibility while the drag is active.
- Extend the editor test to assert that the toolbar waits for mouse release while the selection layer is visible during the drag.

## Validation

- `npm run test -- src/features/editor/Editor.test.tsx`
- `npm run build`