### PR TITLE
Fix RPM signature verification

### DIFF
--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -369,11 +369,11 @@ jobs:
                   chmod 700 "$GNUPGHOME"
                   printf '%s' "$APT_REPO_GPG_PRIVATE_KEY" | gpg --batch --import
                   gpg --batch --armor --export "$APT_REPO_GPG_KEY_ID" > "$RUNNER_TEMP/neverwrite-rpm-signing-key.asc"
-                  sudo rpm --import "$RUNNER_TEMP/neverwrite-rpm-signing-key.asc"
 
                   node scripts/sign-rpm-packages.mjs \
                     --rpm-dir "$RUNNER_TEMP/electron-dist" \
-                    --key-id "$APT_REPO_GPG_KEY_ID"
+                    --key-id "$APT_REPO_GPG_KEY_ID" \
+                    --public-key "$RUNNER_TEMP/neverwrite-rpm-signing-key.asc"
 
             - name: Stage release assets and target metadata
               shell: bash

--- a/scripts/sign-rpm-packages.mjs
+++ b/scripts/sign-rpm-packages.mjs
@@ -7,6 +7,7 @@ function parseArgs(argv) {
     const args = {
         rpmDir: null,
         keyId: null,
+        publicKeyPath: null,
     };
 
     for (let index = 0; index < argv.length; index += 1) {
@@ -23,11 +24,17 @@ function parseArgs(argv) {
             index += 1;
             continue;
         }
+        if (arg === "--public-key") {
+            args.publicKeyPath = path.resolve(next);
+            index += 1;
+            continue;
+        }
         throw new Error(`Unknown argument "${arg}".`);
     }
 
     if (!args.rpmDir) throw new Error("Missing --rpm-dir");
     if (!args.keyId) throw new Error("Missing --key-id");
+    if (!args.publicKeyPath) throw new Error("Missing --public-key");
 
     return args;
 }
@@ -119,6 +126,13 @@ function main() {
     if (!process.env.GNUPGHOME) {
         throw new Error("GNUPGHOME must point to the imported release signing keyring.");
     }
+    if (!fs.existsSync(args.publicKeyPath)) {
+        throw new Error(`RPM public signing key not found: ${args.publicKeyPath}`);
+    }
+
+    // Import the public key as the current user so rpm -Kv can trust the
+    // signature in both this script and later workflow steps.
+    runCommand("rpm", ["--import", args.publicKeyPath]);
 
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "neverwrite-rpm-sign-"));
     try {


### PR DESCRIPTION
## Summary

- Import the RPM public signing key from `scripts/sign-rpm-packages.mjs` as the same user that runs `rpm -Kv`.
- Pass the exported public key from the release workflow into the RPM signing script.
- Remove the root-only `sudo rpm --import` path that made signature verification fail with `NOKEY` on the x86_64 Linux release job.

## Root cause

The v0.4.1 release run signed the RPM package, but the verification step ran as the normal runner user while the public key had been imported into root's RPM database. `rpm -Kv` therefore reported `NOKEY` even though the RPM header signature existed.

## Validation

- `node --check scripts/sign-rpm-packages.mjs`
- `node scripts/validate-release-metadata.mjs --tag v0.4.1`
- `node --test scripts/release-metadata.test.mjs`

## Release note

No tag was moved or relaunched in this PR. After merge, `v0.4.1` can be moved with a guarded force-with-lease to the fixed commit and the release workflow can be relaunched from the same tag version.