### PR TITLE
Preserve stacked tab scroll state

### DIFF
--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -646,6 +646,36 @@ describe("Editor", () => {
         expect(view.scrollDOM.scrollLeft).toBe(11);
     });
 
+    it("restores note scroll after the editor unmounts and remounts", async () => {
+        vi.useFakeTimers();
+        setEditorTabs([
+            {
+                id: "tab-1",
+                noteId: "notes/current",
+                title: "Current",
+                content: "Line 1\nLine 2\nLine 3",
+            },
+        ]);
+
+        const { unmount } = renderComponent(<Editor />);
+        await flushEditorViewUpdates();
+
+        let view = getEditorView();
+        view.scrollDOM.scrollTop = 260;
+        view.scrollDOM.scrollLeft = 17;
+
+        await act(async () => {
+            unmount();
+        });
+
+        renderComponent(<Editor />);
+        await flushEditorViewUpdates();
+
+        view = getEditorView();
+        expect(view.scrollDOM.scrollTop).toBe(260);
+        expect(view.scrollDOM.scrollLeft).toBe(17);
+    });
+
     it("does not activate merge view when inline review is disabled", async () => {
         setEditorTabs([
             {

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -203,6 +203,13 @@ import {
     pruneNoteStateCaches,
     type NoteStateCacheCollection,
 } from "./noteStateCache";
+import {
+    deleteEditorViewportPositions,
+    getEditorViewportCacheMap,
+    getEditorViewportPosition,
+    setEditorViewportPosition,
+    type TabScrollPosition,
+} from "./editorViewportCache";
 
 // Map vim ex-commands (:w, :q, :wq) onto NeverWrite's save/close actions.
 // Idempotent and global to the vim engine, so register once at module load.
@@ -219,12 +226,6 @@ type ReloadedNoteMetadata = {
     opId?: string | null;
     revision?: number;
     contentHash?: string | null;
-};
-type TabScrollPosition = {
-    top: number;
-    left: number;
-    anchorPos: number | null;
-    anchorOffsetTop: number;
 };
 type EditorMode = "source" | "preview";
 interface EditorProps {
@@ -337,6 +338,7 @@ export function Editor({
         null,
     );
     const restoreScrollFrameRef = useRef<number | null>(null);
+    const viewportPersistFrameRef = useRef<number | null>(null);
     const selectionToolbarCleanupRef = useRef<(() => void) | null>(null);
     const scrollbarDragCleanupRef = useRef<(() => void) | null>(null);
     const pendingScrollbarReanchorRef = useRef(false);
@@ -352,9 +354,7 @@ export function Editor({
     // Save/restore full EditorState per note (preserves undo history + selection)
     // Keyed by noteId so each note's state is preserved independently, even within the same tab.
     const tabStatesRef = useRef<Map<string, EditorState>>(new Map());
-    const tabScrollPositionsRef = useRef<Map<string, TabScrollPosition>>(
-        new Map(),
-    );
+    const tabScrollPositionsRef = useRef(getEditorViewportCacheMap());
     const livePreviewModeRef = useRef<EditorMode>(
         getEditorMode(useSettingsStore.getState().livePreviewEnabled),
     );
@@ -645,7 +645,9 @@ export function Editor({
 
     const deleteNoteStateForIds = useCallback(
         (noteIds: Iterable<string>) => {
-            deleteNoteStateCacheEntries(noteIds, getNoteStateCaches());
+            const uniqueNoteIds = new Set(noteIds);
+            deleteNoteStateCacheEntries(uniqueNoteIds, getNoteStateCaches());
+            deleteEditorViewportPositions(uniqueNoteIds);
         },
         [getNoteStateCaches],
     );
@@ -1463,6 +1465,12 @@ export function Editor({
                 anchorPos: anchor.pos,
                 anchorOffsetTop: anchor.offsetTop,
             });
+            setEditorViewportPosition(tabId, {
+                top: view.scrollDOM.scrollTop,
+                left: view.scrollDOM.scrollLeft,
+                anchorPos: anchor.pos,
+                anchorOffsetTop: anchor.offsetTop,
+            });
         },
         [captureViewportAnchor],
     );
@@ -1471,7 +1479,9 @@ export function Editor({
         (tabId: string, view: EditorView | null, mode: EditorMode) => {
             if (!view) return;
 
-            const position = tabScrollPositionsRef.current.get(tabId);
+            const position =
+                tabScrollPositionsRef.current.get(tabId) ??
+                getEditorViewportPosition(tabId);
             if (restoreScrollFrameRef.current !== null) {
                 cancelAnimationFrame(restoreScrollFrameRef.current);
                 restoreScrollFrameRef.current = null;
@@ -2751,6 +2761,16 @@ export function Editor({
             }
 
             const handleScrollOrResize = () => {
+                if (viewportPersistFrameRef.current === null) {
+                    viewportPersistFrameRef.current = requestAnimationFrame(
+                        () => {
+                            viewportPersistFrameRef.current = null;
+                            const tab = activeTabRef.current;
+                            if (!tab || viewRef.current !== nextView) return;
+                            saveTabScrollPosition(tab.noteId, nextView);
+                        },
+                    );
+                }
                 if (scrollbarDragCleanupRef.current) {
                     clearEditorDomSelection(nextView);
                     syncSelectionLayerVisibility(nextView);
@@ -2969,6 +2989,10 @@ export function Editor({
             selectionToolbarCleanupRef.current = () => {
                 selectionToolbarMouseSelectionActiveRef.current = false;
                 selectionToolbarMouseSelectionCleanupRef.current?.();
+                if (viewportPersistFrameRef.current !== null) {
+                    cancelAnimationFrame(viewportPersistFrameRef.current);
+                    viewportPersistFrameRef.current = null;
+                }
                 clearScrollbarDragSession(nextView);
                 pendingScrollbarReanchorRef.current = false;
                 suppressNextScrollbarReanchorClickRef.current = false;
@@ -3012,6 +3036,7 @@ export function Editor({
             clearScrollbarDragSession,
             handleEditorContextMenu,
             safePosAtCoords,
+            saveTabScrollPosition,
             updateSelectionToolbar,
             updateWikilinkSuggester,
         ],
@@ -3030,7 +3055,16 @@ export function Editor({
             markTabSaved(initialTab.noteId, rawContent);
         }
 
-        replaceEditorView(createEditorState(body, initialTab?.noteId ?? null));
+        const initialView = replaceEditorView(
+            createEditorState(body, initialTab?.noteId ?? null),
+        );
+        if (initialTab) {
+            restoreTabScrollPosition(
+                initialTab.noteId,
+                initialView,
+                getEditorMode(useSettingsStore.getState().livePreviewEnabled),
+            );
+        }
 
         setActiveFrontmatter(
             initialTab
@@ -3065,6 +3099,10 @@ export function Editor({
             if (restoreScrollFrameRef.current !== null) {
                 cancelAnimationFrame(restoreScrollFrameRef.current);
                 restoreScrollFrameRef.current = null;
+            }
+            if (viewportPersistFrameRef.current !== null) {
+                cancelAnimationFrame(viewportPersistFrameRef.current);
+                viewportPersistFrameRef.current = null;
             }
             selectionToolbarCleanupRef.current?.();
             selectionToolbarCleanupRef.current = null;

--- a/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
@@ -1,4 +1,5 @@
-import { act, screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
+import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../app/store/editorStore";
 import { renderComponent, setEditorTabs } from "../../test/test-utils";
@@ -10,6 +11,51 @@ function enableStackedOnFocusedPane() {
     act(() => {
         useEditorStore.getState().setPaneTabDisplayMode(paneId, "stacked");
     });
+}
+
+function defineElementMetric(
+    element: HTMLElement,
+    property: "clientWidth" | "scrollLeft",
+    initialValue: number,
+) {
+    let value = initialValue;
+    Object.defineProperty(element, property, {
+        configurable: true,
+        get: () => value,
+        set: (next: number) => {
+            value = next;
+        },
+    });
+}
+
+async function flushAnimationFrame() {
+    for (let i = 0; i < 2; i += 1) {
+        await act(async () => {
+            vi.runOnlyPendingTimers();
+        });
+    }
+}
+
+function getMountedState(tabId: string) {
+    const column = document.querySelector(
+        `[data-stacked-column-id="${tabId}"]`,
+    );
+    expect(column).not.toBeNull();
+    return column
+        ?.querySelector("[data-stacked-column-mounted]")
+        ?.getAttribute("data-stacked-column-mounted");
+}
+
+function getEditorViewInColumn(tabId: string) {
+    const column = document.querySelector(
+        `[data-stacked-column-id="${tabId}"]`,
+    );
+    expect(column).not.toBeNull();
+    const editorElement = column?.querySelector(".cm-editor");
+    expect(editorElement).not.toBeNull();
+    const view = EditorView.findFromDOM(editorElement as HTMLElement);
+    expect(view).not.toBeNull();
+    return view!;
 }
 
 describe("StackedPaneContent", () => {
@@ -112,5 +158,166 @@ describe("StackedPaneContent", () => {
         expect(
             screen.queryByRole("tablist", { name: /stacked tabs/i }),
         ).not.toBeInTheDocument();
+    });
+
+    it("keeps recently hidden stacked columns mounted as a small warm cache", async () => {
+        vi.useFakeTimers();
+        setEditorTabs(
+            [
+                {
+                    id: "n1",
+                    kind: "note",
+                    noteId: "note-1",
+                    title: "Alpha",
+                    content: "A",
+                },
+                {
+                    id: "n2",
+                    kind: "note",
+                    noteId: "note-2",
+                    title: "Beta",
+                    content: "B",
+                },
+                {
+                    id: "n3",
+                    kind: "note",
+                    noteId: "note-3",
+                    title: "Gamma",
+                    content: "C",
+                },
+                {
+                    id: "n4",
+                    kind: "note",
+                    noteId: "note-4",
+                    title: "Delta",
+                    content: "D",
+                },
+            ],
+            "n1",
+        );
+        enableStackedOnFocusedPane();
+
+        renderComponent(<EditorPaneContent />);
+
+        const tablist = screen.getByRole("tablist", {
+            name: /stacked tabs/i,
+        });
+        defineElementMetric(tablist, "clientWidth", 600);
+        defineElementMetric(tablist, "scrollLeft", 0);
+
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        expect(getMountedState("n1")).toBe("true");
+
+        tablist.scrollLeft = 568;
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        expect(getMountedState("n2")).toBe("true");
+
+        tablist.scrollLeft = 1136;
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        expect(getMountedState("n2")).toBe("true");
+        expect(getMountedState("n3")).toBe("true");
+    });
+
+    it("restores scroll for a stacked note column that was visible but not selected", async () => {
+        vi.useFakeTimers();
+        setEditorTabs(
+            [
+                {
+                    id: "n1",
+                    kind: "note",
+                    noteId: "note-1",
+                    title: "Alpha",
+                    content: "A",
+                },
+                {
+                    id: "n2",
+                    kind: "note",
+                    noteId: "note-2",
+                    title: "Beta",
+                    content: Array.from(
+                        { length: 80 },
+                        (_, index) => `Line ${index + 1}`,
+                    ).join("\n"),
+                },
+                {
+                    id: "n3",
+                    kind: "note",
+                    noteId: "note-3",
+                    title: "Gamma",
+                    content: "C",
+                },
+                {
+                    id: "n4",
+                    kind: "note",
+                    noteId: "note-4",
+                    title: "Delta",
+                    content: "D",
+                },
+                {
+                    id: "n5",
+                    kind: "note",
+                    noteId: "note-5",
+                    title: "Epsilon",
+                    content: "E",
+                },
+                {
+                    id: "n6",
+                    kind: "note",
+                    noteId: "note-6",
+                    title: "Zeta",
+                    content: "F",
+                },
+            ],
+            "n1",
+        );
+        enableStackedOnFocusedPane();
+
+        renderComponent(<EditorPaneContent />);
+
+        const tablist = screen.getByRole("tablist", {
+            name: /stacked tabs/i,
+        });
+        defineElementMetric(tablist, "clientWidth", 600);
+        defineElementMetric(tablist, "scrollLeft", 0);
+
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        tablist.scrollLeft = 568;
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        expect(
+            screen.getByRole("tab", { name: /alpha/i }),
+        ).toHaveAttribute("aria-selected", "true");
+        expect(getMountedState("n2")).toBe("true");
+
+        let betaView = getEditorViewInColumn("n2");
+        betaView.scrollDOM.scrollTop = 420;
+        betaView.scrollDOM.scrollLeft = 12;
+        fireEvent.scroll(betaView.scrollDOM);
+        await flushAnimationFrame();
+
+        for (const scrollLeft of [1136, 1704, 2272]) {
+            tablist.scrollLeft = scrollLeft;
+            fireEvent.scroll(tablist);
+            await flushAnimationFrame();
+        }
+
+        expect(getMountedState("n2")).toBe("false");
+
+        tablist.scrollLeft = 568;
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+
+        betaView = getEditorViewInColumn("n2");
+        expect(betaView.scrollDOM.scrollTop).toBe(420);
+        expect(betaView.scrollDOM.scrollLeft).toBe(12);
     });
 });

--- a/apps/desktop/src/features/editor/StackedPaneContent.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.tsx
@@ -2,6 +2,7 @@ import React, {
     useCallback,
     useEffect,
     useLayoutEffect,
+    useMemo,
     useRef,
     useState,
     type ReactNode,
@@ -65,10 +66,19 @@ const SPINE_WIDTH = 32;
 // the pane is very narrow.
 const MIN_PANEL_WIDTH = 280;
 
+// Keep a couple of recently-hidden columns alive so fast horizontal navigation
+// does not destroy editor/PDF scroll state on every spine transition.
+const EXTRA_KEEP_ALIVE_STACKED_COLUMNS = 2;
+
 const SUPPORTS_RESIZE_OBSERVER = typeof ResizeObserver !== "undefined";
 
 function clamp(value: number, min: number, max: number) {
     return Math.min(Math.max(value, min), max);
+}
+
+function areStringArraysEqual(left: readonly string[], right: readonly string[]) {
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => value === right[index]);
 }
 
 // Panels never exceed the available width, so a usable content panel always
@@ -106,6 +116,8 @@ export function StackedPaneContent({
 
     const scrollRef = useRef<HTMLDivElement>(null);
     const tabCountRef = useRef(tabCount);
+    const previousBaseMountedTabIdsRef = useRef<string[]>([]);
+    const [warmMountedTabIds, setWarmMountedTabIds] = useState<string[]>([]);
     tabCountRef.current = tabCount;
 
     // How many panels are stacked as spines on each edge. Derived from scroll
@@ -354,17 +366,79 @@ export function StackedPaneContent({
         indicator.style.transform = `translateX(${left - 1}px)`;
     }, [insertionIndicatorIndex]);
 
+    const firstContent = stack.left;
+    const lastContent = tabCount - 1 - stack.right;
+    const leftStackTabs = tabs.slice(0, stack.left);
+    const rightStackTabs = stack.right > 0 ? tabs.slice(lastContent + 1) : [];
+    const tabIds = useMemo(() => tabs.map((tab) => tab.id), [tabs]);
+    const baseMountedTabIds = useMemo(
+        () =>
+            tabs
+                .filter((tab, index) => {
+                    if (tab.id === activeTabId) return true;
+                    return index >= firstContent && index <= lastContent;
+                })
+                .map((tab) => tab.id),
+        [activeTabId, firstContent, lastContent, tabs],
+    );
+    const openTabIdSet = useMemo(() => new Set(tabIds), [tabIds]);
+    const baseMountedTabIdSet = useMemo(
+        () => new Set(baseMountedTabIds),
+        [baseMountedTabIds],
+    );
+    const previousHiddenBaseTabIds = useMemo(
+        () =>
+            previousBaseMountedTabIdsRef.current.filter(
+                (tabId) =>
+                    openTabIdSet.has(tabId) &&
+                    !baseMountedTabIdSet.has(tabId),
+            ),
+        [baseMountedTabIdSet, openTabIdSet],
+    );
+    const keepAliveTabIdSet = useMemo(
+        () =>
+            new Set([
+                ...baseMountedTabIds,
+                ...warmMountedTabIds,
+                ...previousHiddenBaseTabIds,
+            ]),
+        [baseMountedTabIds, previousHiddenBaseTabIds, warmMountedTabIds],
+    );
+
+    useLayoutEffect(() => {
+        const demotedTabIds = previousBaseMountedTabIdsRef.current.filter(
+            (tabId) =>
+                openTabIdSet.has(tabId) && !baseMountedTabIdSet.has(tabId),
+        );
+
+        setWarmMountedTabIds((current) => {
+            const demotedSet = new Set(demotedTabIds);
+            const carriedTabIds = current.filter(
+                (tabId) =>
+                    openTabIdSet.has(tabId) &&
+                    !baseMountedTabIdSet.has(tabId) &&
+                    !demotedSet.has(tabId),
+            );
+            const next = [...demotedTabIds, ...carriedTabIds].slice(
+                0,
+                EXTRA_KEEP_ALIVE_STACKED_COLUMNS,
+            );
+            return areStringArraysEqual(current, next) ? current : next;
+        });
+
+        previousBaseMountedTabIdsRef.current = baseMountedTabIds;
+    }, [
+        baseMountedTabIds,
+        baseMountedTabIdSet,
+        openTabIdSet,
+    ]);
+
     if (tabCount === 0) {
         if (paneId) {
             return <WorkspacePaneEmptyState paneId={paneId} />;
         }
         return null;
     }
-
-    const firstContent = stack.left;
-    const lastContent = tabCount - 1 - stack.right;
-    const leftStackTabs = tabs.slice(0, stack.left);
-    const rightStackTabs = stack.right > 0 ? tabs.slice(lastContent + 1) : [];
 
     return (
         <div
@@ -413,7 +487,7 @@ export function StackedPaneContent({
                         isContent={isContent}
                         leftStackWidth={stack.left * SPINE_WIDTH}
                         panelWidth={stack.panelWidth}
-                        shouldMount={isActive || isContent}
+                        shouldMount={keepAliveTabIdSet.has(tab.id)}
                         emptyStateMessage={emptyStateMessage}
                         isDragging={draggingTabId === tab.id}
                         icon={renderEditorTabLeadingIcon(
@@ -778,6 +852,7 @@ function StackedColumn({
             )}
             <div
                 className="absolute inset-y-0 right-0 overflow-hidden"
+                data-stacked-column-mounted={shouldMount ? "true" : "false"}
                 style={{ left: SPINE_WIDTH }}
                 onMouseDownCapture={() => {
                     if (!isActive) onActivate();
@@ -905,7 +980,7 @@ function StackedColumnBody({
                     paneId={paneId}
                     tabId={tab.id}
                     emptyStateMessage={emptyStateMessage}
-                    isVisible={isActive}
+                    isVisible
                 />
             );
         case "file":

--- a/apps/desktop/src/features/editor/editorViewportCache.ts
+++ b/apps/desktop/src/features/editor/editorViewportCache.ts
@@ -1,0 +1,33 @@
+export type TabScrollPosition = {
+    top: number;
+    left: number;
+    anchorPos: number | null;
+    anchorOffsetTop: number;
+};
+
+const editorViewportPositions = new Map<string, TabScrollPosition>();
+
+export function getEditorViewportPosition(noteId: string) {
+    return editorViewportPositions.get(noteId);
+}
+
+export function setEditorViewportPosition(
+    noteId: string,
+    position: TabScrollPosition,
+) {
+    editorViewportPositions.set(noteId, position);
+}
+
+export function deleteEditorViewportPositions(noteIds: Iterable<string>) {
+    for (const noteId of noteIds) {
+        editorViewportPositions.delete(noteId);
+    }
+}
+
+export function clearEditorViewportCache() {
+    editorViewportPositions.clear();
+}
+
+export function getEditorViewportCacheMap() {
+    return editorViewportPositions;
+}

--- a/apps/desktop/src/test/setup.ts
+++ b/apps/desktop/src/test/setup.ts
@@ -695,6 +695,7 @@ let useBookmarkStore: typeof import("../app/store/bookmarkStore").useBookmarkSto
 let useCommandStore: typeof import("../features/command-palette/store/commandStore").useCommandStore;
 let resetChatStore: typeof import("../features/ai/store/chatStore").resetChatStore;
 let resetChatTabsStore: typeof import("../features/ai/store/chatTabsStore").resetChatTabsStore;
+let clearEditorViewportCache: typeof import("../features/editor/editorViewportCache").clearEditorViewportCache;
 
 Object.defineProperty(globalThis, "__clipboardMock", {
     value: {
@@ -906,6 +907,9 @@ beforeEach(async () => {
     ({ resetChatStore } = await import("../features/ai/store/chatStore"));
     ({ resetChatTabsStore } =
         await import("../features/ai/store/chatTabsStore"));
+    ({ clearEditorViewportCache } = await import(
+        "../features/editor/editorViewportCache"
+    ));
 
     useEditorStore.setState(useEditorStore.getInitialState(), true);
     useLayoutStore.setState(useLayoutStore.getInitialState(), true);
@@ -924,6 +928,7 @@ beforeEach(async () => {
 
     resetChatStore();
     resetChatTabsStore();
+    clearEditorViewportCache();
 });
 
 afterEach(() => {


### PR DESCRIPTION
## Summary

- Preserve editor viewport state when stacked tab columns unmount and remount.
- Keep a small warm cache of recently hidden stacked columns to smooth horizontal navigation.
- Treat mounted stacked note columns as visible while keeping pane-level interactions scoped to the active tab.
- Add focused tests for active and non-selected stacked tab scroll restoration.

## Root Cause

Stacked tabs virtualize columns with `shouldMount`, so hidden columns could lose their CodeMirror viewport when they were removed from the DOM. The original behavior mostly protected the selected tab, but visible non-selected columns could still lose scroll after being hidden and later remounted.

## Validation

- `npm run test -- src/features/editor/Editor.test.tsx src/features/editor/StackedPaneContent.test.tsx`
- `npm run lint`
- `npx tsc -b`