### PR TITLE
Add find in chat

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -36,6 +36,8 @@ import {
 } from "../store/chatRowUiStore";
 import { useChatStore } from "../store/chatStore";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import { ChatFindBar } from "./find/ChatFindBar";
+import { useChatFind } from "./find/useChatFind";
 
 interface AIChatMessageListProps {
     sessionId?: string | null;
@@ -47,6 +49,8 @@ interface AIChatMessageListProps {
     hasOlderMessages?: boolean;
     isLoadingOlderMessages?: boolean;
     visibleWorkCycleId?: string | null;
+    findOpen?: boolean;
+    onCloseFind?: () => void;
     chatFontSize?: number;
     chatFontFamily?: EditorFontFamily;
     onLoadOlderMessages?: () => void;
@@ -314,6 +318,8 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     hasOlderMessages = false,
     isLoadingOlderMessages = false,
     visibleWorkCycleId = null,
+    findOpen = false,
+    onCloseFind,
     chatFontSize = 14,
     chatFontFamily = "system",
     onLoadOlderMessages,
@@ -323,6 +329,19 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     onUrlElicitationResponse,
 }: AIChatMessageListProps) {
     const containerRef = useRef<HTMLDivElement>(null);
+    const [findQuery, setFindQuery] = useState("");
+    const [findCaseSensitive, setFindCaseSensitive] = useState(false);
+    const {
+        total: findTotal,
+        activeIndex: findActiveIndex,
+        goNext: findGoNext,
+        goPrev: findGoPrev,
+    } = useChatFind({
+        containerRef,
+        query: findQuery,
+        caseSensitive: findCaseSensitive,
+        enabled: findOpen,
+    });
     const wasNearBottomRef = useRef(true);
     const pendingPrependAdjustmentRef = useRef<{
         previousScrollHeight: number;
@@ -679,6 +698,21 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
     return (
         <div className="relative min-h-0 min-w-0 flex-1 flex flex-col">
+            {findOpen && (
+                <ChatFindBar
+                    query={findQuery}
+                    caseSensitive={findCaseSensitive}
+                    total={findTotal}
+                    activeIndex={findActiveIndex}
+                    onQueryChange={setFindQuery}
+                    onToggleCaseSensitive={() =>
+                        setFindCaseSensitive((value) => !value)
+                    }
+                    onNext={findGoNext}
+                    onPrev={findGoPrev}
+                    onClose={() => onCloseFind?.()}
+                />
+            )}
             {visiblePinnedPlan && (
                 <div
                     className="shrink-0 px-3 pt-2 pb-1"

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -44,8 +44,6 @@ interface AIChatMessageListProps {
     messages: AIChatMessage[];
     status: AIChatSessionStatus;
     readOnly?: boolean;
-    highlightedMessageIds?: string[];
-    activeHighlightedMessageId?: string | null;
     hasOlderMessages?: boolean;
     isLoadingOlderMessages?: boolean;
     visibleWorkCycleId?: string | null;
@@ -313,8 +311,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     messages,
     status,
     readOnly = false,
-    highlightedMessageIds = [],
-    activeHighlightedMessageId = null,
     hasOlderMessages = false,
     isLoadingOlderMessages = false,
     visibleWorkCycleId = null,
@@ -514,11 +510,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             visibleWorkCycleId,
         ],
     );
-    const highlightedMessageIdSet = useMemo(
-        () => new Set(highlightedMessageIds),
-        [highlightedMessageIds],
-    );
-
     useLayoutEffect(() => {
         if (restoredScopeRef.current === viewStateScope) {
             return;
@@ -627,19 +618,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             pendingPrependAdjustmentRef.current = null;
         }
     }, [isLoadingOlderMessages, messages.length]);
-
-    useEffect(() => {
-        if (!activeHighlightedMessageId) {
-            return;
-        }
-        const container = containerRef.current;
-        if (!container) return;
-        const target = container.querySelector(
-            `[data-chat-message-id="${CSS.escape(activeHighlightedMessageId)}"]`,
-        ) as HTMLElement | null;
-        if (!target) return;
-        target.scrollIntoView({ block: "center", behavior: "smooth" });
-    }, [activeHighlightedMessageId]);
 
     // Anchor scroll position when container width changes (e.g. sidebar resize).
     // Tracks the topmost visible chat row and its viewport offset on every scroll,
@@ -781,31 +759,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                                 data-chat-message-id={
                                     row.kind === "message"
                                         ? row.message.id
-                                        : undefined
-                                }
-                                className={
-                                    row.kind === "message" &&
-                                    highlightedMessageIdSet.has(row.message.id)
-                                        ? "rounded-md"
-                                        : undefined
-                                }
-                                style={
-                                    row.kind === "message" &&
-                                    highlightedMessageIdSet.has(row.message.id)
-                                        ? {
-                                              backgroundColor:
-                                                  row.message.id ===
-                                                  activeHighlightedMessageId
-                                                      ? "color-mix(in srgb, var(--accent) 14%, transparent)"
-                                                      : "color-mix(in srgb, var(--accent) 7%, transparent)",
-                                              boxShadow:
-                                                  row.message.id ===
-                                                  activeHighlightedMessageId
-                                                      ? "0 0 0 1px color-mix(in srgb, var(--accent) 35%, transparent)"
-                                                      : "0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent)",
-                                              scrollMarginTop: 72,
-                                              scrollMarginBottom: 72,
-                                          }
                                         : undefined
                                 }
                             >

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -2,6 +2,7 @@ import {
     memo,
     useCallback,
     useEffect,
+    useId,
     useLayoutEffect,
     useMemo,
     useRef,
@@ -325,6 +326,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     onUrlElicitationResponse,
 }: AIChatMessageListProps) {
     const containerRef = useRef<HTMLDivElement>(null);
+    const findHighlightOwnerId = useId();
     const [findQuery, setFindQuery] = useState("");
     const [findCaseSensitive, setFindCaseSensitive] = useState(false);
     const {
@@ -333,6 +335,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         goNext: findGoNext,
         goPrev: findGoPrev,
     } = useChatFind({
+        ownerId: findHighlightOwnerId,
         containerRef,
         query: findQuery,
         caseSensitive: findCaseSensitive,

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -355,6 +355,30 @@ describe("AIChatSessionView", () => {
         expect(findButton).toHaveAttribute("aria-pressed", "false");
     });
 
+    it("closes chat find before Escape can stop the focused agent", async () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        const findButton = screen.getByRole("button", {
+            name: "Find in chat",
+        });
+        fireEvent.click(findButton);
+        expect(findButton).toHaveAttribute("aria-pressed", "true");
+
+        const escapeEvent = new KeyboardEvent("keydown", {
+            key: "Escape",
+            bubbles: true,
+            cancelable: true,
+        });
+        window.dispatchEvent(escapeEvent);
+
+        await waitFor(() => {
+            expect(findButton).toHaveAttribute("aria-pressed", "false");
+        });
+        expect(escapeEvent.defaultPrevented).toBe(true);
+    });
+
     it("shows visible feedback when a pasted image is too large", async () => {
         setupWorkspaceSession();
         renderComponent(<AIChatSessionView paneId="primary" />);

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -330,6 +330,31 @@ describe("AIChatSessionView", () => {
         );
     });
 
+    it("closes and disables chat find while the composer is expanded", async () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        const findButton = screen.getByRole("button", {
+            name: "Find in chat",
+        });
+        fireEvent.click(findButton);
+        expect(findButton).toHaveAttribute("aria-pressed", "true");
+
+        fireEvent.click(screen.getByTestId("chat-composer"));
+
+        await waitFor(() => {
+            expect(findButton).toBeDisabled();
+            expect(findButton).toHaveAttribute("aria-pressed", "false");
+        });
+        expect(
+            screen.queryByTestId("chat-message-list"),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(findButton);
+        expect(findButton).toHaveAttribute("aria-pressed", "false");
+    });
+
     it("shows visible feedback when a pasted image is too large", async () => {
         setupWorkspaceSession();
         renderComponent(<AIChatSessionView paneId="primary" />);

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -23,6 +23,7 @@ import {
     isChatTab,
     selectEditorPaneActiveTab,
     selectEditorWorkspaceTabs,
+    selectFocusedPaneId,
     useEditorStore,
 } from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
@@ -519,6 +520,30 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         disabled: composerExpanded,
         onOpen: openFind,
     });
+    useEffect(() => {
+        if (!findOpen) return;
+        const handleEscape = (event: KeyboardEvent) => {
+            if (event.defaultPrevented || event.key !== "Escape") return;
+            if (
+                event.metaKey ||
+                event.ctrlKey ||
+                event.altKey ||
+                event.shiftKey
+            ) {
+                return;
+            }
+            const focusedPaneId = selectFocusedPaneId(useEditorStore.getState());
+            if (paneId && focusedPaneId !== paneId) return;
+
+            event.preventDefault();
+            event.stopPropagation();
+            setFindOpen(false);
+            rootRef.current?.focus();
+        };
+
+        window.addEventListener("keydown", handleEscape, true);
+        return () => window.removeEventListener("keydown", handleEscape, true);
+    }, [findOpen, paneId]);
 
     const isSubagent = Boolean(session?.parentSessionId?.trim());
     const parentTitle = parentSession ? getSessionTitle(parentSession) : null;

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -48,12 +48,12 @@ import { AIChatContextUsageBar } from "./AIChatContextUsageBar";
 import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
 import { QueuedMessagesPanel } from "./QueuedMessagesPanel";
 import { AIChatRuntimeBanner } from "./AIChatRuntimeBanner";
-import { matchesShortcutAction } from "../../../app/shortcuts/registry";
 import { formatShortcutAction } from "../../../app/shortcuts/format";
 import { getDesktopPlatform } from "../../../app/utils/platform";
 import { AIDiscardedRootsBanner } from "./AIDiscardedRootsBanner";
 import { useInlineRename } from "./useInlineRename";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import { useChatFindShortcut } from "./find/useChatFindShortcut";
 import {
     appendFileAttachmentPart,
     appendScreenshotPart,
@@ -511,28 +511,14 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         }
     }, [composerExpanded]);
 
-    // Cmd/Ctrl+F opens the chat finder. The listener lives on this view's root,
-    // so it only fires when focus is inside the chat (CodeMirror keeps its own
-    // "find in note" binding for the editor — no global collision).
-    useEffect(() => {
-        const root = rootRef.current;
-        if (!root) return;
-        const platform = getDesktopPlatform();
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (!matchesShortcutAction(event, "find_in_note", platform)) return;
-            if (composerExpanded) return;
-            event.preventDefault();
-            event.stopPropagation();
-            setFindOpen(true);
-            requestAnimationFrame(() => {
-                root.querySelector<HTMLInputElement>(
-                    '[role="search"] input',
-                )?.focus();
-            });
-        };
-        root.addEventListener("keydown", onKeyDown);
-        return () => root.removeEventListener("keydown", onKeyDown);
-    }, [composerExpanded, sessionId]);
+    const openFind = useCallback(() => {
+        setFindOpen(true);
+    }, []);
+    useChatFindShortcut({
+        rootRef,
+        disabled: composerExpanded,
+        onOpen: openFind,
+    });
 
     const isSubagent = Boolean(session?.parentSessionId?.trim());
     const parentTitle = parentSession ? getSessionTitle(parentSession) : null;

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -503,6 +503,14 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         setFindOpen(false);
     }, [sessionId]);
 
+    // The message list owns the finder UI and is unmounted while the composer is
+    // expanded, so keep the finder state aligned with that visibility boundary.
+    useEffect(() => {
+        if (composerExpanded) {
+            setFindOpen(false);
+        }
+    }, [composerExpanded]);
+
     // Cmd/Ctrl+F opens the chat finder. The listener lives on this view's root,
     // so it only fires when focus is inside the chat (CodeMirror keeps its own
     // "find in note" binding for the editor — no global collision).
@@ -512,6 +520,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         const platform = getDesktopPlatform();
         const onKeyDown = (event: KeyboardEvent) => {
             if (!matchesShortcutAction(event, "find_in_note", platform)) return;
+            if (composerExpanded) return;
             event.preventDefault();
             event.stopPropagation();
             setFindOpen(true);
@@ -523,10 +532,11 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
         };
         root.addEventListener("keydown", onKeyDown);
         return () => root.removeEventListener("keydown", onKeyDown);
-    }, [sessionId]);
+    }, [composerExpanded, sessionId]);
 
     const isSubagent = Boolean(session?.parentSessionId?.trim());
     const parentTitle = parentSession ? getSessionTitle(parentSession) : null;
+    const findDisabled = composerExpanded;
 
     const startTitleEdit = useCallback(() => {
         if (!session || !sessionId || isSubagent) return;
@@ -624,13 +634,21 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                 ) : null}
                 <button
                     type="button"
-                    onClick={() => setFindOpen((value) => !value)}
+                    onClick={() => {
+                        if (findDisabled) return;
+                        setFindOpen((value) => !value);
+                    }}
+                    disabled={findDisabled}
                     aria-label="Find in chat"
                     aria-pressed={findOpen}
-                    title={`Find in chat (${formatShortcutAction(
-                        "find_in_note",
-                        getDesktopPlatform(),
-                    )})`}
+                    title={
+                        findDisabled
+                            ? "Find is unavailable while the composer is expanded"
+                            : `Find in chat (${formatShortcutAction(
+                                  "find_in_note",
+                                  getDesktopPlatform(),
+                              )})`
+                    }
                     className="nw-control-trigger flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md"
                     style={{
                         color: findOpen
@@ -638,6 +656,7 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                             : "var(--text-secondary)",
                         border: "none",
                         backgroundColor: "transparent",
+                        opacity: findDisabled ? 0.45 : 1,
                     }}
                 >
                     <svg

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -48,6 +48,9 @@ import { AIChatContextUsageBar } from "./AIChatContextUsageBar";
 import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
 import { QueuedMessagesPanel } from "./QueuedMessagesPanel";
 import { AIChatRuntimeBanner } from "./AIChatRuntimeBanner";
+import { matchesShortcutAction } from "../../../app/shortcuts/registry";
+import { formatShortcutAction } from "../../../app/shortcuts/format";
+import { getDesktopPlatform } from "../../../app/utils/platform";
 import { AIDiscardedRootsBanner } from "./AIDiscardedRootsBanner";
 import { useInlineRename } from "./useInlineRename";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
@@ -104,6 +107,8 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
     const [imageAttachmentNotice, setImageAttachmentNotice] = useState<
         string | null
     >(null);
+    const [findOpen, setFindOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
 
     // Resolve sessionId from the active ChatTab in this pane
     const sessionId = useEditorStore((state) => {
@@ -493,6 +498,33 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
     }, [session, sessionId]);
 
     const sessionTitle = session ? getSessionTitleText(session) : "Chat";
+    // Close the finder when switching to another session.
+    useEffect(() => {
+        setFindOpen(false);
+    }, [sessionId]);
+
+    // Cmd/Ctrl+F opens the chat finder. The listener lives on this view's root,
+    // so it only fires when focus is inside the chat (CodeMirror keeps its own
+    // "find in note" binding for the editor — no global collision).
+    useEffect(() => {
+        const root = rootRef.current;
+        if (!root) return;
+        const platform = getDesktopPlatform();
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!matchesShortcutAction(event, "find_in_note", platform)) return;
+            event.preventDefault();
+            event.stopPropagation();
+            setFindOpen(true);
+            requestAnimationFrame(() => {
+                root.querySelector<HTMLInputElement>(
+                    '[role="search"] input',
+                )?.focus();
+            });
+        };
+        root.addEventListener("keydown", onKeyDown);
+        return () => root.removeEventListener("keydown", onKeyDown);
+    }, [sessionId]);
+
     const isSubagent = Boolean(session?.parentSessionId?.trim());
     const parentTitle = parentSession ? getSessionTitle(parentSession) : null;
 
@@ -518,7 +550,9 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
 
     return (
         <div
-            className="relative flex h-full min-h-0 flex-col"
+            ref={rootRef}
+            tabIndex={-1}
+            className="relative flex h-full min-h-0 flex-col outline-none"
             style={{ backgroundColor: "var(--bg-secondary)" }}
         >
             {/* Compact local session header for the workspace chat tab */}
@@ -588,6 +622,38 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                             : "Subagent"}
                     </span>
                 ) : null}
+                <button
+                    type="button"
+                    onClick={() => setFindOpen((value) => !value)}
+                    aria-label="Find in chat"
+                    aria-pressed={findOpen}
+                    title={`Find in chat (${formatShortcutAction(
+                        "find_in_note",
+                        getDesktopPlatform(),
+                    )})`}
+                    className="nw-control-trigger flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-md"
+                    style={{
+                        color: findOpen
+                            ? "var(--accent)"
+                            : "var(--text-secondary)",
+                        border: "none",
+                        backgroundColor: "transparent",
+                    }}
+                >
+                    <svg
+                        width="14"
+                        height="14"
+                        viewBox="0 0 14 14"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <circle cx="6" cy="6" r="4" />
+                        <path d="M9 9L12.5 12.5" />
+                    </svg>
+                </button>
             </div>
 
             <AIChatRuntimeBanner
@@ -617,6 +683,11 @@ export function AIChatSessionView({ paneId }: AIChatSessionViewProps) {
                         session?.isLoadingPersistedMessages ?? false
                     }
                     visibleWorkCycleId={session?.visibleWorkCycleId ?? null}
+                    findOpen={findOpen}
+                    onCloseFind={() => {
+                        setFindOpen(false);
+                        rootRef.current?.focus();
+                    }}
                     chatFontSize={chatFontSize}
                     chatFontFamily={chatFontFamily}
                     onLoadOlderMessages={() => {

--- a/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
+++ b/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { EditorFontFamily } from "../../../app/store/settingsStore";
 import { useChatStore } from "../store/chatStore";
 import {
@@ -9,8 +9,7 @@ import {
 } from "../sessionPresentation";
 import type { AIChatSession } from "../types";
 import { AIChatMessageList } from "./AIChatMessageList";
-import { matchesShortcutAction } from "../../../app/shortcuts/registry";
-import { getDesktopPlatform } from "../../../app/utils/platform";
+import { useChatFindShortcut } from "./find/useChatFindShortcut";
 
 interface HistoryTranscriptViewerProps {
     historySessionId: string;
@@ -251,25 +250,10 @@ export function HistoryTranscriptViewer({
         setFindOpen(false);
     }, [historySessionId]);
 
-    // Cmd/Ctrl+F opens the finder while focus is inside this transcript.
-    useEffect(() => {
-        const root = rootRef.current;
-        if (!root) return;
-        const platform = getDesktopPlatform();
-        const onKeyDown = (event: KeyboardEvent) => {
-            if (!matchesShortcutAction(event, "find_in_note", platform)) return;
-            event.preventDefault();
-            event.stopPropagation();
-            setFindOpen(true);
-            requestAnimationFrame(() => {
-                root.querySelector<HTMLInputElement>(
-                    '[role="search"] input',
-                )?.focus();
-            });
-        };
-        root.addEventListener("keydown", onKeyDown);
-        return () => root.removeEventListener("keydown", onKeyDown);
-    }, [historySessionId]);
+    const openFind = useCallback(() => {
+        setFindOpen(true);
+    }, []);
+    useChatFindShortcut({ rootRef, onOpen: openFind });
 
     if (!session) {
         return (

--- a/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
+++ b/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.tsx
@@ -9,6 +9,8 @@ import {
 } from "../sessionPresentation";
 import type { AIChatSession } from "../types";
 import { AIChatMessageList } from "./AIChatMessageList";
+import { matchesShortcutAction } from "../../../app/shortcuts/registry";
+import { getDesktopPlatform } from "../../../app/utils/platform";
 
 interface HistoryTranscriptViewerProps {
     historySessionId: string;
@@ -18,30 +20,18 @@ interface HistoryTranscriptViewerProps {
     onRestore?: () => void;
 }
 
-function matchesMessageSearch(
-    message: AIChatSession["messages"][number],
-    query: string,
-) {
-    const lower = query.trim().toLowerCase();
-    if (!lower) return false;
-    return (
-        message.content.toLowerCase().includes(lower) ||
-        (message.title?.toLowerCase().includes(lower) ?? false)
-    );
-}
-
 function TranscriptHeader({
     session,
     onExport,
     onRestore,
-    searchOpen,
-    onToggleSearch,
+    findOpen,
+    onToggleFind,
 }: {
     session: AIChatSession;
     onExport?: () => void;
     onRestore?: () => void;
-    searchOpen: boolean;
-    onToggleSearch: () => void;
+    findOpen: boolean;
+    onToggleFind: () => void;
 }) {
     const runtimes = useChatStore((s) => s.runtimes);
     const forkSession = useChatStore((s) => s.forkSession);
@@ -152,20 +142,21 @@ function TranscriptHeader({
             )}
             <button
                 type="button"
-                onClick={onToggleSearch}
+                onClick={onToggleFind}
+                aria-pressed={findOpen}
                 className="flex h-6 shrink-0 items-center gap-1 rounded px-2 text-[10px] font-medium"
                 style={{
-                    background: searchOpen
+                    background: findOpen
                         ? "color-mix(in srgb, var(--accent) 12%, transparent)"
                         : "none",
-                    border: searchOpen
+                    border: findOpen
                         ? "1px solid color-mix(in srgb, var(--accent) 35%, var(--border))"
                         : "1px solid var(--border)",
-                    color: searchOpen
+                    color: findOpen
                         ? "var(--text-primary)"
                         : "var(--text-secondary)",
                 }}
-                title="Search in this chat"
+                title="Find in this chat"
             >
                 <svg
                     width="12"
@@ -180,7 +171,7 @@ function TranscriptHeader({
                     <circle cx="5.25" cy="5.25" r="3.25" />
                     <path d="M7.75 7.75 10 10" />
                 </svg>
-                Search
+                Find
             </button>
             <button
                 type="button"
@@ -247,50 +238,38 @@ export function HistoryTranscriptViewer({
     const storeFontFamily = useChatStore((s) => s.chatFontFamily);
     const effectiveFontSize = chatFontSize ?? storeFontSize;
     const effectiveFontFamily = chatFontFamily ?? storeFontFamily;
-    const [searchOpen, setSearchOpen] = useState(false);
-    const [searchQuery, setSearchQuery] = useState("");
-    const [activeMatchState, setActiveMatchState] = useState<{
-        key: string;
-        index: number;
-    }>({ key: "", index: 0 });
-    const searchInputRef = useRef<HTMLInputElement>(null);
-
-    const matchedMessages = useMemo(() => {
-        const query = searchQuery.trim();
-        if (!query) return [];
-        return (
-            session?.messages.filter((message) =>
-                matchesMessageSearch(message, query),
-            ) ?? []
-        );
-    }, [searchQuery, session]);
-    const activeMatchKey = `${historySessionId ?? ""}\u0000${searchQuery}`;
-    const effectiveActiveMatchIndex =
-        activeMatchState.key === activeMatchKey ? activeMatchState.index : 0;
-    const activeMatch =
-        matchedMessages.length > 0
-            ? matchedMessages[
-                  Math.min(
-                      effectiveActiveMatchIndex,
-                      matchedMessages.length - 1,
-                  )
-              ]
-            : null;
-    const highlightedMessageIds = useMemo(
-        () => matchedMessages.map((message) => message.id),
-        [matchedMessages],
-    );
+    const [findOpen, setFindOpen] = useState(false);
+    const rootRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (!sessionId) return;
         void ensureTranscriptLoaded(sessionId, "full");
     }, [ensureTranscriptLoaded, sessionId]);
 
+    // Close the finder when switching to another transcript.
     useEffect(() => {
-        if (!searchOpen) return;
-        searchInputRef.current?.focus();
-        searchInputRef.current?.select();
-    }, [searchOpen]);
+        setFindOpen(false);
+    }, [historySessionId]);
+
+    // Cmd/Ctrl+F opens the finder while focus is inside this transcript.
+    useEffect(() => {
+        const root = rootRef.current;
+        if (!root) return;
+        const platform = getDesktopPlatform();
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!matchesShortcutAction(event, "find_in_note", platform)) return;
+            event.preventDefault();
+            event.stopPropagation();
+            setFindOpen(true);
+            requestAnimationFrame(() => {
+                root.querySelector<HTMLInputElement>(
+                    '[role="search"] input',
+                )?.focus();
+            });
+        };
+        root.addEventListener("keydown", onKeyDown);
+        return () => root.removeEventListener("keydown", onKeyDown);
+    }, [historySessionId]);
 
     if (!session) {
         return (
@@ -306,203 +285,28 @@ export function HistoryTranscriptViewer({
     const hasOlderMessages = (session.loadedPersistedMessageStart ?? 0) > 0;
 
     return (
-        <div className="flex h-full min-h-0 flex-col">
+        <div
+            ref={rootRef}
+            tabIndex={-1}
+            className="flex h-full min-h-0 flex-col outline-none"
+        >
             <TranscriptHeader
                 session={session}
                 onExport={onExport}
                 onRestore={onRestore}
-                searchOpen={searchOpen}
-                onToggleSearch={() => {
-                    setSearchOpen((open) => !open);
-                    if (searchOpen) {
-                        setSearchQuery("");
-                    }
-                }}
+                findOpen={findOpen}
+                onToggleFind={() => setFindOpen((open) => !open)}
             />
-            {searchOpen && (
-                <div
-                    className="flex shrink-0 items-center gap-2 px-3 py-1.5"
-                    style={{
-                        borderBottom: "1px solid var(--border)",
-                        background:
-                            "color-mix(in srgb, var(--bg-tertiary) 35%, transparent)",
-                    }}
-                >
-                    <div
-                        className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md px-2"
-                        style={{
-                            background: "var(--bg-primary)",
-                            border: "1px solid var(--border)",
-                        }}
-                    >
-                        <svg
-                            width="14"
-                            height="14"
-                            viewBox="0 0 16 16"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                            style={{
-                                color: "var(--text-secondary)",
-                                opacity: 0.6,
-                                flexShrink: 0,
-                            }}
-                        >
-                            <circle cx="7" cy="7" r="5" />
-                            <path d="M11 11l3.5 3.5" />
-                        </svg>
-                        <input
-                            ref={searchInputRef}
-                            type="text"
-                            placeholder="Find in this chat…"
-                            value={searchQuery}
-                            onChange={(event) =>
-                                setSearchQuery(event.target.value)
-                            }
-                            onKeyDown={(event) => {
-                                if (event.key === "Escape") {
-                                    event.preventDefault();
-                                    setSearchQuery("");
-                                    setSearchOpen(false);
-                                } else if (
-                                    event.key === "Enter" &&
-                                    matchedMessages.length > 0
-                                ) {
-                                    event.preventDefault();
-                                    setActiveMatchState((state) => {
-                                        const index =
-                                            state.key === activeMatchKey
-                                                ? state.index
-                                                : 0;
-                                        return {
-                                            key: activeMatchKey,
-                                            index: event.shiftKey
-                                                ? (index -
-                                                      1 +
-                                                      matchedMessages.length) %
-                                                  matchedMessages.length
-                                                : (index + 1) %
-                                                  matchedMessages.length,
-                                        };
-                                    });
-                                }
-                            }}
-                            className="min-w-0 flex-1 text-[11px] leading-none outline-none"
-                            style={{
-                                background: "transparent",
-                                color: "var(--text-primary)",
-                                border: "none",
-                            }}
-                        />
-                    </div>
-                    <span
-                        className="shrink-0 text-[10px]"
-                        style={{
-                            color: "var(--text-secondary)",
-                            opacity: 0.75,
-                        }}
-                    >
-                        {searchQuery.trim()
-                            ? matchedMessages.length > 0
-                                ? `${effectiveActiveMatchIndex + 1} of ${matchedMessages.length}`
-                                : "0 results"
-                            : "Type to search"}
-                    </span>
-                    <button
-                        type="button"
-                        onClick={() => {
-                            setActiveMatchState((state) => {
-                                const index =
-                                    state.key === activeMatchKey
-                                        ? state.index
-                                        : 0;
-                                return {
-                                    key: activeMatchKey,
-                                    index:
-                                        matchedMessages.length > 0
-                                            ? (index -
-                                                  1 +
-                                                  matchedMessages.length) %
-                                              matchedMessages.length
-                                            : 0,
-                                };
-                            });
-                        }}
-                        disabled={matchedMessages.length === 0}
-                        className="flex h-6 w-6 shrink-0 items-center justify-center rounded"
-                        style={{
-                            background: "none",
-                            border: "1px solid var(--border)",
-                            color: "var(--text-secondary)",
-                            opacity: matchedMessages.length > 0 ? 1 : 0.4,
-                        }}
-                        title="Previous result"
-                    >
-                        <svg
-                            width="10"
-                            height="10"
-                            viewBox="0 0 10 10"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        >
-                            <path d="M6.5 2 3.5 5l3 3" />
-                        </svg>
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => {
-                            setActiveMatchState((state) => {
-                                const index =
-                                    state.key === activeMatchKey
-                                        ? state.index
-                                        : 0;
-                                return {
-                                    key: activeMatchKey,
-                                    index:
-                                        matchedMessages.length > 0
-                                            ? (index + 1) %
-                                              matchedMessages.length
-                                            : 0,
-                                };
-                            });
-                        }}
-                        disabled={matchedMessages.length === 0}
-                        className="flex h-6 w-6 shrink-0 items-center justify-center rounded"
-                        style={{
-                            background: "none",
-                            border: "1px solid var(--border)",
-                            color: "var(--text-secondary)",
-                            opacity: matchedMessages.length > 0 ? 1 : 0.4,
-                        }}
-                        title="Next result"
-                    >
-                        <svg
-                            width="10"
-                            height="10"
-                            viewBox="0 0 10 10"
-                            fill="none"
-                            stroke="currentColor"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                        >
-                            <path d="m3.5 2 3 3-3 3" />
-                        </svg>
-                    </button>
-                </div>
-            )}
             <AIChatMessageList
                 sessionId={session.sessionId}
                 messages={session.messages}
                 status="idle"
                 readOnly
-                highlightedMessageIds={highlightedMessageIds}
-                activeHighlightedMessageId={activeMatch?.id ?? null}
+                findOpen={findOpen}
+                onCloseFind={() => {
+                    setFindOpen(false);
+                    rootRef.current?.focus();
+                }}
                 hasOlderMessages={hasOlderMessages}
                 isLoadingOlderMessages={
                     session.isLoadingPersistedMessages ?? false

--- a/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
+++ b/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
@@ -1,0 +1,195 @@
+import { useEffect, useRef } from "react";
+
+interface ChatFindBarProps {
+    query: string;
+    caseSensitive: boolean;
+    total: number;
+    activeIndex: number; // -1 when no matches
+    onQueryChange: (value: string) => void;
+    onToggleCaseSensitive: () => void;
+    onNext: () => void;
+    onPrev: () => void;
+    onClose: () => void;
+}
+
+function counterLabel(query: string, total: number, activeIndex: number): string {
+    if (!query) return "";
+    if (total === 0) return "No results";
+    return `${activeIndex + 1}/${total}`;
+}
+
+export function ChatFindBar({
+    query,
+    caseSensitive,
+    total,
+    activeIndex,
+    onQueryChange,
+    onToggleCaseSensitive,
+    onNext,
+    onPrev,
+    onClose,
+}: ChatFindBarProps) {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        const input = inputRef.current;
+        if (!input) return;
+        input.focus();
+        input.select();
+    }, []);
+
+    const disabled = total === 0;
+
+    return (
+        <div
+            role="search"
+            aria-label="Find in chat"
+            className="absolute right-3 top-2 z-10 flex items-center gap-1 rounded-[10px] px-1.5 py-1"
+            style={{
+                background: "var(--bg-elevated)",
+                border: "1px solid var(--border)",
+                boxShadow: "0 4px 16px rgba(0,0,0,0.18)",
+            }}
+            onKeyDown={(event) => {
+                // Keep find shortcuts local to the bar.
+                if (event.key === "Escape") {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onClose();
+                }
+            }}
+        >
+            <input
+                ref={inputRef}
+                value={query}
+                onChange={(event) => onQueryChange(event.target.value)}
+                onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                        event.preventDefault();
+                        if (event.shiftKey) onPrev();
+                        else onNext();
+                    }
+                }}
+                placeholder="Find in visible chat…"
+                aria-label="Find in chat"
+                spellCheck={false}
+                className="h-[26px] min-w-0 rounded-md px-2 text-xs outline-none"
+                style={{
+                    width: 180,
+                    backgroundColor:
+                        "color-mix(in srgb, var(--bg-secondary) 60%, var(--bg-primary))",
+                    color: "var(--text-primary)",
+                    border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
+                }}
+            />
+
+            <span
+                aria-live="polite"
+                className="min-w-[44px] shrink-0 text-center text-[11px] tabular-nums"
+                style={{ color: "var(--text-secondary)" }}
+            >
+                {counterLabel(query, total, activeIndex)}
+            </span>
+
+            <button
+                type="button"
+                onClick={onToggleCaseSensitive}
+                aria-label="Match case"
+                aria-pressed={caseSensitive}
+                title="Match case"
+                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md text-[11px] font-semibold"
+                style={{
+                    color: caseSensitive
+                        ? "var(--accent)"
+                        : "var(--text-secondary)",
+                    border: "none",
+                    backgroundColor: "transparent",
+                }}
+            >
+                Aa
+            </button>
+
+            <button
+                type="button"
+                onClick={onPrev}
+                disabled={disabled}
+                aria-label="Previous match"
+                title="Previous match (Shift+Enter)"
+                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
+                style={{
+                    color: "var(--text-secondary)",
+                    border: "none",
+                    backgroundColor: "transparent",
+                    opacity: disabled ? 0.4 : 1,
+                }}
+            >
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="M3 9L7 5L11 9" />
+                </svg>
+            </button>
+
+            <button
+                type="button"
+                onClick={onNext}
+                disabled={disabled}
+                aria-label="Next match"
+                title="Next match (Enter)"
+                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
+                style={{
+                    color: "var(--text-secondary)",
+                    border: "none",
+                    backgroundColor: "transparent",
+                    opacity: disabled ? 0.4 : 1,
+                }}
+            >
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="M3 5L7 9L11 5" />
+                </svg>
+            </button>
+
+            <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close find"
+                title="Close (Esc)"
+                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
+                style={{
+                    color: "var(--text-secondary)",
+                    border: "none",
+                    backgroundColor: "transparent",
+                }}
+            >
+                <svg
+                    width="12"
+                    height="12"
+                    viewBox="0 0 14 14"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5" />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
+++ b/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
@@ -73,9 +73,11 @@ export function ChatFindBar({
                 placeholder="Find in visible chat…"
                 aria-label="Find in chat"
                 spellCheck={false}
-                className="h-[26px] min-w-0 rounded-md px-2 text-xs outline-none"
+                className="h-[22px] min-w-0 rounded px-2 outline-none"
                 style={{
-                    width: 180,
+                    width: 168,
+                    fontSize: 11,
+                    lineHeight: "20px",
                     backgroundColor:
                         "color-mix(in srgb, var(--bg-secondary) 60%, var(--bg-primary))",
                     color: "var(--text-primary)",

--- a/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
+++ b/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, type ReactNode } from "react";
 
 interface ChatFindBarProps {
     query: string;
@@ -16,6 +16,50 @@ function counterLabel(query: string, total: number, activeIndex: number): string
     if (!query) return "";
     if (total === 0) return "No results";
     return `${activeIndex + 1}/${total}`;
+}
+
+function FindIconButton({
+    ariaLabel,
+    title,
+    onClick,
+    disabled = false,
+    children,
+}: {
+    ariaLabel: string;
+    title: string;
+    onClick: () => void;
+    disabled?: boolean;
+    children: ReactNode;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            disabled={disabled}
+            aria-label={ariaLabel}
+            title={title}
+            className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
+            style={{
+                color: "var(--text-secondary)",
+                border: "none",
+                backgroundColor: "transparent",
+                opacity: disabled ? 0.4 : 1,
+            }}
+        >
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 14 14"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                {children}
+            </svg>
+        </button>
+    );
 }
 
 export function ChatFindBar({
@@ -111,87 +155,31 @@ export function ChatFindBar({
                 Aa
             </button>
 
-            <button
-                type="button"
+            <FindIconButton
                 onClick={onPrev}
                 disabled={disabled}
-                aria-label="Previous match"
+                ariaLabel="Previous match"
                 title="Previous match (Shift+Enter)"
-                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
-                style={{
-                    color: "var(--text-secondary)",
-                    border: "none",
-                    backgroundColor: "transparent",
-                    opacity: disabled ? 0.4 : 1,
-                }}
             >
-                <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 14 14"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                >
-                    <path d="M3 9L7 5L11 9" />
-                </svg>
-            </button>
+                <path d="M3 9L7 5L11 9" />
+            </FindIconButton>
 
-            <button
-                type="button"
+            <FindIconButton
                 onClick={onNext}
                 disabled={disabled}
-                aria-label="Next match"
+                ariaLabel="Next match"
                 title="Next match (Enter)"
-                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
-                style={{
-                    color: "var(--text-secondary)",
-                    border: "none",
-                    backgroundColor: "transparent",
-                    opacity: disabled ? 0.4 : 1,
-                }}
             >
-                <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 14 14"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                >
-                    <path d="M3 5L7 9L11 5" />
-                </svg>
-            </button>
+                <path d="M3 5L7 9L11 5" />
+            </FindIconButton>
 
-            <button
-                type="button"
+            <FindIconButton
                 onClick={onClose}
-                aria-label="Close find"
+                ariaLabel="Close find"
                 title="Close (Esc)"
-                className="nw-control-trigger flex h-[26px] w-[26px] items-center justify-center rounded-md"
-                style={{
-                    color: "var(--text-secondary)",
-                    border: "none",
-                    backgroundColor: "transparent",
-                }}
             >
-                <svg
-                    width="12"
-                    height="12"
-                    viewBox="0 0 14 14"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                >
-                    <path d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5" />
-                </svg>
-            </button>
+                <path d="M3.5 3.5L10.5 10.5M10.5 3.5L3.5 10.5" />
+            </FindIconButton>
         </div>
     );
 }

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    CHAT_FIND_ACTIVE_HIGHLIGHT,
+    CHAT_FIND_HIGHLIGHT,
+    applyChatFindHighlights,
+    clearChatFindHighlights,
+    setActiveChatFindHighlight,
+} from "./chatFindHighlights";
+
+class MockHighlight {
+    ranges: Range[];
+
+    constructor(...ranges: Range[]) {
+        this.ranges = ranges;
+    }
+}
+
+function installHighlightMock() {
+    const store = new Map<string, MockHighlight>();
+    const highlights = {
+        set: vi.fn((name: string, value: MockHighlight) => {
+            store.set(name, value);
+        }),
+        delete: vi.fn((name: string) => {
+            store.delete(name);
+        }),
+    };
+
+    Object.defineProperty(globalThis, "Highlight", {
+        configurable: true,
+        value: MockHighlight,
+    });
+    Object.defineProperty(globalThis, "CSS", {
+        configurable: true,
+        value: {
+            ...(globalThis.CSS ?? {}),
+            highlights,
+        },
+    });
+
+    return store;
+}
+
+function createRange(text: string): Range {
+    const node = document.createTextNode(text);
+    document.body.append(node);
+    const range = document.createRange();
+    range.setStart(node, 0);
+    range.setEnd(node, text.length);
+    return range;
+}
+
+describe("chatFindHighlights", () => {
+    let store: Map<string, MockHighlight>;
+
+    beforeEach(() => {
+        document.body.replaceChildren();
+        store = installHighlightMock();
+        clearChatFindHighlights("owner-a");
+        clearChatFindHighlights("owner-b");
+    });
+
+    it("clears only the ranges owned by one finder instance", () => {
+        const rangeA = createRange("alpha");
+        const rangeB = createRange("beta");
+
+        applyChatFindHighlights("owner-a", [rangeA], 0);
+        applyChatFindHighlights("owner-b", [rangeB], 0);
+
+        expect(store.get(CHAT_FIND_HIGHLIGHT)?.ranges).toEqual([
+            rangeA,
+            rangeB,
+        ]);
+
+        clearChatFindHighlights("owner-a");
+
+        expect(store.get(CHAT_FIND_HIGHLIGHT)?.ranges).toEqual([rangeB]);
+        expect(store.get(CHAT_FIND_ACTIVE_HIGHLIGHT)?.ranges).toEqual([
+            rangeB,
+        ]);
+    });
+
+    it("updates one active match without replacing another owner's active match", () => {
+        const rangeA1 = createRange("alpha one");
+        const rangeA2 = createRange("alpha two");
+        const rangeB = createRange("beta");
+
+        applyChatFindHighlights("owner-a", [rangeA1, rangeA2], 0);
+        applyChatFindHighlights("owner-b", [rangeB], 0);
+        setActiveChatFindHighlight("owner-a", rangeA2);
+
+        expect(store.get(CHAT_FIND_ACTIVE_HIGHLIGHT)?.ranges).toEqual([
+            rangeA2,
+            rangeB,
+        ]);
+    });
+});

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
@@ -117,6 +117,17 @@ describe("chatFindHighlights", () => {
         expect(ranges[0]?.toString()).toBe("lowo");
     });
 
+    it("keeps original DOM offsets when case folding changes string length", () => {
+        const root = document.createElement("div");
+        root.textContent = "İx";
+        document.body.append(root);
+
+        const ranges = buildRangesForQuery(root, "x", false);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0]?.toString()).toBe("x");
+    });
+
     it("does not match across separate chat rows", () => {
         const root = document.createElement("div");
         const rowA = document.createElement("div");

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.test.ts
@@ -3,6 +3,7 @@ import {
     CHAT_FIND_ACTIVE_HIGHLIGHT,
     CHAT_FIND_HIGHLIGHT,
     applyChatFindHighlights,
+    buildRangesForQuery,
     clearChatFindHighlights,
     setActiveChatFindHighlight,
 } from "./chatFindHighlights";
@@ -36,6 +37,10 @@ function installHighlightMock() {
             ...(globalThis.CSS ?? {}),
             highlights,
         },
+    });
+    Object.defineProperty(HTMLElement.prototype, "checkVisibility", {
+        configurable: true,
+        value: () => true,
     });
 
     return store;
@@ -93,5 +98,51 @@ describe("chatFindHighlights", () => {
             rangeA2,
             rangeB,
         ]);
+    });
+
+    it("matches across inline text nodes in the same visible block", () => {
+        const root = document.createElement("div");
+        const block = document.createElement("div");
+        const emphasis = document.createElement("strong");
+        const plain = document.createElement("span");
+        emphasis.textContent = "lo";
+        plain.textContent = "world";
+        block.append("hel", emphasis, plain);
+        root.append(block);
+        document.body.append(root);
+
+        const ranges = buildRangesForQuery(root, "lowo", false);
+
+        expect(ranges).toHaveLength(1);
+        expect(ranges[0]?.toString()).toBe("lowo");
+    });
+
+    it("does not match across separate chat rows", () => {
+        const root = document.createElement("div");
+        const rowA = document.createElement("div");
+        const rowB = document.createElement("div");
+        rowA.dataset.chatRow = "true";
+        rowB.dataset.chatRow = "true";
+        rowA.textContent = "hello";
+        rowB.textContent = "world";
+        root.append(rowA, rowB);
+        document.body.append(root);
+
+        expect(buildRangesForQuery(root, "lowo", false)).toHaveLength(0);
+    });
+
+    it("does not match across separate blocks in one chat row", () => {
+        const root = document.createElement("div");
+        const row = document.createElement("div");
+        const blockA = document.createElement("div");
+        const blockB = document.createElement("div");
+        row.dataset.chatRow = "true";
+        blockA.textContent = "hello";
+        blockB.textContent = "world";
+        row.append(blockA, blockB);
+        root.append(row);
+        document.body.append(root);
+
+        expect(buildRangesForQuery(root, "lowo", false)).toHaveLength(0);
     });
 });

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -194,14 +194,12 @@ const caseInsensitiveCollator =
           })
         : null;
 
-function matchesQueryAt(
+function matchesCaseInsensitiveQueryAt(
     haystack: string,
     needle: string,
     index: number,
-    caseSensitive: boolean,
 ): boolean {
     const candidate = haystack.slice(index, index + needle.length);
-    if (caseSensitive) return candidate === needle;
 
     // Keep offsets in the original string. Lowercasing the full haystack can
     // change its UTF-16 length for some characters (for example, İ -> i + dot).
@@ -221,7 +219,7 @@ function findNextMatch(
 
     const lastStart = haystack.length - needle.length;
     for (let index = from; index <= lastStart; index++) {
-        if (matchesQueryAt(haystack, needle, index, false)) {
+        if (matchesCaseInsensitiveQueryAt(haystack, needle, index)) {
             return index;
         }
     }

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -1,0 +1,164 @@
+// "Find in chat" highlighting via the CSS Custom Highlight API.
+//
+// We never mutate the rendered DOM/markdown. Instead we walk the visible text
+// nodes inside the scroll container, build a `Range` per occurrence, and register
+// them under named highlights styled by `::highlight(...)` in index.css.
+//
+// Matches may span several text nodes (markdown splits text across <em>, <code>,
+// <a>, ... elements), so we flatten all text into one string with a segment map
+// from a global UTF-16 offset back to its node + local offset.
+
+export const CHAT_FIND_HIGHLIGHT = "chat-find";
+export const CHAT_FIND_ACTIVE_HIGHLIGHT = "chat-find-active";
+
+// Safety cap so a pathological 1-char query on a huge chat can't lock the UI.
+export const MAX_CHAT_FIND_MATCHES = 2000;
+
+interface TextSegment {
+    node: Text;
+    start: number; // inclusive global offset
+    end: number; // exclusive global offset
+}
+
+function isVisibleTextNode(node: Text): boolean {
+    const el = node.parentElement;
+    if (!el) return false;
+    const tag = el.tagName;
+    if (tag === "SCRIPT" || tag === "STYLE" || tag === "NOSCRIPT") return false;
+    if (typeof el.checkVisibility === "function") {
+        return el.checkVisibility();
+    }
+    // Fallback: offsetParent is null for display:none subtrees.
+    return el.offsetParent !== null;
+}
+
+function collectSegments(root: HTMLElement): {
+    fullText: string;
+    segments: TextSegment[];
+} {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+        acceptNode(node) {
+            const text = node as Text;
+            if (!text.data || text.data.length === 0) {
+                return NodeFilter.FILTER_REJECT;
+            }
+            return isVisibleTextNode(text)
+                ? NodeFilter.FILTER_ACCEPT
+                : NodeFilter.FILTER_REJECT;
+        },
+    });
+
+    const segments: TextSegment[] = [];
+    const parts: string[] = [];
+    let cursor = 0;
+    let current = walker.nextNode() as Text | null;
+    while (current) {
+        const len = current.data.length;
+        segments.push({ node: current, start: cursor, end: cursor + len });
+        parts.push(current.data);
+        cursor += len;
+        current = walker.nextNode() as Text | null;
+    }
+    return { fullText: parts.join(""), segments };
+}
+
+// Segment containing `offset` as a START position: start <= offset < end.
+function locateStart(segments: TextSegment[], offset: number): TextSegment {
+    let lo = 0;
+    let hi = segments.length - 1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const seg = segments[mid];
+        if (offset < seg.start) hi = mid - 1;
+        else if (offset >= seg.end) lo = mid + 1;
+        else return seg;
+    }
+    return segments[segments.length - 1];
+}
+
+// Segment containing `offset` as an END position: start < offset <= end.
+function locateEnd(segments: TextSegment[], offset: number): TextSegment {
+    let lo = 0;
+    let hi = segments.length - 1;
+    while (lo <= hi) {
+        const mid = (lo + hi) >> 1;
+        const seg = segments[mid];
+        if (offset <= seg.start) hi = mid - 1;
+        else if (offset > seg.end) lo = mid + 1;
+        else return seg;
+    }
+    return segments[segments.length - 1];
+}
+
+/**
+ * Build one Range per occurrence of `query` inside `root`'s visible text.
+ * Case-insensitive unless `caseSensitive` is true. Returns ranges in document
+ * order, capped at MAX_CHAT_FIND_MATCHES.
+ */
+export function buildRangesForQuery(
+    root: HTMLElement,
+    query: string,
+    caseSensitive: boolean,
+): Range[] {
+    if (!query) return [];
+
+    const { fullText, segments } = collectSegments(root);
+    if (segments.length === 0) return [];
+
+    const haystack = caseSensitive ? fullText : fullText.toLowerCase();
+    const needle = caseSensitive ? query : query.toLowerCase();
+    const needleLen = needle.length;
+    if (needleLen === 0) return [];
+
+    const ranges: Range[] = [];
+    let from = 0;
+    while (ranges.length < MAX_CHAT_FIND_MATCHES) {
+        const idx = haystack.indexOf(needle, from);
+        if (idx === -1) break;
+        const endOffset = idx + needleLen;
+
+        const startSeg = locateStart(segments, idx);
+        const endSeg = locateEnd(segments, endOffset);
+
+        const range = document.createRange();
+        range.setStart(startSeg.node, idx - startSeg.start);
+        range.setEnd(endSeg.node, endOffset - endSeg.start);
+        ranges.push(range);
+
+        from = endOffset; // non-overlapping, matches browser find semantics
+    }
+    return ranges;
+}
+
+/** Register all ranges + the active one in the global highlight registry. */
+export function applyChatFindHighlights(
+    ranges: Range[],
+    activeIndex: number,
+): void {
+    if (ranges.length === 0) {
+        clearChatFindHighlights();
+        return;
+    }
+    CSS.highlights.set(CHAT_FIND_HIGHLIGHT, new Highlight(...ranges));
+    const active = ranges[activeIndex];
+    if (active) {
+        CSS.highlights.set(CHAT_FIND_ACTIVE_HIGHLIGHT, new Highlight(active));
+    } else {
+        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+    }
+}
+
+/** Re-register only the active highlight (cheap path used while navigating). */
+export function setActiveChatFindHighlight(range: Range | undefined): void {
+    if (range) {
+        CSS.highlights.set(CHAT_FIND_ACTIVE_HIGHLIGHT, new Highlight(range));
+    } else {
+        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+    }
+}
+
+/** Remove both highlights from the global (document-wide) registry. */
+export function clearChatFindHighlights(): void {
+    CSS.highlights.delete(CHAT_FIND_HIGHLIGHT);
+    CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+}

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -8,13 +8,46 @@
 //
 // Matches may span several text nodes (markdown splits text across <em>, <code>,
 // <a>, ... elements), so we flatten all text into one string with a segment map
-// from a global UTF-16 offset back to its node + local offset.
+// from a global UTF-16 offset back to its node + local offset. A sentinel
+// separator is inserted between visible blocks so matches cannot bridge separate
+// messages, paragraphs, list items, or code blocks.
 
 export const CHAT_FIND_HIGHLIGHT = "chat-find";
 export const CHAT_FIND_ACTIVE_HIGHLIGHT = "chat-find-active";
 
 // Safety cap so a pathological 1-char query on a huge chat can't lock the UI.
 export const MAX_CHAT_FIND_MATCHES = 2000;
+
+const SEARCH_BLOCK_SEPARATOR = "\0";
+const SEARCH_BLOCK_TAGS = new Set([
+    "ARTICLE",
+    "BLOCKQUOTE",
+    "DD",
+    "DIV",
+    "DL",
+    "DT",
+    "FIGCAPTION",
+    "FIGURE",
+    "H1",
+    "H2",
+    "H3",
+    "H4",
+    "H5",
+    "H6",
+    "LI",
+    "OL",
+    "P",
+    "PRE",
+    "SECTION",
+    "TABLE",
+    "TBODY",
+    "TD",
+    "TFOOT",
+    "TH",
+    "THEAD",
+    "TR",
+    "UL",
+]);
 
 type ChatFindHighlightOwnerId = string;
 
@@ -73,6 +106,20 @@ function isVisibleTextNode(node: Text): boolean {
     return el.offsetParent !== null;
 }
 
+function findSearchBlock(node: Text, root: HTMLElement): Element | HTMLElement {
+    let current = node.parentElement;
+    while (current && current !== root) {
+        if (
+            current.hasAttribute("data-chat-row") ||
+            SEARCH_BLOCK_TAGS.has(current.tagName)
+        ) {
+            return current;
+        }
+        current = current.parentElement;
+    }
+    return root;
+}
+
 function collectSegments(root: HTMLElement): {
     fullText: string;
     segments: TextSegment[];
@@ -92,12 +139,20 @@ function collectSegments(root: HTMLElement): {
     const segments: TextSegment[] = [];
     const parts: string[] = [];
     let cursor = 0;
+    let previousBlock: Element | HTMLElement | null = null;
     let current = walker.nextNode() as Text | null;
     while (current) {
+        const block = findSearchBlock(current, root);
+        if (previousBlock && previousBlock !== block) {
+            parts.push(SEARCH_BLOCK_SEPARATOR);
+            cursor += SEARCH_BLOCK_SEPARATOR.length;
+        }
+
         const len = current.data.length;
         segments.push({ node: current, start: cursor, end: cursor + len });
         parts.push(current.data);
         cursor += len;
+        previousBlock = block;
         current = walker.nextNode() as Text | null;
     }
     return { fullText: parts.join(""), segments };
@@ -142,6 +197,7 @@ export function buildRangesForQuery(
     caseSensitive: boolean,
 ): Range[] {
     if (!query) return [];
+    if (query.includes(SEARCH_BLOCK_SEPARATOR)) return [];
 
     const { fullText, segments } = collectSegments(root);
     if (segments.length === 0) return [];

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -67,7 +67,18 @@ const highlightEntries = new Map<
     ChatFindHighlightEntry
 >();
 
+function getHighlightRegistry(): HighlightRegistry | null {
+    return typeof CSS !== "undefined" &&
+        "highlights" in CSS &&
+        typeof Highlight !== "undefined"
+        ? CSS.highlights
+        : null;
+}
+
 function syncChatFindHighlights(): void {
+    const highlightRegistry = getHighlightRegistry();
+    if (!highlightRegistry) return;
+
     const ranges: Range[] = [];
     const activeRanges: Range[] = [];
 
@@ -79,18 +90,18 @@ function syncChatFindHighlights(): void {
     }
 
     if (ranges.length > 0) {
-        CSS.highlights.set(CHAT_FIND_HIGHLIGHT, new Highlight(...ranges));
+        highlightRegistry.set(CHAT_FIND_HIGHLIGHT, new Highlight(...ranges));
     } else {
-        CSS.highlights.delete(CHAT_FIND_HIGHLIGHT);
+        highlightRegistry.delete(CHAT_FIND_HIGHLIGHT);
     }
 
     if (activeRanges.length > 0) {
-        CSS.highlights.set(
+        highlightRegistry.set(
             CHAT_FIND_ACTIVE_HIGHLIGHT,
             new Highlight(...activeRanges),
         );
     } else {
-        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+        highlightRegistry.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
     }
 }
 

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -186,6 +186,48 @@ function locateEnd(segments: TextSegment[], offset: number): TextSegment {
     return segments[segments.length - 1];
 }
 
+const caseInsensitiveCollator =
+    typeof Intl !== "undefined"
+        ? new Intl.Collator(undefined, {
+              usage: "search",
+              sensitivity: "accent",
+          })
+        : null;
+
+function matchesQueryAt(
+    haystack: string,
+    needle: string,
+    index: number,
+    caseSensitive: boolean,
+): boolean {
+    const candidate = haystack.slice(index, index + needle.length);
+    if (caseSensitive) return candidate === needle;
+
+    // Keep offsets in the original string. Lowercasing the full haystack can
+    // change its UTF-16 length for some characters (for example, İ -> i + dot).
+    if (caseInsensitiveCollator) {
+        return caseInsensitiveCollator.compare(candidate, needle) === 0;
+    }
+    return candidate.toLowerCase() === needle.toLowerCase();
+}
+
+function findNextMatch(
+    haystack: string,
+    needle: string,
+    from: number,
+    caseSensitive: boolean,
+): number {
+    if (caseSensitive) return haystack.indexOf(needle, from);
+
+    const lastStart = haystack.length - needle.length;
+    for (let index = from; index <= lastStart; index++) {
+        if (matchesQueryAt(haystack, needle, index, false)) {
+            return index;
+        }
+    }
+    return -1;
+}
+
 /**
  * Build one Range per occurrence of `query` inside `root`'s visible text.
  * Case-insensitive unless `caseSensitive` is true. Returns ranges in document
@@ -202,15 +244,15 @@ export function buildRangesForQuery(
     const { fullText, segments } = collectSegments(root);
     if (segments.length === 0) return [];
 
-    const haystack = caseSensitive ? fullText : fullText.toLowerCase();
-    const needle = caseSensitive ? query : query.toLowerCase();
+    const haystack = fullText;
+    const needle = query;
     const needleLen = needle.length;
     if (needleLen === 0) return [];
 
     const ranges: Range[] = [];
     let from = 0;
     while (ranges.length < MAX_CHAT_FIND_MATCHES) {
-        const idx = haystack.indexOf(needle, from);
+        const idx = findNextMatch(haystack, needle, from, caseSensitive);
         if (idx === -1) break;
         const endOffset = idx + needleLen;
 

--- a/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
+++ b/apps/desktop/src/features/ai/components/find/chatFindHighlights.ts
@@ -3,6 +3,8 @@
 // We never mutate the rendered DOM/markdown. Instead we walk the visible text
 // nodes inside the scroll container, build a `Range` per occurrence, and register
 // them under named highlights styled by `::highlight(...)` in index.css.
+// CSS.highlights is document-global, so each finder instance owns a slice of the
+// aggregate highlights through a stable owner id.
 //
 // Matches may span several text nodes (markdown splits text across <em>, <code>,
 // <a>, ... elements), so we flatten all text into one string with a segment map
@@ -14,10 +16,49 @@ export const CHAT_FIND_ACTIVE_HIGHLIGHT = "chat-find-active";
 // Safety cap so a pathological 1-char query on a huge chat can't lock the UI.
 export const MAX_CHAT_FIND_MATCHES = 2000;
 
+type ChatFindHighlightOwnerId = string;
+
 interface TextSegment {
     node: Text;
     start: number; // inclusive global offset
     end: number; // exclusive global offset
+}
+
+interface ChatFindHighlightEntry {
+    ranges: Range[];
+    activeRange?: Range;
+}
+
+const highlightEntries = new Map<
+    ChatFindHighlightOwnerId,
+    ChatFindHighlightEntry
+>();
+
+function syncChatFindHighlights(): void {
+    const ranges: Range[] = [];
+    const activeRanges: Range[] = [];
+
+    for (const entry of highlightEntries.values()) {
+        ranges.push(...entry.ranges);
+        if (entry.activeRange) {
+            activeRanges.push(entry.activeRange);
+        }
+    }
+
+    if (ranges.length > 0) {
+        CSS.highlights.set(CHAT_FIND_HIGHLIGHT, new Highlight(...ranges));
+    } else {
+        CSS.highlights.delete(CHAT_FIND_HIGHLIGHT);
+    }
+
+    if (activeRanges.length > 0) {
+        CSS.highlights.set(
+            CHAT_FIND_ACTIVE_HIGHLIGHT,
+            new Highlight(...activeRanges),
+        );
+    } else {
+        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+    }
 }
 
 function isVisibleTextNode(node: Text): boolean {
@@ -130,35 +171,41 @@ export function buildRangesForQuery(
     return ranges;
 }
 
-/** Register all ranges + the active one in the global highlight registry. */
+/** Register one finder's ranges + active match in the global highlight registry. */
 export function applyChatFindHighlights(
+    ownerId: ChatFindHighlightOwnerId,
     ranges: Range[],
     activeIndex: number,
 ): void {
     if (ranges.length === 0) {
-        clearChatFindHighlights();
+        clearChatFindHighlights(ownerId);
         return;
     }
-    CSS.highlights.set(CHAT_FIND_HIGHLIGHT, new Highlight(...ranges));
-    const active = ranges[activeIndex];
-    if (active) {
-        CSS.highlights.set(CHAT_FIND_ACTIVE_HIGHLIGHT, new Highlight(active));
-    } else {
-        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
-    }
+    highlightEntries.set(ownerId, {
+        ranges,
+        activeRange: ranges[activeIndex],
+    });
+    syncChatFindHighlights();
 }
 
 /** Re-register only the active highlight (cheap path used while navigating). */
-export function setActiveChatFindHighlight(range: Range | undefined): void {
-    if (range) {
-        CSS.highlights.set(CHAT_FIND_ACTIVE_HIGHLIGHT, new Highlight(range));
-    } else {
-        CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
-    }
+export function setActiveChatFindHighlight(
+    ownerId: ChatFindHighlightOwnerId,
+    range: Range | undefined,
+): void {
+    const entry = highlightEntries.get(ownerId);
+    if (!entry) return;
+    highlightEntries.set(ownerId, {
+        ...entry,
+        activeRange: range,
+    });
+    syncChatFindHighlights();
 }
 
-/** Remove both highlights from the global (document-wide) registry. */
-export function clearChatFindHighlights(): void {
-    CSS.highlights.delete(CHAT_FIND_HIGHLIGHT);
-    CSS.highlights.delete(CHAT_FIND_ACTIVE_HIGHLIGHT);
+/** Remove one finder's ranges from the document-wide highlight registry. */
+export function clearChatFindHighlights(
+    ownerId: ChatFindHighlightOwnerId,
+): void {
+    highlightEntries.delete(ownerId);
+    syncChatFindHighlights();
 }

--- a/apps/desktop/src/features/ai/components/find/useChatFind.ts
+++ b/apps/desktop/src/features/ai/components/find/useChatFind.ts
@@ -8,6 +8,7 @@ import {
 } from "./chatFindHighlights";
 
 interface UseChatFindArgs {
+    ownerId: string;
     containerRef: RefObject<HTMLElement | null>;
     query: string;
     caseSensitive: boolean;
@@ -31,6 +32,7 @@ const REBUILD_DEBOUNCE_MS = 150;
  * chatFindHighlights; this hook owns lifecycle, debouncing and the active cursor.
  */
 export function useChatFind({
+    ownerId,
     containerRef,
     query,
     caseSensitive,
@@ -78,7 +80,7 @@ export function useChatFind({
             const container = containerRef.current;
             if (!enabled || !container || !query) {
                 rangesRef.current = [];
-                clearChatFindHighlights();
+                clearChatFindHighlights(ownerId);
                 setTotal(0);
                 setActive(-1);
                 return;
@@ -98,9 +100,9 @@ export function useChatFind({
                 next = 0;
             }
             setActive(next);
-            applyChatFindHighlights(ranges, next);
+            applyChatFindHighlights(ownerId, ranges, next);
         },
-        [containerRef, enabled, query, caseSensitive, setActive],
+        [containerRef, enabled, ownerId, query, caseSensitive, setActive],
     );
 
     // Fresh search: react to query / case / enabled changes. Clears immediately
@@ -143,8 +145,8 @@ export function useChatFind({
         };
     }, [enabled, query, caseSensitive, containerRef, rebuild]);
 
-    // Safety net: always drop the document-wide highlights on unmount.
-    useEffect(() => () => clearChatFindHighlights(), []);
+    // Safety net: always drop this finder instance's document-wide highlights.
+    useEffect(() => () => clearChatFindHighlights(ownerId), [ownerId]);
 
     const move = useCallback(
         (step: number) => {
@@ -153,10 +155,10 @@ export function useChatFind({
             const next =
                 (activeIndexRef.current + step + ranges.length) % ranges.length;
             setActive(next);
-            setActiveChatFindHighlight(ranges[next]);
+            setActiveChatFindHighlight(ownerId, ranges[next]);
             scrollToActive();
         },
-        [scrollToActive, setActive],
+        [ownerId, scrollToActive, setActive],
     );
 
     const goNext = useCallback(() => move(1), [move]);

--- a/apps/desktop/src/features/ai/components/find/useChatFind.ts
+++ b/apps/desktop/src/features/ai/components/find/useChatFind.ts
@@ -1,0 +1,166 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { RefObject } from "react";
+import {
+    applyChatFindHighlights,
+    buildRangesForQuery,
+    clearChatFindHighlights,
+    setActiveChatFindHighlight,
+} from "./chatFindHighlights";
+
+interface UseChatFindArgs {
+    containerRef: RefObject<HTMLElement | null>;
+    query: string;
+    caseSensitive: boolean;
+    enabled: boolean;
+}
+
+interface UseChatFindResult {
+    total: number;
+    /** 0-based index of the active match; -1 when there are no matches. */
+    activeIndex: number;
+    goNext: () => void;
+    goPrev: () => void;
+}
+
+const REBUILD_DEBOUNCE_MS = 150;
+
+/**
+ * Drives "find in chat": builds Ranges for `query` inside the scroll container,
+ * registers them as CSS highlights, keeps them in sync while the agent streams,
+ * and centers the active match on navigation. All DOM-level work is delegated to
+ * chatFindHighlights; this hook owns lifecycle, debouncing and the active cursor.
+ */
+export function useChatFind({
+    containerRef,
+    query,
+    caseSensitive,
+    enabled,
+}: UseChatFindArgs): UseChatFindResult {
+    const rangesRef = useRef<Range[]>([]);
+    const activeIndexRef = useRef(-1);
+    const [total, setTotal] = useState(0);
+    const [activeIndex, setActiveIndexState] = useState(-1);
+
+    const setActive = useCallback((next: number) => {
+        activeIndexRef.current = next;
+        setActiveIndexState(next);
+    }, []);
+
+    const scrollToActive = useCallback(() => {
+        const container = containerRef.current;
+        const ranges = rangesRef.current;
+        const idx = activeIndexRef.current;
+        if (!container || idx < 0 || idx >= ranges.length) return;
+        const range = ranges[idx];
+        const rect = range.getBoundingClientRect();
+        if (rect.height === 0 && rect.width === 0) {
+            range.startContainer.parentElement?.scrollIntoView({
+                block: "center",
+                behavior: "smooth",
+            });
+            return;
+        }
+        const containerRect = container.getBoundingClientRect();
+        const delta =
+            rect.top -
+            containerRect.top -
+            (container.clientHeight / 2 - rect.height / 2);
+        container.scrollTo({
+            top: container.scrollTop + delta,
+            behavior: "smooth",
+        });
+    }, [containerRef]);
+
+    // Core: rebuild ranges + highlights. `preserveActive` keeps the current
+    // cursor (used while streaming); otherwise it resets to the first match.
+    const rebuild = useCallback(
+        (preserveActive: boolean) => {
+            const container = containerRef.current;
+            if (!enabled || !container || !query) {
+                rangesRef.current = [];
+                clearChatFindHighlights();
+                setTotal(0);
+                setActive(-1);
+                return;
+            }
+            const ranges = buildRangesForQuery(container, query, caseSensitive);
+            rangesRef.current = ranges;
+            setTotal(ranges.length);
+            let next: number;
+            if (ranges.length === 0) {
+                next = -1;
+            } else if (preserveActive) {
+                next = Math.min(
+                    Math.max(activeIndexRef.current, 0),
+                    ranges.length - 1,
+                );
+            } else {
+                next = 0;
+            }
+            setActive(next);
+            applyChatFindHighlights(ranges, next);
+        },
+        [containerRef, enabled, query, caseSensitive, setActive],
+    );
+
+    // Fresh search: react to query / case / enabled changes. Clears immediately
+    // when empty or disabled; debounces while the user is typing.
+    useEffect(() => {
+        if (!enabled || !query) {
+            rebuild(false);
+            return;
+        }
+        const timer = window.setTimeout(() => {
+            rebuild(false);
+            scrollToActive();
+        }, REBUILD_DEBOUNCE_MS);
+        return () => window.clearTimeout(timer);
+    }, [enabled, query, caseSensitive, rebuild, scrollToActive]);
+
+    // Streaming invalidation: the agent rewrites/append DOM nodes, which voids the
+    // old Ranges. Recompute (preserving the cursor, without stealing scroll).
+    useEffect(() => {
+        if (!enabled || !query) return;
+        const container = containerRef.current;
+        if (!container) return;
+        let timer = 0;
+        const schedule = () => {
+            if (timer) return;
+            timer = window.setTimeout(() => {
+                timer = 0;
+                rebuild(true);
+            }, REBUILD_DEBOUNCE_MS);
+        };
+        const observer = new MutationObserver(schedule);
+        observer.observe(container, {
+            childList: true,
+            subtree: true,
+            characterData: true,
+        });
+        return () => {
+            observer.disconnect();
+            if (timer) window.clearTimeout(timer);
+        };
+    }, [enabled, query, caseSensitive, containerRef, rebuild]);
+
+    // Safety net: always drop the document-wide highlights on unmount.
+    useEffect(() => () => clearChatFindHighlights(), []);
+
+    const move = useCallback(
+        (step: number) => {
+            const ranges = rangesRef.current;
+            if (ranges.length === 0) return;
+            const next =
+                (activeIndexRef.current + step + ranges.length) % ranges.length;
+            setActive(next);
+            setActiveChatFindHighlight(ranges[next]);
+            scrollToActive();
+        },
+        [scrollToActive, setActive],
+    );
+
+    const goNext = useCallback(() => move(1), [move]);
+    const goPrev = useCallback(() => move(-1), [move]);
+
+    return { total, activeIndex, goNext, goPrev };
+}

--- a/apps/desktop/src/features/ai/components/find/useChatFindShortcut.test.tsx
+++ b/apps/desktop/src/features/ai/components/find/useChatFindShortcut.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { getDesktopPlatform } from "../../../../app/utils/platform";
+import { renderComponent } from "../../../../test/test-utils";
+import { useChatFindShortcut } from "./useChatFindShortcut";
+
+function shortcutModifier() {
+    return getDesktopPlatform() === "macos"
+        ? { metaKey: true }
+        : { ctrlKey: true };
+}
+
+function Harness({
+    showRoot,
+    onOpen,
+}: {
+    showRoot: boolean;
+    onOpen: () => void;
+}) {
+    const rootRef = useRef<HTMLDivElement>(null);
+    useChatFindShortcut({ rootRef, onOpen });
+
+    if (!showRoot) {
+        return <div>No chat selected</div>;
+    }
+
+    return (
+        <div ref={rootRef}>
+            <button type="button">Inside chat</button>
+        </div>
+    );
+}
+
+describe("useChatFindShortcut", () => {
+    it("attaches after the root ref appears on a later render", () => {
+        const onOpen = vi.fn();
+        const view = renderComponent(
+            <Harness showRoot={false} onOpen={onOpen} />,
+        );
+
+        view.rerender(<Harness showRoot onOpen={onOpen} />);
+        const insideChat = screen.getByRole("button", {
+            name: "Inside chat",
+        });
+
+        fireEvent.keyDown(insideChat, {
+            key: "f",
+            ...shortcutModifier(),
+        });
+
+        expect(onOpen).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/desktop/src/features/ai/components/find/useChatFindShortcut.ts
+++ b/apps/desktop/src/features/ai/components/find/useChatFindShortcut.ts
@@ -21,6 +21,8 @@ export function useChatFindShortcut({
     onOpen,
 }: UseChatFindShortcutArgs): void {
     useEffect(() => {
+        // rootRef.current can become non-null after an early empty render without
+        // any dependency changing, so retry the scoped listener after each render.
         const root = rootRef.current;
         if (!root) return;
         const platform = getDesktopPlatform();
@@ -38,5 +40,5 @@ export function useChatFindShortcut({
         };
         root.addEventListener("keydown", onKeyDown);
         return () => root.removeEventListener("keydown", onKeyDown);
-    }, [disabled, onOpen, rootRef]);
+    });
 }

--- a/apps/desktop/src/features/ai/components/find/useChatFindShortcut.ts
+++ b/apps/desktop/src/features/ai/components/find/useChatFindShortcut.ts
@@ -1,0 +1,42 @@
+import { useEffect } from "react";
+import type { RefObject } from "react";
+import { matchesShortcutAction } from "../../../../app/shortcuts/registry";
+import { getDesktopPlatform } from "../../../../app/utils/platform";
+
+interface UseChatFindShortcutArgs {
+    rootRef: RefObject<HTMLElement | null>;
+    disabled?: boolean;
+    onOpen: () => void;
+}
+
+const CHAT_FIND_INPUT_SELECTOR = '[role="search"] input';
+
+/**
+ * Opens the chat finder from Cmd/Ctrl+F while focus is inside a chat surface.
+ * The listener is scoped to `rootRef`, so editor find bindings remain isolated.
+ */
+export function useChatFindShortcut({
+    rootRef,
+    disabled = false,
+    onOpen,
+}: UseChatFindShortcutArgs): void {
+    useEffect(() => {
+        const root = rootRef.current;
+        if (!root) return;
+        const platform = getDesktopPlatform();
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (!matchesShortcutAction(event, "find_in_note", platform)) return;
+            if (disabled) return;
+            event.preventDefault();
+            event.stopPropagation();
+            onOpen();
+            requestAnimationFrame(() => {
+                root.querySelector<HTMLInputElement>(
+                    CHAT_FIND_INPUT_SELECTOR,
+                )?.focus();
+            });
+        };
+        root.addEventListener("keydown", onKeyDown);
+        return () => root.removeEventListener("keydown", onKeyDown);
+    }, [disabled, onOpen, rootRef]);
+}

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1239,6 +1239,18 @@ body.dragging-tab * {
     outline-offset: 1px;
 }
 
+/* "Find in chat" matches, painted via the CSS Custom Highlight API. The active
+   match is distinguished by a stronger background. ::highlight() only supports a
+   small subset of properties (background-color, color, text-decoration). */
+::highlight(chat-find) {
+    background-color: color-mix(in srgb, var(--accent) 28%, transparent);
+    color: inherit;
+}
+::highlight(chat-find-active) {
+    background-color: color-mix(in srgb, var(--accent) 60%, transparent);
+    color: var(--text-primary);
+}
+
 /* Composer send/stop pill buttons. The press should feel like a physical
    button depressing: shrink slightly, dim, and gain an inset shadow that
    replaces the lifted drop shadow. */


### PR DESCRIPTION
## Summary

Adds a local find-in-chat flow for active chat sessions and history transcripts.

- Adds a compact find bar with match count, previous/next navigation, case-sensitive toggle, and keyboard handling.
- Uses the CSS Custom Highlight API to highlight matches without mutating rendered markdown or message DOM.
- Unifies history transcript search with the same finder used by active chat.
- Keeps highlight ownership scoped per chat pane so multiple finders do not clear each other.
- Handles Unicode case-insensitive search without losing original DOM offsets.

## Why

The previous history search worked at message granularity and did not provide inline text highlighting or a matching workflow for active chat sessions. This adds a consistent power-user flow across chat surfaces while preserving rendered message structure.

## Validation

- `git diff --check origin/main...HEAD`
- `npm test -- --run src/features/ai/components/find/chatFindHighlights.test.ts src/features/ai/components/AIChatSessionView.test.tsx`
- `npx eslint src/features/ai/components/AIChatMessageList.tsx src/features/ai/components/AIChatSessionView.tsx src/features/ai/components/HistoryTranscriptViewer.tsx src/features/ai/components/find/ChatFindBar.tsx src/features/ai/components/find/chatFindHighlights.ts src/features/ai/components/find/useChatFind.ts src/features/ai/components/find/chatFindHighlights.test.ts src/features/ai/components/AIChatSessionView.test.tsx`
- `npm run build`

Note: `npm run build` still emits Lightning CSS warnings for `::highlight(...)`, but the build succeeds and preserves the rules.