### PR TITLE
Prepare 0.4.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.2] - 2026-07-01
+
+### Added
+
+- Added Claude Fast Mode support in chat controls, presented as a clear Off/Fast toggle while preserving the underlying ACP values.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.54.1`, including Claude Sonnet 5 SDK support.
+
+### Fixed
+
+- Fixed Claude model availability when runtime model overrides are used.
+
 ## [0.4.1] - 2026-06-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.4.1",
+            "version": "0.4.2",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.4.1",
+    "version": "0.4.2",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.4.2 changelog entry with the user-facing Claude ACP runtime changes.
- Bump the desktop app, native backend, Cargo lockfile, and Web Clipper versions to 0.4.2.
- Keep release metadata aligned for the tag-driven desktop release workflow.

## Validation

- `cargo check -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.4.2`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`