### PR TITLE
Document stacked pane tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 - File tree modes for curated writing/media files, all vault files, or an explicit extension allowlist
 - Persistent bookmarks per vault
 - Persistent tabs and window session restore
+- Per-pane tab display modes, including stacked tabs for scanning several open documents in one pane
 - Detached note windows and separate vault windows
 - First-class terminal tabs with themed xterm rendering, persistent workspace state, search, and Claude Code integration in the Agents sidebar
 

--- a/docs/editor-architecture.md
+++ b/docs/editor-architecture.md
@@ -249,10 +249,19 @@ than resolving against old tracked-file state.
 ## Multi-Pane And Detached Windows
 
 Workspace panes are first-class owners of tab order, active tab, pinned tabs,
-activation history, and navigation history. Most editor code should use
-pane-aware selectors such as `selectEditorPaneState`,
+activation history, navigation history, and tab display mode. Most editor code
+should use pane-aware selectors such as `selectEditorPaneState`,
 `selectEditorPaneActiveTab`, `selectEditorWorkspaceTabs`, and
 `selectFocusedEditorTab`.
+
+Each pane can render tabs in the classic `"default"` mode or in `"stacked"`
+mode, where open tabs are shown as side-by-side columns for scanning several
+documents within one pane. The mode is stored as `tabDisplayMode` on
+`EditorPaneState`, normalized through `normalizeTabDisplayMode()`, toggled by
+`setPaneTabDisplayMode()` / `togglePaneTabDisplayMode()`, and rendered through
+`StackedPaneContent` when active. Treat it as pane-owned workspace state: it
+must persist with session restore, detach payloads, and cross-window hydration,
+but it should not become a property of individual tabs.
 
 `EditorPaneContent` keeps the note CodeMirror editor mounted behind non-editor
 tabs when an editable note exists in the pane. This preserves note-local scroll,


### PR DESCRIPTION
## Summary

- Add stacked pane tabs to the README capability list.
- Document the pane-owned tab display mode in the editor architecture guide.

## Notes

This documents that `tabDisplayMode` belongs to each pane, is normalized through the workspace store, renders through `StackedPaneContent`, and should persist through session restore, detached windows, and cross-window hydration.

## Validation

- Documentation-only change; no tests run.