### PR TITLE
Upgrade CodeMirror view to 6.43.3 (fixes live preview table crash)

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -26,7 +26,7 @@
                 "@codemirror/merge": "^6.12.1",
                 "@codemirror/search": "^6.7.0",
                 "@codemirror/state": "^6.6.0",
-                "@codemirror/view": "^6.41.1",
+                "@codemirror/view": "^6.43.3",
                 "@excalidraw/excalidraw": "^0.18.1",
                 "@iconify-json/catppuccin": "^1.2.17",
                 "@lezer/common": "^1.5.2",
@@ -654,21 +654,21 @@
             }
         },
         "node_modules/@codemirror/state": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
-            "integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+            "version": "6.7.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+            "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
             "license": "MIT",
             "dependencies": {
                 "@marijn/find-cluster-break": "^1.0.0"
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.41.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.1.tgz",
-            "integrity": "sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==",
+            "version": "6.43.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.3.tgz",
+            "integrity": "sha512-MwEwCAr/o0agJefhC2+reBv5kfOQpMcDRUNQrRYZgWlhH8IwQcerMZrpqWyUFSyO0ebgN2cnh/w87F7G4BGSng==",
             "license": "MIT",
             "dependencies": {
-                "@codemirror/state": "^6.6.0",
+                "@codemirror/state": "^6.7.0",
                 "crelt": "^1.0.6",
                 "style-mod": "^4.1.0",
                 "w3c-keyname": "^2.2.4"

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,7 @@
         "@codemirror/merge": "^6.12.1",
         "@codemirror/search": "^6.7.0",
         "@codemirror/state": "^6.6.0",
-        "@codemirror/view": "^6.41.1",
+        "@codemirror/view": "^6.43.3",
         "@excalidraw/excalidraw": "^0.18.1",
         "@iconify-json/catppuccin": "^1.2.17",
         "@lezer/common": "^1.5.2",


### PR DESCRIPTION
## Summary

Upgrades `@codemirror/view` from **6.41.1 → 6.43.3** to fix the live preview table-selection crash that corrupts layout and crashes mode switching (#233). No source changes — the bump is within the existing `^6.x` range.

## Root cause

The crash was a regression in `@codemirror/view` 6.41.1's content-DOM / tile update engine, not in our code. Dragging a selection across a rendered Markdown table (a `Decoration.replace({ block: true })` widget) left CodeMirror's internal tile tree shorter than the document. After that, every `posAtCoords` / `measure` threw — `TilePointer.advance` (`parents.pop()` undefined) and `InlineCoordsScan.scanTile` (`null.length`) — during `MouseSelection.move`, `drawSelection`, and finally the live-preview reconfigure dispatch, which tore down the `<Editor>` via the root error boundary.

6.43.3 (released 2026-06-25) ships the upstream fix, described in its changelog as:

> Fix a bug in the content DOM update code that could corrupt the editor state.

Supporting fixes in the same range: 6.42.0 (`posAtCoords` no longer recurses endlessly) and 6.42.1 (block wrappers applied incorrectly).

## Verification

- `tsc -b` clean.
- 130/130 editor extension tests pass.
- Crash no longer reproduces when dragging a selection across a rendered table and toggling Live Preview.

Closes #233.