### PR TITLE
Prepare 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,24 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.3] - 2026-07-02
+
+### Added
+
+- Added a configurable default PDF zoom setting under Settings > Editor > PDF, including a new Fit width mode that opens PDFs scaled to the current viewport width.
+- Added a Fit Width toggle to the PDF toolbar, with session-aware PDF tab state so fit-width mode is restored consistently across reopened tabs and history entries.
+
+### Changed
+
+- Changed the default PDF opening zoom from 100% to Fit width, making documents easier to read on larger screens by default. Thanks to @spamsch.
+- Updated the embedded Claude ACP runtime to `0.55.0`.
+- Polished the PDF toolbar with a simpler page counter, refined navigation controls, and a more compact layout in narrow panes.
+
+### Fixed
+
+- Fixed PDF fit-width behavior across resize, reopen, and alternate opening paths so the computed zoom remains stable and explicit zoom actions cleanly leave fit-width mode.
+- Fixed Claude runtime model fallback coverage for the updated ACP runtime.
+
 ## [0.4.2] - 2026-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.4.2",
+            "version": "0.4.3",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.4.3",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.4.2",
+    "version": "0.4.3",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.4.3 changelog entry with PDF improvements, Claude ACP 0.55.0. 
- Bump desktop, native backend, Cargo lockfile, and web clipper versions to 0.4.3.
- Keep release metadata aligned for the tag-driven desktop release flow.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.4.3`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`