### PR TITLE
Clean Rust Clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Cache Rust build outputs
         uses: Swatinem/rust-cache@v2
 
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+
       - name: Run workspace tests
         run: cargo test
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -7652,10 +7652,10 @@ fn should_run_acp_logout(runtime_id: &str, setup: &RuntimeSetupState) -> bool {
     match (runtime_id, setup.auth_method.as_deref()) {
         (CODEX_RUNTIME_ID, Some("chatgpt")) => true,
         (CLAUDE_RUNTIME_ID, Some("claude-ai-login" | "claude-login")) => true,
-        (CLAUDE_RUNTIME_ID, Some("console-login")) => !setup
+        (CLAUDE_RUNTIME_ID, Some("console-login")) => setup
             .env
             .get("ANTHROPIC_AUTH_TOKEN")
-            .is_some_and(|value| !value.trim().is_empty()),
+            .is_none_or(|value| value.trim().is_empty()),
         _ => false,
     }
 }

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -878,6 +878,28 @@ struct AcpPromptCapabilities {
     embedded_context: bool,
 }
 
+#[derive(Clone)]
+struct AcpActorSharedState {
+    event_tx: Sender<RpcOutput>,
+    session_state: Arc<Mutex<NativeAiInner>>,
+    tool_diffs: ToolDiffState,
+    agent_writes: AgentWriteTracker,
+}
+
+#[derive(Clone)]
+struct AcpElicitationState {
+    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
+    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
+    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
+}
+
+#[derive(Clone)]
+struct AcpActorContext {
+    shared: AcpActorSharedState,
+    elicitations: AcpElicitationState,
+    prompt_capabilities: Arc<Mutex<AcpPromptCapabilities>>,
+}
+
 struct ElicitationWaiter {
     session_id: String,
     fields: HashMap<String, ElicitationFieldSpec>,
@@ -1059,6 +1081,23 @@ impl NativeAi {
             completed_url_elicitations: Arc::new(Mutex::new(VecDeque::new())),
             auth_terminal_sessions: Arc::new(Mutex::new(HashMap::new())),
             auth_terminal_counter: Arc::new(AtomicU64::new(1)),
+        }
+    }
+
+    fn acp_actor_context(&self) -> AcpActorContext {
+        AcpActorContext {
+            shared: AcpActorSharedState {
+                event_tx: self.event_tx.clone(),
+                session_state: Arc::clone(&self.inner),
+                tool_diffs: self.tool_diffs.clone(),
+                agent_writes: self.agent_writes.clone(),
+            },
+            elicitations: AcpElicitationState {
+                user_input_waiters: Arc::clone(&self.user_input_waiters),
+                url_elicitation_waiters: Arc::clone(&self.url_elicitation_waiters),
+                completed_url_elicitations: Arc::clone(&self.completed_url_elicitations),
+            },
+            prompt_capabilities: Arc::new(Mutex::new(AcpPromptCapabilities::default())),
         }
     }
 
@@ -1350,13 +1389,7 @@ impl NativeAi {
             AcpSessionStartMode::New {
                 additional_directories: normalized.kept.clone(),
             },
-            self.event_tx.clone(),
-            Arc::clone(&self.inner),
-            self.tool_diffs.clone(),
-            self.agent_writes.clone(),
-            Arc::clone(&self.user_input_waiters),
-            Arc::clone(&self.url_elicitation_waiters),
-            Arc::clone(&self.completed_url_elicitations),
+            self.acp_actor_context(),
         ) {
             Ok(created) => created,
             Err(error) => {
@@ -1463,13 +1496,7 @@ impl NativeAi {
                 session_id: input.session_id,
                 additional_directories: normalized.kept.clone(),
             },
-            self.event_tx.clone(),
-            Arc::clone(&self.inner),
-            self.tool_diffs.clone(),
-            self.agent_writes.clone(),
-            Arc::clone(&self.user_input_waiters),
-            Arc::clone(&self.url_elicitation_waiters),
-            Arc::clone(&self.completed_url_elicitations),
+            self.acp_actor_context(),
         ) {
             Ok(created) => created,
             Err(error) => {
@@ -3628,21 +3655,14 @@ fn neverwrite_acp12_client_capabilities(_runtime_id: &str) -> acp12::schema::Cli
 fn start_acp_session(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
-    event_tx: Sender<RpcOutput>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    tool_diffs: ToolDiffState,
-    agent_writes: AgentWriteTracker,
-    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
-    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
-    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
+    context: AcpActorContext,
 ) -> Result<CreatedAcpSession, String> {
     let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel::<AcpCommand>();
     let (created_tx, created_rx) = mpsc::channel();
     let flavor = acp_protocol_flavor(&spec.runtime_id);
-    let prompt_capabilities = Arc::new(Mutex::new(AcpPromptCapabilities::default()));
     let handle = AcpSessionHandle {
         command_tx: command_tx.clone(),
-        prompt_capabilities: Arc::clone(&prompt_capabilities),
+        prompt_capabilities: Arc::clone(&context.prompt_capabilities),
     };
     thread::spawn(move || {
         let runtime = match Builder::new_current_thread().enable_all().build() {
@@ -3655,38 +3675,10 @@ fn start_acp_session(
         runtime.block_on(async move {
             match flavor {
                 AcpProtocolFlavor::Current14 => {
-                    run_acp_actor(
-                        spec,
-                        start_mode,
-                        event_tx,
-                        session_state,
-                        tool_diffs,
-                        agent_writes,
-                        user_input_waiters,
-                        url_elicitation_waiters,
-                        completed_url_elicitations,
-                        prompt_capabilities,
-                        command_rx,
-                        created_tx,
-                    )
-                    .await;
+                    run_acp_actor(spec, start_mode, context, command_rx, created_tx).await;
                 }
                 AcpProtocolFlavor::Legacy12 => {
-                    run_acp12_actor(
-                        spec,
-                        start_mode,
-                        event_tx,
-                        session_state,
-                        tool_diffs,
-                        agent_writes,
-                        user_input_waiters,
-                        url_elicitation_waiters,
-                        completed_url_elicitations,
-                        prompt_capabilities,
-                        command_rx,
-                        created_tx,
-                    )
-                    .await;
+                    run_acp12_actor(spec, start_mode, context, command_rx, created_tx).await;
                 }
             }
         });
@@ -4029,28 +4021,14 @@ async fn run_acp12_auth_inner(
 async fn run_acp_actor(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
-    event_tx: Sender<RpcOutput>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    tool_diffs: ToolDiffState,
-    agent_writes: AgentWriteTracker,
-    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
-    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
-    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
-    prompt_capabilities: Arc<Mutex<AcpPromptCapabilities>>,
+    context: AcpActorContext,
     mut command_rx: tokio::sync::mpsc::UnboundedReceiver<AcpCommand>,
     created_tx: mpsc::Sender<Result<AiSession, String>>,
 ) {
     let result = run_acp_actor_inner(
         spec,
         start_mode,
-        event_tx,
-        session_state,
-        tool_diffs,
-        agent_writes,
-        user_input_waiters,
-        url_elicitation_waiters,
-        completed_url_elicitations,
-        prompt_capabilities,
+        context,
         &mut command_rx,
         created_tx.clone(),
     )
@@ -4063,28 +4041,14 @@ async fn run_acp_actor(
 async fn run_acp12_actor(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
-    event_tx: Sender<RpcOutput>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    tool_diffs: ToolDiffState,
-    agent_writes: AgentWriteTracker,
-    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
-    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
-    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
-    prompt_capabilities: Arc<Mutex<AcpPromptCapabilities>>,
+    context: AcpActorContext,
     mut command_rx: tokio::sync::mpsc::UnboundedReceiver<AcpCommand>,
     created_tx: mpsc::Sender<Result<AiSession, String>>,
 ) {
     let result = run_acp12_actor_inner(
         spec,
         start_mode,
-        event_tx,
-        session_state,
-        tool_diffs,
-        agent_writes,
-        user_input_waiters,
-        url_elicitation_waiters,
-        completed_url_elicitations,
-        prompt_capabilities,
+        context,
         &mut command_rx,
         created_tx.clone(),
     )
@@ -4097,14 +4061,7 @@ async fn run_acp12_actor(
 async fn run_acp12_actor_inner(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
-    event_tx: Sender<RpcOutput>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    tool_diffs: ToolDiffState,
-    agent_writes: AgentWriteTracker,
-    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
-    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
-    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
-    prompt_capabilities: Arc<Mutex<AcpPromptCapabilities>>,
+    context: AcpActorContext,
     command_rx: &mut tokio::sync::mpsc::UnboundedReceiver<AcpCommand>,
     created_tx: mpsc::Sender<Result<AiSession, String>>,
 ) -> Result<(), String> {
@@ -4130,18 +4087,19 @@ async fn run_acp12_actor_inner(
         .stdout
         .take()
         .ok_or_else(|| "Failed to acquire ACP stdout".to_string())?;
+    let event_tx = context.shared.event_tx.clone();
     let client = NativeAcpClient {
         event_tx: event_tx.clone(),
-        session_state,
+        session_state: Arc::clone(&context.shared.session_state),
         message_ids: Arc::new(Mutex::new(HashMap::new())),
         thinking_ids: Arc::new(Mutex::new(HashMap::new())),
         permission_waiters: Arc::new(Mutex::new(HashMap::new())),
-        user_input_waiters,
-        url_elicitation_waiters,
-        completed_url_elicitations,
+        user_input_waiters: Arc::clone(&context.elicitations.user_input_waiters),
+        url_elicitation_waiters: Arc::clone(&context.elicitations.url_elicitation_waiters),
+        completed_url_elicitations: Arc::clone(&context.elicitations.completed_url_elicitations),
         suppressed_status_tool_calls: Arc::new(Mutex::new(HashSet::new())),
-        tool_diffs,
-        agent_writes,
+        tool_diffs: context.shared.tool_diffs.clone(),
+        agent_writes: context.shared.agent_writes.clone(),
         terminal_output: Arc::new(Mutex::new(HashMap::new())),
         terminal_exit: Arc::new(Mutex::new(HashMap::new())),
     };
@@ -4151,6 +4109,7 @@ async fn run_acp12_actor_inner(
     let session_created_for_connection = Arc::clone(&session_created);
     let disconnect_runtime_id = spec.runtime_id.clone();
     let event_tx_for_connection = event_tx.clone();
+    let prompt_capabilities = Arc::clone(&context.prompt_capabilities);
     let client_for_shutdown = client.clone();
 
     let result = acp12::Client
@@ -4299,14 +4258,7 @@ async fn run_acp12_actor_inner(
 async fn run_acp_actor_inner(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
-    event_tx: Sender<RpcOutput>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    tool_diffs: ToolDiffState,
-    agent_writes: AgentWriteTracker,
-    user_input_waiters: Arc<Mutex<HashMap<String, ElicitationWaiter>>>,
-    url_elicitation_waiters: Arc<Mutex<HashMap<String, UrlElicitationWaiter>>>,
-    completed_url_elicitations: Arc<Mutex<VecDeque<String>>>,
-    prompt_capabilities: Arc<Mutex<AcpPromptCapabilities>>,
+    context: AcpActorContext,
     command_rx: &mut tokio::sync::mpsc::UnboundedReceiver<AcpCommand>,
     created_tx: mpsc::Sender<Result<AiSession, String>>,
 ) -> Result<(), String> {
@@ -4332,18 +4284,19 @@ async fn run_acp_actor_inner(
         .stdout
         .take()
         .ok_or_else(|| "Failed to acquire ACP stdout".to_string())?;
+    let event_tx = context.shared.event_tx.clone();
     let client = NativeAcpClient {
         event_tx: event_tx.clone(),
-        session_state,
+        session_state: Arc::clone(&context.shared.session_state),
         message_ids: Arc::new(Mutex::new(HashMap::new())),
         thinking_ids: Arc::new(Mutex::new(HashMap::new())),
         permission_waiters: Arc::new(Mutex::new(HashMap::new())),
-        user_input_waiters,
-        url_elicitation_waiters,
-        completed_url_elicitations,
+        user_input_waiters: Arc::clone(&context.elicitations.user_input_waiters),
+        url_elicitation_waiters: Arc::clone(&context.elicitations.url_elicitation_waiters),
+        completed_url_elicitations: Arc::clone(&context.elicitations.completed_url_elicitations),
         suppressed_status_tool_calls: Arc::new(Mutex::new(HashSet::new())),
-        tool_diffs,
-        agent_writes,
+        tool_diffs: context.shared.tool_diffs.clone(),
+        agent_writes: context.shared.agent_writes.clone(),
         terminal_output: Arc::new(Mutex::new(HashMap::new())),
         terminal_exit: Arc::new(Mutex::new(HashMap::new())),
     };
@@ -4353,6 +4306,7 @@ async fn run_acp_actor_inner(
     let session_created_for_connection = Arc::clone(&session_created);
     let disconnect_runtime_id = spec.runtime_id.clone();
     let event_tx_for_connection = event_tx.clone();
+    let prompt_capabilities = Arc::clone(&context.prompt_capabilities);
     let client_for_shutdown = client.clone();
 
     let result = Client

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -8297,10 +8297,12 @@ fn build_prompt_blocks_with_attachments(
                         &mut text_context_parts,
                         attachment,
                         file_path,
-                        vault_root,
-                        additional_roots,
-                        capabilities,
-                        &image_limits,
+                        FileAttachmentBuildContext {
+                            vault_root,
+                            additional_roots,
+                            capabilities,
+                            image_limits: &image_limits,
+                        },
                     )?;
                 }
             }
@@ -8375,6 +8377,13 @@ struct NativeImageAttachmentLimits {
     max_bytes: u64,
     max_images_per_message: usize,
     allowed_mime_types: &'static [&'static str],
+}
+
+struct FileAttachmentBuildContext<'a> {
+    vault_root: Option<&'a Path>,
+    additional_roots: &'a [PathBuf],
+    capabilities: AcpPromptCapabilities,
+    image_limits: &'a NativeImageAttachmentLimits,
 }
 
 const DEFAULT_NATIVE_IMAGE_MIME_TYPES: &[&str] =
@@ -8471,17 +8480,14 @@ fn append_file_attachment_blocks(
     text_context_parts: &mut Vec<String>,
     attachment: &AiAttachmentInput,
     file_path: &str,
-    vault_root: Option<&Path>,
-    additional_roots: &[PathBuf],
-    capabilities: AcpPromptCapabilities,
-    image_limits: &NativeImageAttachmentLimits,
+    context: FileAttachmentBuildContext<'_>,
 ) -> Result<(), String> {
-    let path = allowed_attachment_path(file_path, vault_root, additional_roots)?;
+    let path = allowed_attachment_path(file_path, context.vault_root, context.additional_roots)?;
     let mime = attachment
         .mime_type
         .as_deref()
         .unwrap_or("application/octet-stream");
-    let rel_path = display_attachment_path(&path, vault_root);
+    let rel_path = display_attachment_path(&path, context.vault_root);
 
     if mime == "application/pdf" {
         text_context_parts.push(format!(
@@ -8489,7 +8495,7 @@ fn append_file_attachment_blocks(
             attachment.label, rel_path
         ));
     } else if mime.starts_with("text/") || mime == "application/json" {
-        if capabilities.embedded_context {
+        if context.capabilities.embedded_context {
             match std::fs::read_to_string(&path) {
                 Ok(text) => blocks.push(embedded_text_resource_block(
                     &text,
@@ -8515,11 +8521,11 @@ fn append_file_attachment_blocks(
         }
     } else if mime.starts_with("image/") {
         let size = std::fs::metadata(&path).map(|meta| meta.len()).unwrap_or(0);
-        if capabilities.image {
-            if size > image_limits.max_bytes {
+        if context.capabilities.image {
+            if size > context.image_limits.max_bytes {
                 return Err(format!(
                     "Image attachment is too large for {}: {} exceeds the {} byte limit.",
-                    image_limits.runtime_label, rel_path, image_limits.max_bytes
+                    context.image_limits.runtime_label, rel_path, context.image_limits.max_bytes
                 ));
             }
             match std::fs::read(&path) {

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -968,6 +968,25 @@ struct AuthTerminalLaunchConfig {
     method_id: String,
 }
 
+#[derive(Clone)]
+struct AuthTerminalContext {
+    snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
+    closed: Arc<AtomicBool>,
+    session_state: Arc<Mutex<NativeAiInner>>,
+    setup_store: RuntimeSetupStore,
+    runtime_id: String,
+    method_id: String,
+    event_tx: Sender<RpcOutput>,
+}
+
+#[derive(Clone)]
+struct AuthTerminalProcessHandles {
+    master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
+    writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
+    child: Arc<Mutex<Option<Box<dyn PtyChild + Send + Sync>>>>,
+    killer: Arc<Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>>,
+}
+
 struct AuthTerminalHandle {
     snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
     master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
@@ -2154,29 +2173,24 @@ impl NativeAi {
             closed: Arc::new(AtomicBool::new(false)),
         };
 
-        spawn_auth_terminal_output_reader(
-            reader,
-            Arc::clone(&handle.snapshot),
-            Arc::clone(&handle.closed),
-            Arc::clone(&self.inner),
-            self.setup_store.clone(),
-            launch_config.runtime_id.clone(),
-            launch_config.method_id.clone(),
-            self.event_tx.clone(),
-        );
-        spawn_auth_terminal_exit_monitor(
-            Arc::clone(&handle.master),
-            Arc::clone(&handle.writer),
-            Arc::clone(&handle.child),
-            Arc::clone(&handle.killer),
-            Arc::clone(&handle.snapshot),
-            Arc::clone(&handle.closed),
-            Arc::clone(&self.inner),
-            self.setup_store.clone(),
-            launch_config.runtime_id.clone(),
-            launch_config.method_id.clone(),
-            self.event_tx.clone(),
-        );
+        let terminal_context = AuthTerminalContext {
+            snapshot: Arc::clone(&handle.snapshot),
+            closed: Arc::clone(&handle.closed),
+            session_state: Arc::clone(&self.inner),
+            setup_store: self.setup_store.clone(),
+            runtime_id: launch_config.runtime_id.clone(),
+            method_id: launch_config.method_id.clone(),
+            event_tx: self.event_tx.clone(),
+        };
+        let process_handles = AuthTerminalProcessHandles {
+            master: Arc::clone(&handle.master),
+            writer: Arc::clone(&handle.writer),
+            child: Arc::clone(&handle.child),
+            killer: Arc::clone(&handle.killer),
+        };
+
+        spawn_auth_terminal_output_reader(reader, terminal_context.clone());
+        spawn_auth_terminal_exit_monitor(process_handles, terminal_context);
 
         let created_snapshot = handle.snapshot()?;
         emit_auth_terminal_started(&self.event_tx, &created_snapshot);
@@ -8931,42 +8945,36 @@ fn release_auth_terminal_runtime_resources(
 
 fn spawn_auth_terminal_output_reader(
     mut reader: Box<dyn Read + Send>,
-    snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
-    closed: Arc<AtomicBool>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    setup_store: RuntimeSetupStore,
-    runtime_id: String,
-    method_id: String,
-    event_tx: Sender<RpcOutput>,
+    context: AuthTerminalContext,
 ) {
     thread::spawn(move || {
         let mut buffer = [0_u8; AUTH_TERMINAL_OUTPUT_CHUNK_SIZE];
         let mut verified_auth = false;
         loop {
-            if closed.load(Ordering::Relaxed) {
+            if context.closed.load(Ordering::Relaxed) {
                 break;
             }
             match reader.read(&mut buffer) {
                 Ok(0) => break,
                 Ok(read) => {
-                    if closed.load(Ordering::Relaxed) {
+                    if context.closed.load(Ordering::Relaxed) {
                         break;
                     }
                     let chunk = String::from_utf8_lossy(&buffer[..read]).into_owned();
-                    let session_id = match snapshot.lock() {
+                    let session_id = match context.snapshot.lock() {
                         Ok(mut snapshot) => {
                             append_auth_terminal_buffer(&mut snapshot.buffer, &chunk);
                             if !verified_auth
                                 && auth_terminal_output_indicates_success(
-                                    &runtime_id,
+                                    &context.runtime_id,
                                     &snapshot.buffer,
                                 )
                             {
                                 mark_runtime_auth_verified(
-                                    &session_state,
-                                    Some(&setup_store),
-                                    &runtime_id,
-                                    &method_id,
+                                    &context.session_state,
+                                    Some(&context.setup_store),
+                                    &context.runtime_id,
+                                    &context.method_id,
                                 );
                                 verified_auth = true;
                             }
@@ -8974,11 +8982,11 @@ fn spawn_auth_terminal_output_reader(
                         }
                         Err(_) => break,
                     };
-                    emit_auth_terminal_output(&event_tx, &session_id, chunk);
+                    emit_auth_terminal_output(&context.event_tx, &session_id, chunk);
                 }
                 Err(error) => {
-                    if !closed.load(Ordering::Relaxed) {
-                        let (session_id, message) = match snapshot.lock() {
+                    if !context.closed.load(Ordering::Relaxed) {
+                        let (session_id, message) = match context.snapshot.lock() {
                             Ok(mut snapshot) => {
                                 snapshot.status = AiAuthTerminalStatus::Error;
                                 snapshot.error_message =
@@ -8990,7 +8998,7 @@ fn spawn_auth_terminal_output_reader(
                             }
                             Err(_) => break,
                         };
-                        emit_auth_terminal_error(&event_tx, &session_id, message);
+                        emit_auth_terminal_error(&context.event_tx, &session_id, message);
                     }
                     break;
                 }
@@ -9034,25 +9042,16 @@ fn acp_process_launch_cwd(_runtime_id: &str, cwd: &Path) -> PathBuf {
 }
 
 fn spawn_auth_terminal_exit_monitor(
-    master: Arc<Mutex<Option<Box<dyn MasterPty + Send>>>>,
-    writer: Arc<Mutex<Option<Box<dyn Write + Send>>>>,
-    child: Arc<Mutex<Option<Box<dyn PtyChild + Send + Sync>>>>,
-    killer: Arc<Mutex<Option<Box<dyn ChildKiller + Send + Sync>>>>,
-    snapshot: Arc<Mutex<AiAuthTerminalSessionSnapshot>>,
-    closed: Arc<AtomicBool>,
-    session_state: Arc<Mutex<NativeAiInner>>,
-    setup_store: RuntimeSetupStore,
-    runtime_id: String,
-    method_id: String,
-    event_tx: Sender<RpcOutput>,
+    handles: AuthTerminalProcessHandles,
+    context: AuthTerminalContext,
 ) {
     thread::spawn(move || loop {
-        if closed.load(Ordering::Relaxed) {
+        if context.closed.load(Ordering::Relaxed) {
             break;
         }
 
         let exit_status = {
-            let mut child_guard = match child.lock() {
+            let mut child_guard = match handles.child.lock() {
                 Ok(child_guard) => child_guard,
                 Err(_) => break,
             };
@@ -9064,7 +9063,7 @@ fn spawn_auth_terminal_exit_monitor(
                 Ok(status) => status,
                 Err(error) => {
                     let (session_id, message) = {
-                        let mut snapshot_guard = match snapshot.lock() {
+                        let mut snapshot_guard = match context.snapshot.lock() {
                             Ok(snapshot_guard) => snapshot_guard,
                             Err(_) => break,
                         };
@@ -9080,9 +9079,13 @@ fn spawn_auth_terminal_exit_monitor(
                         )
                     };
                     release_auth_terminal_runtime_resources(
-                        &master, &writer, &child, &killer, false,
+                        &handles.master,
+                        &handles.writer,
+                        &handles.child,
+                        &handles.killer,
+                        false,
                     );
-                    emit_auth_terminal_error(&event_tx, &session_id, message);
+                    emit_auth_terminal_error(&context.event_tx, &session_id, message);
                     break;
                 }
             }
@@ -9092,14 +9095,14 @@ fn spawn_auth_terminal_exit_monitor(
             let exit_code = i32::try_from(exit_status.exit_code()).ok();
             if exit_code == Some(0) {
                 mark_runtime_auth_verified(
-                    &session_state,
-                    Some(&setup_store),
-                    &runtime_id,
-                    &method_id,
+                    &context.session_state,
+                    Some(&context.setup_store),
+                    &context.runtime_id,
+                    &context.method_id,
                 );
             }
             let snapshot = {
-                let mut snapshot_guard = match snapshot.lock() {
+                let mut snapshot_guard = match context.snapshot.lock() {
                     Ok(snapshot_guard) => snapshot_guard,
                     Err(_) => break,
                 };
@@ -9108,8 +9111,14 @@ fn spawn_auth_terminal_exit_monitor(
                 snapshot_guard.error_message = None;
                 snapshot_guard.clone()
             };
-            release_auth_terminal_runtime_resources(&master, &writer, &child, &killer, false);
-            emit_auth_terminal_exited(&event_tx, &snapshot);
+            release_auth_terminal_runtime_resources(
+                &handles.master,
+                &handles.writer,
+                &handles.child,
+                &handles.killer,
+                false,
+            );
+            emit_auth_terminal_exited(&context.event_tx, &snapshot);
             break;
         }
 

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -1095,18 +1095,19 @@ impl NativeBackend {
                     previous_note_id.as_deref(),
                 )
                 .max(1);
-                build_vault_note_change_with_origin(
-                    &vault_path,
-                    "upsert",
-                    Some(note_document_to_dto(&note)),
-                    Some(note.id.0.clone()),
-                    None,
-                    Some(final_relative_path),
-                    VAULT_CHANGE_ORIGIN_AGENT,
-                    op_id,
-                    revision,
-                    Some(note_content_hash(&note.raw_markdown)),
-                    state.graph_revision.max(1),
+                build_vault_note_change(
+                    VaultNoteChangeInput::new(
+                        &vault_path,
+                        "upsert",
+                        revision,
+                        state.graph_revision.max(1),
+                    )
+                    .with_origin(VAULT_CHANGE_ORIGIN_AGENT)
+                    .with_note(note_document_to_dto(&note))
+                    .with_note_id(note.id.0.clone())
+                    .with_relative_path(final_relative_path)
+                    .with_op_id(op_id)
+                    .with_content_hash(Some(note_content_hash(&note.raw_markdown))),
                 )
             } else {
                 let entry = state.vault.read_vault_entry_from_path(&final_path).ok();
@@ -1119,18 +1120,18 @@ impl NativeBackend {
                     previous_key,
                 )
                 .max(1);
-                build_vault_note_change_with_origin(
-                    &vault_path,
-                    "upsert",
-                    None,
-                    None,
-                    entry,
-                    Some(final_relative_path),
-                    VAULT_CHANGE_ORIGIN_AGENT,
-                    op_id,
-                    revision,
-                    Some(note_content_hash(&text)),
-                    state.graph_revision.max(1),
+                build_vault_note_change(
+                    VaultNoteChangeInput::new(
+                        &vault_path,
+                        "upsert",
+                        revision,
+                        state.graph_revision.max(1),
+                    )
+                    .with_origin(VAULT_CHANGE_ORIGIN_AGENT)
+                    .with_optional_entry(entry)
+                    .with_relative_path(final_relative_path)
+                    .with_op_id(op_id)
+                    .with_content_hash(Some(note_content_hash(&text))),
                 )
             }
         } else {
@@ -1151,18 +1152,17 @@ impl NativeBackend {
                 let note_id = markdown_note_id_from_relative_path(&current_relative_path)
                     .unwrap_or_else(|| state.vault.path_to_id(&current_path));
                 let revision = advance_revision(&mut state.note_revisions, &note_id, None).max(1);
-                build_vault_note_change_with_origin(
-                    &vault_path,
-                    "delete",
-                    None,
-                    Some(note_id),
-                    None,
-                    Some(current_relative_path),
-                    VAULT_CHANGE_ORIGIN_AGENT,
-                    op_id,
-                    revision,
-                    None,
-                    state.graph_revision.max(1),
+                build_vault_note_change(
+                    VaultNoteChangeInput::new(
+                        &vault_path,
+                        "delete",
+                        revision,
+                        state.graph_revision.max(1),
+                    )
+                    .with_origin(VAULT_CHANGE_ORIGIN_AGENT)
+                    .with_note_id(note_id)
+                    .with_relative_path(current_relative_path)
+                    .with_op_id(op_id),
                 )
             } else {
                 let revision = advance_revision(
@@ -1171,18 +1171,16 @@ impl NativeBackend {
                     target_relative_path.as_deref(),
                 )
                 .max(1);
-                build_vault_note_change_with_origin(
-                    &vault_path,
-                    "delete",
-                    None,
-                    None,
-                    None,
-                    Some(current_relative_path),
-                    VAULT_CHANGE_ORIGIN_AGENT,
-                    op_id,
-                    revision,
-                    None,
-                    state.graph_revision.max(1),
+                build_vault_note_change(
+                    VaultNoteChangeInput::new(
+                        &vault_path,
+                        "delete",
+                        revision,
+                        state.graph_revision.max(1),
+                    )
+                    .with_origin(VAULT_CHANGE_ORIGIN_AGENT)
+                    .with_relative_path(current_relative_path)
+                    .with_op_id(op_id),
                 )
             }
         };
@@ -1276,18 +1274,20 @@ impl NativeBackend {
                 .read_vault_entry_from_path(&note.path.0)
                 .map_err(|error| error.to_string())?;
             let revision = advance_revision(&mut state.note_revisions, &note.id.0, None).max(1);
-            let change = build_vault_note_change_with_origin(
-                &vault_key,
-                "upsert",
-                Some(note_document_to_dto(&note)),
-                Some(note.id.0.clone()),
-                Some(entry),
-                Some(relative_path.clone()),
-                VAULT_CHANGE_ORIGIN_EXTERNAL,
-                op_id,
-                revision,
-                Some(note_content_hash(&content)),
-                state.graph_revision.max(1),
+            let change = build_vault_note_change(
+                VaultNoteChangeInput::new(
+                    &vault_key,
+                    "upsert",
+                    revision,
+                    state.graph_revision.max(1),
+                )
+                .with_origin(VAULT_CHANGE_ORIGIN_EXTERNAL)
+                .with_note(note_document_to_dto(&note))
+                .with_note_id(note.id.0.clone())
+                .with_entry(entry)
+                .with_relative_path(relative_path.clone())
+                .with_op_id(op_id)
+                .with_content_hash(Some(note_content_hash(&content))),
             );
             Self::refresh_vault_state(state)?;
             (note, relative_path, change)
@@ -1407,16 +1407,11 @@ impl NativeBackend {
         let revision =
             advance_revision(&mut state.file_revisions, &entry.relative_path, None).max(1);
         let change = build_vault_note_change(
-            &vault_path,
-            "upsert",
-            None,
-            None,
-            Some(entry),
-            Some(detail.relative_path.clone()),
-            op_id,
-            revision,
-            Some(note_content_hash(&content)),
-            state.graph_revision.max(1),
+            VaultNoteChangeInput::new(&vault_path, "upsert", revision, state.graph_revision.max(1))
+                .with_entry(entry)
+                .with_relative_path(detail.relative_path.clone())
+                .with_op_id(op_id)
+                .with_content_hash(Some(note_content_hash(&content))),
         );
         Self::refresh_vault_state(state)?;
         self.emit_vault_change(change);
@@ -1449,16 +1444,10 @@ impl NativeBackend {
             advance_revision(&mut state.file_revisions, &entry.relative_path, None).max(1);
         Self::refresh_vault_state(state)?;
         let change = build_vault_note_change(
-            &vault_path,
-            "upsert",
-            None,
-            None,
-            Some(entry),
-            Some(detail.relative_path.clone()),
-            op_id,
-            revision,
-            None,
-            state.graph_revision.max(1),
+            VaultNoteChangeInput::new(&vault_path, "upsert", revision, state.graph_revision.max(1))
+                .with_entry(entry)
+                .with_relative_path(detail.relative_path.clone())
+                .with_op_id(op_id),
         );
         self.emit_vault_change(change);
         Ok(json!(detail))
@@ -1519,16 +1508,14 @@ impl NativeBackend {
             let revision =
                 advance_revision(&mut state.file_revisions, &entry.relative_path, None).max(1);
             build_vault_note_change(
-                &vault_path,
-                "upsert",
-                None,
-                None,
-                Some(entry),
-                Some(detail.relative_path.clone()),
-                None,
-                revision,
-                None,
-                state.graph_revision.max(1),
+                VaultNoteChangeInput::new(
+                    &vault_path,
+                    "upsert",
+                    revision,
+                    state.graph_revision.max(1),
+                )
+                .with_entry(entry)
+                .with_relative_path(detail.relative_path.clone()),
             )
         };
         self.emit_vault_change(change);
@@ -1648,16 +1635,9 @@ impl NativeBackend {
         let relative_path = format!("{note_id}.md");
         let revision = advance_revision(&mut state.note_revisions, &note_id, None).max(1);
         let change = build_vault_note_change(
-            &vault_path,
-            "delete",
-            None,
-            Some(note_id.clone()),
-            None,
-            Some(relative_path),
-            None,
-            revision,
-            None,
-            state.graph_revision.max(1),
+            VaultNoteChangeInput::new(&vault_path, "delete", revision, state.graph_revision.max(1))
+                .with_note_id(note_id.clone())
+                .with_relative_path(relative_path),
         );
         Self::refresh_vault_state(state)?;
         self.emit_vault_change(change);
@@ -1767,28 +1747,14 @@ impl NativeBackend {
             advance_revision(&mut state.file_revisions, &entry.relative_path, None).max(1);
         let graph_revision = state.graph_revision.max(1);
         let delete_change = build_vault_note_change(
-            &vault_path,
-            "delete",
-            None,
-            Some(note_id.clone()),
-            None,
-            Some(format!("{note_id}.md")),
-            None,
-            delete_revision,
-            None,
-            graph_revision,
+            VaultNoteChangeInput::new(&vault_path, "delete", delete_revision, graph_revision)
+                .with_note_id(note_id.clone())
+                .with_relative_path(format!("{note_id}.md")),
         );
         let upsert_change = build_vault_note_change(
-            &vault_path,
-            "upsert",
-            None,
-            None,
-            Some(entry.clone()),
-            Some(entry.relative_path.clone()),
-            None,
-            upsert_revision,
-            None,
-            graph_revision,
+            VaultNoteChangeInput::new(&vault_path, "upsert", upsert_revision, graph_revision)
+                .with_entry(entry.clone())
+                .with_relative_path(entry.relative_path.clone()),
         );
         Self::refresh_vault_state(state)?;
         self.emit_vault_change(delete_change);
@@ -2395,18 +2361,11 @@ impl NativeBackend {
         .max(1);
         Self::refresh_vault_state(state)?;
         let graph_revision = state.graph_revision.max(1);
-        let change = build_vault_note_change_with_origin(
-            vault_path,
-            "delete",
-            None,
-            note_id,
-            None,
-            Some(relative_path),
-            origin,
-            None,
-            revision,
-            None,
-            graph_revision,
+        let change = build_vault_note_change(
+            VaultNoteChangeInput::new(vault_path, "delete", revision, graph_revision)
+                .with_origin(origin)
+                .with_optional_note_id(note_id)
+                .with_relative_path(relative_path),
         );
         self.emit_vault_change(change);
         Ok(())
@@ -2436,18 +2395,11 @@ impl NativeBackend {
                 .find(|entry| entry.relative_path == relative_path)
                 .cloned();
             let revision = advance_revision(&mut state.file_revisions, &relative_path, None).max(1);
-            let change = build_vault_note_change_with_origin(
-                vault_path,
-                "upsert",
-                None,
-                None,
-                entry,
-                Some(relative_path),
-                origin,
-                None,
-                revision,
-                None,
-                graph_revision,
+            let change = build_vault_note_change(
+                VaultNoteChangeInput::new(vault_path, "upsert", revision, graph_revision)
+                    .with_origin(origin)
+                    .with_optional_entry(entry)
+                    .with_relative_path(relative_path),
             );
             self.emit_vault_change(change);
             return Ok(());
@@ -2464,18 +2416,13 @@ impl NativeBackend {
             };
             let content_hash = lossy_text_file_content_hash(&path);
             let revision = advance_revision(&mut state.note_revisions, &note_id, None).max(1);
-            let change = build_vault_note_change_with_origin(
-                vault_path,
-                "upsert",
-                Some(note),
-                Some(note_id),
-                None,
-                Some(relative_path),
-                origin,
-                None,
-                revision,
-                content_hash,
-                graph_revision,
+            let change = build_vault_note_change(
+                VaultNoteChangeInput::new(vault_path, "upsert", revision, graph_revision)
+                    .with_origin(origin)
+                    .with_note(note)
+                    .with_note_id(note_id)
+                    .with_relative_path(relative_path)
+                    .with_content_hash(content_hash),
             );
             self.emit_vault_change(change);
             return Ok(());
@@ -2488,18 +2435,12 @@ impl NativeBackend {
             .cloned();
         let revision = advance_revision(&mut state.file_revisions, &relative_path, None).max(1);
         let content_hash = lossy_text_file_content_hash(&path);
-        let change = build_vault_note_change_with_origin(
-            vault_path,
-            "upsert",
-            None,
-            None,
-            entry,
-            Some(relative_path),
-            origin,
-            None,
-            revision,
-            content_hash,
-            graph_revision,
+        let change = build_vault_note_change(
+            VaultNoteChangeInput::new(vault_path, "upsert", revision, graph_revision)
+                .with_origin(origin)
+                .with_optional_entry(entry)
+                .with_relative_path(relative_path)
+                .with_content_hash(content_hash),
         );
         self.emit_vault_change(change);
         Ok(())
@@ -2942,58 +2883,96 @@ fn advance_revision(
     next_revision
 }
 
-fn build_vault_note_change(
-    vault_path: &str,
-    kind: &str,
+struct VaultNoteChangeInput {
+    vault_path: String,
+    kind: String,
     note: Option<NoteDto>,
     note_id: Option<String>,
     entry: Option<VaultEntryDto>,
     relative_path: Option<String>,
+    origin: String,
     op_id: Option<String>,
     revision: u64,
     content_hash: Option<String>,
     graph_revision: u64,
-) -> VaultNoteChangeDto {
-    build_vault_note_change_with_origin(
-        vault_path,
-        kind,
-        note,
-        note_id,
-        entry,
-        relative_path,
-        VAULT_CHANGE_ORIGIN_USER,
-        op_id,
-        revision,
-        content_hash,
-        graph_revision,
-    )
 }
 
-fn build_vault_note_change_with_origin(
-    vault_path: &str,
-    kind: &str,
-    note: Option<NoteDto>,
-    note_id: Option<String>,
-    entry: Option<VaultEntryDto>,
-    relative_path: Option<String>,
-    origin: &str,
-    op_id: Option<String>,
-    revision: u64,
-    content_hash: Option<String>,
-    graph_revision: u64,
-) -> VaultNoteChangeDto {
+impl VaultNoteChangeInput {
+    fn new(vault_path: &str, kind: &str, revision: u64, graph_revision: u64) -> Self {
+        Self {
+            vault_path: vault_path.to_string(),
+            kind: kind.to_string(),
+            note: None,
+            note_id: None,
+            entry: None,
+            relative_path: None,
+            origin: VAULT_CHANGE_ORIGIN_USER.to_string(),
+            op_id: None,
+            revision,
+            content_hash: None,
+            graph_revision,
+        }
+    }
+
+    fn with_origin(mut self, origin: &str) -> Self {
+        self.origin = origin.to_string();
+        self
+    }
+
+    fn with_note(mut self, note: NoteDto) -> Self {
+        self.note = Some(note);
+        self
+    }
+
+    fn with_note_id(mut self, note_id: String) -> Self {
+        self.note_id = Some(note_id);
+        self
+    }
+
+    fn with_optional_note_id(mut self, note_id: Option<String>) -> Self {
+        self.note_id = note_id;
+        self
+    }
+
+    fn with_entry(mut self, entry: VaultEntryDto) -> Self {
+        self.entry = Some(entry);
+        self
+    }
+
+    fn with_optional_entry(mut self, entry: Option<VaultEntryDto>) -> Self {
+        self.entry = entry;
+        self
+    }
+
+    fn with_relative_path(mut self, relative_path: String) -> Self {
+        self.relative_path = Some(relative_path);
+        self
+    }
+
+    fn with_op_id(mut self, op_id: Option<String>) -> Self {
+        self.op_id = op_id;
+        self
+    }
+
+    fn with_content_hash(mut self, content_hash: Option<String>) -> Self {
+        self.content_hash = content_hash;
+        self
+    }
+}
+
+fn build_vault_note_change(input: VaultNoteChangeInput) -> VaultNoteChangeDto {
     VaultNoteChangeDto {
-        vault_path: vault_path.to_string(),
-        kind: kind.to_string(),
-        note,
-        note_id,
-        entry,
-        relative_path,
-        origin: origin.to_string(),
-        op_id,
-        revision,
-        content_hash,
-        graph_revision,
+        vault_path: input.vault_path,
+        kind: input.kind,
+        note: input.note,
+        note_id: input.note_id,
+        entry: input.entry,
+        relative_path: input.relative_path,
+        origin: input.origin,
+        op_id: input.op_id,
+        revision: input.revision,
+        content_hash: input.content_hash,
+        graph_revision: input.graph_revision,
     }
 }
 
@@ -3006,16 +2985,12 @@ fn note_change_from_document(
     graph_revision: u64,
 ) -> VaultNoteChangeDto {
     build_vault_note_change(
-        vault_path,
-        "upsert",
-        Some(note_document_to_dto(note)),
-        Some(note.id.0.clone()),
-        None,
-        Some(relative_path),
-        op_id,
-        revision,
-        Some(note_content_hash(&note.raw_markdown)),
-        graph_revision,
+        VaultNoteChangeInput::new(vault_path, "upsert", revision, graph_revision)
+            .with_note(note_document_to_dto(note))
+            .with_note_id(note.id.0.clone())
+            .with_relative_path(relative_path)
+            .with_op_id(op_id)
+            .with_content_hash(Some(note_content_hash(&note.raw_markdown))),
     )
 }
 


### PR DESCRIPTION
## Summary

This PR clears the Rust Clippy warnings that were present in the workspace and adds Clippy enforcement to CI.

## What changed

- Refactored vault note change construction to avoid long positional argument lists.
- Grouped ACP actor/session shared state into explicit context structs.
- Grouped auth terminal thread context and process handles.
- Grouped native prompt file attachment policy into a small build context.
- Simplified the Claude logout token check per Clippy's `nonminimal_bool` suggestion.
- Added `cargo clippy --workspace --all-targets -- -D warnings` to the Rust CI job.

## Why

The existing warnings were mostly `too_many_arguments`, caused by related runtime state being passed as loose positional parameters. The refactors keep behavior the same while making ownership boundaries clearer and reducing the chance of wiring mistakes in sensitive flows like ACP sessions, auth terminal lifecycle, prompt attachments, and vault change events.

## Validation

- `cargo fmt`
- `cargo clippy --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p neverwrite-native-backend`
- `npm run electron:ai-runtime:smoke`