### PR TITLE
feat: hover preview de wikilinks

### DIFF
--- a/apps/desktop/src/app/shortcuts/registry.ts
+++ b/apps/desktop/src/app/shortcuts/registry.ts
@@ -42,6 +42,7 @@ export type ShortcutActionId =
     | "remove_heading"
     | "bold_selection"
     | "highlight_selection"
+    | "preview_link_at_caret"
     | "add_selection_to_chat"
     | "save_note";
 
@@ -380,6 +381,15 @@ const shortcutDefinitions = [
         },
     },
     {
+        id: "preview_link_at_caret",
+        label: "Preview Link at Caret",
+        category: "Editor",
+        bindings: {
+            macos: [{ key: "p", modifiers: ["meta", "alt"] }],
+            windows: [{ key: "p", modifiers: ["ctrl", "alt"] }],
+        },
+    },
+    {
         id: "add_selection_to_chat",
         label: "Add Selection to Chat",
         category: "AI",
@@ -464,6 +474,7 @@ export const SHORTCUT_SETTINGS_ORDER: ShortcutActionId[] = [
     "remove_heading",
     "bold_selection",
     "highlight_selection",
+    "preview_link_at_caret",
     "toggle_live_preview",
     "save_note",
     "add_selection_to_chat",

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -80,6 +80,36 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().vimRelativeLineNumbers).toBe(true);
     });
 
+    it("persists hover preview settings globally across vaults", () => {
+        useVaultStore.setState({ vaultPath: "/vaults/hover-one" });
+
+        useSettingsStore.getState().setSetting("hoverPreviewEnabled", false);
+        useSettingsStore.getState().setSetting("hoverPreviewDelayMs", 500);
+
+        expect(useSettingsStore.getState().hoverPreviewEnabled).toBe(false);
+        expect(useSettingsStore.getState().hoverPreviewDelayMs).toBe(500);
+        expect(
+            JSON.parse(localStorage.getItem("neverwrite:settings") ?? ""),
+        ).toMatchObject({
+            state: {
+                hoverPreviewEnabled: false,
+                hoverPreviewDelayMs: 500,
+            },
+        });
+        expect(
+            JSON.parse(
+                localStorage.getItem(
+                    "neverwrite:settings:/vaults/hover-one",
+                ) ?? "",
+            ).state,
+        ).not.toHaveProperty("hoverPreviewEnabled");
+
+        useVaultStore.setState({ vaultPath: "/vaults/hover-two" });
+
+        expect(useSettingsStore.getState().hoverPreviewEnabled).toBe(false);
+        expect(useSettingsStore.getState().hoverPreviewDelayMs).toBe(500);
+    });
+
     it("persists settings per vault", () => {
         useVaultStore.setState({ vaultPath: "/vaults/devtools" });
 

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -22,6 +22,8 @@ export interface Settings {
     justifyText: boolean;
     livePreviewEnabled: boolean;
     inlineReviewEnabled: boolean;
+    hoverPreviewEnabled: boolean;
+    hoverPreviewDelayMs: number; // 0–2000
     pdfFilter: PdfFilterMode;
     tabSize: 2 | 4;
     editorSpellcheck: boolean;
@@ -180,6 +182,8 @@ const defaults: Settings = {
     justifyText: false,
     livePreviewEnabled: true,
     inlineReviewEnabled: true,
+    hoverPreviewEnabled: true,
+    hoverPreviewDelayMs: 300,
     pdfFilter: "none",
     tabSize: 2,
     editorSpellcheck: false,
@@ -431,6 +435,15 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             inlineReviewEnabled:
                 parsed.state.inlineReviewEnabled ??
                 defaults.inlineReviewEnabled,
+            hoverPreviewEnabled:
+                parsed.state.hoverPreviewEnabled ??
+                defaults.hoverPreviewEnabled,
+            hoverPreviewDelayMs: normalizeIntInRange(
+                parsed.state.hoverPreviewDelayMs,
+                defaults.hoverPreviewDelayMs,
+                0,
+                2000,
+            ),
             pdfFilter: normalizePdfFilterMode(parsed.state.pdfFilter),
             tabSize: normalizeTabSize(parsed.state.tabSize),
             editorSpellcheck:
@@ -552,6 +565,8 @@ function pickSettings(state: SettingsStore): Settings {
         justifyText: state.justifyText,
         livePreviewEnabled: state.livePreviewEnabled,
         inlineReviewEnabled: state.inlineReviewEnabled,
+        hoverPreviewEnabled: state.hoverPreviewEnabled,
+        hoverPreviewDelayMs: state.hoverPreviewDelayMs,
         pdfFilter: state.pdfFilter,
         tabSize: state.tabSize,
         editorSpellcheck: state.editorSpellcheck,

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -65,6 +65,8 @@ const LAST_VAULT_KEY = "neverwrite:lastVaultPath";
 const GLOBAL_SETTING_KEYS = [
     "vimModeEnabled",
     "vimRelativeLineNumbers",
+    "hoverPreviewEnabled",
+    "hoverPreviewDelayMs",
 ] as const;
 
 type GlobalSettingKey = (typeof GLOBAL_SETTING_KEYS)[number];
@@ -369,7 +371,7 @@ function hasVaultScopedSettings(raw: string | null) {
     );
 }
 
-function hasStoredVimSettings(raw: string | null) {
+function hasStoredGlobalSettings(raw: string | null) {
     const state = extractPersistedState(raw);
     if (!state) return false;
 
@@ -606,6 +608,8 @@ function pickGlobalSettings(
     return {
         vimModeEnabled: settings.vimModeEnabled,
         vimRelativeLineNumbers: settings.vimRelativeLineNumbers,
+        hoverPreviewEnabled: settings.hoverPreviewEnabled,
+        hoverPreviewDelayMs: settings.hoverPreviewDelayMs,
     };
 }
 
@@ -681,12 +685,14 @@ function migrateGlobalSpellcheckToVault(vaultPath: string) {
     }
 }
 
-function migrateVaultVimSettingsToGlobal(vaultRaw: string | null) {
+function migrateVaultGlobalSettingsToGlobal(vaultRaw: string | null) {
     try {
-        if (hasStoredVimSettings(safeStorageGetItem(SETTINGS_KEY_FALLBACK))) {
+        if (
+            hasStoredGlobalSettings(safeStorageGetItem(SETTINGS_KEY_FALLBACK))
+        ) {
             return;
         }
-        if (!hasStoredVimSettings(vaultRaw)) return;
+        if (!hasStoredGlobalSettings(vaultRaw)) return;
 
         const vaultSettings = extractSettingsFromStorage(vaultRaw);
         if (!vaultSettings) return;
@@ -704,7 +710,7 @@ function loadSettings(vaultPath: string | null): Settings {
         }
         const raw = safeStorageGetItem(getStorageKey(vaultPath));
         if (vaultPath) {
-            migrateVaultVimSettingsToGlobal(raw);
+            migrateVaultGlobalSettingsToGlobal(raw);
         }
         const settings = extractSettingsFromStorage(raw) ?? defaults;
         return vaultPath ? mergeGlobalSettings(settings) : settings;

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -63,6 +63,7 @@ import {
 // Re-export for existing importers (e.g. UnifiedBar).
 export { REQUEST_CLOSE_ACTIVE_TAB_EVENT };
 import { wikilinkExtension } from "./extensions/wikilinks";
+import { showWikilinkPreviewAtCaret } from "./extensions/wikilinkHoverPreview";
 import { urlLinksExtension } from "./extensions/urlLinks";
 import { imagePasteDropExtension } from "./extensions/imagePasteDrop";
 import {
@@ -2590,6 +2591,13 @@ export function Editor({
                                 });
                                 return true;
                             },
+                        },
+                        {
+                            key:
+                                getCodeMirrorShortcut(
+                                    "preview_link_at_caret",
+                                ) ?? "Mod-Alt-p",
+                            run: showWikilinkPreviewAtCaret,
                         },
                         ...defaultKeymap,
                         ...historyKeymap,

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -63,6 +63,7 @@ import {
 // Re-export for existing importers (e.g. UnifiedBar).
 export { REQUEST_CLOSE_ACTIVE_TAB_EVENT };
 import { wikilinkExtension } from "./extensions/wikilinks";
+import { wikilinkHoverPreviewExtension } from "./extensions/wikilinkHoverPreview";
 import { urlLinksExtension } from "./extensions/urlLinks";
 import { imagePasteDropExtension } from "./extensions/imagePasteDrop";
 import {
@@ -2592,6 +2593,7 @@ export function Editor({
                         () => activeTabRef.current?.noteId ?? null,
                         navigateWikilink,
                     ),
+                    wikilinkHoverPreviewExtension(),
                     urlLinksExtension,
                     imagePasteDropExtension(),
                     EditorView.updateListener.of((update) => {

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -63,7 +63,6 @@ import {
 // Re-export for existing importers (e.g. UnifiedBar).
 export { REQUEST_CLOSE_ACTIVE_TAB_EVENT };
 import { wikilinkExtension } from "./extensions/wikilinks";
-import { wikilinkHoverPreviewExtension } from "./extensions/wikilinkHoverPreview";
 import { urlLinksExtension } from "./extensions/urlLinks";
 import { imagePasteDropExtension } from "./extensions/imagePasteDrop";
 import {
@@ -107,6 +106,7 @@ import {
     baseTheme,
     syntaxCompartment,
     livePreviewCompartment,
+    hoverPreviewCompartment,
     alignmentCompartment,
     wrappingCompartment,
     activeLineCompartment,
@@ -118,6 +118,7 @@ import {
     lineNumberCompartment,
     getSyntaxExtension,
     getLivePreviewExtension,
+    getWikilinkHoverPreviewExtension,
     getAlignmentExtension,
     getWrappingExtension,
     getActiveLineExtension,
@@ -489,6 +490,12 @@ export function Editor({
     const justifyText = useSettingsStore((s) => s.justifyText);
     const livePreviewEnabled = useSettingsStore((s) => s.livePreviewEnabled);
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
+    const hoverPreviewEnabled = useSettingsStore(
+        (s) => s.hoverPreviewEnabled,
+    );
+    const hoverPreviewDelayMs = useSettingsStore(
+        (s) => s.hoverPreviewDelayMs,
+    );
     const tabSize = useSettingsStore((s) => s.tabSize);
     const vimModeEnabled = useSettingsStore((s) => s.vimModeEnabled);
     const vimRelativeLineNumbers = useSettingsStore(
@@ -2593,7 +2600,12 @@ export function Editor({
                         () => activeTabRef.current?.noteId ?? null,
                         navigateWikilink,
                     ),
-                    wikilinkHoverPreviewExtension(),
+                    hoverPreviewCompartment.of(
+                        getWikilinkHoverPreviewExtension(
+                            useSettingsStore.getState().hoverPreviewEnabled,
+                            useSettingsStore.getState().hoverPreviewDelayMs,
+                        ),
+                    ),
                     urlLinksExtension,
                     imagePasteDropExtension(),
                     EditorView.updateListener.of((update) => {
@@ -3380,6 +3392,18 @@ export function Editor({
         scheduleMergeViewSync,
         vaultPath,
     ]);
+
+    // Reconfigure the wikilink hover preview when its toggle or delay changes.
+    useEffect(() => {
+        viewRef.current?.dispatch({
+            effects: hoverPreviewCompartment.reconfigure(
+                getWikilinkHoverPreviewExtension(
+                    hoverPreviewEnabled,
+                    hoverPreviewDelayMs,
+                ),
+            ),
+        });
+    }, [hoverPreviewEnabled, hoverPreviewDelayMs]);
 
     useEffect(() => {
         runMergeViewSync();

--- a/apps/desktop/src/features/editor/editorExtensions.ts
+++ b/apps/desktop/src/features/editor/editorExtensions.ts
@@ -20,6 +20,7 @@ import type {
 import { vim } from "@replit/codemirror-vim";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { livePreviewExtension } from "./extensions/livePreview";
+import { wikilinkHoverPreviewExtension } from "./extensions/wikilinkHoverPreview";
 import { vimStatusBarExtension } from "./extensions/vimStatusBar";
 import { resolveWikilink } from "./wikilinkResolution";
 import { navigateWikilink, getNoteLinkTarget } from "./wikilinkNavigation";
@@ -158,6 +159,8 @@ export const baseTheme = EditorView.theme({
 export const syntaxCompartment = new Compartment();
 // Compartment for the live preview extension (reconfigured when vault changes)
 export const livePreviewCompartment = new Compartment();
+// Compartment for the wikilink hover preview (toggle + configurable delay)
+export const hoverPreviewCompartment = new Compartment();
 // Compartment for justified alignment
 export const alignmentCompartment = new Compartment();
 // Compartment for line wrapping
@@ -257,6 +260,17 @@ export function getLivePreviewExtension(
             openLinkContextMenu,
         }),
     ];
+}
+
+// Wikilink hover preview. Returns an empty extension when disabled so the
+// `hoverTooltip` is not registered at all; otherwise it applies the configured
+// open delay. Lives in its own compartment so the per-vault toggle and delay
+// can be reconfigured without recreating the editor state.
+export function getWikilinkHoverPreviewExtension(
+    enabled: boolean,
+    delayMs: number,
+) {
+    return enabled ? wikilinkHoverPreviewExtension(delayMs) : [];
 }
 
 // Vim modal editing. Must take precedence over the default keymap, so the

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -14,7 +14,6 @@ import {
 } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
 import katex from "katex";
-import { vaultInvoke } from "../../../app/utils/vaultInvoke";
 import {
     buildVaultPreviewUrlFromAbsolutePath,
     isAuthorizedVaultPreviewPath,
@@ -29,7 +28,6 @@ import {
 import {
     useEditorStore,
     isNoteTab,
-    selectEditorWorkspaceTabs,
     selectFocusedEditorTab,
 } from "../../../app/store/editorStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
@@ -47,6 +45,12 @@ import {
     selectionTouchesLine,
     selectionTouchesRange,
 } from "./selectionActivity";
+import {
+    extractSection,
+    findPreviewNote,
+    getNotePreviewContentState,
+    renderEmbedPreview,
+} from "./notePreviewSource";
 
 const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif)([?#].*)?$/i;
 const PDF_EXTENSION = /\.pdf([?#].*)?$/i;
@@ -55,7 +59,6 @@ const TABLE_WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
 const TABLE_URL_RE = /https?:\/\/[^\s<>()"\]]+/g;
 const TABLE_BOLD_RE = /\*\*(?=\S)(.+?\S)\*\*/g;
 const STANDALONE_URL_RE = /^https?:\/\/[^\s<>()"\]]+$/i;
-const NOTE_PREVIEW_CACHE_LIMIT = 64;
 type TableAlignment = "left" | "center" | "right";
 export interface TableInteractionHandlers {
     resolveWikilink: (target: string) => boolean;
@@ -78,29 +81,9 @@ type ParsedTableRow = {
     lineEnd: number;
 };
 
-const notePreviewContentCache = new Map<string, string>();
-const notePreviewRequestCache = new Map<string, Promise<string | null>>();
-
-function rememberNotePreviewContent(noteId: string, content: string) {
-    if (notePreviewContentCache.has(noteId)) {
-        notePreviewContentCache.delete(noteId);
-    }
-    notePreviewContentCache.set(noteId, content);
-
-    while (notePreviewContentCache.size > NOTE_PREVIEW_CACHE_LIMIT) {
-        const oldestKey = notePreviewContentCache.keys().next().value;
-        if (oldestKey === undefined) break;
-        notePreviewContentCache.delete(oldestKey);
-    }
-}
-
-export function invalidateLivePreviewNoteCache(
-    noteId: string | null | undefined,
-) {
-    if (!noteId) return;
-    notePreviewContentCache.delete(noteId);
-    notePreviewRequestCache.delete(noteId);
-}
+// Re-exported under its historical name; the implementation now lives in the
+// shared note-preview source consumed by both embeds and hover previews.
+export { invalidateNotePreviewCache as invalidateLivePreviewNoteCache } from "./notePreviewSource";
 
 function getActiveNotePath() {
     const activeTab = selectFocusedEditorTab(useEditorStore.getState());
@@ -231,28 +214,6 @@ export function resolvePreviewAssetPath(
     }
 
     return `${joinFilePath(baseDirectory, pathname)}${suffix}`;
-}
-
-async function loadNotePreviewContent(noteId: string) {
-    const cached = notePreviewContentCache.get(noteId);
-    if (cached !== undefined) return cached;
-
-    const pending = notePreviewRequestCache.get(noteId);
-    if (pending) return pending;
-
-    const request = vaultInvoke<{ content: string }>("read_note", { noteId })
-        .then((detail) => {
-            rememberNotePreviewContent(noteId, detail.content);
-            notePreviewRequestCache.delete(noteId);
-            return detail.content;
-        })
-        .catch(() => {
-            notePreviewRequestCache.delete(noteId);
-            return null;
-        });
-
-    notePreviewRequestCache.set(noteId, request);
-    return request;
 }
 
 // --- Image size toolbar ---
@@ -769,102 +730,6 @@ class YouTubeWidget extends WidgetType {
 
 const EMBED_MAX_LINES = 6;
 
-/**
- * Append inline-formatted text to a parent element using DOM nodes (no innerHTML).
- * Handles **bold**, *italic*, `code`, and [[wikilinks|label]].
- */
-function appendFormattedInline(parent: HTMLElement, text: string): void {
-    const re =
-        /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`|\[\[([^\]|]+?)(?:\|([^\]]+))?\]\])/g;
-    let last = 0;
-    let m: RegExpExecArray | null;
-
-    while ((m = re.exec(text)) !== null) {
-        if (m.index > last) {
-            parent.appendChild(
-                document.createTextNode(text.slice(last, m.index)),
-            );
-        }
-        if (m[2]) {
-            const el = document.createElement("strong");
-            el.textContent = m[2];
-            parent.appendChild(el);
-        } else if (m[3]) {
-            const el = document.createElement("em");
-            el.textContent = m[3];
-            parent.appendChild(el);
-        } else if (m[4]) {
-            const el = document.createElement("code");
-            el.textContent = m[4];
-            parent.appendChild(el);
-        } else if (m[5]) {
-            const el = document.createElement("span");
-            el.className = "cm-note-embed-wikilink";
-            el.textContent = m[6] ?? m[5];
-            parent.appendChild(el);
-        }
-        last = m.index + m[0].length;
-    }
-
-    if (last < text.length) {
-        parent.appendChild(document.createTextNode(text.slice(last)));
-    }
-}
-
-/** Render a few lines of markdown content into a DocumentFragment (safe DOM). */
-function renderEmbedPreview(text: string, maxLines: number): DocumentFragment {
-    const fragment = document.createDocumentFragment();
-    const lines = text
-        .split("\n")
-        .filter((l) => l.trim())
-        .slice(0, maxLines);
-
-    for (const line of lines) {
-        const hMatch = line.match(/^(#{1,6})\s+(.+)$/);
-        if (hMatch) {
-            const div = document.createElement("div");
-            div.className = `cm-note-embed-h${hMatch[1].length}`;
-            appendFormattedInline(div, hMatch[2]);
-            fragment.appendChild(div);
-            continue;
-        }
-
-        const liMatch = line.match(/^\s*[-*+]\s+(.+)$/);
-        if (liMatch) {
-            const div = document.createElement("div");
-            div.className = "cm-note-embed-li";
-            appendFormattedInline(div, liMatch[1]);
-            fragment.appendChild(div);
-            continue;
-        }
-
-        const div = document.createElement("div");
-        appendFormattedInline(div, line);
-        fragment.appendChild(div);
-    }
-
-    return fragment;
-}
-
-/** Extract content under a specific heading until the next heading of same or higher level. */
-function extractSection(content: string, heading: string): string {
-    const lines = content.split("\n");
-    const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const headingRe = new RegExp(`^(#{1,6})\\s+${escaped}\\s*$`, "i");
-    const startIdx = lines.findIndex((l) => headingRe.test(l));
-    if (startIdx < 0) return "";
-
-    const level = lines[startIdx].match(/^(#+)/)?.[1].length ?? 1;
-    let endIdx = startIdx + 1;
-    while (endIdx < lines.length) {
-        const lm = lines[endIdx].match(/^(#+)\s/);
-        if (lm && lm[1].length <= level) break;
-        endIdx++;
-    }
-
-    return lines.slice(startIdx, endIdx).join("\n");
-}
-
 class NoteEmbedWidget extends WidgetType {
     private target: string;
     private heading?: string;
@@ -898,22 +763,7 @@ class NoteEmbedWidget extends WidgetType {
         wrapper.tabIndex = 0;
         wrapper.setAttribute("role", "link");
 
-        const note = useVaultStore
-            .getState()
-            .notes.find(
-                (entry) =>
-                    entry.id === this.target ||
-                    entry.title === this.target ||
-                    entry.id.replace(/\.md$/i, "") === this.target,
-            );
-        const openTab = selectEditorWorkspaceTabs(
-            useEditorStore.getState(),
-        ).find(
-            (tab) =>
-                (isNoteTab(tab) && tab.noteId === note?.id) ||
-                (isNoteTab(tab) && tab.noteId === this.target) ||
-                tab.title === this.target,
-        );
+        const note = findPreviewNote(this.target);
 
         const title = document.createElement("div");
         title.className = "cm-note-embed-title";
@@ -953,32 +803,22 @@ class NoteEmbedWidget extends WidgetType {
             wrapper.appendChild(meta);
         };
 
-        const fullContent =
-            openTab && isNoteTab(openTab) ? openTab.content : null;
-        if (fullContent !== null) {
-            if (note?.id) {
-                rememberNotePreviewContent(note.id, fullContent);
-            }
-            renderContent(fullContent);
-            outer.appendChild(wrapper);
-            return outer;
-        }
-
-        const cachedContent = note?.id
-            ? (notePreviewContentCache.get(note.id) ?? null)
-            : null;
-        if (cachedContent !== null) {
-            renderContent(cachedContent);
+        const { content, load } = getNotePreviewContentState(
+            note,
+            this.target,
+        );
+        if (content !== null) {
+            renderContent(content);
             outer.appendChild(wrapper);
             return outer;
         }
 
         renderContent(null);
 
-        if (note?.id) {
-            void loadNotePreviewContent(note.id).then((content) => {
-                if (!outer.isConnected || content === null) return;
-                renderContent(content);
+        if (load) {
+            void load().then((loaded) => {
+                if (!outer.isConnected || loaded === null) return;
+                renderContent(loaded);
             });
         }
 

--- a/apps/desktop/src/features/editor/extensions/notePreviewSource.test.ts
+++ b/apps/desktop/src/features/editor/extensions/notePreviewSource.test.ts
@@ -1,0 +1,56 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, expect, it } from "vitest";
+import { extractSection, renderEmbedPreview } from "./notePreviewSource";
+
+describe("renderEmbedPreview", () => {
+    it("renders headings, list items and inline formatting to safe DOM", () => {
+        const fragment = renderEmbedPreview(
+            "# Title\n- item with **bold**\nplain `code` text",
+            10,
+        );
+        const host = document.createElement("div");
+        host.appendChild(fragment);
+
+        expect(host.querySelector(".cm-note-embed-h1")?.textContent).toBe(
+            "Title",
+        );
+        const li = host.querySelector(".cm-note-embed-li");
+        expect(li?.querySelector("strong")?.textContent).toBe("bold");
+        expect(host.querySelector("code")?.textContent).toBe("code");
+        // No raw HTML injection: everything is built with DOM nodes.
+        expect(host.querySelector("script")).toBeNull();
+    });
+
+    it("limits the preview to maxLines non-empty lines", () => {
+        const fragment = renderEmbedPreview("a\n\nb\nc\nd", 2);
+        const host = document.createElement("div");
+        host.appendChild(fragment);
+        expect(host.childElementCount).toBe(2);
+        expect(host.textContent).toBe("ab");
+    });
+});
+
+describe("extractSection", () => {
+    const doc = [
+        "# Intro",
+        "intro body",
+        "## Details",
+        "detail body",
+        "### Sub",
+        "sub body",
+        "## Other",
+        "other body",
+    ].join("\n");
+
+    it("extracts a section up to the next heading of same or higher level", () => {
+        expect(extractSection(doc, "Details")).toBe(
+            ["## Details", "detail body", "### Sub", "sub body"].join("\n"),
+        );
+    });
+
+    it("returns an empty string when the heading is missing", () => {
+        expect(extractSection(doc, "Nope")).toBe("");
+    });
+});

--- a/apps/desktop/src/features/editor/extensions/notePreviewSource.ts
+++ b/apps/desktop/src/features/editor/extensions/notePreviewSource.ts
@@ -1,0 +1,228 @@
+import {
+    useEditorStore,
+    isNoteTab,
+    selectEditorWorkspaceTabs,
+} from "../../../app/store/editorStore";
+import { useVaultStore } from "../../../app/store/vaultStore";
+import { vaultInvoke } from "../../../app/utils/vaultInvoke";
+
+// Shared source of truth for rendering a short preview of a note's content.
+// Both the inline `![[embed]]` widget and the wikilink hover preview read a
+// note's content (cached, with async fetch) and render a few markdown lines to
+// a safe DocumentFragment. Keeping the reader + renderer here avoids
+// duplicating cache and markdown-to-DOM logic across the two call sites.
+
+const NOTE_PREVIEW_CACHE_LIMIT = 64;
+
+const notePreviewContentCache = new Map<string, string>();
+const notePreviewRequestCache = new Map<string, Promise<string | null>>();
+
+function rememberNotePreviewContent(noteId: string, content: string) {
+    if (notePreviewContentCache.has(noteId)) {
+        notePreviewContentCache.delete(noteId);
+    }
+    notePreviewContentCache.set(noteId, content);
+
+    while (notePreviewContentCache.size > NOTE_PREVIEW_CACHE_LIMIT) {
+        const oldestKey = notePreviewContentCache.keys().next().value;
+        if (oldestKey === undefined) break;
+        notePreviewContentCache.delete(oldestKey);
+    }
+}
+
+export function invalidateNotePreviewCache(noteId: string | null | undefined) {
+    if (!noteId) return;
+    notePreviewContentCache.delete(noteId);
+    notePreviewRequestCache.delete(noteId);
+}
+
+export async function loadNotePreviewContent(noteId: string) {
+    const cached = notePreviewContentCache.get(noteId);
+    if (cached !== undefined) return cached;
+
+    const pending = notePreviewRequestCache.get(noteId);
+    if (pending) return pending;
+
+    const request = vaultInvoke<{ content: string }>("read_note", { noteId })
+        .then((detail) => {
+            rememberNotePreviewContent(noteId, detail.content);
+            notePreviewRequestCache.delete(noteId);
+            return detail.content;
+        })
+        .catch(() => {
+            notePreviewRequestCache.delete(noteId);
+            return null;
+        });
+
+    notePreviewRequestCache.set(noteId, request);
+    return request;
+}
+
+export interface PreviewNote {
+    id: string;
+    title: string;
+    path: string;
+}
+
+/** Resolve a wikilink target to a note entry in the current vault, if any. */
+export function findPreviewNote(target: string): PreviewNote | null {
+    const note = useVaultStore
+        .getState()
+        .notes.find(
+            (entry) =>
+                entry.id === target ||
+                entry.title === target ||
+                entry.id.replace(/\.md$/i, "") === target,
+        );
+    return note
+        ? { id: note.id, title: note.title, path: note.path }
+        : null;
+}
+
+export interface NotePreviewContentState {
+    /** Content available synchronously (open tab or warm cache), else null. */
+    content: string | null;
+    /** Loader for async fetch when no synchronous content is available. */
+    load: (() => Promise<string | null>) | null;
+}
+
+/**
+ * Resolve a note's content for previewing. Prefers a live open-tab buffer,
+ * then a warm cache, and otherwise exposes an async loader. Mirrors the
+ * embed widget's original openTab → cache → fetch ordering.
+ */
+export function getNotePreviewContentState(
+    note: PreviewNote | null,
+    target: string,
+): NotePreviewContentState {
+    const openTab = selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+        (tab) =>
+            (isNoteTab(tab) && tab.noteId === note?.id) ||
+            (isNoteTab(tab) && tab.noteId === target) ||
+            tab.title === target,
+    );
+
+    const fullContent =
+        openTab && isNoteTab(openTab) ? openTab.content : null;
+    if (fullContent !== null) {
+        if (note?.id) {
+            rememberNotePreviewContent(note.id, fullContent);
+        }
+        return { content: fullContent, load: null };
+    }
+
+    const cachedContent = note?.id
+        ? (notePreviewContentCache.get(note.id) ?? null)
+        : null;
+    if (cachedContent !== null) {
+        return { content: cachedContent, load: null };
+    }
+
+    const noteId = note?.id ?? null;
+    return {
+        content: null,
+        load: noteId ? () => loadNotePreviewContent(noteId) : null,
+    };
+}
+
+/**
+ * Append inline-formatted text to a parent element using DOM nodes (no
+ * innerHTML). Handles **bold**, *italic*, `code`, and [[wikilinks|label]].
+ */
+export function appendFormattedInline(parent: HTMLElement, text: string): void {
+    const re =
+        /(\*\*(.+?)\*\*|\*(.+?)\*|`(.+?)`|\[\[([^\]|]+?)(?:\|([^\]]+))?\]\])/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+
+    while ((m = re.exec(text)) !== null) {
+        if (m.index > last) {
+            parent.appendChild(
+                document.createTextNode(text.slice(last, m.index)),
+            );
+        }
+        if (m[2]) {
+            const el = document.createElement("strong");
+            el.textContent = m[2];
+            parent.appendChild(el);
+        } else if (m[3]) {
+            const el = document.createElement("em");
+            el.textContent = m[3];
+            parent.appendChild(el);
+        } else if (m[4]) {
+            const el = document.createElement("code");
+            el.textContent = m[4];
+            parent.appendChild(el);
+        } else if (m[5]) {
+            const el = document.createElement("span");
+            el.className = "cm-note-embed-wikilink";
+            el.textContent = m[6] ?? m[5];
+            parent.appendChild(el);
+        }
+        last = m.index + m[0].length;
+    }
+
+    if (last < text.length) {
+        parent.appendChild(document.createTextNode(text.slice(last)));
+    }
+}
+
+/** Render a few lines of markdown content into a DocumentFragment (safe DOM). */
+export function renderEmbedPreview(
+    text: string,
+    maxLines: number,
+): DocumentFragment {
+    const fragment = document.createDocumentFragment();
+    const lines = text
+        .split("\n")
+        .filter((l) => l.trim())
+        .slice(0, maxLines);
+
+    for (const line of lines) {
+        const hMatch = line.match(/^(#{1,6})\s+(.+)$/);
+        if (hMatch) {
+            const div = document.createElement("div");
+            div.className = `cm-note-embed-h${hMatch[1].length}`;
+            appendFormattedInline(div, hMatch[2]);
+            fragment.appendChild(div);
+            continue;
+        }
+
+        const liMatch = line.match(/^\s*[-*+]\s+(.+)$/);
+        if (liMatch) {
+            const div = document.createElement("div");
+            div.className = "cm-note-embed-li";
+            appendFormattedInline(div, liMatch[1]);
+            fragment.appendChild(div);
+            continue;
+        }
+
+        const div = document.createElement("div");
+        appendFormattedInline(div, line);
+        fragment.appendChild(div);
+    }
+
+    return fragment;
+}
+
+/**
+ * Extract content under a specific heading until the next heading of the same
+ * or higher level.
+ */
+export function extractSection(content: string, heading: string): string {
+    const lines = content.split("\n");
+    const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const headingRe = new RegExp(`^(#{1,6})\\s+${escaped}\\s*$`, "i");
+    const startIdx = lines.findIndex((l) => headingRe.test(l));
+    if (startIdx < 0) return "";
+
+    const level = lines[startIdx].match(/^(#+)/)?.[1].length ?? 1;
+    let endIdx = startIdx + 1;
+    while (endIdx < lines.length) {
+        const lm = lines[endIdx].match(/^(#+)\s/);
+        if (lm && lm[1].length <= level) break;
+        endIdx++;
+    }
+
+    return lines.slice(startIdx, endIdx).join("\n");
+}

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -3,8 +3,13 @@
  */
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildWikilinkHoverTooltip } from "./wikilinkHoverPreview";
+import { invalidateNotePreviewCache } from "./notePreviewSource";
+import { useVaultStore } from "../../../app/store/vaultStore";
+
+vi.mock("@neverwrite/runtime", () => ({ invoke: vi.fn() }));
+import { invoke } from "@neverwrite/runtime";
 
 function createView(doc: string) {
     const parent = document.createElement("div");
@@ -17,8 +22,26 @@ function createView(doc: string) {
     return { parent, view };
 }
 
+function seedNote(id: string, title: string) {
+    useVaultStore.setState({
+        vaultPath: "/vault",
+        notes: [
+            {
+                id,
+                path: `/vault/${id}.md`,
+                title,
+                modified_at: 0,
+                created_at: 0,
+            },
+        ],
+    });
+}
+
 afterEach(() => {
     document.body.innerHTML = "";
+    vi.clearAllMocks();
+    invalidateNotePreviewCache("Note");
+    useVaultStore.setState({ notes: [] });
 });
 
 describe("buildWikilinkHoverTooltip", () => {
@@ -55,6 +78,67 @@ describe("buildWikilinkHoverTooltip", () => {
     it("returns null outside any wikilink", () => {
         const { parent, view } = createView("before [[Target]] after");
         expect(buildWikilinkHoverTooltip(view, 2)).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("renders loading then note content, and serves the second hover from cache", async () => {
+        seedNote("Note", "Note");
+        vi.mocked(invoke).mockResolvedValue({
+            content: "# Note body\nhello world",
+        });
+
+        const { parent, view } = createView("see [[Note]] here");
+
+        // First hover: no synchronous content, so a loading placeholder shows
+        // while the async read resolves.
+        const first = buildWikilinkHoverTooltip(view, 7)?.create?.(view);
+        const firstBody = first?.dom.querySelector(".cm-wikilink-hover-body");
+        expect(firstBody?.textContent).toBe("Loading…");
+
+        await vi.waitFor(() => {
+            expect(firstBody?.querySelector(".cm-note-embed-h1")?.textContent).toBe(
+                "Note body",
+            );
+        });
+        expect(firstBody?.textContent).toContain("hello world");
+        expect(invoke).toHaveBeenCalledTimes(1);
+
+        // Second hover: content is cached, so it renders synchronously with no
+        // additional read.
+        const second = buildWikilinkHoverTooltip(view, 7)?.create?.(view);
+        const secondBody = second?.dom.querySelector(".cm-wikilink-hover-body");
+        expect(secondBody?.querySelector(".cm-note-embed-h1")?.textContent).toBe(
+            "Note body",
+        );
+        expect(invoke).toHaveBeenCalledTimes(1);
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("does not repaint after the tooltip is destroyed", async () => {
+        seedNote("Note", "Note");
+        let resolveRead: (value: { content: string }) => void = () => {};
+        vi.mocked(invoke).mockReturnValue(
+            new Promise((resolve) => {
+                resolveRead = resolve;
+            }),
+        );
+
+        const { parent, view } = createView("see [[Note]] here");
+        const mounted = buildWikilinkHoverTooltip(view, 7)?.create?.(view);
+        const body = mounted?.dom.querySelector(".cm-wikilink-hover-body");
+        expect(body?.textContent).toBe("Loading…");
+
+        mounted?.destroy?.();
+        resolveRead({ content: "# Note body" });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        // Still the placeholder — the resolved load was ignored post-destroy.
+        expect(body?.querySelector(".cm-note-embed-h1")).toBeNull();
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -4,7 +4,11 @@
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { buildWikilinkHoverTooltip } from "./wikilinkHoverPreview";
+import {
+    buildWikilinkHoverTooltip,
+    wikilinkHoverPreviewExtension,
+} from "./wikilinkHoverPreview";
+import { getWikilinkHoverPreviewExtension } from "../editorExtensions";
 import { invalidateNotePreviewCache } from "./notePreviewSource";
 import { useVaultStore } from "../../../app/store/vaultStore";
 
@@ -171,6 +175,7 @@ describe("buildWikilinkHoverTooltip", () => {
                     id: "diagram.png",
                     path: "/vault/diagram.png",
                     relative_path: "diagram.png",
+                    title: "diagram",
                     file_name: "diagram.png",
                     extension: "png",
                     kind: "file",
@@ -220,5 +225,21 @@ describe("buildWikilinkHoverTooltip", () => {
 
         view.destroy();
         parent.remove();
+    });
+});
+
+describe("getWikilinkHoverPreviewExtension", () => {
+    it("registers the hover extension when enabled", () => {
+        const extension = getWikilinkHoverPreviewExtension(true, 300);
+        expect(Array.isArray(extension)).toBe(true);
+        expect(extension).toHaveLength(2);
+    });
+
+    it("registers nothing when disabled", () => {
+        expect(getWikilinkHoverPreviewExtension(false, 300)).toEqual([]);
+    });
+
+    it("builds the extension with a configurable delay", () => {
+        expect(wikilinkHoverPreviewExtension(750)).toHaveLength(2);
     });
 });

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -6,6 +6,7 @@ import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
     buildWikilinkHoverTooltip,
+    showWikilinkPreviewAtCaret,
     wikilinkHoverPreviewExtension,
 } from "./wikilinkHoverPreview";
 import { getWikilinkHoverPreviewExtension } from "../editorExtensions";
@@ -232,7 +233,7 @@ describe("getWikilinkHoverPreviewExtension", () => {
     it("registers the hover extension when enabled", () => {
         const extension = getWikilinkHoverPreviewExtension(true, 300);
         expect(Array.isArray(extension)).toBe(true);
-        expect(extension).toHaveLength(2);
+        expect(extension).toHaveLength(4);
     });
 
     it("registers nothing when disabled", () => {
@@ -240,6 +241,44 @@ describe("getWikilinkHoverPreviewExtension", () => {
     });
 
     it("builds the extension with a configurable delay", () => {
-        expect(wikilinkHoverPreviewExtension(750)).toHaveLength(2);
+        expect(wikilinkHoverPreviewExtension(750)).toHaveLength(4);
+    });
+});
+
+describe("showWikilinkPreviewAtCaret", () => {
+    function createConfiguredView(doc: string, caret: number) {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+        const view = new EditorView({
+            state: EditorState.create({
+                doc,
+                selection: EditorSelection.cursor(caret),
+                extensions: [wikilinkHoverPreviewExtension()],
+            }),
+            parent,
+        });
+        return { parent, view };
+    }
+
+    it("opens a caret preview when the caret is inside a wikilink", () => {
+        const { parent, view } = createConfiguredView("see [[Ghost]] now", 8);
+        expect(showWikilinkPreviewAtCaret(view)).toBe(true);
+        expect(view.dom.querySelector(".cm-wikilink-hover")).not.toBeNull();
+
+        // Moving the caret dismisses the on-demand preview.
+        view.dispatch({ selection: EditorSelection.cursor(0) });
+        expect(view.dom.querySelector(".cm-wikilink-hover")).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("does nothing when the caret is not inside a wikilink", () => {
+        const { parent, view } = createConfiguredView("see [[Ghost]] now", 0);
+        expect(showWikilinkPreviewAtCaret(view)).toBe(false);
+        expect(view.dom.querySelector(".cm-wikilink-hover")).toBeNull();
+
+        view.destroy();
+        parent.remove();
     });
 });

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -1,0 +1,62 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, describe, expect, it } from "vitest";
+import { buildWikilinkHoverTooltip } from "./wikilinkHoverPreview";
+
+function createView(doc: string) {
+    const parent = document.createElement("div");
+    document.body.appendChild(parent);
+    const state = EditorState.create({
+        doc,
+        selection: EditorSelection.cursor(0),
+    });
+    const view = new EditorView({ state, parent });
+    return { parent, view };
+}
+
+afterEach(() => {
+    document.body.innerHTML = "";
+});
+
+describe("buildWikilinkHoverTooltip", () => {
+    it("returns an anchored tooltip when hovering inside a wikilink", () => {
+        const { parent, view } = createView("before [[Target]] after");
+
+        // Position inside the [[Target]] token.
+        const tooltip = buildWikilinkHoverTooltip(view, 11);
+        expect(tooltip).not.toBeNull();
+        expect(tooltip?.pos).toBe(7);
+        expect(tooltip?.end).toBe(17);
+
+        const mounted = tooltip?.create?.(view);
+        expect(
+            mounted?.dom.querySelector(".cm-wikilink-hover-title")?.textContent,
+        ).toBe("Target");
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("uses the target side of a piped wikilink", () => {
+        const { parent, view } = createView("[[Target|alias]]");
+        const tooltip = buildWikilinkHoverTooltip(view, 4);
+        const mounted = tooltip?.create?.(view);
+        expect(
+            mounted?.dom.querySelector(".cm-wikilink-hover-title")?.textContent,
+        ).toBe("Target");
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("returns null outside any wikilink", () => {
+        const { parent, view } = createView("before [[Target]] after");
+        expect(buildWikilinkHoverTooltip(view, 2)).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+});

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -118,6 +118,84 @@ describe("buildWikilinkHoverTooltip", () => {
         parent.remove();
     });
 
+    it("previews a #section from the target heading", async () => {
+        seedNote("Note", "Note");
+        vi.mocked(invoke).mockResolvedValue({
+            content: [
+                "# Intro",
+                "intro body",
+                "## Details",
+                "detail body line",
+            ].join("\n"),
+        });
+
+        const { parent, view } = createView("see [[Note#Details]] now");
+        const mounted = buildWikilinkHoverTooltip(view, 8)?.create?.(view);
+        const body = mounted?.dom.querySelector(".cm-wikilink-hover-body");
+        const titleText = mounted?.dom.querySelector(
+            ".cm-wikilink-hover-title",
+        )?.textContent;
+        expect(titleText).toBe("Note > Details");
+
+        await vi.waitFor(() => {
+            expect(body?.textContent).toContain("detail body line");
+        });
+        // Section preview is scoped: content from before the heading is excluded.
+        expect(body?.textContent).not.toContain("intro body");
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("shows a create action for an unresolved target", async () => {
+        const { parent, view } = createView("see [[Ghost]] now");
+        const mounted = buildWikilinkHoverTooltip(view, 8)?.create?.(view);
+        const body = mounted?.dom.querySelector(".cm-wikilink-hover-body");
+
+        await vi.waitFor(() => {
+            expect(body?.textContent).toBe("No note yet — click to create");
+        });
+        expect(
+            body?.querySelector(".cm-wikilink-hover-action"),
+        ).not.toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("labels a non-markdown file target by name and type", () => {
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            entries: [
+                {
+                    id: "diagram.png",
+                    path: "/vault/diagram.png",
+                    relative_path: "diagram.png",
+                    file_name: "diagram.png",
+                    extension: "png",
+                    kind: "file",
+                    modified_at: 0,
+                    created_at: 0,
+                    size: 0,
+                    mime_type: "image/png",
+                },
+            ],
+        });
+
+        const { parent, view } = createView("see [[diagram.png]] now");
+        const mounted = buildWikilinkHoverTooltip(view, 8)?.create?.(view);
+        expect(
+            mounted?.dom.querySelector(".cm-wikilink-hover-title")?.textContent,
+        ).toBe("diagram.png");
+        expect(
+            mounted?.dom.querySelector(".cm-wikilink-hover-meta")?.textContent,
+        ).toBe("Image");
+
+        useVaultStore.setState({ entries: [] });
+        view.destroy();
+        parent.remove();
+    });
+
     it("does not repaint after the tooltip is destroyed", async () => {
         seedNote("Note", "Note");
         let resolveRead: (value: { content: string }) => void = () => {};

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.test.ts
@@ -10,6 +10,7 @@ import {
     wikilinkHoverPreviewExtension,
 } from "./wikilinkHoverPreview";
 import { getWikilinkHoverPreviewExtension } from "../editorExtensions";
+import { wikilinkExtension } from "./wikilinks";
 import { invalidateNotePreviewCache } from "./notePreviewSource";
 import { useVaultStore } from "../../../app/store/vaultStore";
 
@@ -233,7 +234,7 @@ describe("getWikilinkHoverPreviewExtension", () => {
     it("registers the hover extension when enabled", () => {
         const extension = getWikilinkHoverPreviewExtension(true, 300);
         expect(Array.isArray(extension)).toBe(true);
-        expect(extension).toHaveLength(4);
+        expect(extension).toHaveLength(5);
     });
 
     it("registers nothing when disabled", () => {
@@ -241,7 +242,7 @@ describe("getWikilinkHoverPreviewExtension", () => {
     });
 
     it("builds the extension with a configurable delay", () => {
-        expect(wikilinkHoverPreviewExtension(750)).toHaveLength(4);
+        expect(wikilinkHoverPreviewExtension(750)).toHaveLength(5);
     });
 });
 
@@ -277,6 +278,55 @@ describe("showWikilinkPreviewAtCaret", () => {
         const { parent, view } = createConfiguredView("see [[Ghost]] now", 0);
         expect(showWikilinkPreviewAtCaret(view)).toBe(false);
         expect(view.dom.querySelector(".cm-wikilink-hover")).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("prefetches note content on pointer enter so the preview opens without a flash", async () => {
+        seedNote("Note", "Note");
+        vi.mocked(invoke).mockResolvedValue({ content: "# Note body" });
+
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+        const view = new EditorView({
+            state: EditorState.create({
+                doc: "see [[Note]] here",
+                selection: EditorSelection.cursor(0),
+                extensions: [
+                    wikilinkExtension(
+                        (_noteId, targets) =>
+                            new Map(
+                                targets.map((t) => [t, "valid" as const]),
+                            ),
+                        () => "current",
+                        () => {},
+                    ),
+                    wikilinkHoverPreviewExtension(),
+                ],
+            }),
+            parent,
+        });
+
+        // Simulate the pointer entering the rendered wikilink span.
+        const link = view.dom.querySelector<HTMLElement>(
+            "[data-wikilink-target]",
+        );
+        expect(link).not.toBeNull();
+        link?.dispatchEvent(
+            new MouseEvent("mouseover", { bubbles: true }),
+        );
+
+        // Once the prefetch read resolves, opening the tooltip renders content
+        // straight from cache — no second read.
+        await vi.waitFor(() => {
+            const mounted = buildWikilinkHoverTooltip(view, 7)?.create?.(view);
+            const body = mounted?.dom.querySelector(".cm-wikilink-hover-body");
+            expect(body?.querySelector(".cm-note-embed-h1")?.textContent).toBe(
+                "Note body",
+            );
+        });
+        expect(invoke).toHaveBeenCalledTimes(1);
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
@@ -84,6 +84,10 @@ const hoverTheme = EditorView.baseTheme({
         font: "inherit",
         color: "var(--text-primary)",
         lineHeight: "1.4",
+        // Stable width so the box doesn't jump horizontally when a loading
+        // placeholder is replaced by the rendered note content.
+        minWidth: "240px",
+        boxSizing: "border-box",
     },
     ".cm-wikilink-hover-title": {
         fontWeight: "700",
@@ -349,6 +353,25 @@ const caretPreviewKeymap = keymap.of([
     },
 ]);
 
+// Warm the note content cache as soon as the pointer enters a wikilink, before
+// the open delay elapses. By the time the tooltip opens the read has usually
+// completed, so it renders content directly instead of flashing a "Loading…"
+// placeholder and then reflowing. loadNotePreviewContent dedupes by note id, so
+// repeated mouseover events are cheap (cache hit, no extra read).
+const prefetchHandler = EditorView.domEventHandlers({
+    mouseover(event) {
+        const node = event.target;
+        if (!(node instanceof HTMLElement)) return false;
+        const link = node.closest<HTMLElement>("[data-wikilink-target]");
+        const raw = link?.dataset.wikilinkTarget;
+        if (!raw) return false;
+        const { base } = parseWikilinkTarget(raw);
+        const note = findPreviewNote(base);
+        if (note) void loadNotePreviewContent(note.id);
+        return false;
+    },
+});
+
 /**
  * Show a floating preview when hovering over a `[[wikilink]]`, plus a
  * keyboard-triggered preview for the link under the caret.
@@ -357,5 +380,11 @@ export function wikilinkHoverPreviewExtension(
     hoverTime: number = DEFAULT_WIKILINK_HOVER_DELAY_MS,
 ) {
     const tooltip = hoverTooltip(buildWikilinkHoverTooltip, { hoverTime });
-    return [tooltip, caretPreviewField, caretPreviewKeymap, hoverTheme];
+    return [
+        tooltip,
+        prefetchHandler,
+        caretPreviewField,
+        caretPreviewKeymap,
+        hoverTheme,
+    ];
 }

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
@@ -1,9 +1,18 @@
 import { EditorView, hoverTooltip, type Tooltip } from "@codemirror/view";
 import { findWikilinkAtPosition } from "./wikilinks";
+import {
+    findPreviewNote,
+    getNotePreviewContentState,
+    renderEmbedPreview,
+} from "./notePreviewSource";
 
 // Default delay before the hover preview opens. Long enough to avoid firing on
 // every sweep of the mouse across links.
 export const DEFAULT_WIKILINK_HOVER_DELAY_MS = 300;
+
+// Lines of the target note to show in the floating preview. Bounded so large
+// notes never load or render in full just for a hover.
+const HOVER_MAX_LINES = 8;
 
 const hoverTheme = EditorView.baseTheme({
     ".cm-tooltip:has(.cm-wikilink-hover)": {
@@ -15,15 +24,57 @@ const hoverTheme = EditorView.baseTheme({
         overflow: "hidden",
     },
     ".cm-wikilink-hover": {
-        padding: "8px 10px",
+        padding: "10px 12px",
         font: "inherit",
         color: "var(--text-primary)",
         lineHeight: "1.4",
     },
     ".cm-wikilink-hover-title": {
-        fontWeight: "600",
-        fontSize: "0.85em",
+        fontWeight: "700",
+        color: "var(--text-primary)",
+        marginBottom: "4px",
+    },
+    ".cm-wikilink-hover-meta": {
         color: "var(--text-secondary)",
+        fontSize: "0.82em",
+    },
+    ".cm-wikilink-hover-body": {
+        fontSize: "0.88em",
+        color: "var(--text-secondary)",
+        lineHeight: "1.5",
+    },
+    ".cm-wikilink-hover-body > div": {
+        marginBottom: "2px",
+    },
+    ".cm-wikilink-hover-body .cm-note-embed-h1, .cm-wikilink-hover-body .cm-note-embed-h2, .cm-wikilink-hover-body .cm-note-embed-h3, .cm-wikilink-hover-body .cm-note-embed-h4, .cm-wikilink-hover-body .cm-note-embed-h5, .cm-wikilink-hover-body .cm-note-embed-h6":
+        {
+            fontWeight: "600",
+            color: "var(--text-primary)",
+        },
+    ".cm-wikilink-hover-body .cm-note-embed-h1": { fontSize: "1.15em" },
+    ".cm-wikilink-hover-body .cm-note-embed-h2": { fontSize: "1.08em" },
+    ".cm-wikilink-hover-body .cm-note-embed-li": {
+        paddingLeft: "1.2em",
+        position: "relative",
+    },
+    ".cm-wikilink-hover-body .cm-note-embed-li::before": {
+        content: '"\\2022"',
+        position: "absolute",
+        left: "0.3em",
+        color: "var(--text-secondary)",
+    },
+    ".cm-wikilink-hover-body code": {
+        fontSize: "0.9em",
+        padding: "1px 4px",
+        borderRadius: "3px",
+        background:
+            "color-mix(in srgb, var(--bg-tertiary) 60%, var(--bg-primary))",
+    },
+    ".cm-wikilink-hover-body .cm-note-embed-wikilink": {
+        color: "var(--accent)",
+        textDecoration: "underline",
+        textDecorationStyle: "dotted",
+        textUnderlineOffset: "2px",
     },
 });
 
@@ -31,9 +82,6 @@ const hoverTheme = EditorView.baseTheme({
  * Build the hover tooltip for a document position, or null when the position
  * is not inside a wikilink. Exposed separately so the trigger logic can be unit
  * tested without simulating real mouse hover and timers.
- *
- * This commit wires only the trigger: the tooltip is a minimal anchor showing
- * the target name. Content rendering arrives in a later commit.
  */
 export function buildWikilinkHoverTooltip(
     view: EditorView,
@@ -41,6 +89,8 @@ export function buildWikilinkHoverTooltip(
 ): Tooltip | null {
     const match = findWikilinkAtPosition(view, pos);
     if (!match || !match.target) return null;
+
+    const target = match.target;
 
     return {
         pos: match.from,
@@ -51,12 +101,51 @@ export function buildWikilinkHoverTooltip(
             const dom = document.createElement("div");
             dom.className = "cm-wikilink-hover";
 
+            const note = findPreviewNote(target);
+
             const title = document.createElement("div");
             title.className = "cm-wikilink-hover-title";
-            title.textContent = match.target;
+            title.textContent = note?.title ?? target;
             dom.appendChild(title);
 
-            return { dom };
+            const body = document.createElement("div");
+            body.className = "cm-wikilink-hover-body";
+            dom.appendChild(body);
+
+            // Track teardown so an async content load can't repaint a tooltip
+            // CodeMirror has already closed.
+            let active = true;
+
+            const renderPreview = (content: string) => {
+                body.replaceChildren(
+                    renderEmbedPreview(content, HOVER_MAX_LINES),
+                );
+            };
+
+            const showPlaceholder = (text: string) => {
+                const meta = document.createElement("div");
+                meta.className = "cm-wikilink-hover-meta";
+                meta.textContent = text;
+                body.replaceChildren(meta);
+            };
+
+            const { content, load } = getNotePreviewContentState(note, target);
+            if (content !== null) {
+                renderPreview(content);
+            } else if (load) {
+                showPlaceholder("Loading…");
+                void load().then((loaded) => {
+                    if (!active || loaded === null) return;
+                    renderPreview(loaded);
+                });
+            }
+
+            return {
+                dom,
+                destroy() {
+                    active = false;
+                },
+            };
         },
     };
 }

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
@@ -1,10 +1,15 @@
 import { EditorView, hoverTooltip, type Tooltip } from "@codemirror/view";
 import { findWikilinkAtPosition } from "./wikilinks";
 import {
+    extractSection,
     findPreviewNote,
     getNotePreviewContentState,
+    loadNotePreviewContent,
     renderEmbedPreview,
 } from "./notePreviewSource";
+import { findWikilinkResource } from "../wikilinkResolution";
+import { navigateWikilink } from "../wikilinkNavigation";
+import { useVaultStore } from "../../../app/store/vaultStore";
 
 // Default delay before the hover preview opens. Long enough to avoid firing on
 // every sweep of the mouse across links.
@@ -13,6 +18,50 @@ export const DEFAULT_WIKILINK_HOVER_DELAY_MS = 300;
 // Lines of the target note to show in the floating preview. Bounded so large
 // notes never load or render in full just for a hover.
 const HOVER_MAX_LINES = 8;
+
+const IMAGE_FILE_RE = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif)$/i;
+const PDF_FILE_RE = /\.pdf$/i;
+
+/** Split a wikilink target into its note part and optional `#section`. */
+function parseWikilinkTarget(target: string): {
+    base: string;
+    section: string | null;
+} {
+    const hashIndex = target.indexOf("#");
+    if (hashIndex < 0) return { base: target.trim(), section: null };
+    return {
+        base: target.slice(0, hashIndex).trim(),
+        section: target.slice(hashIndex + 1).trim() || null,
+    };
+}
+
+/** Human label + display name for a non-markdown file target. */
+function describeFileTarget(relativePath: string): {
+    type: string;
+    name: string;
+} {
+    const name = relativePath.split("/").pop() || relativePath;
+    if (PDF_FILE_RE.test(relativePath)) return { type: "PDF", name };
+    if (IMAGE_FILE_RE.test(relativePath)) return { type: "Image", name };
+    return { type: "File", name };
+}
+
+/**
+ * Resolve a wikilink target to a non-note file entry in the vault store.
+ * Covers PDFs and images, which the note/text-file resolver does not surface.
+ */
+function findVaultFileEntry(base: string): { relativePath: string } | null {
+    const normalized = base.replace(/\\/g, "/").replace(/^\/+/, "");
+    const entry = useVaultStore
+        .getState()
+        .entries.find(
+            (candidate) =>
+                (candidate.kind === "file" || candidate.kind === "pdf") &&
+                (candidate.relative_path === normalized ||
+                    candidate.file_name === base),
+        );
+    return entry ? { relativePath: entry.relative_path } : null;
+}
 
 const hoverTheme = EditorView.baseTheme({
     ".cm-tooltip:has(.cm-wikilink-hover)": {
@@ -37,6 +86,10 @@ const hoverTheme = EditorView.baseTheme({
     ".cm-wikilink-hover-meta": {
         color: "var(--text-secondary)",
         fontSize: "0.82em",
+    },
+    ".cm-wikilink-hover-action": {
+        cursor: "pointer",
+        color: "var(--accent)",
     },
     ".cm-wikilink-hover-body": {
         fontSize: "0.88em",
@@ -90,7 +143,8 @@ export function buildWikilinkHoverTooltip(
     const match = findWikilinkAtPosition(view, pos);
     if (!match || !match.target) return null;
 
-    const target = match.target;
+    const { base, section } = parseWikilinkTarget(match.target);
+    if (!base) return null;
 
     return {
         pos: match.from,
@@ -101,44 +155,131 @@ export function buildWikilinkHoverTooltip(
             const dom = document.createElement("div");
             dom.className = "cm-wikilink-hover";
 
-            const note = findPreviewNote(target);
-
             const title = document.createElement("div");
             title.className = "cm-wikilink-hover-title";
-            title.textContent = note?.title ?? target;
             dom.appendChild(title);
 
             const body = document.createElement("div");
             body.className = "cm-wikilink-hover-body";
             dom.appendChild(body);
 
-            // Track teardown so an async content load can't repaint a tooltip
+            // Track teardown so an async load can't repaint a tooltip
             // CodeMirror has already closed.
             let active = true;
 
-            const renderPreview = (content: string) => {
-                body.replaceChildren(
-                    renderEmbedPreview(content, HOVER_MAX_LINES),
-                );
+            const setTitle = (name: string) => {
+                title.textContent = section ? `${name} > ${section}` : name;
             };
 
-            const showPlaceholder = (text: string) => {
+            const showMeta = (text: string, onClick?: () => void) => {
                 const meta = document.createElement("div");
                 meta.className = "cm-wikilink-hover-meta";
                 meta.textContent = text;
+                if (onClick) {
+                    meta.classList.add("cm-wikilink-hover-action");
+                    // mousedown (not click) so the action fires before the
+                    // tooltip closes, without stealing editor focus.
+                    meta.addEventListener("mousedown", (event) => {
+                        event.preventDefault();
+                        onClick();
+                    });
+                }
                 body.replaceChildren(meta);
             };
 
-            const { content, load } = getNotePreviewContentState(note, target);
-            if (content !== null) {
-                renderPreview(content);
-            } else if (load) {
-                showPlaceholder("Loading…");
-                void load().then((loaded) => {
-                    if (!active || loaded === null) return;
-                    renderPreview(loaded);
+            // Render note content, narrowing to a `#section` when present.
+            const renderNoteContent = (content: string) => {
+                const text = section
+                    ? extractSection(content, section)
+                    : content;
+                if (text.trim()) {
+                    body.replaceChildren(
+                        renderEmbedPreview(text, HOVER_MAX_LINES),
+                    );
+                    return;
+                }
+                showMeta(section ? "Section not found" : "Empty note");
+            };
+
+            const loadNoteContent = (noteId: string) => {
+                showMeta("Loading…");
+                void loadNotePreviewContent(noteId).then((content) => {
+                    if (!active) return;
+                    if (content === null) {
+                        showMeta("Could not load note");
+                        return;
+                    }
+                    renderNoteContent(content);
                 });
+            };
+
+            // Fast path: target is a markdown note already in the vault store.
+            const note = findPreviewNote(base);
+            if (note) {
+                setTitle(note.title);
+                const { content, load } = getNotePreviewContentState(
+                    note,
+                    base,
+                );
+                if (content !== null) {
+                    renderNoteContent(content);
+                } else if (load) {
+                    showMeta("Loading…");
+                    void load().then((loaded) => {
+                        if (!active) return;
+                        if (loaded === null) {
+                            showMeta("Could not load note");
+                            return;
+                        }
+                        renderNoteContent(loaded);
+                    });
+                }
+                return {
+                    dom,
+                    destroy() {
+                        active = false;
+                    },
+                };
             }
+
+            // Non-note file already known to the vault (PDF, image, etc.).
+            const fileEntry = findVaultFileEntry(base);
+            if (fileEntry) {
+                const { type, name } = describeFileTarget(
+                    fileEntry.relativePath,
+                );
+                title.textContent = name;
+                showMeta(type);
+                return {
+                    dom,
+                    destroy() {
+                        active = false;
+                    },
+                };
+            }
+
+            // Otherwise resolve the target type: note, file, or unresolved.
+            setTitle(base);
+            showMeta("Loading…");
+            void findWikilinkResource(base).then((resource) => {
+                if (!active) return;
+                if (resource?.kind === "note") {
+                    setTitle(resource.title ?? base);
+                    loadNoteContent(resource.id);
+                    return;
+                }
+                if (resource?.kind === "file") {
+                    const { type, name } = describeFileTarget(
+                        resource.relativePath,
+                    );
+                    title.textContent = name;
+                    showMeta(type);
+                    return;
+                }
+                showMeta("No note yet — click to create", () => {
+                    void navigateWikilink(base);
+                });
+            });
 
             return {
                 dom,

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
@@ -1,4 +1,11 @@
-import { EditorView, hoverTooltip, type Tooltip } from "@codemirror/view";
+import {
+    EditorView,
+    hoverTooltip,
+    keymap,
+    showTooltip,
+    type Tooltip,
+} from "@codemirror/view";
+import { StateEffect, StateField } from "@codemirror/state";
 import { findWikilinkAtPosition } from "./wikilinks";
 import {
     extractSection,
@@ -291,12 +298,64 @@ export function buildWikilinkHoverTooltip(
     };
 }
 
+// --- Keyboard accessibility: preview the link under the caret on demand ---
+
+const setCaretPreviewTooltip = StateEffect.define<Tooltip | null>();
+
+// Holds the on-demand (keyboard-triggered) preview tooltip. It dismisses itself
+// as soon as the user edits or moves the caret, so it never lingers stale.
+const caretPreviewField = StateField.define<Tooltip | null>({
+    create() {
+        return null;
+    },
+    update(value, tr) {
+        let next = value;
+        for (const effect of tr.effects) {
+            if (effect.is(setCaretPreviewTooltip)) next = effect.value;
+        }
+        if (next && next === value && (tr.docChanged || tr.selection)) {
+            return null;
+        }
+        return next;
+    },
+    provide: (field) => showTooltip.from(field),
+});
+
 /**
- * Show a floating preview when hovering over a `[[wikilink]]`.
+ * Open the note preview for the wikilink under the caret. Keyboard-equivalent
+ * of hovering, so the feature is reachable without a mouse. Returns false when
+ * the caret is not inside a wikilink.
+ */
+export function showWikilinkPreviewAtCaret(view: EditorView): boolean {
+    const tooltip = buildWikilinkHoverTooltip(
+        view,
+        view.state.selection.main.head,
+    );
+    if (!tooltip) return false;
+    view.dispatch({ effects: setCaretPreviewTooltip.of(tooltip) });
+    return true;
+}
+
+const caretPreviewKeymap = keymap.of([
+    {
+        key: "Escape",
+        run(view) {
+            if (view.state.field(caretPreviewField, false)) {
+                view.dispatch({ effects: setCaretPreviewTooltip.of(null) });
+                return true;
+            }
+            return false;
+        },
+    },
+]);
+
+/**
+ * Show a floating preview when hovering over a `[[wikilink]]`, plus a
+ * keyboard-triggered preview for the link under the caret.
  */
 export function wikilinkHoverPreviewExtension(
     hoverTime: number = DEFAULT_WIKILINK_HOVER_DELAY_MS,
 ) {
     const tooltip = hoverTooltip(buildWikilinkHoverTooltip, { hoverTime });
-    return [tooltip, hoverTheme];
+    return [tooltip, caretPreviewField, caretPreviewKeymap, hoverTheme];
 }

--- a/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinkHoverPreview.ts
@@ -1,0 +1,72 @@
+import { EditorView, hoverTooltip, type Tooltip } from "@codemirror/view";
+import { findWikilinkAtPosition } from "./wikilinks";
+
+// Default delay before the hover preview opens. Long enough to avoid firing on
+// every sweep of the mouse across links.
+export const DEFAULT_WIKILINK_HOVER_DELAY_MS = 300;
+
+const hoverTheme = EditorView.baseTheme({
+    ".cm-tooltip:has(.cm-wikilink-hover)": {
+        border: "1px solid var(--border)",
+        borderRadius: "8px",
+        backgroundColor: "var(--bg-elevated, var(--bg-secondary))",
+        boxShadow: "0 8px 24px rgba(0, 0, 0, 0.18)",
+        maxWidth: "420px",
+        overflow: "hidden",
+    },
+    ".cm-wikilink-hover": {
+        padding: "8px 10px",
+        font: "inherit",
+        color: "var(--text-primary)",
+        lineHeight: "1.4",
+    },
+    ".cm-wikilink-hover-title": {
+        fontWeight: "600",
+        fontSize: "0.85em",
+        color: "var(--text-secondary)",
+    },
+});
+
+/**
+ * Build the hover tooltip for a document position, or null when the position
+ * is not inside a wikilink. Exposed separately so the trigger logic can be unit
+ * tested without simulating real mouse hover and timers.
+ *
+ * This commit wires only the trigger: the tooltip is a minimal anchor showing
+ * the target name. Content rendering arrives in a later commit.
+ */
+export function buildWikilinkHoverTooltip(
+    view: EditorView,
+    pos: number,
+): Tooltip | null {
+    const match = findWikilinkAtPosition(view, pos);
+    if (!match || !match.target) return null;
+
+    return {
+        pos: match.from,
+        end: match.to,
+        above: true,
+        arrow: false,
+        create() {
+            const dom = document.createElement("div");
+            dom.className = "cm-wikilink-hover";
+
+            const title = document.createElement("div");
+            title.className = "cm-wikilink-hover-title";
+            title.textContent = match.target;
+            dom.appendChild(title);
+
+            return { dom };
+        },
+    };
+}
+
+/**
+ * Show a floating preview when hovering over a `[[wikilink]]`.
+ */
+export function wikilinkHoverPreviewExtension(
+    hoverTime: number = DEFAULT_WIKILINK_HOVER_DELAY_MS,
+) {
+    const tooltip = hoverTooltip(buildWikilinkHoverTooltip, { hoverTime });
+    return [tooltip, hoverTheme];
+}

--- a/apps/desktop/src/features/editor/extensions/wikilinks.ts
+++ b/apps/desktop/src/features/editor/extensions/wikilinks.ts
@@ -34,7 +34,7 @@ type IdleDeadlineLike = {
 
 type IdleCallbackHandle = number;
 
-interface WikilinkMatch {
+export interface WikilinkMatch {
     from: number;
     to: number;
     target: string;
@@ -86,7 +86,7 @@ function findVisibleWikilinks(view: EditorView): WikilinkMatch[] {
     return matches;
 }
 
-function findWikilinkAtPosition(
+export function findWikilinkAtPosition(
     view: EditorView,
     pos: number,
 ): WikilinkMatch | null {

--- a/apps/desktop/src/features/editor/wikilinkNavigation.ts
+++ b/apps/desktop/src/features/editor/wikilinkNavigation.ts
@@ -41,7 +41,8 @@ export async function navigateWikilink(target: string) {
                 .getState()
                 .entries.find(
                     (candidate) =>
-                        candidate.kind === "file" &&
+                        (candidate.kind === "file" ||
+                            candidate.kind === "pdf") &&
                         candidate.relative_path === resource.relativePath,
                 ) ?? null;
         if (entry) {
@@ -67,7 +68,8 @@ export async function openWikilinkInNewTab(target: string) {
                 .getState()
                 .entries.find(
                     (candidate) =>
-                        candidate.kind === "file" &&
+                        (candidate.kind === "file" ||
+                            candidate.kind === "pdf") &&
                         candidate.relative_path === resource.relativePath,
                 ) ?? null;
         if (entry) {

--- a/apps/desktop/src/features/editor/wikilinkResolution.test.ts
+++ b/apps/desktop/src/features/editor/wikilinkResolution.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    findWikilinkResource,
+    invalidateWikilinkCaches,
+} from "./wikilinkResolution";
+import {
+    useVaultStore,
+    type VaultEntryDto,
+} from "../../app/store/vaultStore";
+
+vi.mock("@neverwrite/runtime", () => ({ invoke: vi.fn() }));
+import { invoke } from "@neverwrite/runtime";
+
+function buildEntry(
+    relativePath: string,
+    kind: VaultEntryDto["kind"],
+    mimeType: string,
+): VaultEntryDto {
+    const fileName = relativePath.split("/").pop() ?? relativePath;
+    const extension = fileName.includes(".")
+        ? (fileName.split(".").pop() ?? "")
+        : "";
+    return {
+        id: relativePath,
+        path: `/vault/${relativePath}`,
+        relative_path: relativePath,
+        title: fileName.replace(/\.[^.]+$/, ""),
+        file_name: fileName,
+        extension,
+        kind,
+        modified_at: 0,
+        created_at: 0,
+        size: 0,
+        mime_type: mimeType,
+    };
+}
+
+describe("findWikilinkResource", () => {
+    beforeEach(() => {
+        invalidateWikilinkCaches("test");
+        vi.mocked(invoke).mockResolvedValue([]);
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            resolverRevision: 1,
+            entries: [],
+            notes: [],
+        });
+    });
+
+    afterEach(() => {
+        invalidateWikilinkCaches("test");
+        vi.clearAllMocks();
+        useVaultStore.setState({ entries: [], notes: [] });
+    });
+
+    it("resolves a note-relative image wikilink as a file resource", async () => {
+        useVaultStore.setState({
+            entries: [
+                buildEntry("projects/assets/diagram.png", "file", "image/png"),
+            ],
+        });
+
+        const resource = await findWikilinkResource(
+            "../assets/diagram.png",
+            "projects/notes/current",
+        );
+
+        expect(resource).toEqual({
+            kind: "file",
+            path: "/vault/projects/assets/diagram.png",
+            relativePath: "projects/assets/diagram.png",
+        });
+    });
+
+    it("resolves a note-relative PDF wikilink with a suffix", async () => {
+        useVaultStore.setState({
+            entries: [
+                buildEntry(
+                    "projects/assets/spec.pdf",
+                    "pdf",
+                    "application/pdf",
+                ),
+            ],
+        });
+
+        const resource = await findWikilinkResource(
+            "../assets/spec.pdf?page=2",
+            "projects/notes/current",
+        );
+
+        expect(resource).toEqual({
+            kind: "file",
+            path: "/vault/projects/assets/spec.pdf",
+            relativePath: "projects/assets/spec.pdf",
+        });
+    });
+});

--- a/apps/desktop/src/features/editor/wikilinkResolution.ts
+++ b/apps/desktop/src/features/editor/wikilinkResolution.ts
@@ -4,7 +4,6 @@ import {
     selectFocusedEditorTab,
 } from "../../app/store/editorStore";
 import { useVaultStore } from "../../app/store/vaultStore";
-import { isTextLikeVaultEntry } from "../../app/utils/vaultEntries";
 import {
     perfCount,
     perfMeasure,
@@ -109,7 +108,7 @@ function resolveRelativeTargetPath(
     baseNoteId: string | null,
     target: string,
 ): string {
-    const cleanedTarget = target.replace(/\\/g, "/");
+    const cleanedTarget = target.trim().split(/[?#^]/, 1)[0].replace(/\\/g, "/");
     const segments = cleanedTarget.startsWith("/")
         ? []
         : (baseNoteId?.split("/").slice(0, -1) ?? []);
@@ -126,6 +125,10 @@ function resolveRelativeTargetPath(
     return segments.join("/");
 }
 
+function isWikilinkFileEntry(entry: { kind: string }) {
+    return entry.kind === "file" || entry.kind === "pdf";
+}
+
 function findFileByWikilinkTarget(target: string, noteId: string | null) {
     const normalizedDirectTarget = normalizeFileTarget(target);
     const normalizedRelativeTarget = resolveRelativeTargetPath(noteId, target);
@@ -138,8 +141,7 @@ function findFileByWikilinkTarget(target: string, noteId: string | null) {
             .getState()
             .entries.find(
                 (entry) =>
-                    entry.kind === "file" &&
-                    isTextLikeVaultEntry(entry) &&
+                    isWikilinkFileEntry(entry) &&
                     candidateTargets.has(entry.relative_path),
             ) ?? null
     );

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -186,9 +186,13 @@ describe("SettingsPanel", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "Editor" }));
 
-        expect(screen.getByText("Autosave delay")).toBeInTheDocument();
+        const autosaveLabel = screen.getByText("Autosave delay");
+        const autosaveRow = autosaveLabel.parentElement?.parentElement;
+        expect(autosaveRow).not.toBeNull();
 
-        const input = screen.getByDisplayValue("300");
+        const input = within(autosaveRow as HTMLElement).getByDisplayValue(
+            "300",
+        );
 
         fireEvent.focus(input);
         fireEvent.change(input, { target: { value: "750" } });
@@ -651,6 +655,24 @@ describe("SettingsPanel", () => {
         fireEvent.click(toggle);
 
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
+        expect(toggle).toHaveAttribute("aria-checked", "false");
+    });
+
+    it("renders and persists the wikilink hover preview toggle in editor settings", () => {
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Editor" }));
+
+        const label = screen.getByText("Note preview on hover");
+        const row = label.parentElement?.parentElement;
+        expect(row).not.toBeNull();
+
+        const toggle = within(row as HTMLElement).getByRole("switch");
+        expect(toggle).toHaveAttribute("aria-checked", "true");
+
+        fireEvent.click(toggle);
+
+        expect(useSettingsStore.getState().hoverPreviewEnabled).toBe(false);
         expect(toggle).toHaveAttribute("aria-checked", "false");
     });
 

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -1156,7 +1156,7 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         [
             [
                 "Note preview on hover",
-                "Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference is saved per vault.",
+                "Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference applies to all vaults.",
                 "wikilink",
                 "popover",
                 "tooltip",
@@ -1328,7 +1328,7 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                 searchQuery={searchQuery}
                 section="Preview"
                 label="Note preview on hover"
-                description="Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference is saved per vault."
+                description="Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference applies to all vaults."
                 keywords={["wikilink", "popover", "tooltip"]}
                 control={
                     <Toggle

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -1105,6 +1105,8 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         editorActiveLineHighlight,
         justifyText,
         tabSize,
+        hoverPreviewEnabled,
+        hoverPreviewDelayMs,
         vimModeEnabled,
         vimRelativeLineNumbers,
         setSetting,
@@ -1148,6 +1150,23 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
             ["Tab size", "Number of spaces inserted when pressing Tab.", 2, 4],
         ],
     );
+    const showPreview = sectionHasSettingsSearchMatches(
+        searchQuery,
+        "Preview",
+        [
+            [
+                "Note preview on hover",
+                "Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference is saved per vault.",
+                "wikilink",
+                "popover",
+                "tooltip",
+            ],
+            [
+                "Hover delay",
+                "Time the pointer must rest on a wikilink before the preview opens, in milliseconds.",
+            ],
+        ],
+    );
     const showVim = sectionHasSettingsSearchMatches(searchQuery, "Vim", [
         [
             "Vim key bindings",
@@ -1163,7 +1182,13 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         ["Text width", "Maximum width of the editor content, in pixels."],
     ]);
 
-    if (!showTypography && !showFormatting && !showVim && !showLayout) {
+    if (
+        !showTypography &&
+        !showFormatting &&
+        !showPreview &&
+        !showVim &&
+        !showLayout
+    ) {
         return <EmptyPanelSearchResult />;
     }
 
@@ -1294,6 +1319,39 @@ function EditorSettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                             { value: 4, label: "4" },
                         ]}
                         onChange={(v) => setSetting("tabSize", v as 2 | 4)}
+                    />
+                }
+            />
+
+            {showPreview ? <SectionLabel>Preview</SectionLabel> : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Preview"
+                label="Note preview on hover"
+                description="Show a floating preview of the linked note when hovering over a [[wikilink]]. This preference is saved per vault."
+                keywords={["wikilink", "popover", "tooltip"]}
+                control={
+                    <Toggle
+                        value={hoverPreviewEnabled}
+                        onChange={(v) => setSetting("hoverPreviewEnabled", v)}
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Preview"
+                label="Hover delay"
+                description="Time the pointer must rest on a wikilink before the preview opens, in milliseconds."
+                control={
+                    <SliderField
+                        value={hoverPreviewDelayMs}
+                        min={100}
+                        max={1500}
+                        step={50}
+                        onChange={(v) =>
+                            setSetting("hoverPreviewDelayMs", v)
+                        }
+                        formatValue={(value) => `${value}ms`}
                     />
                 }
             />
@@ -4354,6 +4412,9 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Line wrapping",
         "Justify text",
         "Tab size",
+        "Preview",
+        "Note preview on hover",
+        "Hover delay",
         "Layout",
         "Text width",
     ],

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -39,15 +39,17 @@ The main settings store uses these keys:
 | `neverwrite:settings:<vault-path>` | Per-vault | Main `Settings` values for the vault, excluding explicitly global keys. |
 | `neverwrite:lastVaultPath` | Global app state | Initial vault path lookup for hydration, not a user-facing setting itself. |
 
-`GLOBAL_SETTING_KEYS` currently contains only:
+`GLOBAL_SETTING_KEYS` currently contains:
 
 | Setting | Scope |
 | --- | --- |
 | `vimModeEnabled` | Global |
 | `vimRelativeLineNumbers` | Global |
+| `hoverPreviewEnabled` | Global |
+| `hoverPreviewDelayMs` | Global |
 
 When a vault is open, `settingsStore` writes all other `Settings` values to
-`neverwrite:settings:<vault-path>` and writes the Vim values back to
+`neverwrite:settings:<vault-path>` and writes the global keys back to
 `neverwrite:settings`. When no vault is available, the fallback key can contain a
 full `Settings` object.
 
@@ -77,6 +79,8 @@ the same Settings stores.
 | Editor / Formatting | `tabSize` | Per-vault | `2` | `neverwrite:settings:<vault-path>` | Normalized to `2` or `4`. |
 | Editor / Vim | `vimModeEnabled` | Global | `false` | `neverwrite:settings` | Migrated from vault-scoped data if found. |
 | Editor / Vim | `vimRelativeLineNumbers` | Global | `false` | `neverwrite:settings` | Migrated from vault-scoped data if found. |
+| Editor / Preview | `hoverPreviewEnabled` | Global | `true` | `neverwrite:settings` | Toggles the wikilink hover preview across all vaults. |
+| Editor / Preview | `hoverPreviewDelayMs` | Global | `300` | `neverwrite:settings` | Open delay for the hover preview; clamped to `0..2000`. |
 | Editor / Layout | `editorContentWidth` | Per-vault | `940` | `neverwrite:settings:<vault-path>` | Clamped to `600..1200`. |
 | PDF toolbar | `pdfFilter` | Per-vault | `none` | `neverwrite:settings:<vault-path>` | Cycled from the PDF tab toolbar. Valid values are `none`, `dark`, `sepia`, and `grayscale`. |
 | AI / Context | `inlineReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates inline review in source mode. This is a review-system correctness setting. |


### PR DESCRIPTION
## Wikilink hover preview

Hovering over a `[[wikilink]]` (with a ~300 ms delay) opens a floating popover with a preview of the first lines of the target note, without opening it or switching tabs. It reuses the pieces that already existed (wikilink resolution + safe Markdown rendering), so the real work was the hover trigger, state handling, and configuration.

### What's included
- **Hover trigger** via CodeMirror's `hoverTooltip`, detecting whether the position falls inside a wikilink.
- **Preview content**: `Loading…` placeholder → repaint on resolve, with per-note cache; never steals editor focus.
- **Target types**: Markdown note, `[[Note#Heading]]` (preview from the heading), unresolved target (`No note yet — click to create`), and PDF/image (name + type).
- **Keyboard accessibility**: `Preview Link at Caret` shortcut (`Mod-Alt-P`) that opens the preview for the link under the caret; dismissed on edit, caret move, or Escape.
- **Global setting** `hoverPreviewEnabled` (on by default) + `hoverPreviewDelayMs` (300, clamped 0–2000), with UI in the Settings panel (*Preview* section).
- **Anti-flicker**: content prefetch on `mouseover` so the tooltip opens with already-cached content, plus a stable `min-width`.

### Underlying refactor
Commit 1 extracts the reusable preview source (`notePreviewSource.ts`) out of `NoteEmbedWidget`: the content reader (openTab → cache → async fetch) + `renderEmbedPreview` + `extractSection`. The inline embed and the hover now share a single source of truth instead of duplicating read/cache logic.

### Commits
1. `refactor: extract reusable note preview source from NoteEmbedWidget`
2. `feat: detect wikilink hover and show tooltip anchor`
3. `feat: render note preview content in wikilink hover`
4. `feat: handle section, unresolved and non-markdown hover targets`
5. `feat: add per-vault hover preview setting and configurable delay`
6. `feat: settings UI toggle for wikilink hover preview`
7. `style: theme and accessibility for hover preview popover`
8. `fix: avoid wikilink hover preview flicker on open`
9. `feat: make wikilink hover preview setting global`

### Tests
`tsc` and lint clean. Green tests across `notePreviewSource`, `wikilinkHoverPreview`, `settingsStore`, `SettingsPanel`, `wikilinks`, and `Editor`.
