### PR TITLE
Prepare 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,23 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.1] - 2026-06-30
+
+### Added
+
+- Added RPM packages for Fedora and other RPM-based Linux distributions, including DNF repository metadata for release distribution.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.53.0`.
+- Improved Claude chat titles so automatic thread rename and title updates are consumed automatically, while runtime-provided title information is ignored after the user manually renames a thread.
+
+### Fixed
+
+- Fixed stacked tabs so their horizontal scroll position is preserved when switching between tabs and panes.
+- Fixed dragging stacked tabs into the AI composer so stacked pane tabs behave consistently with regular workspace tabs.
+- Fixed HTML preview links so external URLs open outside the app instead of navigating the preview window.
+
 ## [0.4.0] - 2026-06-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.4.0",
+            "version": "0.4.1",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.4.0",
+    "version": "0.4.1",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.4.0",
+    "version": "0.4.1",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Bump NeverWrite desktop, native backend, lockfile, and Web Clipper versions to 0.4.1.
- Add the 0.4.1 changelog entry with user-facing release notes.
- Keep package metadata aligned for the v0.4.1 release workflow.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.4.1`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`