### PR TITLE
Fix submenu hover gap

### DIFF
--- a/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
@@ -190,6 +190,34 @@ describe("ContextMenu scroll-to-close behaviour", () => {
         expect(callOrder).toEqual(["close", "action"]);
     });
 
+    it("keeps the submenu hover bridge attached to the parent item", () => {
+        render(
+            <ContextMenu
+                menu={{ x: 100, y: 100, payload: undefined }}
+                entries={[
+                    {
+                        label: "New Agent",
+                        children: [{ label: "Claude", action: vi.fn() }],
+                    },
+                ]}
+                onClose={vi.fn()}
+            />,
+        );
+
+        fireEvent.mouseEnter(screen.getByRole("button", { name: "New Agent" }));
+
+        const submenuSurface = screen.getByRole("button", {
+            name: "Claude",
+        }).parentElement;
+        const submenuBridge = submenuSurface?.parentElement;
+
+        expect(submenuBridge).not.toBeNull();
+        expect(submenuBridge).toHaveStyle({
+            left: "100%",
+            paddingLeft: "4px",
+        });
+    });
+
     it("resets open submenu state when the menu identity changes", () => {
         const { rerender } = render(
             <ContextMenu

--- a/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.test.tsx
@@ -218,6 +218,62 @@ describe("ContextMenu scroll-to-close behaviour", () => {
         });
     });
 
+    it("keeps the submenu hover bridge attached when opening to the left", () => {
+        const originalInnerWidth = window.innerWidth;
+        Object.defineProperty(window, "innerWidth", {
+            configurable: true,
+            value: 200,
+        });
+
+        try {
+            render(
+                <ContextMenu
+                    menu={{ x: 100, y: 100, payload: undefined }}
+                    entries={[
+                        {
+                            label: "New Agent",
+                            children: [{ label: "Claude", action: vi.fn() }],
+                        },
+                    ]}
+                    onClose={vi.fn()}
+                />,
+            );
+
+            const parentItem = screen.getByRole("button", {
+                name: "New Agent",
+            }).parentElement;
+            expect(parentItem).not.toBeNull();
+            Object.defineProperty(parentItem, "getBoundingClientRect", {
+                value: () => ({
+                    left: 180,
+                    top: 100,
+                    right: 190,
+                    bottom: 130,
+                    width: 10,
+                    height: 30,
+                }),
+            });
+
+            fireEvent.mouseEnter(parentItem!);
+
+            const submenuSurface = screen.getByRole("button", {
+                name: "Claude",
+            }).parentElement;
+            const submenuBridge = submenuSurface?.parentElement;
+
+            expect(submenuBridge).not.toBeNull();
+            expect(submenuBridge).toHaveStyle({
+                right: "100%",
+                paddingRight: "4px",
+            });
+        } finally {
+            Object.defineProperty(window, "innerWidth", {
+                configurable: true,
+                value: originalInnerWidth,
+            });
+        }
+    });
+
     it("resets open submenu state when the menu identity changes", () => {
         const { rerender } = render(
             <ContextMenu

--- a/apps/desktop/src/components/context-menu/ContextMenu.tsx
+++ b/apps/desktop/src/components/context-menu/ContextMenu.tsx
@@ -22,6 +22,7 @@ export interface ContextMenuState<T = void> {
 }
 
 const EMPTY_SUBMENU_DIRECTIONS: Readonly<Record<string, "left" | "right">> = {};
+const SUBMENU_GAP_PX = 4;
 
 export function ContextMenu<T>({
     menu,
@@ -312,74 +313,97 @@ export function ContextMenu<T>({
                                     top: -4,
                                     [submenuDirection === "right"
                                         ? "left"
-                                        : "right"]: "calc(100% + 4px)",
+                                        : "right"]: "100%",
                                     zIndex: zIndex + 1,
-                                    display: "inline-flex",
-                                    flexDirection: "column",
-                                    alignItems: "stretch",
-                                    width: "fit-content",
-                                    minWidth,
-                                    padding: 4,
-                                    borderRadius: 8,
-                                    backgroundColor: "var(--bg-secondary)",
-                                    border: "1px solid var(--border)",
-                                    boxShadow: "0 4px 16px rgba(0,0,0,0.25)",
+                                    paddingLeft:
+                                        submenuDirection === "right"
+                                            ? SUBMENU_GAP_PX
+                                            : 0,
+                                    paddingRight:
+                                        submenuDirection === "left"
+                                            ? SUBMENU_GAP_PX
+                                            : 0,
                                 }}
                             >
-                                {entry.children!.map((child, childIndex) => {
-                                    if (child.type === "separator") {
-                                        return (
-                                            <div
-                                                key={`submenu-separator-${childIndex}`}
-                                                style={{
-                                                    borderTop:
-                                                        "1px solid var(--border)",
-                                                    margin: "4px 0",
-                                                }}
-                                            />
-                                        );
-                                    }
+                                <div
+                                    style={{
+                                        display: "inline-flex",
+                                        flexDirection: "column",
+                                        alignItems: "stretch",
+                                        width: "fit-content",
+                                        minWidth,
+                                        padding: 4,
+                                        borderRadius: 8,
+                                        backgroundColor: "var(--bg-secondary)",
+                                        border: "1px solid var(--border)",
+                                        boxShadow:
+                                            "0 4px 16px rgba(0,0,0,0.25)",
+                                    }}
+                                >
+                                    {entry.children!.map(
+                                        (child, childIndex) => {
+                                            if (child.type === "separator") {
+                                                return (
+                                                    <div
+                                                        key={`submenu-separator-${childIndex}`}
+                                                        style={{
+                                                            borderTop:
+                                                                "1px solid var(--border)",
+                                                            margin: "4px 0",
+                                                        }}
+                                                    />
+                                                );
+                                            }
 
-                                    return (
-                                        <button
-                                            key={`${child.label}-${childIndex}`}
-                                            type="button"
-                                            disabled={child.disabled}
-                                            onClick={() => {
-                                                if (child.disabled) return;
-                                                closeAndRunAction(child.action);
-                                            }}
-                                            className="text-left px-3 py-1.5 text-xs rounded"
-                                            style={{
-                                                display: "block",
-                                                color: child.danger
-                                                    ? "#ef4444"
-                                                    : "var(--text-primary)",
-                                                background: "transparent",
-                                                opacity: child.disabled
-                                                    ? 0.45
-                                                    : 1,
-                                                cursor: child.disabled
-                                                    ? "default"
-                                                    : "pointer",
-                                                whiteSpace: "nowrap",
-                                            }}
-                                            onMouseEnter={(event) => {
-                                                if (child.disabled) return;
-                                                event.currentTarget.style.backgroundColor =
-                                                    child.danger
-                                                        ? "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))"
-                                                        : "var(--bg-tertiary)";
-                                            }}
-                                            onMouseLeave={(event) => {
-                                                event.currentTarget.style.backgroundColor =
-                                                    "transparent";
-                                            }}
-                                        >
-                                            {child.label}
-                                        </button>
-                                    );
-                                })}
+                                            return (
+                                                <button
+                                                    key={`${child.label}-${childIndex}`}
+                                                    type="button"
+                                                    disabled={child.disabled}
+                                                    onClick={() => {
+                                                        if (child.disabled) {
+                                                            return;
+                                                        }
+                                                        closeAndRunAction(
+                                                            child.action,
+                                                        );
+                                                    }}
+                                                    className="text-left px-3 py-1.5 text-xs rounded"
+                                                    style={{
+                                                        display: "block",
+                                                        color: child.danger
+                                                            ? "#ef4444"
+                                                            : "var(--text-primary)",
+                                                        background:
+                                                            "transparent",
+                                                        opacity: child.disabled
+                                                            ? 0.45
+                                                            : 1,
+                                                        cursor: child.disabled
+                                                            ? "default"
+                                                            : "pointer",
+                                                        whiteSpace: "nowrap",
+                                                    }}
+                                                    onMouseEnter={(event) => {
+                                                        if (child.disabled) {
+                                                            return;
+                                                        }
+                                                        event.currentTarget.style.backgroundColor =
+                                                            child.danger
+                                                                ? "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))"
+                                                                : "var(--bg-tertiary)";
+                                                    }}
+                                                    onMouseLeave={(event) => {
+                                                        event.currentTarget.style.backgroundColor =
+                                                            "transparent";
+                                                    }}
+                                                >
+                                                    {child.label}
+                                                </button>
+                                            );
+                                        },
+                                    )}
+                                </div>
                             </div>
                         ) : null}
                     </div>


### PR DESCRIPTION
## Summary

- Keep context-menu submenus attached to their parent item through an invisible hover bridge.
- Preserve the existing 4px visual gap by moving it into wrapper padding instead of physical positioning.
- Add a focused regression test for the submenu bridge layout.

## Root Cause

Submenus were positioned at `calc(100% + 4px)`, leaving a real 4px dead zone between the parent menu item and the submenu. Moving the pointer through that gap triggered the parent item's `mouseleave`, immediately closing the submenu before the pointer could enter it.

## Validation

- `npm test -- src/components/context-menu/ContextMenu.test.tsx`
- `git diff --check`