### PR TITLE
Remove unused workspace drop helpers

### DIFF
--- a/apps/desktop/src/features/editor/workspacePaneFileDrop.ts
+++ b/apps/desktop/src/features/editor/workspacePaneFileDrop.ts
@@ -10,7 +10,6 @@ import { vaultInvoke } from "../../app/utils/vaultInvoke";
 import type { FileTreeNoteDragDetail } from "../ai/dragEvents";
 import { isPointOverAiComposerDropZone } from "./tabDragAttachments";
 import {
-    resolvePaneStripDropIndex,
     resolveWorkspaceTabDropIntent,
     type CrossPaneTabDropPreview,
 } from "./workspaceTabDropPreview";
@@ -22,56 +21,6 @@ type WorkspaceFileDropTarget = Extract<
     WorkspaceDropTarget,
     { type: "strip" | "pane-center" | "split" }
 >;
-
-export interface WorkspacePaneFileDropTarget {
-    paneId: string;
-    insertIndex: number;
-}
-
-export function resolveWorkspacePaneFileDropTarget(
-    clientX: number,
-    clientY: number,
-): WorkspacePaneFileDropTarget | null {
-    if (isPointOverAiComposerDropZone(clientX, clientY)) {
-        return null;
-    }
-
-    const paneNodes = Array.from(
-        document.querySelectorAll<HTMLElement>("[data-editor-pane-id]"),
-    );
-
-    for (const paneNode of paneNodes) {
-        const paneId = paneNode.dataset.editorPaneId ?? null;
-        if (!paneId) {
-            continue;
-        }
-
-        const paneRect = paneNode.getBoundingClientRect();
-        if (!isPointInsideRect(clientX, clientY, paneRect)) {
-            continue;
-        }
-
-        const strip = paneNode.querySelector<HTMLElement>(
-            `[data-pane-tab-strip="${paneId}"]`,
-        );
-        if (strip) {
-            const stripRect = strip.getBoundingClientRect();
-            if (isPointInsideRect(clientX, clientY, stripRect)) {
-                return {
-                    paneId,
-                    insertIndex: resolvePaneStripDropIndex(strip, clientX),
-                };
-            }
-        }
-
-        return {
-            paneId,
-            insertIndex: countPaneTabs(strip),
-        };
-    }
-
-    return null;
-}
 
 export function isWorkspaceFileDropTarget(
     target: WorkspaceDropTarget,
@@ -97,31 +46,6 @@ export function resolveWorkspaceFileDropIntent(
         clientX,
         clientY,
     });
-}
-
-export async function openDroppedVaultPathsInPane(
-    paths: string[],
-    paneId: string,
-    insertIndex: number,
-) {
-    const entriesByPath = new Map(
-        useVaultStore.getState().entries.map((entry) => [entry.path, entry]),
-    );
-    let nextIndex = insertIndex;
-
-    for (const path of paths) {
-        const entry = entriesByPath.get(path);
-        if (!entry) {
-            continue;
-        }
-
-        const inserted = await insertVaultEntryTab(entry, nextIndex, {
-            paneId,
-        });
-        if (inserted) {
-            nextIndex += 1;
-        }
-    }
 }
 
 export async function openDroppedVaultPathsAtTarget(
@@ -153,55 +77,6 @@ export async function openDroppedVaultPathsAtTarget(
         }
 
         if (!paneId) {
-            continue;
-        }
-
-        const inserted = await insertVaultEntryTab(entry, nextIndex, {
-            paneId,
-        });
-        if (inserted) {
-            nextIndex += 1;
-        }
-    }
-}
-
-export async function openDroppedTreeItemsInPane(
-    detail: FileTreeNoteDragDetail,
-    paneId: string,
-    insertIndex: number,
-) {
-    let nextIndex = insertIndex;
-
-    for (const note of detail.notes) {
-        try {
-            const noteDetail = await vaultInvoke<{ content: string }>(
-                "read_note",
-                {
-                    noteId: note.id,
-                },
-            );
-            useEditorStore.getState().insertExternalTabInPane(
-                {
-                    id: crypto.randomUUID(),
-                    kind: "note",
-                    noteId: note.id,
-                    title: note.title,
-                    content: noteDetail.content,
-                },
-                paneId,
-                nextIndex,
-            );
-            nextIndex += 1;
-        } catch (error) {
-            console.error("Failed to open dropped note tab:", error);
-        }
-    }
-
-    for (const file of detail.files ?? []) {
-        const entry = useVaultStore
-            .getState()
-            .entries.find((item) => item.path === file.filePath);
-        if (!entry) {
             continue;
         }
 
@@ -320,25 +195,4 @@ function getInitialInsertIndex(target: WorkspaceFileDropTarget) {
             .getState()
             .panes.find((pane) => pane.id === target.paneId)?.tabs.length ?? 0
     );
-}
-
-function isPointInsideRect(
-    clientX: number,
-    clientY: number,
-    rect: Pick<DOMRect, "left" | "right" | "top" | "bottom">,
-) {
-    return (
-        clientX >= rect.left &&
-        clientX <= rect.right &&
-        clientY >= rect.top &&
-        clientY <= rect.bottom
-    );
-}
-
-function countPaneTabs(strip: HTMLElement | null) {
-    if (!strip) {
-        return 0;
-    }
-
-    return strip.querySelectorAll("[data-pane-tab-id]").length;
 }


### PR DESCRIPTION
## Summary

- remove the unused pane/index workspace drop helpers
- keep the current WorkspaceDropTarget-based drop flow unchanged
- remove private helpers and imports that only served the old path

## Validation

- npm run test -- src/features/editor/MultiPaneWorkspace.test.tsx
- npm run test -- src/features/vault/FileTree.test.tsx
- npm run lint
