### PR TITLE
Prepare 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,39 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.0] - 2026-06-26
+
+### Added
+
+- Added per-pane stacked tabs for editor panes, with an Obsidian-style sliding pane layout, persistent per-pane mode, horizontal spine rails, tab type icons, close buttons on every spine, and adaptive sizing for narrow panes.
+- Added full drag-and-drop support for stacked tabs, including reordering within a stacked pane, moving stacked columns between panes, splitting them out, and preserving stacked mode when tabs are inserted, moved, or panes are merged.
+- Added lazy mounting for stacked tab content so off-screen editor, PDF, CSV, file, chat, review, and history columns stay lightweight until they are revealed.
+- Added hover previews for wikilinks, including previews for full notes, heading sections, unresolved notes, PDFs, images, and relative assets.
+- Added a global "Note preview on hover" editor setting with a configurable hover delay, plus a keyboard shortcut for previewing the link at the caret.
+- Added chat transcript search to active agent tabs and chat history, with Cmd/Ctrl+F support, CSS-highlighted matches, match counts, previous/next navigation, Unicode-safe matching, and pane-scoped highlights.
+- Added a prompt outline menu for AI chats so long conversations can be navigated by user prompts.
+- Added a visible rename button to the chat title bar, making the existing inline rename flow discoverable without relying on double-click.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.51.0`.
+- Updated the desktop runtime to Electron `42.4`.
+- Improved AI user-input option buttons with a pressed state.
+
+### Fixed
+
+- Fixed a live preview crash that could corrupt editor layout or break mode switching after dragging a selection across rendered Markdown tables.
+- Fixed chat search behavior while the composer is expanded, when Escape is pressed, and when matches span separate message blocks.
+- Fixed wikilink hover preview flicker by prefetching note content before the tooltip opens and keeping the popover width stable.
+- Fixed wikilink previews for relative assets.
+- Fixed stacked tab scrolling so activating an already visible column no longer unexpectedly shifts neighboring columns.
+- Fixed stacked tab hover styling so stacked columns no longer receive the normal tab-strip hover background.
+- Hardened stacked tabs against narrow panes and overlay z-index conflicts.
+
+### Security
+
+- Updated Undici from `6.25.0` to `6.27.0`.
+
 ## [0.3.6] - 2026-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.3.6",
+    "version": "0.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.3.6",
+            "version": "0.4.0",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.3.6",
+    "version": "0.4.0",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.3.6",
+    "version": "0.4.0",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.4.0 changelog entry with the user-facing release notes since v0.3.6.
- Bump the desktop app, native backend, Cargo lockfile entry, and Web Clipper metadata to 0.4.0.
- Align release metadata for the future v0.4.0 tag.

## Validation

- `cargo check -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.4.0`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`

## Release Notes

This prepares the release metadata only. The release tag should be created after this PR lands on `main`.