### PR TITLE
Fix stacked tab drops into AI composer

### DIFF
--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -38,10 +38,7 @@ import { useTerminalRuntimeStore } from "../terminal/terminalRuntimeStore";
 import { getWindowMode } from "../../app/detachedWindows";
 import { buildNewTabContextMenuEntries } from "./newTabMenuActions";
 import { useCommandStore } from "../command-palette/store/commandStore";
-import {
-    buildTabFileDragDetail,
-    resolveComposerDropTarget,
-} from "./tabDragAttachments";
+import { createWorkspaceTabExternalDragHandlers } from "./tabDragAttachments";
 import { renderEditorTabActivityIndicator } from "./EditorTabActivityIndicator";
 import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 import { useResponsiveEditorTabLayout } from "./editorTabStripLayout";
@@ -203,6 +200,11 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
             selectEditorWorkspaceTabs(useEditorStore.getState()).length,
         closeTab,
     });
+    const externalTabDrag = createWorkspaceTabExternalDragHandlers({
+        getTabById: (tabId) =>
+            pane.tabs.find((candidate) => candidate.id === tabId) ?? null,
+        resolveDetachDropTarget: detachedTabWindowDrop.resolveDetachDropTarget,
+    });
 
     const {
         dragPreviewNodeRef,
@@ -239,17 +241,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         },
         onActivate: switchTab,
         liveReorder: false,
-        resolveExternalDropTarget: (tabId, coords) => {
-            const composerTarget = resolveComposerDropTarget(
-                coords.clientX,
-                coords.clientY,
-            );
-            if (composerTarget.type !== "none") {
-                return composerTarget;
-            }
-
-            return detachedTabWindowDrop.resolveDetachDropTarget(tabId, coords);
-        },
+        resolveExternalDropTarget: externalTabDrag.resolveExternalDropTarget,
         onCommitExternalDrop: (tabId, target, coords) => {
             if (target.type !== "detach-window") {
                 return;
@@ -260,20 +252,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         onDetachStart: detachedTabWindowDrop.handleDetachStart,
         onDetachMove: detachedTabWindowDrop.handleDetachMove,
         onDetachCancel: detachedTabWindowDrop.handleDetachCancel,
-        buildAttachmentDetail: (tabId, phase, coords) => {
-            const tab =
-                pane.tabs.find((candidate) => candidate.id === tabId) ?? null;
-            if (!tab) {
-                return null;
-            }
-
-            return buildTabFileDragDetail(tab, phase, coords, {
-                resolveNotePath: (noteId) =>
-                    useVaultStore
-                        .getState()
-                        .notes.find((note) => note.id === noteId)?.path ?? null,
-            });
-        },
+        buildAttachmentDetail: externalTabDrag.buildAttachmentDetail,
     });
     const tabLayout = useResponsiveEditorTabLayout({
         stripRef: tabStripRef,

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -204,6 +204,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         getTabById: (tabId) =>
             pane.tabs.find((candidate) => candidate.id === tabId) ?? null,
         resolveDetachDropTarget: detachedTabWindowDrop.resolveDetachDropTarget,
+        commitDetachDrop: detachedTabWindowDrop.commitDetachDrop,
     });
 
     const {
@@ -242,13 +243,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         onActivate: switchTab,
         liveReorder: false,
         resolveExternalDropTarget: externalTabDrag.resolveExternalDropTarget,
-        onCommitExternalDrop: (tabId, target, coords) => {
-            if (target.type !== "detach-window") {
-                return;
-            }
-
-            return detachedTabWindowDrop.commitDetachDrop(tabId, coords);
-        },
+        onCommitExternalDrop: externalTabDrag.onCommitExternalDrop,
         onDetachStart: detachedTabWindowDrop.handleDetachStart,
         onDetachMove: detachedTabWindowDrop.handleDetachMove,
         onDetachCancel: detachedTabWindowDrop.handleDetachCancel,

--- a/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
@@ -1,8 +1,16 @@
-import { act, fireEvent, screen } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { EditorView } from "@codemirror/view";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import { useEditorStore } from "../../app/store/editorStore";
-import { renderComponent, setEditorTabs } from "../../test/test-utils";
+import {
+    flushPromises,
+    renderComponent,
+    setEditorTabs,
+    setVaultNotes,
+} from "../../test/test-utils";
+import { AIChatComposer } from "../ai/components/AIChatComposer";
+import type { AIComposerPart } from "../ai/types";
 import { EditorPaneContent } from "./EditorPaneContent";
 
 function enableStackedOnFocusedPane() {
@@ -15,7 +23,12 @@ function enableStackedOnFocusedPane() {
 
 function defineElementMetric(
     element: HTMLElement,
-    property: "clientWidth" | "scrollLeft",
+    property:
+        | "clientWidth"
+        | "offsetLeft"
+        | "offsetWidth"
+        | "scrollLeft"
+        | "scrollWidth",
     initialValue: number,
 ) {
     let value = initialValue;
@@ -26,6 +39,63 @@ function defineElementMetric(
             value = next;
         },
     });
+}
+
+function rect({
+    left,
+    top,
+    width,
+    height,
+}: {
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+}) {
+    return {
+        x: left,
+        y: top,
+        left,
+        top,
+        right: left + width,
+        bottom: top + height,
+        width,
+        height,
+        toJSON: () => ({}),
+    } as DOMRect;
+}
+
+function dispatchPointerEvent(
+    target: EventTarget,
+    type: "pointerdown" | "pointermove" | "pointerup",
+    init: {
+        pointerId: number;
+        button?: number;
+        buttons: number;
+        clientX: number;
+        clientY: number;
+        screenX: number;
+        screenY: number;
+    },
+) {
+    const event = new Event(type, {
+        bubbles: true,
+        cancelable: true,
+    });
+
+    Object.defineProperties(event, {
+        pointerId: { value: init.pointerId },
+        pointerType: { value: "mouse" },
+        isPrimary: { value: true },
+        button: { value: init.button ?? 0 },
+        buttons: { value: init.buttons },
+        clientX: { value: init.clientX },
+        clientY: { value: init.clientY },
+        screenX: { value: init.screenX },
+        screenY: { value: init.screenY },
+    });
+
+    fireEvent(target, event);
 }
 
 async function flushAnimationFrame() {
@@ -60,6 +130,7 @@ function getEditorViewInColumn(tabId: string) {
 
 describe("StackedPaneContent", () => {
     afterEach(() => {
+        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
@@ -319,5 +390,177 @@ describe("StackedPaneContent", () => {
         betaView = getEditorViewInColumn("n2");
         expect(betaView.scrollDOM.scrollTop).toBe(420);
         expect(betaView.scrollDOM.scrollLeft).toBe(12);
+    });
+
+    it("drops a stacked note tab into the AI composer without moving the tab", async () => {
+        setVaultNotes([
+            {
+                id: "notes/alpha.md",
+                title: "Alpha",
+                path: "/vault/notes/alpha.md",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-a",
+                    kind: "note",
+                    noteId: "notes/alpha.md",
+                    title: "Alpha",
+                    content: "alpha",
+                },
+                {
+                    id: "tab-b",
+                    kind: "note",
+                    noteId: "notes/beta.md",
+                    title: "Beta",
+                    content: "beta",
+                },
+            ],
+            "tab-a",
+        );
+        enableStackedOnFocusedPane();
+
+        function ComposerHarness() {
+            const [parts, setParts] = useState<AIComposerPart[]>([]);
+
+            return (
+                <>
+                    <EditorPaneContent />
+                    <AIChatComposer
+                        parts={parts}
+                        notes={[
+                            {
+                                id: "notes/alpha.md",
+                                title: "Alpha",
+                                path: "/vault/notes/alpha.md",
+                            },
+                        ]}
+                        status="idle"
+                        runtimeName="Assistant"
+                        onChange={setParts}
+                        onMentionAttach={vi.fn()}
+                        onFolderAttach={vi.fn()}
+                        onSubmit={vi.fn()}
+                        onStop={vi.fn()}
+                    />
+                </>
+            );
+        }
+
+        const { container } = renderComponent(<ComposerHarness />);
+        await flushPromises();
+
+        const tablist = screen.getByRole("tablist", {
+            name: /stacked tabs/i,
+        });
+        const sourceColumn = container.querySelector(
+            '[data-stacked-column-id="tab-a"]',
+        ) as HTMLElement | null;
+        const secondColumn = container.querySelector(
+            '[data-stacked-column-id="tab-b"]',
+        ) as HTMLElement | null;
+        const sourceSpine = sourceColumn?.querySelector(
+            '[role="tab"][title="Alpha"]',
+        ) as HTMLElement | null;
+        const composerDropZone = container.querySelector(
+            '[data-ai-composer-drop-zone="true"]',
+        ) as HTMLElement | null;
+        const composerShell = composerDropZone?.querySelector(
+            '[data-testid="chat-composer-shell"]',
+        ) as HTMLElement | null;
+
+        expect(sourceColumn).not.toBeNull();
+        expect(secondColumn).not.toBeNull();
+        expect(sourceSpine).not.toBeNull();
+        expect(composerDropZone).not.toBeNull();
+        expect(composerShell).not.toBeNull();
+
+        vi.spyOn(tablist, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(sourceColumn!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(secondColumn!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 700, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(sourceSpine!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 32, height: 300 }),
+        );
+        vi.spyOn(composerDropZone!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 120, top: 360, width: 520, height: 140 }),
+        );
+
+        defineElementMetric(tablist, "scrollLeft", 0);
+        defineElementMetric(tablist, "clientWidth", 600);
+        defineElementMetric(tablist, "scrollWidth", 1200);
+        defineElementMetric(sourceColumn!, "offsetLeft", 0);
+        defineElementMetric(sourceColumn!, "offsetWidth", 600);
+        defineElementMetric(secondColumn!, "offsetLeft", 600);
+        defineElementMetric(secondColumn!, "offsetWidth", 600);
+
+        await act(async () => {
+            dispatchPointerEvent(sourceSpine!, "pointerdown", {
+                pointerId: 1,
+                button: 0,
+                buttons: 1,
+                clientX: 116,
+                clientY: 64,
+                screenX: 116,
+                screenY: 64,
+            });
+        });
+
+        await flushPromises();
+
+        await act(async () => {
+            dispatchPointerEvent(sourceSpine!, "pointermove", {
+                pointerId: 1,
+                buttons: 1,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+            dispatchPointerEvent(window, "pointermove", {
+                pointerId: 1,
+                buttons: 1,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+        });
+
+        await waitFor(() => {
+            expect(sourceColumn).toHaveStyle({ opacity: "0.5" });
+        });
+        expect(composerShell!.style.boxShadow).toContain("color-mix");
+
+        await act(async () => {
+            dispatchPointerEvent(window, "pointerup", {
+                pointerId: 1,
+                buttons: 0,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+        });
+
+        await flushPromises();
+
+        expect(useEditorStore.getState().tabs.map((tab) => tab.id)).toEqual([
+            "tab-a",
+            "tab-b",
+        ]);
+        expect(
+            composerDropZone!.querySelector(
+                '[data-kind="mention"][data-note-id="notes/alpha.md"]',
+            ),
+        ).not.toBeNull();
     });
 });

--- a/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
@@ -66,7 +66,7 @@ function rect({
 }
 
 function dispatchPointerEvent(
-    target: EventTarget,
+    target: Window | Document | Node | Element,
     type: "pointerdown" | "pointermove" | "pointerup",
     init: {
         pointerId: number;

--- a/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
@@ -128,6 +128,33 @@ function getEditorViewInColumn(tabId: string) {
     return view!;
 }
 
+interface ComposerHarnessNote {
+    id: string;
+    title: string;
+    path: string;
+}
+
+function StackedComposerHarness({ notes }: { notes: ComposerHarnessNote[] }) {
+    const [parts, setParts] = useState<AIComposerPart[]>([]);
+
+    return (
+        <>
+            <EditorPaneContent />
+            <AIChatComposer
+                parts={parts}
+                notes={notes}
+                status="idle"
+                runtimeName="Assistant"
+                onChange={setParts}
+                onMentionAttach={vi.fn()}
+                onFolderAttach={vi.fn()}
+                onSubmit={vi.fn()}
+                onStop={vi.fn()}
+            />
+        </>
+    );
+}
+
 describe("StackedPaneContent", () => {
     afterEach(() => {
         vi.useRealTimers();
@@ -423,34 +450,17 @@ describe("StackedPaneContent", () => {
         );
         enableStackedOnFocusedPane();
 
-        function ComposerHarness() {
-            const [parts, setParts] = useState<AIComposerPart[]>([]);
-
-            return (
-                <>
-                    <EditorPaneContent />
-                    <AIChatComposer
-                        parts={parts}
-                        notes={[
-                            {
-                                id: "notes/alpha.md",
-                                title: "Alpha",
-                                path: "/vault/notes/alpha.md",
-                            },
-                        ]}
-                        status="idle"
-                        runtimeName="Assistant"
-                        onChange={setParts}
-                        onMentionAttach={vi.fn()}
-                        onFolderAttach={vi.fn()}
-                        onSubmit={vi.fn()}
-                        onStop={vi.fn()}
-                    />
-                </>
-            );
-        }
-
-        const { container } = renderComponent(<ComposerHarness />);
+        const { container } = renderComponent(
+            <StackedComposerHarness
+                notes={[
+                    {
+                        id: "notes/alpha.md",
+                        title: "Alpha",
+                        path: "/vault/notes/alpha.md",
+                    },
+                ]}
+            />,
+        );
         await flushPromises();
 
         const tablist = screen.getByRole("tablist", {
@@ -557,6 +567,186 @@ describe("StackedPaneContent", () => {
             "tab-a",
             "tab-b",
         ]);
+        expect(
+            composerDropZone!.querySelector(
+                '[data-kind="mention"][data-note-id="notes/alpha.md"]',
+            ),
+        ).not.toBeNull();
+    });
+
+    it("drops an inactive rail tab into the AI composer without activating it", async () => {
+        vi.useFakeTimers();
+        setVaultNotes([
+            {
+                id: "notes/alpha.md",
+                title: "Alpha",
+                path: "/vault/notes/alpha.md",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+        setEditorTabs(
+            [
+                {
+                    id: "tab-a",
+                    kind: "note",
+                    noteId: "notes/alpha.md",
+                    title: "Alpha",
+                    content: "alpha",
+                },
+                {
+                    id: "tab-b",
+                    kind: "note",
+                    noteId: "notes/beta.md",
+                    title: "Beta",
+                    content: "beta",
+                },
+                {
+                    id: "tab-c",
+                    kind: "note",
+                    noteId: "notes/gamma.md",
+                    title: "Gamma",
+                    content: "gamma",
+                },
+            ],
+            "tab-b",
+        );
+        enableStackedOnFocusedPane();
+
+        const { container } = renderComponent(
+            <StackedComposerHarness
+                notes={[
+                    {
+                        id: "notes/alpha.md",
+                        title: "Alpha",
+                        path: "/vault/notes/alpha.md",
+                    },
+                ]}
+            />,
+        );
+        await flushPromises();
+
+        const tablist = screen.getByRole("tablist", {
+            name: /stacked tabs/i,
+        });
+        const sourceColumn = container.querySelector(
+            '[data-stacked-column-id="tab-a"]',
+        ) as HTMLElement | null;
+        const activeColumn = container.querySelector(
+            '[data-stacked-column-id="tab-b"]',
+        ) as HTMLElement | null;
+        const rightColumn = container.querySelector(
+            '[data-stacked-column-id="tab-c"]',
+        ) as HTMLElement | null;
+        const composerDropZone = container.querySelector(
+            '[data-ai-composer-drop-zone="true"]',
+        ) as HTMLElement | null;
+        const composerShell = composerDropZone?.querySelector(
+            '[data-testid="chat-composer-shell"]',
+        ) as HTMLElement | null;
+
+        expect(sourceColumn).not.toBeNull();
+        expect(activeColumn).not.toBeNull();
+        expect(rightColumn).not.toBeNull();
+        expect(composerDropZone).not.toBeNull();
+        expect(composerShell).not.toBeNull();
+
+        vi.spyOn(tablist, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(sourceColumn!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(activeColumn!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 700, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(rightColumn!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 1300, top: 10, width: 600, height: 300 }),
+        );
+        vi.spyOn(composerDropZone!, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 120, top: 360, width: 520, height: 140 }),
+        );
+
+        defineElementMetric(tablist, "scrollLeft", 568);
+        defineElementMetric(tablist, "clientWidth", 600);
+        defineElementMetric(tablist, "scrollWidth", 1800);
+        defineElementMetric(sourceColumn!, "offsetLeft", 0);
+        defineElementMetric(sourceColumn!, "offsetWidth", 600);
+        defineElementMetric(activeColumn!, "offsetLeft", 600);
+        defineElementMetric(activeColumn!, "offsetWidth", 600);
+        defineElementMetric(rightColumn!, "offsetLeft", 1200);
+        defineElementMetric(rightColumn!, "offsetWidth", 600);
+
+        fireEvent.scroll(tablist);
+        await flushAnimationFrame();
+        vi.useRealTimers();
+
+        const railSpine = screen.getByRole("tab", { name: /alpha/i });
+        expect(railSpine).toHaveAttribute("aria-selected", "false");
+        defineElementMetric(railSpine, "offsetLeft", 0);
+        defineElementMetric(railSpine, "offsetWidth", 32);
+        vi.spyOn(railSpine, "getBoundingClientRect").mockReturnValue(
+            rect({ left: 100, top: 10, width: 32, height: 300 }),
+        );
+
+        await act(async () => {
+            dispatchPointerEvent(railSpine, "pointerdown", {
+                pointerId: 1,
+                button: 0,
+                buttons: 1,
+                clientX: 116,
+                clientY: 64,
+                screenX: 116,
+                screenY: 64,
+            });
+        });
+
+        await flushPromises();
+
+        await act(async () => {
+            dispatchPointerEvent(railSpine, "pointermove", {
+                pointerId: 1,
+                buttons: 1,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+            dispatchPointerEvent(window, "pointermove", {
+                pointerId: 1,
+                buttons: 1,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+        });
+
+        await waitFor(() => {
+            expect(sourceColumn).toHaveStyle({ opacity: "0.5" });
+        });
+        expect(composerShell!.style.boxShadow).toContain("color-mix");
+
+        await act(async () => {
+            dispatchPointerEvent(window, "pointerup", {
+                pointerId: 1,
+                buttons: 0,
+                clientX: 220,
+                clientY: 404,
+                screenX: 220,
+                screenY: 404,
+            });
+        });
+
+        await flushPromises();
+
+        const editorState = useEditorStore.getState();
+        expect(editorState.tabs.map((tab) => tab.id)).toEqual([
+            "tab-a",
+            "tab-b",
+            "tab-c",
+        ]);
+        expect(editorState.activeTabId).toBe("tab-b");
         expect(
             composerDropZone!.querySelector(
                 '[data-kind="mention"][data-note-id="notes/alpha.md"]',

--- a/apps/desktop/src/features/editor/StackedPaneContent.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.tsx
@@ -487,17 +487,22 @@ export function StackedPaneContent({
             {/* Left spine rail: a zero-width sticky anchor whose opaque spines
                 cover panels that have scrolled underneath it. */}
             <SpineRail side="left" count={stack.left}>
-                {leftStackTabs.map((tab) => (
+                {leftStackTabs.map((tab, index) => (
                     <SpineButton
                         key={tab.id}
                         tab={tab}
+                        index={index}
                         isActive={tab.id === activeTabId}
                         icon={renderEditorTabLeadingIcon(
                             tab,
                             chatSessionsById,
                         )}
-                        onClick={() => switchTab(tab.id)}
+                        onClick={() => handleSpineClick(tab.id)}
                         onRequestClose={() => void requestCloseTab(tab.id)}
+                        onPointerDown={handlePointerDown}
+                        onPointerMove={handlePointerMove}
+                        onPointerUp={handlePointerUp}
+                        onLostPointerCapture={handleLostPointerCapture}
                     />
                 ))}
             </SpineRail>
@@ -537,17 +542,22 @@ export function StackedPaneContent({
             })}
 
             <SpineRail side="right" count={stack.right}>
-                {rightStackTabs.map((tab) => (
+                {rightStackTabs.map((tab, index) => (
                     <SpineButton
                         key={tab.id}
                         tab={tab}
+                        index={lastContent + 1 + index}
                         isActive={tab.id === activeTabId}
                         icon={renderEditorTabLeadingIcon(
                             tab,
                             chatSessionsById,
                         )}
-                        onClick={() => switchTab(tab.id)}
+                        onClick={() => handleSpineClick(tab.id)}
                         onRequestClose={() => void requestCloseTab(tab.id)}
+                        onPointerDown={handlePointerDown}
+                        onPointerMove={handlePointerMove}
+                        onPointerUp={handlePointerUp}
+                        onLostPointerCapture={handleLostPointerCapture}
                     />
                 ))}
             </SpineRail>
@@ -717,17 +727,36 @@ function SpineTitle({ title }: { title: string }) {
 
 function SpineButton({
     tab,
+    index,
     isActive,
     icon,
     onClick,
     onRequestClose,
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onLostPointerCapture,
 }: {
     tab: Tab;
+    index: number;
     isActive: boolean;
     icon: ReactNode;
     onClick: () => void;
     onRequestClose: () => void;
+    onPointerDown: (
+        tabId: string,
+        index: number,
+        event: React.PointerEvent<HTMLDivElement>,
+    ) => void;
+    onPointerMove: (
+        tabId: string,
+        event: React.PointerEvent<HTMLDivElement>,
+    ) => void;
+    onPointerUp: (pointerId?: number, coords?: DragCoords) => void;
+    onLostPointerCapture: (pointerId: number) => void;
 }) {
+    const tabId = tab.id;
+
     return (
         <div
             role="tab"
@@ -740,12 +769,33 @@ function SpineButton({
                     onClick();
                 }
             }}
+            onPointerDown={(event) => onPointerDown(tabId, index, event)}
+            onPointerMove={(event) => onPointerMove(tabId, event)}
+            onPointerUp={(event) =>
+                onPointerUp(event.pointerId, {
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                    screenX: event.screenX,
+                    screenY: event.screenY,
+                })
+            }
+            onPointerCancel={(event) =>
+                onPointerUp(event.pointerId, {
+                    clientX: event.clientX,
+                    clientY: event.clientY,
+                    screenX: event.screenX,
+                    screenY: event.screenY,
+                })
+            }
+            onLostPointerCapture={(event) =>
+                onLostPointerCapture(event.pointerId)
+            }
             title={tab.title}
             className="group pointer-events-auto flex h-full flex-col items-center py-2"
             style={{
                 width: SPINE_WIDTH,
                 flexShrink: 0,
-                cursor: "pointer",
+                cursor: "grab",
                 background: isActive
                     ? "var(--bg-primary)"
                     : "var(--bg-secondary)",

--- a/apps/desktop/src/features/editor/StackedPaneContent.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.tsx
@@ -17,6 +17,8 @@ import {
     type Tab,
     type TerminalTab,
 } from "../../app/store/editorStore";
+import { getWindowMode } from "../../app/detachedWindows";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { useChatStore } from "../ai/store/chatStore";
 import {
     findActiveSessionsAffectedByClose,
@@ -34,6 +36,8 @@ import { WorkspacePaneEmptyState } from "./WorkspacePaneEmptyState";
 import { resolveEditorPanelView } from "./editorPanelView";
 import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 import { useWorkspaceTabDrag } from "./useWorkspaceTabDrag";
+import { useDetachedTabWindowDrop } from "./useDetachedTabWindowDrop";
+import { createWorkspaceTabExternalDragHandlers } from "./tabDragAttachments";
 
 const LazyExcalidrawTabView = React.lazy(() =>
     import("../maps/ExcalidrawTabView").then((m) => ({
@@ -107,6 +111,8 @@ export function StackedPaneContent({
     const moveTabToPaneDropTarget = useEditorStore(
         (state) => state.moveTabToPaneDropTarget,
     );
+    const vaultPath = useVaultStore((state) => state.vaultPath);
+    const windowMode = getWindowMode();
 
     const tabs = pane.tabs;
     const tabCount = tabs.length;
@@ -241,6 +247,23 @@ export function StackedPaneContent({
         recomputeStack();
     }, [activeIndex, tabCount, recomputeStack]);
 
+    const detachedTabWindowDrop = useDetachedTabWindowDrop({
+        vaultPath,
+        windowMode,
+        getTabById: (tabId) =>
+            selectEditorWorkspaceTabs(useEditorStore.getState()).find(
+                (candidate) => candidate.id === tabId,
+            ) ?? null,
+        getWorkspaceTabCount: () =>
+            selectEditorWorkspaceTabs(useEditorStore.getState()).length,
+        closeTab,
+    });
+    const externalTabDrag = createWorkspaceTabExternalDragHandlers({
+        getTabById: (tabId) =>
+            tabs.find((candidate) => candidate.id === tabId) ?? null,
+        resolveDetachDropTarget: detachedTabWindowDrop.resolveDetachDropTarget,
+    });
+
     // Pointer-based drag shared with the normal tab strip: lets a column be
     // reordered within the pane AND dragged out to other panes / new splits,
     // using the same drop-target resolution as the classic strip.
@@ -277,6 +300,18 @@ export function StackedPaneContent({
         },
         onActivate: switchTab,
         liveReorder: false,
+        resolveExternalDropTarget: externalTabDrag.resolveExternalDropTarget,
+        onCommitExternalDrop: (tabId, target, coords) => {
+            if (target.type !== "detach-window") {
+                return;
+            }
+
+            return detachedTabWindowDrop.commitDetachDrop(tabId, coords);
+        },
+        onDetachStart: detachedTabWindowDrop.handleDetachStart,
+        onDetachMove: detachedTabWindowDrop.handleDetachMove,
+        onDetachCancel: detachedTabWindowDrop.handleDetachCancel,
+        buildAttachmentDetail: externalTabDrag.buildAttachmentDetail,
     });
 
     // The horizontal column row is both the stack scroll container and the drag

--- a/apps/desktop/src/features/editor/StackedPaneContent.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.tsx
@@ -262,6 +262,7 @@ export function StackedPaneContent({
         getTabById: (tabId) =>
             tabs.find((candidate) => candidate.id === tabId) ?? null,
         resolveDetachDropTarget: detachedTabWindowDrop.resolveDetachDropTarget,
+        commitDetachDrop: detachedTabWindowDrop.commitDetachDrop,
     });
 
     // Pointer-based drag shared with the normal tab strip: lets a column be
@@ -301,13 +302,7 @@ export function StackedPaneContent({
         onActivate: switchTab,
         liveReorder: false,
         resolveExternalDropTarget: externalTabDrag.resolveExternalDropTarget,
-        onCommitExternalDrop: (tabId, target, coords) => {
-            if (target.type !== "detach-window") {
-                return;
-            }
-
-            return detachedTabWindowDrop.commitDetachDrop(tabId, coords);
-        },
+        onCommitExternalDrop: externalTabDrag.onCommitExternalDrop,
         onDetachStart: detachedTabWindowDrop.handleDetachStart,
         onDetachMove: detachedTabWindowDrop.handleDetachMove,
         onDetachCancel: detachedTabWindowDrop.handleDetachCancel,

--- a/apps/desktop/src/features/editor/tabDragAttachments.test.ts
+++ b/apps/desktop/src/features/editor/tabDragAttachments.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
     buildTabFileDragDetail,
     createWorkspaceTabExternalDragHandlers,
@@ -348,5 +348,29 @@ describe("createWorkspaceTabExternalDragHandlers", () => {
                 clientY: 32,
             }),
         ).toBeNull();
+    });
+
+    it("commits only detach-window external drops", () => {
+        const commitDetachDrop = vi.fn();
+        const handlers = createWorkspaceTabExternalDragHandlers({
+            getTabById: () => null,
+            commitDetachDrop,
+        });
+        const coords = {
+            clientX: -80,
+            clientY: 12,
+            screenX: 400,
+            screenY: 120,
+        };
+
+        handlers.onCommitExternalDrop("note-1", { type: "composer" }, coords);
+        expect(commitDetachDrop).not.toHaveBeenCalled();
+
+        handlers.onCommitExternalDrop(
+            "note-1",
+            { type: "detach-window" },
+            coords,
+        );
+        expect(commitDetachDrop).toHaveBeenCalledWith("note-1", coords);
     });
 });

--- a/apps/desktop/src/features/editor/tabDragAttachments.test.ts
+++ b/apps/desktop/src/features/editor/tabDragAttachments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     buildTabFileDragDetail,
+    createWorkspaceTabExternalDragHandlers,
     resolveComposerDropTarget,
 } from "./tabDragAttachments";
 import type {
@@ -234,5 +235,118 @@ describe("resolveComposerDropTarget", () => {
         expect(resolveComposerDropTarget(24, 48)).toEqual({
             type: "none",
         });
+    });
+});
+
+describe("createWorkspaceTabExternalDragHandlers", () => {
+    it("resolves composer before delegating to detach targets", () => {
+        document.body.innerHTML =
+            '<div data-ai-composer-drop-zone="true"></div>';
+        const dropZone = document.querySelector(
+            '[data-ai-composer-drop-zone="true"]',
+        ) as HTMLElement;
+        let detachResolverCalled = false;
+
+        dropZone.getBoundingClientRect = () =>
+            ({
+                left: 100,
+                top: 200,
+                right: 340,
+                bottom: 320,
+                width: 240,
+                height: 120,
+                x: 100,
+                y: 200,
+                toJSON: () => ({}),
+            }) as DOMRect;
+
+        const handlers = createWorkspaceTabExternalDragHandlers({
+            getTabById: () => null,
+            resolveDetachDropTarget: () => {
+                detachResolverCalled = true;
+                return { type: "detach-window" };
+            },
+        });
+
+        expect(
+            handlers.resolveExternalDropTarget("note-1", {
+                clientX: 180,
+                clientY: 240,
+            }),
+        ).toEqual({ type: "composer" });
+        expect(detachResolverCalled).toBe(false);
+    });
+
+    it("falls back to detach resolution outside composer zones", () => {
+        document.body.innerHTML = "";
+        const handlers = createWorkspaceTabExternalDragHandlers({
+            getTabById: () => null,
+            resolveDetachDropTarget: () => ({ type: "detach-window" }),
+        });
+
+        expect(
+            handlers.resolveExternalDropTarget("note-1", {
+                clientX: -80,
+                clientY: 12,
+            }),
+        ).toEqual({ type: "detach-window" });
+    });
+
+    it("builds attachment details from a tab id and resolved vault note path", () => {
+        const tab: NoteTab = {
+            id: "note-1",
+            kind: "note",
+            noteId: "notes/daily.md",
+            title: "Daily",
+            content: "",
+            history: [],
+            historyIndex: 0,
+        };
+        useVaultStore.setState({
+            notes: [
+                {
+                    id: "notes/daily.md",
+                    title: "Daily",
+                    path: "/vault/notes/daily.md",
+                    modified_at: 1,
+                    created_at: 1,
+                },
+            ],
+        });
+
+        const handlers = createWorkspaceTabExternalDragHandlers({
+            getTabById: (tabId) => (tabId === tab.id ? tab : null),
+        });
+
+        expect(
+            handlers.buildAttachmentDetail("note-1", "end", {
+                clientX: 16,
+                clientY: 32,
+            }),
+        ).toEqual({
+            phase: "end",
+            x: 16,
+            y: 32,
+            notes: [
+                {
+                    id: "notes/daily.md",
+                    title: "Daily",
+                    path: "/vault/notes/daily.md",
+                },
+            ],
+        });
+    });
+
+    it("returns null attachment details for missing tabs", () => {
+        const handlers = createWorkspaceTabExternalDragHandlers({
+            getTabById: () => null,
+        });
+
+        expect(
+            handlers.buildAttachmentDetail("missing", "end", {
+                clientX: 16,
+                clientY: 32,
+            }),
+        ).toBeNull();
     });
 });

--- a/apps/desktop/src/features/editor/tabDragAttachments.ts
+++ b/apps/desktop/src/features/editor/tabDragAttachments.ts
@@ -20,6 +20,11 @@ export interface TabDragCoordinates {
     clientY: number;
 }
 
+export interface TabDragCommitCoordinates extends TabDragCoordinates {
+    screenX: number;
+    screenY: number;
+}
+
 interface BuildTabFileDragDetailOptions {
     resolveNotePath?: (noteId: string) => string | null;
 }
@@ -35,6 +40,10 @@ export interface WorkspaceTabExternalDragOptions {
         tabId: string,
         coords: TabDragCoordinates,
     ) => Extract<WorkspaceDropTarget, { type: "detach-window" | "none" }>;
+    commitDetachDrop?: (
+        tabId: string,
+        coords: TabDragCommitCoordinates,
+    ) => Promise<void> | void;
 }
 
 export interface WorkspaceTabExternalDragHandlers {
@@ -47,6 +56,11 @@ export interface WorkspaceTabExternalDragHandlers {
         phase: FileTreeNoteDragPhase,
         coords: TabDragCoordinates,
     ) => FileTreeNoteDragDetail | null;
+    onCommitExternalDrop: (
+        tabId: string,
+        target: WorkspaceTabExternalDropTarget,
+        coords: TabDragCommitCoordinates,
+    ) => Promise<void> | void;
 }
 
 function buildDraggedFiles(tab: Tab): FileTreeDraggedFile[] | null {
@@ -174,6 +188,7 @@ function resolveVaultNotePath(noteId: string) {
 export function createWorkspaceTabExternalDragHandlers({
     getTabById,
     resolveDetachDropTarget,
+    commitDetachDrop,
 }: WorkspaceTabExternalDragOptions): WorkspaceTabExternalDragHandlers {
     return {
         resolveExternalDropTarget: (tabId, coords) => {
@@ -198,6 +213,13 @@ export function createWorkspaceTabExternalDragHandlers({
             return buildTabFileDragDetail(tab, phase, coords, {
                 resolveNotePath: resolveVaultNotePath,
             });
+        },
+        onCommitExternalDrop: (tabId, target, coords) => {
+            if (target.type !== "detach-window") {
+                return;
+            }
+
+            return commitDetachDrop?.(tabId, coords);
         },
     };
 }

--- a/apps/desktop/src/features/editor/tabDragAttachments.ts
+++ b/apps/desktop/src/features/editor/tabDragAttachments.ts
@@ -15,13 +15,38 @@ import type {
     FileTreeNoteDragPhase,
 } from "../ai/dragEvents";
 
-interface TabDragCoordinates {
+export interface TabDragCoordinates {
     clientX: number;
     clientY: number;
 }
 
 interface BuildTabFileDragDetailOptions {
     resolveNotePath?: (noteId: string) => string | null;
+}
+
+export type WorkspaceTabExternalDropTarget = Extract<
+    WorkspaceDropTarget,
+    { type: "composer" | "detach-window" | "none" }
+>;
+
+export interface WorkspaceTabExternalDragOptions {
+    getTabById: (tabId: string) => Tab | null;
+    resolveDetachDropTarget?: (
+        tabId: string,
+        coords: TabDragCoordinates,
+    ) => Extract<WorkspaceDropTarget, { type: "detach-window" | "none" }>;
+}
+
+export interface WorkspaceTabExternalDragHandlers {
+    resolveExternalDropTarget: (
+        tabId: string,
+        coords: TabDragCoordinates,
+    ) => WorkspaceTabExternalDropTarget;
+    buildAttachmentDetail: (
+        tabId: string,
+        phase: FileTreeNoteDragPhase,
+        coords: TabDragCoordinates,
+    ) => FileTreeNoteDragDetail | null;
 }
 
 function buildDraggedFiles(tab: Tab): FileTreeDraggedFile[] | null {
@@ -136,4 +161,43 @@ export function resolveComposerDropTarget(
     }
 
     return { type: "none" };
+}
+
+function resolveVaultNotePath(noteId: string) {
+    return (
+        useVaultStore
+            .getState()
+            .notes.find((note) => note.id === noteId)?.path ?? null
+    );
+}
+
+export function createWorkspaceTabExternalDragHandlers({
+    getTabById,
+    resolveDetachDropTarget,
+}: WorkspaceTabExternalDragOptions): WorkspaceTabExternalDragHandlers {
+    return {
+        resolveExternalDropTarget: (tabId, coords) => {
+            const composerTarget = resolveComposerDropTarget(
+                coords.clientX,
+                coords.clientY,
+            );
+            if (composerTarget.type !== "none") {
+                return composerTarget;
+            }
+
+            return (
+                resolveDetachDropTarget?.(tabId, coords) ?? { type: "none" }
+            );
+        },
+        buildAttachmentDetail: (tabId, phase, coords) => {
+            const tab = getTabById(tabId);
+            if (!tab) {
+                return null;
+            }
+
+            return buildTabFileDragDetail(tab, phase, coords, {
+                resolveNotePath: resolveVaultNotePath,
+            });
+        },
+    };
 }


### PR DESCRIPTION
## Summary

Fixes stacked-pane tab drags so they behave like normal pane tabs when dropped into the AI chat composer.

## Root cause

The normal pane tab strip passed the shared drag hook both the external drop target resolver and the attachment-detail builder. Stacked tabs used the same drag hook for reordering and workspace moves, but did not provide the external composer/drop attachment behavior, so drags could look active while never reaching the composer.

## Changes

- Added shared workspace-tab external drag helpers for composer detection, attachment detail construction, and detach-window commit routing.
- Rewired normal pane tabs to use the shared helper without changing behavior.
- Connected stacked tab spines to the same external drag behavior, including composer drops and detach-window parity.
- Added stacked composer-drop coverage that verifies the composer hover state, mention insertion, and that the source tab is not moved or reordered.
- Removed residual duplicate external-drop routing between normal and stacked tab surfaces.

## Validation

- `npm run test -- tabDragAttachments`
- `npm run test -- EditorPaneBar`
- `npm run test -- StackedPaneContent`
- `npm run test -- useWorkspaceTabDrag`