### PR TITLE
Prepare 0.3.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,31 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
-## Unreleased
+## [0.3.6] - 2026-06-19
+
+### Added
+
+- Added an Escape shortcut for stopping the focused agent, with shortcut settings coverage and safeguards so Escape still works correctly in dialogs, menus, and editable controls.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.47.0`.
+- Improved Claude ACP user-input prompts with option values, descriptions, previews, custom "Other" answers, and cleaner response handling.
+- Delayed the floating selection toolbar until mouse selection finishes so it no longer appears while dragging across editor text.
+- Hid the editor active-line highlight when the editor is not focused.
+
+### Fixed
+
+- Fixed drag-selection visibility in the editor.
+- Fixed context-menu submenus so moving across the hover gap keeps nested menus open, including left-opening submenus.
 
 ### Removed
 
 - Removed the Gemini ACP provider integration after upstream Gemini CLI subscription changes redirected users toward Antigravity, which does not expose ACP support for third-party apps.
+
+### Security
+
+- Updated DOMPurify dependency resolutions in the desktop app and Web Clipper.
 
 ## [0.3.5] - 2026-06-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.5",
+    "version": "0.3.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.5",
+            "version": "0.3.6",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.5",
+    "version": "0.3.6",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.5",
+    "version": "0.3.6",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.3.6 changelog entry from the commits since v0.3.5.
- Bump the desktop app, native backend, Cargo lockfile, and Web Clipper package versions to 0.3.6.
- Keep release metadata aligned for the tag-driven desktop release flow.

## Validation

- `cargo check -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.3.6`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `node --test apps/desktop/scripts/electron-builder-config.test.mjs apps/desktop/scripts/stage-electron-release-assets.test.mjs`
- `node --test scripts/appcast.test.mjs`
- `node --test scripts/apt-repo.test.mjs`
- `node --test scripts/platform-validation.test.mjs scripts/release-assets.test.mjs`
- `node --check scripts/build-apt-repository.mjs`
- `node --check scripts/sign-apt-repository.mjs`
- `node --check scripts/validate-apt-repository.mjs`