### PR TITLE
Open HTML preview links externally

### DIFF
--- a/apps/desktop/src-electron/main/window.test.ts
+++ b/apps/desktop/src-electron/main/window.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+    getFrameNavigationAction,
     resolveRendererDevUrl,
     resolveWindowIconPath,
     shouldOpenInSystemBrowser,
@@ -85,5 +86,72 @@ describe("shouldOpenInSystemBrowser", () => {
             false,
         );
         expect(shouldOpenInSystemBrowser("not a url")).toBe(false);
+    });
+});
+
+describe("getFrameNavigationAction", () => {
+    it("opens external website and email navigations from HTML previews in the system browser", () => {
+        expect(
+            getFrameNavigationAction({
+                url: "https://example.com/docs",
+                isMainFrame: false,
+                frameUrl:
+                    "neverwrite-file://localhost/assets/dmF1bHQ/docs/preview.html",
+            }),
+        ).toBe("open-external");
+        expect(
+            getFrameNavigationAction({
+                url: "mailto:team@example.com",
+                isMainFrame: false,
+                initiatorUrl:
+                    "neverwrite-file://localhost/assets/dmF1bHQ/docs/preview.html",
+            }),
+        ).toBe("open-external");
+    });
+
+    it("allows HTML preview navigations that stay inside the vault preview protocol", () => {
+        expect(
+            getFrameNavigationAction({
+                url: "neverwrite-file://localhost/assets/dmF1bHQ/docs/related.html",
+                isMainFrame: false,
+                frameUrl:
+                    "neverwrite-file://localhost/assets/dmF1bHQ/docs/preview.html",
+            }),
+        ).toBe("allow");
+    });
+
+    it("blocks unsafe or malformed navigations from HTML previews", () => {
+        expect(
+            getFrameNavigationAction({
+                url: "file:///Users/test/secret.html",
+                isMainFrame: false,
+                frameUrl:
+                    "neverwrite-file://localhost/assets/dmF1bHQ/docs/preview.html",
+            }),
+        ).toBe("deny");
+        expect(
+            getFrameNavigationAction({
+                url: "not a url",
+                isMainFrame: false,
+                frameUrl:
+                    "neverwrite-file://localhost/assets/dmF1bHQ/docs/preview.html",
+            }),
+        ).toBe("deny");
+    });
+
+    it("does not interfere with main frame navigations or unrelated iframes", () => {
+        expect(
+            getFrameNavigationAction({
+                url: "https://example.com/app",
+                isMainFrame: true,
+            }),
+        ).toBe("allow");
+        expect(
+            getFrameNavigationAction({
+                url: "https://www.youtube.com/watch?v=test",
+                isMainFrame: false,
+                frameUrl: "https://www.youtube.com/embed/test",
+            }),
+        ).toBe("allow");
     });
 });

--- a/apps/desktop/src-electron/main/window.ts
+++ b/apps/desktop/src-electron/main/window.ts
@@ -45,6 +45,8 @@ function readTrafficLightPosition(
 const windowsByLabel = new Map<string, BrowserWindow>();
 const labelsByWebContentsId = new Map<number, string>();
 const SYSTEM_BROWSER_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+const FILE_PREVIEW_PROTOCOL = "neverwrite-file:";
+type FrameNavigationAction = "allow" | "open-external" | "deny";
 
 function preloadPath() {
     return fileURLToPath(
@@ -183,19 +185,73 @@ export function shouldOpenInSystemBrowser(url: string) {
     }
 }
 
+function isFilePreviewUrl(url: string | null | undefined) {
+    if (!url) return false;
+    try {
+        return new URL(url).protocol === FILE_PREVIEW_PROTOCOL;
+    } catch {
+        return false;
+    }
+}
+
+export function getFrameNavigationAction({
+    url,
+    isMainFrame,
+    frameUrl,
+    initiatorUrl,
+}: {
+    url: string;
+    isMainFrame: boolean;
+    frameUrl?: string | null;
+    initiatorUrl?: string | null;
+}): FrameNavigationAction {
+    if (isMainFrame) return "allow";
+
+    const isPreviewFrameNavigation =
+        isFilePreviewUrl(url) ||
+        isFilePreviewUrl(frameUrl) ||
+        isFilePreviewUrl(initiatorUrl);
+
+    if (!isPreviewFrameNavigation) return "allow";
+    if (shouldOpenInSystemBrowser(url)) return "open-external";
+    if (isFilePreviewUrl(url)) return "allow";
+    return "deny";
+}
+
+function openExternalLink(url: string) {
+    void shell.openExternal(url).catch((error: unknown) => {
+        writeAppLog("main", "error", "Failed to open external link", {
+            url,
+            error: error instanceof Error ? error.message : String(error),
+        });
+    });
+}
+
 function bindExternalWindowOpenHandler(window: BrowserWindow) {
     window.webContents.setWindowOpenHandler(({ url }) => {
         if (shouldOpenInSystemBrowser(url)) {
-            void shell.openExternal(url).catch((error: unknown) => {
-                writeAppLog("main", "error", "Failed to open external link", {
-                    url,
-                    error:
-                        error instanceof Error ? error.message : String(error),
-                });
-            });
+            openExternalLink(url);
         }
 
         return { action: "deny" };
+    });
+}
+
+function bindExternalFrameNavigationHandler(window: BrowserWindow) {
+    window.webContents.on("will-frame-navigate", (event) => {
+        const action = getFrameNavigationAction({
+            url: event.url,
+            isMainFrame: event.isMainFrame,
+            frameUrl: event.frame?.url,
+            initiatorUrl: event.initiator?.url,
+        });
+
+        if (action === "allow") return;
+
+        event.preventDefault();
+        if (action === "open-external") {
+            openExternalLink(event.url);
+        }
     });
 }
 
@@ -410,6 +466,7 @@ export function createAppWindow(
     });
 
     bindExternalWindowOpenHandler(window);
+    bindExternalFrameNavigationHandler(window);
     bindWindowLifecycle(label, window);
 
     const rendererEntry = resolveRendererEntry(search);


### PR DESCRIPTION
## Summary

- Intercept frame navigations from HTML previews served through `neverwrite-file://`.
- Open `http:`, `https:`, and `mailto:` targets in the user's default browser/app instead of navigating the preview iframe.
- Keep vault-local preview navigations allowed and block unsafe `file://` or malformed preview navigations.

## Root cause

The existing external-link handler only covered new-window flows like `target="_blank"` and `window.open`. Plain links inside the HTML preview iframe navigated the iframe itself, so external sites could replace or blank the preview pane instead of opening outside NeverWrite.

## Validation

- `./node_modules/.bin/vitest run src-electron/main/window.test.ts`
- `./node_modules/.bin/tsc -p tsconfig.electron.json --noEmit`
- `git diff --check`