### PR TITLE
Pin Rust 1.96 toolchain

### DIFF
--- a/.github/actions/setup-rust/action.yml
+++ b/.github/actions/setup-rust/action.yml
@@ -1,0 +1,27 @@
+name: Setup Rust toolchain
+description: >
+  Install the Rust toolchain whose version is pinned by rust-toolchain.toml,
+  so the channel lives in exactly one place.
+inputs:
+  targets:
+    description: Comma-separated target triples to install in addition to the host target.
+    required: false
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Resolve channel from rust-toolchain.toml
+      id: toolchain
+      shell: bash
+      run: |
+        channel="$(sed -nE 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' rust-toolchain.toml | head -n1)"
+        if [[ -z "$channel" ]]; then
+          echo "::error::Could not resolve 'channel' from rust-toolchain.toml" >&2
+          exit 1
+        fi
+        echo "channel=$channel" >> "$GITHUB_OUTPUT"
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
+      with:
+        toolchain: ${{ steps.toolchain.outputs.channel }}
+        targets: ${{ inputs.targets }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             wget
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: ./.github/actions/setup-rust
 
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: apps/desktop/package-lock.json
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.96.0
+        uses: ./.github/actions/setup-rust
 
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
             wget
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2
@@ -57,7 +57,7 @@ jobs:
           cache-dependency-path: apps/desktop/package-lock.json
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@1.96.0
 
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -14,6 +14,7 @@ on:
             - apps/desktop/native-backend/**
             - vendor/codex-acp/**
             - vendor/Claude-agent-acp-upstream/**
+            - rust-toolchain.toml
             - .github/workflows/electron-package-smoke.yml
             - .github/workflows/release-desktop.yml
     workflow_dispatch:
@@ -43,7 +44,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@1.96.0
               with:
                   targets: aarch64-apple-darwin,x86_64-apple-darwin
 
@@ -153,7 +154,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@1.96.0
               with:
                   targets: x86_64-pc-windows-msvc
 
@@ -229,7 +230,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@1.96.0
               with:
                   targets: ${{ matrix.target }}
 

--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -44,7 +44,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@1.96.0
+              uses: ./.github/actions/setup-rust
               with:
                   targets: aarch64-apple-darwin,x86_64-apple-darwin
 
@@ -154,7 +154,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@1.96.0
+              uses: ./.github/actions/setup-rust
               with:
                   targets: x86_64-pc-windows-msvc
 
@@ -230,7 +230,7 @@ jobs:
                   cache-dependency-path: apps/desktop/package-lock.json
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@1.96.0
+              uses: ./.github/actions/setup-rust
               with:
                   targets: ${{ matrix.target }}
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,7 +135,7 @@ jobs:
                   node-version: 22
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@stable
+              uses: dtolnay/rust-toolchain@1.96.0
               with:
                   targets: ${{ matrix.rust_targets }}
 

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -135,7 +135,7 @@ jobs:
                   node-version: 22
 
             - name: Setup Rust toolchain
-              uses: dtolnay/rust-toolchain@1.96.0
+              uses: ./.github/actions/setup-rust
               with:
                   targets: ${{ matrix.rust_targets }}
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thanks for your interest in contributing to NeverWrite. This guide covers everyt
 | **Node.js** | 22+ | Required for desktop app and CI |
 | **npm** | 11+ | Package manager for `apps/desktop` |
 | **pnpm** | 10.33+ | Package manager for `apps/web-clipper` |
-| **Rust** | 1.94+ | Edition 2021 across all crates |
+| **Rust** | 1.96.0 | Pinned by `rust-toolchain.toml`; Edition 2021 across all crates |
 
 ### Platform-specific
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1032,7 +1032,7 @@ impl NativeAi {
     pub(crate) fn new(event_tx: Sender<RpcOutput>) -> Self {
         #[cfg(test)]
         {
-            return Self::with_setup_store(event_tx, RuntimeSetupStore::in_memory_for_tests());
+            Self::with_setup_store(event_tx, RuntimeSetupStore::in_memory_for_tests())
         }
         #[cfg(not(test))]
         Self::with_setup_store(event_tx, RuntimeSetupStore::default())
@@ -2826,9 +2826,7 @@ impl NativeAcpClient {
 
         let session = self.session_state.lock().ok().and_then(|mut state| {
             let managed = state.sessions.get_mut(session_id)?;
-            if managed.session.parent_session_id.is_none() {
-                return None;
-            }
+            managed.session.parent_session_id.as_ref()?;
             managed.active_turn_id = None;
             managed.session.status = AiSessionStatus::Idle;
             managed.session.closed_at = Some(epoch_millis_string());
@@ -5749,9 +5747,8 @@ fn cancel_user_input_waiters_matching(
         .map(|mut waiters| {
             let request_ids = waiters
                 .iter()
-                .filter_map(|(request_id, waiter)| {
-                    matches_waiter(waiter).then(|| request_id.clone())
-                })
+                .filter(|(_, waiter)| matches_waiter(waiter))
+                .map(|(request_id, _)| request_id.clone())
                 .collect::<Vec<_>>();
             request_ids
                 .into_iter()
@@ -5775,9 +5772,8 @@ fn cancel_url_elicitation_waiters_matching(
         .map(|mut waiters| {
             let request_ids = waiters
                 .iter()
-                .filter_map(|(request_id, waiter)| {
-                    matches_waiter(waiter).then(|| request_id.clone())
-                })
+                .filter(|(_, waiter)| matches_waiter(waiter))
+                .map(|(request_id, _)| request_id.clone())
                 .collect::<Vec<_>>();
             request_ids
                 .into_iter()
@@ -6652,16 +6648,13 @@ fn inherited_auth_method_applies_to_setup(
         return false;
     }
 
-    match setup.auth_method.as_deref() {
+    !matches!(
+        setup.auth_method.as_deref(),
         Some(selected_method)
             if is_local_auth_method(selected_method)
                 && selected_method != inherited_method
-                && !auth_method_has_local_config(setup, selected_method) =>
-        {
-            false
-        }
-        _ => true,
-    }
+                && !auth_method_has_local_config(setup, selected_method)
+    )
 }
 
 fn runtime_setup_load_error(error: String) -> String {
@@ -7353,33 +7346,33 @@ fn persisted_cli_auth_method_for_home_with_invalidated_at(
 }
 
 fn kilo_auth_file_candidates(home: &Path) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    candidates.push(
-        home.join(".local")
-            .join("share")
-            .join("kilo")
-            .join("auth.json"),
-    );
+    let user_data_auth_file = home
+        .join(".local")
+        .join("share")
+        .join("kilo")
+        .join("auth.json");
 
     #[cfg(target_os = "windows")]
     {
-        candidates.push(
+        vec![
+            user_data_auth_file,
             std::env::var_os("APPDATA")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| home.join("AppData").join("Roaming"))
                 .join("kilo")
                 .join("auth.json"),
-        );
-        candidates.push(
             std::env::var_os("LOCALAPPDATA")
                 .map(PathBuf::from)
                 .unwrap_or_else(|| home.join("AppData").join("Local"))
                 .join("kilo")
                 .join("auth.json"),
-        );
+        ]
     }
 
-    candidates
+    #[cfg(not(target_os = "windows"))]
+    {
+        vec![user_data_auth_file]
+    }
 }
 
 fn opencode_env_auth_keys() -> &'static [&'static str] {
@@ -7528,10 +7521,10 @@ fn auth_method_has_local_config(setup: &RuntimeSetupState, method_id: &str) -> b
             .is_some_and(|value| !value.is_empty()),
         "gateway" => {
             setup.has_gateway_config
-                && !setup
+                && setup
                     .env
                     .get("ANTHROPIC_BEDROCK_BASE_URL")
-                    .is_some_and(|value| !value.is_empty())
+                    .is_none_or(|value| value.is_empty())
         }
         "gateway-bedrock" => setup
             .env

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -7999,10 +7999,8 @@ fn update_auth_state(
         .anthropic_custom_headers
         .clone()
         .or_else(|| input.gateway_headers.clone());
-    let gateway_config_touched = runtime_id == CLAUDE_RUNTIME_ID
-        && (gateway_url_touched
-            || gateway_headers_patch.is_some()
-            || (input.anthropic_auth_token.is_some() && gateway_url_touched));
+    let gateway_config_touched =
+        runtime_id == CLAUDE_RUNTIME_ID && (gateway_url_touched || gateway_headers_patch.is_some());
     let gateway_base_url = input
         .gateway_base_url
         .as_ref()

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -453,7 +453,7 @@ fn history_from_metadata(
 }
 
 fn load_legacy_history_file(path: &Path) -> Result<PersistedSessionHistory, String> {
-    let history = read_json_file::<PersistedSessionHistory>(&path)?;
+    let history = read_json_file::<PersistedSessionHistory>(path)?;
     Ok(PersistedSessionHistory {
         version: history.version,
         session_id: history.session_id,
@@ -1413,7 +1413,7 @@ pub fn load_all_session_histories(
         .into_values()
         .map(|(_, history)| history)
         .collect::<Vec<_>>();
-    histories.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    histories.sort_by_key(|history| std::cmp::Reverse(history.updated_at));
     Ok(histories)
 }
 
@@ -1482,7 +1482,7 @@ pub fn search_session_content(
         }
     }
 
-    results.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    results.sort_by_key(|result| std::cmp::Reverse(result.updated_at));
     Ok(results)
 }
 

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -632,7 +632,9 @@ fn build_claude_structured_patch_hunks_by_content_index(
 
         used_candidate_indexes.insert(candidate_index);
         let candidate = &candidates[candidate_index];
-        if let Some(hunks) = claude_structured_patch_to_ai_diff_hunks(&[candidate.hunk.clone()]) {
+        if let Some(hunks) =
+            claude_structured_patch_to_ai_diff_hunks(std::slice::from_ref(&candidate.hunk))
+        {
             anchored_hunks_by_content_index.insert(content_index, hunks);
         }
     }

--- a/crates/diff/src/lib.rs
+++ b/crates/diff/src/lib.rs
@@ -411,7 +411,7 @@ fn merge_word_diff_ranges(ranges: &[WordDiffRange]) -> Vec<WordDiffRange> {
     }
 
     let mut sorted = ranges.to_vec();
-    sorted.sort_by(|left, right| left.from.cmp(&right.from));
+    sorted.sort_by_key(|range| range.from);
 
     let mut merged = vec![sorted[0].clone()];
     for range in sorted.into_iter().skip(1) {

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -151,34 +151,26 @@ impl VaultIndex {
         created_at: u64,
         size: u64,
     ) {
-        self.register_pdf_metadata(
-            doc.id.clone(),
-            doc.path.clone(),
-            doc.title.clone(),
-            doc.page_count,
+        self.register_pdf_metadata(PdfMetadata {
+            id: doc.id.clone(),
+            path: doc.path.clone(),
+            title: doc.title.clone(),
+            page_count: doc.page_count,
             modified_at,
             created_at,
             size,
-        );
+        });
     }
 
-    pub fn register_pdf_metadata(
-        &mut self,
-        id: NoteId,
-        path: neverwrite_types::NotePath,
-        title: String,
-        page_count: usize,
-        modified_at: u64,
-        created_at: u64,
-        size: u64,
-    ) {
-        let metadata_id = id.clone();
+    pub fn register_pdf_metadata(&mut self, metadata: PdfMetadata) {
+        let id = metadata.id.clone();
         self.pdf_search_index.insert(
             id.clone(),
             SearchEntry {
-                title_lower: title.to_lowercase(),
+                title_lower: metadata.title.to_lowercase(),
                 path_lower: id.0.to_lowercase(),
-                file_name_lower: path
+                file_name_lower: metadata
+                    .path
                     .0
                     .file_name()
                     .and_then(|value| value.to_str())
@@ -186,18 +178,7 @@ impl VaultIndex {
                     .unwrap_or_else(|| id.0.rsplit('/').next().unwrap_or(&id.0).to_lowercase()),
             },
         );
-        self.pdf_metadata.insert(
-            id,
-            PdfMetadata {
-                id: metadata_id,
-                path,
-                title,
-                page_count,
-                modified_at,
-                created_at,
-                size,
-            },
-        );
+        self.pdf_metadata.insert(id, metadata);
     }
 
     pub fn remove_pdf(&mut self, pdf_id: &NoteId) {
@@ -210,18 +191,9 @@ impl VaultIndex {
         self.register_pdf(doc, modified_at, created_at, size);
     }
 
-    pub fn reindex_pdf_metadata(
-        &mut self,
-        id: NoteId,
-        path: neverwrite_types::NotePath,
-        title: String,
-        page_count: usize,
-        modified_at: u64,
-        created_at: u64,
-        size: u64,
-    ) {
-        self.remove_pdf(&id);
-        self.register_pdf_metadata(id, path, title, page_count, modified_at, created_at, size);
+    pub fn reindex_pdf_metadata(&mut self, metadata: PdfMetadata) {
+        self.remove_pdf(&metadata.id);
+        self.register_pdf_metadata(metadata);
     }
 
     pub fn get_note_metadata(&self, note_id: &NoteId) -> Option<&NoteMetadata> {
@@ -993,6 +965,8 @@ struct ResolveCacheKey {
     from_parent_dir: String,
 }
 
+type ResolveCache = Arc<Mutex<HashMap<ResolveCacheKey, Option<NoteId>>>>;
+
 struct ResolvedChunk {
     forward_links: Vec<(NoteId, Vec<NoteId>)>,
     backlinks: Vec<(NoteId, NoteId)>,
@@ -1024,7 +998,7 @@ impl ResolverContext {
         &self,
         link: &PreparedLink,
         from_parent_dir: &str,
-        cache: Option<&Arc<Mutex<HashMap<ResolveCacheKey, Option<NoteId>>>>>,
+        cache: Option<&ResolveCache>,
     ) -> Option<NoteId> {
         if let Some(cache) = cache {
             let key = ResolveCacheKey {
@@ -1260,12 +1234,10 @@ fn suggestion_prefix_keys(value: &str) -> Vec<String> {
 }
 
 fn suggestion_lookup_key(value: &str) -> &str {
-    let mut count = 0;
-    for (index, _) in value.char_indices() {
+    for (count, (index, _)) in value.char_indices().enumerate() {
         if count == MAX_SUGGESTION_PREFIX_CHARS {
             return &value[..index];
         }
-        count += 1;
     }
     value
 }

--- a/crates/index/src/resolve.rs
+++ b/crates/index/src/resolve.rs
@@ -4,6 +4,10 @@ use neverwrite_types::NoteId;
 
 use crate::VaultIndex;
 
+type LocalGraphNodes = Vec<(NoteId, u32)>;
+type LocalGraphLinks = Vec<(NoteId, NoteId)>;
+type LocalGraph = (LocalGraphNodes, LocalGraphLinks);
+
 impl VaultIndex {
     /// Resolves a wikilink to a NoteId.
     /// `link_text`: the wikilink target (for example, "My Note" or "folder/note").
@@ -39,11 +43,7 @@ impl VaultIndex {
 
     /// BFS from `root` up to `max_depth` hops, using forward_links + backlinks.
     /// Returns (visited nodes with their distance, internal links within the subgraph).
-    pub fn get_local_graph(
-        &self,
-        root: &NoteId,
-        max_depth: u32,
-    ) -> (Vec<(NoteId, u32)>, Vec<(NoteId, NoteId)>) {
+    pub fn get_local_graph(&self, root: &NoteId, max_depth: u32) -> LocalGraph {
         let mut visited: HashSet<NoteId> = HashSet::new();
         let mut queue: VecDeque<(NoteId, u32)> = VecDeque::new();
         let mut nodes: Vec<(NoteId, u32)> = Vec::new();

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -875,14 +875,15 @@ fn search_content(content: &str, cs: &ContentSearchParam) -> Vec<ContentMatchDto
                     let section_text: String = lines[section_start..i].join("\n");
                     let section_lower = section_text.to_lowercase();
                     if matcher.matches(&section_lower) {
-                        for j in section_start..i {
-                            let line_lower = lines[j].to_lowercase();
+                        for (j, line) in lines.iter().enumerate().take(i).skip(section_start) {
+                            let line = *line;
+                            let line_lower = line.to_lowercase();
                             let hits = matcher.find_in(&line_lower);
                             if !hits.is_empty() {
                                 for (start, end) in hits.iter().take(1) {
                                     results.push(ContentMatchDto {
                                         line_number: j + 1,
-                                        line_content: truncate_line(lines[j], 200),
+                                        line_content: truncate_line(line, 200),
                                         match_start: *start,
                                         match_end: *end,
                                         page: None,

--- a/crates/index/tests/integration.rs
+++ b/crates/index/tests/integration.rs
@@ -4,7 +4,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use neverwrite_index::VaultIndex;
 use neverwrite_types::{
     AdvancedSearchFileScope, AdvancedSearchParams, NoteDocument, NoteId, NotePath, PdfDocument,
-    SearchTermParam, TextRange, VaultEntryDto, WikiLink,
+    PdfMetadata, SearchTermParam, TextRange, VaultEntryDto, WikiLink,
 };
 use neverwrite_vault::Vault;
 
@@ -737,15 +737,15 @@ fn register_pdf_adds_to_index() {
 #[test]
 fn register_pdf_metadata_adds_to_index_without_content_extraction() {
     let mut index = build_sample_index();
-    index.register_pdf_metadata(
-        NoteId("papers/quantum".into()),
-        NotePath(PathBuf::from("papers/quantum.pdf")),
-        "Quantum Computing".into(),
-        0,
-        1000,
-        900,
-        5000,
-    );
+    index.register_pdf_metadata(PdfMetadata {
+        id: NoteId("papers/quantum".into()),
+        path: NotePath(PathBuf::from("papers/quantum.pdf")),
+        title: "Quantum Computing".into(),
+        page_count: 0,
+        modified_at: 1000,
+        created_at: 900,
+        size: 5000,
+    });
 
     assert!(index
         .pdf_metadata
@@ -796,25 +796,25 @@ fn reindex_pdf_updates_metadata() {
 #[test]
 fn reindex_pdf_metadata_updates_metadata() {
     let mut index = build_sample_index();
-    index.register_pdf_metadata(
-        NoteId("report".into()),
-        NotePath(PathBuf::from("report.pdf")),
-        "Old Title".into(),
-        0,
-        1000,
-        900,
-        5000,
-    );
+    index.register_pdf_metadata(PdfMetadata {
+        id: NoteId("report".into()),
+        path: NotePath(PathBuf::from("report.pdf")),
+        title: "Old Title".into(),
+        page_count: 0,
+        modified_at: 1000,
+        created_at: 900,
+        size: 5000,
+    });
 
-    index.reindex_pdf_metadata(
-        NoteId("report".into()),
-        NotePath(PathBuf::from("report.pdf")),
-        "New Title".into(),
-        0,
-        2000,
-        900,
-        8000,
-    );
+    index.reindex_pdf_metadata(PdfMetadata {
+        id: NoteId("report".into()),
+        path: NotePath(PathBuf::from("report.pdf")),
+        title: "New Title".into(),
+        page_count: 0,
+        modified_at: 2000,
+        created_at: 900,
+        size: 8000,
+    });
 
     let meta = &index.pdf_metadata[&NoteId("report".into())];
     assert_eq!(meta.title, "New Title");

--- a/crates/vault/src/parser/headings.rs
+++ b/crates/vault/src/parser/headings.rs
@@ -56,7 +56,7 @@ static WHITESPACE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"\s+").unwr
 
 fn clean_heading_title(raw: &str) -> String {
     let s = raw.trim();
-    let s = TRAILING_HASHES_RE.replace_all(&s, "");
+    let s = TRAILING_HASHES_RE.replace_all(s, "");
     let s = EMBED_WIKILINK_ALIAS_RE.replace_all(&s, "$2");
     let s = EMBED_WIKILINK_RE.replace_all(&s, "$1");
     let s = WIKILINK_ALIAS_RE.replace_all(&s, "$2");

--- a/crates/vault/src/parser/tags.rs
+++ b/crates/vault/src/parser/tags.rs
@@ -53,9 +53,9 @@ pub fn extract_tags(text: &str) -> Vec<String> {
 }
 
 fn strip_frontmatter(text: &str) -> &str {
-    if text.starts_with("---") {
-        if let Some(end) = text[3..].find("\n---") {
-            return &text[end + 7..]; // 3 (primer ---) + end + 4 (\n---)
+    if let Some(stripped) = text.strip_prefix("---") {
+        if let Some(end) = stripped.find("\n---") {
+            return &stripped[end + 4..];
         }
     }
     text

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -81,7 +81,7 @@ impl Vault {
             }
 
             let path = entry.path();
-            if !path.extension().is_some_and(|ext| ext == "md") {
+            if path.extension().is_none_or(|ext| ext != "md") {
                 continue;
             }
 
@@ -156,7 +156,7 @@ impl Vault {
                 continue;
             }
             let path = entry.path();
-            if !path.extension().is_some_and(|ext| ext == "pdf") {
+            if path.extension().is_none_or(|ext| ext != "pdf") {
                 continue;
             }
 

--- a/crates/vault/src/watcher.rs
+++ b/crates/vault/src/watcher.rs
@@ -81,6 +81,12 @@ impl WriteTracker {
     }
 }
 
+impl Default for WriteTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 const SELF_WRITE_WINDOW: Duration = Duration::from_secs(2);
 
 fn prune_expired(written: &mut HashMap<PathBuf, TrackedWrite>) {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.96.0"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
## Summary

- Pin the Rust toolchain to `1.96.0` with `rust-toolchain.toml` and update contributor docs.
- Keep crates on Rust 2021 edition.
- Clean up Clippy warnings across owned Rust crates: `vault`, `index`, `diff`, `ai`, and trivial native backend warnings.
- Leave native backend `too_many_arguments` warnings intentionally deferred, since those require a focused ACP/backend refactor rather than mechanical cleanup.

## Validation

- `cargo check --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets` passes; remaining output is limited to expected `too_many_arguments` warnings in native backend code
- `cargo fmt --check`

## Notes

No files under `vendor/` were changed.