### PR TITLE
Add Mermaid previews for Markdown and diagram files

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NeverWrite is a local-first knowledge workspace for people who need to handle wo
 Today the repository combines:
 
 - An Electron desktop app with a Rust sidecar that opens a local vault and keeps working state on disk.
-- A Markdown, CSV, and text/code editing workflow with wikilinks, live preview, frontmatter editing, spellcheck, and grammar checking.
+- A Markdown, CSV, Mermaid, and text/code editing workflow with wikilinks, live preview, frontmatter editing, spellcheck, and grammar checking.
 - Knowledge navigation tools such as backlinks, tags, advanced search, bookmarks, concept maps, and a 2D/3D graph view.
 - An ACP-based AI layer with Codex, Claude, Grok, Kilo, and OpenCode runtimes.
 - An explicit AI change-review system with inline review inside the editor and a dedicated surface in chat and a tab with changes pending approval.
@@ -30,7 +30,7 @@ The current product already includes:
 
 - Local vault opening with progress reporting, persisted snapshots, filesystem watching, and incremental re-sync
 - A desktop workspace with tabs, sidebars, command palette, quick switcher, detached windows, and first-class terminal tabs
-- Native-feeling editing for Markdown notes, CSV files, PDFs, images, HTML previews, and generic text/code files
+- Native-feeling editing for Markdown notes, Mermaid diagrams, CSV files, PDFs, images, HTML previews, and generic text/code files
 - Embedded Excalidraw-based concept maps stored as `.excalidraw` files in the vault. The map format is visible and editable by agents.
 - A graph view with global, local, and overview modes plus 2D and 3D rendering
 - AI chat sessions with attachments from the vault, slash commands, transcript persistence, and runtime-specific capabilities
@@ -66,8 +66,9 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 - Markdown editing with CodeMirror 6
 - Optional Vim key bindings for modal editing, with Vim-style ex commands and relative line numbers
 - Wikilink suggestions, resolution, and navigation
-- Live preview with tasks, tables, embeds, math, and YouTube previews
+- Live preview with tasks, tables, embeds, math, Mermaid diagrams, and YouTube previews
 - Frontmatter/properties editing
+- Mermaid diagram files with source editing and preview switching
 - CSV editing with table and raw fallback views
 - Editable text/code files with syntax highlighting and autosave
 - Sandboxed in-app HTML viewing for `.html` and `.htm` files

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -40,6 +40,7 @@
                 "@xterm/xterm": "^6.0.0",
                 "electron-updater": "^6.8.3",
                 "katex": "^0.16.45",
+                "mermaid": "^11.16.0",
                 "papaparse": "^5.5.3",
                 "pdfjs-dist": "^5.6.205",
                 "react": "19.2.5",
@@ -5672,9 +5673,9 @@
             "license": "MIT"
         },
         "node_modules/cytoscape": {
-            "version": "3.33.2",
-            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
-            "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+            "version": "3.34.0",
+            "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.34.0.tgz",
+            "integrity": "sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==",
             "license": "MIT",
             "engines": {
                 "node": ">=0.10"
@@ -8704,26 +8705,26 @@
             }
         },
         "node_modules/mermaid": {
-            "version": "11.15.0",
-            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
-            "integrity": "sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==",
+            "version": "11.16.0",
+            "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
+            "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
             "license": "MIT",
             "dependencies": {
-                "@braintree/sanitize-url": "^7.1.1",
+                "@braintree/sanitize-url": "^7.1.2",
                 "@iconify/utils": "^3.0.2",
-                "@mermaid-js/parser": "^1.1.1",
+                "@mermaid-js/parser": "^1.2.0",
                 "@types/d3": "^7.4.3",
                 "@upsetjs/venn.js": "^2.0.0",
-                "cytoscape": "^3.33.1",
+                "cytoscape": "^3.33.3",
                 "cytoscape-cose-bilkent": "^4.1.0",
                 "cytoscape-fcose": "^2.2.0",
                 "d3": "^7.9.0",
                 "d3-sankey": "^0.12.3",
                 "dagre-d3-es": "7.0.14",
-                "dayjs": "^1.11.19",
-                "dompurify": "^3.3.1",
+                "dayjs": "^1.11.20",
+                "dompurify": "^3.3.3",
                 "es-toolkit": "^1.45.1",
-                "katex": "^0.16.25",
+                "katex": "^0.16.45",
                 "khroma": "^2.1.0",
                 "marked": "^16.3.0",
                 "roughjs": "^4.6.6",
@@ -8745,12 +8746,12 @@
             "license": "Apache-2.0"
         },
         "node_modules/mermaid/node_modules/@mermaid-js/parser": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.1.tgz",
-            "integrity": "sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
+            "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
             "license": "MIT",
             "dependencies": {
-                "@chevrotain/types": "~11.1.1"
+                "@chevrotain/types": "~11.1.2"
             }
         },
         "node_modules/mermaid/node_modules/points-on-curve": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -67,6 +67,7 @@
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
         "katex": "^0.16.45",
+        "mermaid": "^11.16.0",
         "papaparse": "^5.5.3",
         "pdfjs-dist": "^5.6.205",
         "react": "19.2.5",

--- a/apps/desktop/src-electron/main/vaultBackend.test.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 import { ElectronVaultBackend } from "./vaultBackend";
 import type { NativeBackendBridge } from "./nativeBackend";
 import type { AppUpdaterBackend } from "./updater";
+
+type VaultEntryForTest = {
+    file_name: string;
+    kind: string;
+    mime_type: string | null;
+    is_text_like: boolean | null;
+    open_in_app: boolean | null;
+    viewer_kind: string | null;
+};
 
 const electronAppMock = vi.hoisted(() => ({
     isPackaged: true,
@@ -109,5 +121,48 @@ describe("ElectronVaultBackend updater routing", () => {
             "check_for_app_update",
         );
         expect(nativeBackend.invoke).not.toHaveBeenCalled();
+    });
+});
+
+describe("ElectronVaultBackend vault classification", () => {
+    it("classifies Mermaid files as in-app diagram files in the fallback backend", async () => {
+        const vaultPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), "neverwrite-mermaid-"),
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "flow.mmd"),
+            "flowchart TD\nA --> B\n",
+            "utf8",
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "sequence.mermaid"),
+            "sequenceDiagram\nA->>B: hello\n",
+            "utf8",
+        );
+
+        const backend = new ElectronVaultBackend(
+            vi.fn(),
+            createUpdater(),
+            null,
+        );
+
+        await backend.invoke("start_open_vault", { path: vaultPath });
+        const entries = (await backend.invoke("list_vault_entries", {
+            vaultPath,
+        })) as VaultEntryForTest[];
+
+        for (const fileName of ["flow.mmd", "sequence.mermaid"]) {
+            const entry = entries.find(
+                (candidate) => candidate.file_name === fileName,
+            );
+
+            expect(entry).toMatchObject({
+                kind: "file",
+                mime_type: "text/plain",
+                is_text_like: true,
+                open_in_app: true,
+                viewer_kind: "mermaid",
+            });
+        }
     });
 });

--- a/apps/desktop/src-electron/main/vaultBackend.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.ts
@@ -359,6 +359,9 @@ function guessMimeType(fileName: string) {
             return "text/css";
         case "csv":
             return "text/csv";
+        case "mermaid":
+        case "mmd":
+            return "text/plain";
         case "svg":
             return "image/svg+xml";
         case "png":
@@ -436,6 +439,9 @@ function classifyEntry(fileName: string, kind: VaultEntryKind) {
     }
     if (extension === "excalidraw") {
         return { mimeType, isTextLike, isImageLike, openInApp: true, viewerKind: "map" };
+    }
+    if (extension === "mermaid" || extension === "mmd") {
+        return { mimeType, isTextLike, isImageLike, openInApp: true, viewerKind: "mermaid" };
     }
     if (isImageLike) {
         return { mimeType, isTextLike, isImageLike, openInApp: true, viewerKind: "image" };

--- a/apps/desktop/src/app/store/editorSession.test.ts
+++ b/apps/desktop/src/app/store/editorSession.test.ts
@@ -5,7 +5,7 @@ import {
     getEditorSessionKey,
     restorePersistedSession,
 } from "./editorSession";
-import type { Tab } from "./editorTabs";
+import { inferFileViewer, type Tab } from "./editorTabs";
 import { normalizeHistoryTab } from "./editorTabRegistry";
 import { safeStorageClear } from "../utils/safeStorage";
 import { useLayoutStore } from "./layoutStore";
@@ -24,6 +24,15 @@ describe("editorSession", () => {
         vi.restoreAllMocks();
         safeStorageClear();
         localStorage.clear();
+    });
+
+    it("infers Mermaid files as the dedicated Mermaid viewer", () => {
+        expect(inferFileViewer("/vault/diagrams/flow.mmd", null)).toBe(
+            "mermaid",
+        );
+        expect(inferFileViewer("/vault/diagrams/flow.mermaid", null)).toBe(
+            "mermaid",
+        );
     });
 
     it("serializes persisted session state without review tab payloads", () => {

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -2,7 +2,7 @@ import { toVaultRelativePath } from "../utils/vaultPaths";
 import { useVaultStore } from "./vaultStore";
 
 export type PdfViewMode = "single" | "continuous";
-export type FileViewerMode = "text" | "image" | "csv" | "html";
+export type FileViewerMode = "text" | "image" | "csv" | "html" | "mermaid";
 
 const IMAGE_FILE_EXTENSIONS = new Set([
     "png",
@@ -19,6 +19,7 @@ const IMAGE_FILE_EXTENSIONS = new Set([
 ]);
 
 const CSV_FILE_EXTENSIONS = new Set(["csv"]);
+const MERMAID_FILE_EXTENSIONS = new Set(["mermaid", "mmd"]);
 
 export interface NoteHistoryEntry {
     kind: "note";
@@ -1040,7 +1041,8 @@ export function isFileViewerMode(value: unknown): value is FileViewerMode {
         value === "text" ||
         value === "image" ||
         value === "csv" ||
-        value === "html"
+        value === "html" ||
+        value === "mermaid"
     );
 }
 
@@ -1052,6 +1054,7 @@ export function inferFileViewer(
     if (mimeType?.startsWith("image/")) return "image";
     if (mimeType?.startsWith("text/csv")) return "csv";
     if (CSV_FILE_EXTENSIONS.has(extension)) return "csv";
+    if (MERMAID_FILE_EXTENSIONS.has(extension)) return "mermaid";
     if (IMAGE_FILE_EXTENSIONS.has(extension)) {
         return "image";
     }

--- a/apps/desktop/src/app/utils/vaultEntries.test.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.test.ts
@@ -104,6 +104,20 @@ describe("vaultEntries", () => {
                 mime_type: null,
             }),
         ).toBe(true);
+        expect(
+            isTextLikeVaultEntry({
+                extension: "mmd",
+                file_name: "flow.mmd",
+                mime_type: null,
+            }),
+        ).toBe(true);
+        expect(
+            isTextLikeVaultEntry({
+                extension: "mermaid",
+                file_name: "flow.mermaid",
+                mime_type: null,
+            }),
+        ).toBe(true);
     });
 
     it("identifies the curated default vault entry set", () => {
@@ -126,6 +140,10 @@ describe("vaultEntries", () => {
                 }),
             ),
         ).toBe(true);
+        expect(isCuratedVaultEntry(buildEntry("docs/flow.mmd"))).toBe(true);
+        expect(isCuratedVaultEntry(buildEntry("docs/flow.mermaid"))).toBe(
+            true,
+        );
         expect(
             isCuratedVaultEntry(buildEntry("docs/readme.txt", { mimeType: "text/plain" })),
         ).toBe(true);
@@ -161,6 +179,7 @@ describe("vaultEntries", () => {
         const toml = buildEntry("docs/config.toml", {
             mimeType: "application/toml",
         });
+        const mermaid = buildEntry("docs/flow.mmd");
 
         expect(
             shouldShowVaultEntryInFileTree(folder, {
@@ -176,6 +195,12 @@ describe("vaultEntries", () => {
         ).toBe(false);
         expect(
             shouldShowVaultEntryInFileTree(csv, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldShowVaultEntryInFileTree(mermaid, {
                 contentMode: "notes_only",
                 extensionFilter: [],
             }),
@@ -238,9 +263,20 @@ describe("vaultEntries", () => {
             relativePath: "docs/photo.png",
             mimeType: "image/png",
         };
+        const mermaid = {
+            fileName: "flow.mermaid",
+            relativePath: "docs/flow.mermaid",
+            mimeType: null,
+        };
 
         expect(
             shouldIncludeFileSummaryInFileScope(csv, {
+                contentMode: "notes_only",
+                extensionFilter: [],
+            }),
+        ).toBe(true);
+        expect(
+            shouldIncludeFileSummaryInFileScope(mermaid, {
                 contentMode: "notes_only",
                 extensionFilter: [],
             }),

--- a/apps/desktop/src/app/utils/vaultEntries.ts
+++ b/apps/desktop/src/app/utils/vaultEntries.ts
@@ -64,7 +64,9 @@ const TEXT_EXTENSIONS = new Set([
     "m",
     "md",
     "mdx",
+    "mermaid",
     "mjs",
+    "mmd",
     "mts",
     "mk",
     "nim",
@@ -169,6 +171,8 @@ const CURATED_VAULT_ENTRY_EXTENSIONS = new Set([
     "excalidraw",
     "htm",
     "html",
+    "mermaid",
+    "mmd",
     "txt",
 ]);
 

--- a/apps/desktop/src/components/icons/FileTypeIcon.test.ts
+++ b/apps/desktop/src/components/icons/FileTypeIcon.test.ts
@@ -55,6 +55,8 @@ describe("resolveCatppuccinFileIcon", () => {
     it.each([
         ["notes/draft.md", "markdown"],
         ["docs/intro.mdx", "markdown-mdx"],
+        ["diagrams/flow.mmd", "mermaid"],
+        ["diagrams/flow.mermaid", "mermaid"],
         ["src/App.tsx", "typescript-react"],
         ["src/App.jsx", "javascript-react"],
         ["src/index.ts", "typescript"],

--- a/apps/desktop/src/components/icons/fileTypeIcons.ts
+++ b/apps/desktop/src/components/icons/fileTypeIcons.ts
@@ -145,6 +145,8 @@ const EXTENSION_TO_ICON: Record<string, IconCandidates> = {
     lock: "lock",
     md: "markdown",
     mdx: "markdown-mdx",
+    mermaid: "mermaid",
+    mmd: "mermaid",
     pdf: "pdf",
     prisma: "prisma",
     ppt: "file",

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -55,6 +55,8 @@ import {
 } from "./extensions/changeAuthor";
 import { MermaidFilePreview } from "./MermaidFilePreview";
 
+type MermaidFileMode = "source" | "preview";
+
 function FileTabStripButton({
     onClick,
     children,
@@ -91,6 +93,39 @@ function FileTabStripButton({
     );
 }
 
+function FileTabModeButton({
+    active,
+    onClick,
+    children,
+}: {
+    active: boolean;
+    onClick: () => void;
+    children: string;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            className="rounded-sm px-2 py-0.5 transition-colors uppercase"
+            style={{
+                fontSize: "10px",
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+                color: active ? "var(--text-primary)" : "var(--text-secondary)",
+                backgroundColor: active
+                    ? "color-mix(in srgb, var(--accent) 18%, transparent)"
+                    : "transparent",
+                border: active
+                    ? "1px solid color-mix(in srgb, var(--accent) 42%, var(--border))"
+                    : "1px solid transparent",
+                cursor: "pointer",
+            }}
+        >
+            {children}
+        </button>
+    );
+}
+
 interface FileTextTabViewProps {
     paneId?: string;
     tabId?: string;
@@ -108,6 +143,8 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
     const applyingExternalUpdateRef = useRef(false);
     const [, setEditorView] = useState<EditorView | null>(null);
     const [mermaidSource, setMermaidSource] = useState("");
+    const [mermaidMode, setMermaidMode] =
+        useState<MermaidFileMode>("source");
     const [editorContextMenu, setEditorContextMenu] =
         useState<ContextMenuState<{
             hasSelection: boolean;
@@ -537,6 +574,7 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
     useEffect(() => {
         if (tab?.viewer !== "mermaid") {
             setMermaidSource("");
+            setMermaidMode("source");
             return;
         }
         setMermaidSource(tab.content);
@@ -706,6 +744,29 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
                     </span>
                 </div>
                 <div className="flex items-center gap-0.5 shrink-0">
+                    {tab.viewer === "mermaid" ? (
+                        <div
+                            className="mr-1 flex items-center rounded-sm p-0.5"
+                            style={{
+                                border: "1px solid var(--border)",
+                                backgroundColor: "var(--bg-primary)",
+                            }}
+                            aria-label="Mermaid file mode"
+                        >
+                            <FileTabModeButton
+                                active={mermaidMode === "source"}
+                                onClick={() => setMermaidMode("source")}
+                            >
+                                Source
+                            </FileTabModeButton>
+                            <FileTabModeButton
+                                active={mermaidMode === "preview"}
+                                onClick={() => setMermaidMode("preview")}
+                            >
+                                Preview
+                            </FileTabModeButton>
+                        </div>
+                    ) : null}
                     <FileTabStripButton onClick={() => void openPath(tab.path)}>
                         Open Externally
                     </FileTabStripButton>
@@ -719,14 +780,23 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
 
             <div className="min-h-0 flex-1 relative">
                 <div className="flex h-full min-w-0">
-                    <div className="min-w-0 flex-1 relative">
+                    <div
+                        className="min-w-0 flex-1 relative"
+                        style={{
+                            display:
+                                tab.viewer === "mermaid" &&
+                                mermaidMode === "preview"
+                                    ? "none"
+                                    : undefined,
+                        }}
+                    >
                         <div
                             ref={containerRef}
                             className="h-full relative z-1"
                         />
                     </div>
-                    {tab.viewer === "mermaid" ? (
-                        <div className="hidden min-w-[280px] flex-[0_0_45%] md:block">
+                    {tab.viewer === "mermaid" && mermaidMode === "preview" ? (
+                        <div className="min-w-0 flex-1">
                             <MermaidFilePreview
                                 source={mermaidSource}
                                 tabId={tab.id}

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -53,6 +53,7 @@ import {
     changeAuthorAnnotation,
     userEditNotifier,
 } from "./extensions/changeAuthor";
+import { MermaidFilePreview } from "./MermaidFilePreview";
 
 function FileTabStripButton({
     onClick,
@@ -106,6 +107,7 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
     const contextMenuCleanupRef = useRef<(() => void) | null>(null);
     const applyingExternalUpdateRef = useRef(false);
     const [, setEditorView] = useState<EditorView | null>(null);
+    const [mermaidSource, setMermaidSource] = useState("");
     const [editorContextMenu, setEditorContextMenu] =
         useState<ContextMenuState<{
             hasSelection: boolean;
@@ -154,6 +156,7 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
             annotations: [changeAuthorAnnotation.of("agent")],
         });
         applyingExternalUpdateRef.current = false;
+        setMermaidSource(nextContent);
     }, []);
 
     const {
@@ -399,6 +402,7 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
                         }
 
                         handleLocalContentChange(update.state.doc.toString());
+                        setMermaidSource(update.state.doc.toString());
                     }),
                     userEditNotifier(
                         () => tabRef.current?.path ?? null,
@@ -529,6 +533,14 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
 
     const tabPath = tab?.path ?? null;
     const tabContent = tab?.content ?? null;
+
+    useEffect(() => {
+        if (tab?.viewer !== "mermaid") {
+            setMermaidSource("");
+            return;
+        }
+        setMermaidSource(tab.content);
+    }, [tab?.content, tab?.id, tab?.viewer]);
 
     useEffect(() => {
         if (!tabPath || tabContent == null) {
@@ -713,6 +725,14 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
                             className="h-full relative z-1"
                         />
                     </div>
+                    {tab.viewer === "mermaid" ? (
+                        <div className="hidden min-w-[280px] flex-[0_0_45%] md:block">
+                            <MermaidFilePreview
+                                source={mermaidSource}
+                                tabId={tab.id}
+                            />
+                        </div>
+                    ) : null}
                 </div>
             </div>
             {editorContextMenu && (

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -65,13 +65,20 @@ function FileTabStripButton({
     children: string;
 }) {
     const [hovered, setHovered] = useState(false);
+    const [pressed, setPressed] = useState(false);
     return (
         <button
             type="button"
             onClick={onClick}
             onMouseEnter={() => setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            className="rounded-sm px-2 py-0.5 transition-colors uppercase"
+            onMouseLeave={() => {
+                setHovered(false);
+                setPressed(false);
+            }}
+            onMouseDown={() => setPressed(true)}
+            onMouseUp={() => setPressed(false)}
+            onBlur={() => setPressed(false)}
+            className="rounded-sm px-2 py-0.5 uppercase"
             style={{
                 fontSize: "10px",
                 fontWeight: 600,
@@ -80,11 +87,17 @@ function FileTabStripButton({
                     ? "var(--text-primary)"
                     : "var(--text-secondary)",
                 backgroundColor: hovered
-                    ? "color-mix(in srgb, var(--text-primary) 7%, transparent)"
-                    : "transparent",
+                    ? "color-mix(in srgb, var(--bg-tertiary) 78%, transparent)"
+                    : "var(--bg-primary)",
                 border: `1px solid color-mix(in srgb, var(--border) ${
-                    hovered ? "70%" : "0%"
+                    hovered ? "78%" : "62%"
                 }, transparent)`,
+                boxShadow: pressed
+                    ? "inset 0 1px 2px color-mix(in srgb, black 22%, transparent)"
+                    : "0 1px 1px color-mix(in srgb, black 8%, transparent), inset 0 1px 0 color-mix(in srgb, white 14%, transparent)",
+                transform: hovered && !pressed ? "translateY(-1px)" : "none",
+                transition:
+                    "background-color 100ms ease, border-color 100ms ease, box-shadow 100ms ease, color 100ms ease, transform 100ms ease",
                 cursor: "pointer",
             }}
         >
@@ -102,22 +115,43 @@ function FileTabModeButton({
     onClick: () => void;
     children: string;
 }) {
+    const [hovered, setHovered] = useState(false);
+    const [pressed, setPressed] = useState(false);
+    const isPressed = active || pressed;
+
     return (
         <button
             type="button"
+            aria-pressed={active}
             onClick={onClick}
-            className="rounded-sm px-2 py-0.5 transition-colors uppercase"
+            onMouseEnter={() => setHovered(true)}
+            onMouseLeave={() => {
+                setHovered(false);
+                setPressed(false);
+            }}
+            onMouseDown={() => setPressed(true)}
+            onMouseUp={() => setPressed(false)}
+            onBlur={() => setPressed(false)}
+            className="rounded-sm px-2 py-0.5 uppercase"
             style={{
                 fontSize: "10px",
                 fontWeight: 600,
                 letterSpacing: "0.04em",
                 color: active ? "var(--text-primary)" : "var(--text-secondary)",
                 backgroundColor: active
-                    ? "color-mix(in srgb, var(--accent) 18%, transparent)"
-                    : "transparent",
+                    ? "color-mix(in srgb, var(--accent) 16%, var(--bg-primary))"
+                    : hovered
+                      ? "color-mix(in srgb, var(--bg-tertiary) 78%, transparent)"
+                      : "var(--bg-primary)",
                 border: active
-                    ? "1px solid color-mix(in srgb, var(--accent) 42%, var(--border))"
-                    : "1px solid transparent",
+                    ? "1px solid color-mix(in srgb, var(--accent) 48%, var(--border))"
+                    : "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
+                boxShadow: isPressed
+                    ? "inset 0 1px 2px color-mix(in srgb, black 22%, transparent)"
+                    : "0 1px 1px color-mix(in srgb, black 10%, transparent), inset 0 1px 0 color-mix(in srgb, white 16%, transparent)",
+                transform: hovered && !isPressed ? "translateY(-1px)" : "none",
+                transition:
+                    "background-color 100ms ease, border-color 100ms ease, box-shadow 100ms ease, color 100ms ease, transform 100ms ease",
                 cursor: "pointer",
             }}
         >
@@ -746,10 +780,11 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
                 <div className="flex items-center gap-0.5 shrink-0">
                     {tab.viewer === "mermaid" ? (
                         <div
-                            className="mr-1 flex items-center rounded-sm p-0.5"
+                            className="mr-1 flex items-center gap-0.5 rounded-sm p-0.5"
                             style={{
                                 border: "1px solid var(--border)",
-                                backgroundColor: "var(--bg-primary)",
+                                backgroundColor:
+                                    "color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary))",
                             }}
                             aria-label="Mermaid file mode"
                         >

--- a/apps/desktop/src/features/editor/MermaidFilePreview.test.tsx
+++ b/apps/desktop/src/features/editor/MermaidFilePreview.test.tsx
@@ -1,0 +1,92 @@
+import { act, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { renderMermaidDiagram } from "./mermaid/mermaidRenderer";
+import { renderComponent } from "../../test/test-utils";
+import { MermaidFilePreview } from "./MermaidFilePreview";
+
+vi.mock("./mermaid/mermaidRenderer", () => ({
+    renderMermaidDiagram: vi.fn(),
+}));
+
+const mockedRenderMermaidDiagram = vi.mocked(renderMermaidDiagram);
+
+function deferredRender() {
+    let resolve!: (value: Awaited<ReturnType<typeof renderMermaidDiagram>>) => void;
+    const promise = new Promise<Awaited<ReturnType<typeof renderMermaidDiagram>>>(
+        (nextResolve) => {
+            resolve = nextResolve;
+        },
+    );
+    return { promise, resolve };
+}
+
+describe("MermaidFilePreview", () => {
+    beforeEach(() => {
+        mockedRenderMermaidDiagram.mockReset();
+    });
+
+    it("renders valid Mermaid output as SVG", async () => {
+        const source = `flowchart TD
+A --> B`;
+        mockedRenderMermaidDiagram.mockResolvedValueOnce({
+            status: "ok",
+            svg: '<svg viewBox="0 0 10 10"><text>Flow</text></svg>',
+        });
+
+        renderComponent(<MermaidFilePreview source={source} tabId="tab-1" />);
+
+        expect(screen.getByText("Rendering Mermaid diagram...")).toBeInTheDocument();
+
+        expect(await screen.findByText("Flow")).not.toBeNull();
+        expect(mockedRenderMermaidDiagram).toHaveBeenCalledWith(
+            source,
+            expect.stringMatching(/^mermaid-file-tab-1-/),
+        );
+    });
+
+    it("shows Mermaid render errors inline", async () => {
+        mockedRenderMermaidDiagram.mockResolvedValueOnce({
+            status: "error",
+            message: "Parse error",
+        });
+
+        renderComponent(<MermaidFilePreview source="not a diagram" tabId="tab-1" />);
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Mermaid diagram error",
+        );
+        expect(screen.getByText("Parse error")).toBeInTheDocument();
+    });
+
+    it("ignores stale render results after quick source changes", async () => {
+        const oldSource = `flowchart TD
+A --> B`;
+        const newSource = `flowchart TD
+A --> C`;
+        const first = deferredRender();
+        const second = deferredRender();
+        mockedRenderMermaidDiagram
+            .mockReturnValueOnce(first.promise)
+            .mockReturnValueOnce(second.promise);
+
+        const { rerender } = renderComponent(
+            <MermaidFilePreview source={oldSource} tabId="tab-1" />,
+        );
+
+        rerender(<MermaidFilePreview source={newSource} tabId="tab-1" />);
+
+        await act(async () => {
+            first.resolve({
+                status: "ok",
+                svg: '<svg><text>Old diagram</text></svg>',
+            });
+            second.resolve({
+                status: "ok",
+                svg: '<svg><text>New diagram</text></svg>',
+            });
+        });
+
+        expect(await screen.findByText("New diagram")).not.toBeNull();
+        expect(screen.queryByText("Old diagram")).not.toBeInTheDocument();
+    });
+});

--- a/apps/desktop/src/features/editor/MermaidFilePreview.tsx
+++ b/apps/desktop/src/features/editor/MermaidFilePreview.tsx
@@ -1,0 +1,149 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+    renderMermaidDiagram,
+    type MermaidRenderResult,
+} from "./mermaid/mermaidRenderer";
+
+type MermaidFilePreviewState =
+    | { status: "idle" }
+    | { status: "loading" }
+    | { status: "rendered"; svg: SVGElement }
+    | { status: "error"; message: string };
+
+interface MermaidFilePreviewProps {
+    source: string;
+    tabId: string;
+}
+
+export function MermaidFilePreview({ source, tabId }: MermaidFilePreviewProps) {
+    const requestRef = useRef(0);
+    const [state, setState] = useState<MermaidFilePreviewState>({
+        status: source.trim() ? "loading" : "idle",
+    });
+    const diagramId = useMemo(
+        () => `mermaid-file-${sanitizeIdPart(tabId)}-${hashString(source)}`,
+        [source, tabId],
+    );
+
+    useEffect(() => {
+        const trimmedSource = source.trim();
+        const requestId = requestRef.current + 1;
+        requestRef.current = requestId;
+
+        if (!trimmedSource) {
+            setState({ status: "idle" });
+            return;
+        }
+
+        setState({ status: "loading" });
+
+        void renderMermaidDiagram(source, diagramId).then((result) => {
+            if (requestRef.current !== requestId) return;
+
+            setState(toPreviewState(result));
+        });
+    }, [diagramId, source]);
+
+    return (
+        <div
+            className="mermaid-file-preview flex h-full min-w-0 flex-col"
+            style={{
+                borderLeft: "1px solid var(--border)",
+                backgroundColor: "var(--bg-primary)",
+            }}
+            aria-label="Mermaid preview"
+        >
+            <div
+                className="flex h-8 shrink-0 items-center px-3 text-[11px] font-medium"
+                style={{
+                    borderBottom:
+                        "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
+                    color: "var(--text-secondary)",
+                }}
+            >
+                Preview
+            </div>
+            <div className="min-h-0 flex-1 overflow-auto p-4">
+                {state.status === "idle" ? (
+                    <div
+                        className="flex h-full items-center justify-center text-[12px]"
+                        style={{ color: "var(--text-secondary)" }}
+                    >
+                        Mermaid source is empty.
+                    </div>
+                ) : null}
+                {state.status === "loading" ? (
+                    <div
+                        className="flex h-full items-center justify-center text-[12px]"
+                        style={{ color: "var(--text-secondary)" }}
+                    >
+                        Rendering Mermaid diagram...
+                    </div>
+                ) : null}
+                {state.status === "rendered" ? (
+                    <div
+                        className="mermaid-file-preview-body flex min-h-full items-start justify-center"
+                        ref={(node) => {
+                            if (!node) return;
+                            node.replaceChildren(state.svg.cloneNode(true));
+                        }}
+                    />
+                ) : null}
+                {state.status === "error" ? (
+                    <div
+                        className="rounded-md p-3 text-[12px]"
+                        style={{
+                            border: "1px solid color-mix(in srgb, #ef4444 35%, var(--border))",
+                            backgroundColor:
+                                "color-mix(in srgb, #ef4444 10%, var(--bg-secondary))",
+                            color: "var(--text-primary)",
+                        }}
+                        role="alert"
+                    >
+                        <div className="mb-2 font-medium">
+                            Mermaid diagram error
+                        </div>
+                        <pre
+                            className="m-0 whitespace-pre-wrap font-mono text-[11px]"
+                            style={{ color: "var(--text-secondary)" }}
+                        >
+                            {state.message}
+                        </pre>
+                    </div>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+function toPreviewState(result: MermaidRenderResult): MermaidFilePreviewState {
+    if (result.status === "error") {
+        return { status: "error", message: result.message };
+    }
+
+    const svg = parseMermaidSvg(result.svg);
+    if (!svg) {
+        return { status: "error", message: "Unable to read Mermaid SVG output." };
+    }
+
+    return { status: "rendered", svg };
+}
+
+function parseMermaidSvg(svg: string): SVGElement | null {
+    const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+    const root = parsed.documentElement;
+    if (root.nodeName.toLowerCase() !== "svg") return null;
+    return document.importNode(root, true) as unknown as SVGElement;
+}
+
+function sanitizeIdPart(value: string) {
+    return value.replace(/[^a-zA-Z0-9_-]/g, "-");
+}
+
+function hashString(value: string) {
+    let hash = 5381;
+    for (let index = 0; index < value.length; index++) {
+        hash = (hash * 33) ^ value.charCodeAt(index);
+    }
+    return (hash >>> 0).toString(36);
+}

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -6,7 +6,10 @@ import { forceParsing } from "@codemirror/language";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
 import { describe, expect, it } from "vitest";
-import { resolvePreviewAssetPath } from "./livePreviewBlocks";
+import {
+    getFencedCodeBlockKind,
+    resolvePreviewAssetPath,
+} from "./livePreviewBlocks";
 import { livePreviewExtension } from "./livePreview";
 
 describe("resolvePreviewAssetPath", () => {
@@ -42,6 +45,15 @@ describe("resolvePreviewAssetPath", () => {
 });
 
 describe("code block live preview", () => {
+    it("classifies Mermaid info strings separately from regular code blocks", () => {
+        expect(getFencedCodeBlockKind("mermaid")).toBe("mermaid");
+        expect(getFencedCodeBlockKind(" mermaid")).toBe("mermaid");
+        expect(getFencedCodeBlockKind('mermaid title="Flow"')).toBe("mermaid");
+        expect(getFencedCodeBlockKind("Mermaid")).toBe("mermaid");
+        expect(getFencedCodeBlockKind("typescript")).toBe("code");
+        expect(getFencedCodeBlockKind("")).toBe("code");
+    });
+
     it("compacts inactive blank lines around rendered tables", () => {
         const parent = document.createElement("div");
         document.body.appendChild(parent);
@@ -81,6 +93,80 @@ describe("code block live preview", () => {
                 line.classList.contains("cm-lp-block-gap-hidden"),
             ),
         ).toBe(true);
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("marks Mermaid fenced code blocks without affecting regular fences", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = [
+            "```mermaid",
+            "flowchart TD",
+            "  A --> B",
+            "```",
+            "",
+            "```ts",
+            "const value = 1;",
+            "```",
+        ].join("\n");
+        const state = EditorState.create({
+            doc,
+            selection: EditorSelection.cursor(doc.length),
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                livePreviewExtension(null, {
+                    resolveWikilink: () => false,
+                    navigateWikilink: () => {},
+                    getNoteLinkTarget: () => null,
+                    openLinkContextMenu: () => {},
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent });
+        const headers = [
+            ...view.dom.querySelectorAll<HTMLElement>(".cm-code-block-header"),
+        ];
+
+        expect(headers).toHaveLength(2);
+        expect(headers[0].dataset.codeBlockKind).toBe("mermaid");
+        expect(headers[0].textContent).toContain("mermaid");
+        expect(headers[1].dataset.codeBlockKind).toBe("code");
+        expect(headers[1].textContent).toContain("ts");
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("does not mark incomplete Mermaid fences as rendered blocks", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = ["```mermaid", "flowchart TD", "  A --> B"].join("\n");
+        const state = EditorState.create({
+            doc,
+            selection: EditorSelection.cursor(doc.length),
+            extensions: [
+                markdown({ base: markdownLanguage }),
+                livePreviewExtension(null, {
+                    resolveWikilink: () => false,
+                    navigateWikilink: () => {},
+                    getNoteLinkTarget: () => null,
+                    openLinkContextMenu: () => {},
+                }),
+            ],
+        });
+
+        const view = new EditorView({ state, parent });
+
+        expect(
+            view.dom.querySelector(
+                '.cm-code-block-header[data-code-block-kind="mermaid"]',
+            ),
+        ).toBeNull();
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -39,6 +39,16 @@ function flushPromises() {
     return new Promise((resolve) => window.setTimeout(resolve, 0));
 }
 
+function createDeferredRender() {
+    let resolve!: (value: Awaited<ReturnType<typeof renderMermaidDiagram>>) => void;
+    const promise = new Promise<Awaited<ReturnType<typeof renderMermaidDiagram>>>(
+        (resolver) => {
+            resolve = resolver;
+        },
+    );
+    return { promise, resolve };
+}
+
 beforeEach(() => {
     mockedRenderMermaidDiagram.mockReset();
 });
@@ -208,6 +218,108 @@ describe("code block live preview", () => {
             view.dom.querySelector(".cm-mermaid-preview svg text")?.textContent,
         ).toBe("Diagram");
         expect(view.dom.querySelector(".cm-mermaid-preview-error")).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("renders multiple Mermaid diagrams independently", async () => {
+        mockedRenderMermaidDiagram
+            .mockResolvedValueOnce({
+                status: "ok",
+                svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>First</text></svg>',
+            })
+            .mockResolvedValueOnce({
+                status: "ok",
+                svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Second</text></svg>',
+            });
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const first = ["```mermaid", "flowchart TD", "  A --> B", "```"].join(
+            "\n",
+        );
+        const second = [
+            "```mermaid",
+            "sequenceDiagram",
+            "  Alice->>Bob: Hi",
+            "```",
+        ].join("\n");
+        const view = new EditorView({
+            state: createLivePreviewState(`${first}\n\n${second}`),
+            parent,
+        });
+
+        await flushPromises();
+
+        const renderedLabels = [
+            ...view.dom.querySelectorAll(".cm-mermaid-preview svg text"),
+        ].map((node) => node.textContent);
+
+        expect(renderedLabels).toEqual(["First", "Second"]);
+        expect(mockedRenderMermaidDiagram).toHaveBeenNthCalledWith(
+            1,
+            "flowchart TD\n  A --> B",
+            expect.stringMatching(/^mermaid-\d+-0-[a-z0-9]+$/),
+        );
+        expect(mockedRenderMermaidDiagram).toHaveBeenNthCalledWith(
+            2,
+            "sequenceDiagram\n  Alice->>Bob: Hi",
+            expect.stringMatching(/^mermaid-\d+-\d+-[a-z0-9]+$/),
+        );
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("ignores stale Mermaid renders after rapid edits", async () => {
+        const firstRender = createDeferredRender();
+        mockedRenderMermaidDiagram
+            .mockReturnValueOnce(firstRender.promise)
+            .mockResolvedValueOnce({
+                status: "ok",
+                svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Updated</text></svg>',
+            });
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const initialDoc = [
+            "```mermaid",
+            "flowchart TD",
+            "  A --> B",
+            "```",
+        ].join("\n");
+        const view = new EditorView({
+            state: createLivePreviewState(initialDoc),
+            parent,
+        });
+
+        const updatedDoc = [
+            "```mermaid",
+            "flowchart TD",
+            "  A --> C",
+            "```",
+        ].join("\n");
+        view.dispatch({
+            changes: {
+                from: 0,
+                to: view.state.doc.length,
+                insert: updatedDoc,
+            },
+        });
+
+        await flushPromises();
+
+        firstRender.resolve({
+            status: "ok",
+            svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Stale</text></svg>',
+        });
+        await flushPromises();
+
+        expect(
+            view.dom.querySelector(".cm-mermaid-preview svg text")?.textContent,
+        ).toBe("Updated");
+        expect(view.dom.textContent).not.toContain("Stale");
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -325,6 +325,53 @@ describe("code block live preview", () => {
         parent.remove();
     });
 
+    it("rerenders Mermaid blocks after text-only edits inside the diagram", async () => {
+        mockedRenderMermaidDiagram
+            .mockResolvedValueOnce({
+                status: "ok",
+                svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Original</text></svg>',
+            })
+            .mockResolvedValueOnce({
+                status: "ok",
+                svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Updated</text></svg>',
+            });
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = ["```mermaid", "flowchart TD", "  A --> B", "```"].join(
+            "\n",
+        );
+        const view = new EditorView({
+            state: createLivePreviewState(doc),
+            parent,
+        });
+
+        await flushPromises();
+
+        const from = doc.indexOf("B");
+        view.dispatch({
+            changes: {
+                from,
+                to: from + 1,
+                insert: "C",
+            },
+        });
+
+        await flushPromises();
+
+        expect(
+            view.dom.querySelector(".cm-mermaid-preview svg text")?.textContent,
+        ).toBe("Updated");
+        expect(mockedRenderMermaidDiagram).toHaveBeenNthCalledWith(
+            2,
+            "flowchart TD\n  A --> C",
+            expect.stringMatching(/^mermaid-\d+-0-[a-z0-9]+$/),
+        );
+
+        view.destroy();
+        parent.remove();
+    });
+
     it("shows Mermaid render errors inline", async () => {
         mockedRenderMermaidDiagram.mockResolvedValueOnce({
             status: "error",

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -5,12 +5,43 @@ import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { forceParsing } from "@codemirror/language";
 import { EditorSelection, EditorState } from "@codemirror/state";
 import { EditorView } from "@codemirror/view";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     getFencedCodeBlockKind,
     resolvePreviewAssetPath,
 } from "./livePreviewBlocks";
 import { livePreviewExtension } from "./livePreview";
+import { renderMermaidDiagram } from "../mermaid/mermaidRenderer";
+
+vi.mock("../mermaid/mermaidRenderer", () => ({
+    renderMermaidDiagram: vi.fn(),
+}));
+
+const mockedRenderMermaidDiagram = vi.mocked(renderMermaidDiagram);
+
+function createLivePreviewState(doc: string, cursor = doc.length) {
+    return EditorState.create({
+        doc,
+        selection: EditorSelection.cursor(cursor),
+        extensions: [
+            markdown({ base: markdownLanguage }),
+            livePreviewExtension(null, {
+                resolveWikilink: () => false,
+                navigateWikilink: () => {},
+                getNoteLinkTarget: () => null,
+                openLinkContextMenu: () => {},
+            }),
+        ],
+    });
+}
+
+function flushPromises() {
+    return new Promise((resolve) => window.setTimeout(resolve, 0));
+}
+
+beforeEach(() => {
+    mockedRenderMermaidDiagram.mockReset();
+});
 
 describe("resolvePreviewAssetPath", () => {
     it("resolves note-relative assets against the current note path", () => {
@@ -99,6 +130,10 @@ describe("code block live preview", () => {
     });
 
     it("marks Mermaid fenced code blocks without affecting regular fences", () => {
+        mockedRenderMermaidDiagram.mockResolvedValue({
+            status: "ok",
+            svg: '<svg xmlns="http://www.w3.org/2000/svg"></svg>',
+        });
         const parent = document.createElement("div");
         document.body.appendChild(parent);
 
@@ -112,30 +147,17 @@ describe("code block live preview", () => {
             "const value = 1;",
             "```",
         ].join("\n");
-        const state = EditorState.create({
-            doc,
-            selection: EditorSelection.cursor(doc.length),
-            extensions: [
-                markdown({ base: markdownLanguage }),
-                livePreviewExtension(null, {
-                    resolveWikilink: () => false,
-                    navigateWikilink: () => {},
-                    getNoteLinkTarget: () => null,
-                    openLinkContextMenu: () => {},
-                }),
-            ],
-        });
+        const state = createLivePreviewState(doc);
 
         const view = new EditorView({ state, parent });
         const headers = [
             ...view.dom.querySelectorAll<HTMLElement>(".cm-code-block-header"),
         ];
 
-        expect(headers).toHaveLength(2);
-        expect(headers[0].dataset.codeBlockKind).toBe("mermaid");
-        expect(headers[0].textContent).toContain("mermaid");
-        expect(headers[1].dataset.codeBlockKind).toBe("code");
-        expect(headers[1].textContent).toContain("ts");
+        expect(view.dom.querySelector(".cm-mermaid-preview")).not.toBeNull();
+        expect(headers).toHaveLength(1);
+        expect(headers[0].dataset.codeBlockKind).toBe("code");
+        expect(headers[0].textContent).toContain("ts");
 
         view.destroy();
         parent.remove();
@@ -146,27 +168,75 @@ describe("code block live preview", () => {
         document.body.appendChild(parent);
 
         const doc = ["```mermaid", "flowchart TD", "  A --> B"].join("\n");
-        const state = EditorState.create({
-            doc,
-            selection: EditorSelection.cursor(doc.length),
-            extensions: [
-                markdown({ base: markdownLanguage }),
-                livePreviewExtension(null, {
-                    resolveWikilink: () => false,
-                    navigateWikilink: () => {},
-                    getNoteLinkTarget: () => null,
-                    openLinkContextMenu: () => {},
-                }),
-            ],
-        });
+        const state = createLivePreviewState(doc);
 
         const view = new EditorView({ state, parent });
 
+        expect(view.dom.querySelector(".cm-mermaid-preview")).toBeNull();
+        expect(mockedRenderMermaidDiagram).not.toHaveBeenCalled();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("renders Mermaid SVG blocks asynchronously", async () => {
+        mockedRenderMermaidDiagram.mockResolvedValueOnce({
+            status: "ok",
+            svg: '<svg xmlns="http://www.w3.org/2000/svg"><text>Diagram</text></svg>',
+        });
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = ["```mermaid", "flowchart TD", "  A --> B", "```"].join(
+            "\n",
+        );
+        const view = new EditorView({
+            state: createLivePreviewState(doc),
+            parent,
+        });
+
+        const preview = view.dom.querySelector(".cm-mermaid-preview");
+        expect(preview?.textContent).toContain("Rendering Mermaid diagram...");
+        expect(mockedRenderMermaidDiagram).toHaveBeenCalledWith(
+            "flowchart TD\n  A --> B",
+            expect.stringMatching(/^mermaid-\d+-0-[a-z0-9]+$/),
+        );
+
+        await flushPromises();
+
         expect(
-            view.dom.querySelector(
-                '.cm-code-block-header[data-code-block-kind="mermaid"]',
-            ),
-        ).toBeNull();
+            view.dom.querySelector(".cm-mermaid-preview svg text")?.textContent,
+        ).toBe("Diagram");
+        expect(view.dom.querySelector(".cm-mermaid-preview-error")).toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("shows Mermaid render errors inline", async () => {
+        mockedRenderMermaidDiagram.mockResolvedValueOnce({
+            status: "error",
+            message: "Parse error",
+        });
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const doc = ["```mermaid", "not a diagram", "```"].join("\n");
+        const view = new EditorView({
+            state: createLivePreviewState(doc),
+            parent,
+        });
+
+        await flushPromises();
+
+        expect(
+            view.dom.querySelector(".cm-mermaid-preview-error-title")
+                ?.textContent,
+        ).toBe("Mermaid diagram error");
+        expect(
+            view.dom.querySelector(".cm-mermaid-preview-error-message")
+                ?.textContent,
+        ).toBe("Parse error");
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -1233,6 +1233,37 @@ function buildCodeBlockDecorations(
  */
 const BLOCK_MARKER_RE = /(?:[`$!|\n#]|\[)/;
 
+function rangesOverlap(fromA: number, toA: number, fromB: number, toB: number) {
+    return fromA <= toB && toA >= fromB;
+}
+
+function transactionTouchesMermaidBlock(tr: Transaction): boolean {
+    if (!tr.docChanged) return false;
+
+    let touchesMermaid = false;
+
+    syntaxTree(tr.startState).iterate({
+        enter(node) {
+            if (touchesMermaid || node.name !== "FencedCode") return;
+
+            const previewBlock = getFencedCodeBlockPreview(
+                tr.startState,
+                node.node,
+            );
+            if (previewBlock?.kind !== "mermaid") return;
+
+            tr.changes.iterChangedRanges((fromA, toA) => {
+                if (touchesMermaid) return;
+                if (rangesOverlap(fromA, toA, node.from, node.to)) {
+                    touchesMermaid = true;
+                }
+            });
+        },
+    });
+
+    return touchesMermaid;
+}
+
 /** Returns true when a transaction requires block decorations to be rebuilt. */
 function needsBlockRebuild(tr: Transaction): boolean {
     if (tr.docChanged) {
@@ -1275,6 +1306,9 @@ function needsSyntaxBackedBlockRebuild(tr: Transaction): boolean {
     // transaction with no document or selection change. Syntax-backed widgets
     // must rebuild when new nodes become available.
     if (!tr.docChanged && syntaxTree(tr.startState) !== syntaxTree(tr.state)) {
+        return true;
+    }
+    if (transactionTouchesMermaidBlock(tr)) {
         return true;
     }
     return needsBlockRebuild(tr);

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -52,6 +52,7 @@ import {
     getNotePreviewContentState,
     renderEmbedPreview,
 } from "./notePreviewSource";
+import { renderMermaidDiagram } from "../mermaid/mermaidRenderer";
 
 const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif)([?#].*)?$/i;
 const PDF_EXTENSION = /\.pdf([?#].*)?$/i;
@@ -60,6 +61,7 @@ const TABLE_WIKILINK_RE = /\[\[([^\]]+)\]\]/g;
 const TABLE_URL_RE = /https?:\/\/[^\s<>()"\]]+/g;
 const TABLE_BOLD_RE = /\*\*(?=\S)(.+?\S)\*\*/g;
 const STANDALONE_URL_RE = /^https?:\/\/[^\s<>()"\]]+$/i;
+let nextMermaidPreviewInstanceId = 0;
 type TableAlignment = "left" | "center" | "right";
 export interface TableInteractionHandlers {
     resolveWikilink: (target: string) => boolean;
@@ -916,6 +918,75 @@ class CodeBlockHeaderWidget extends WidgetType {
     }
 }
 
+class MermaidDiagramWidget extends WidgetType {
+    private source: string;
+    private diagramId: string;
+
+    constructor(source: string, diagramId: string) {
+        super();
+        this.source = source;
+        this.diagramId = diagramId;
+    }
+
+    eq(other: MermaidDiagramWidget) {
+        return (
+            this.source === other.source && this.diagramId === other.diagramId
+        );
+    }
+
+    toDOM() {
+        const outer = document.createElement("div");
+        outer.className = "cm-mermaid-preview";
+        outer.dataset.mermaidId = this.diagramId;
+        outer.dataset.mermaidSource = this.source;
+        outer.setAttribute("contenteditable", "false");
+
+        const body = document.createElement("div");
+        body.className = "cm-mermaid-preview-body";
+        body.textContent = "Rendering Mermaid diagram...";
+        outer.appendChild(body);
+
+        const expectedId = this.diagramId;
+        const expectedSource = this.source;
+
+        void renderMermaidDiagram(this.source, this.diagramId).then(
+            (result) => {
+                if (
+                    !outer.isConnected ||
+                    outer.dataset.mermaidId !== expectedId ||
+                    outer.dataset.mermaidSource !== expectedSource
+                ) {
+                    return;
+                }
+
+                body.replaceChildren();
+                if (result.status === "ok") {
+                    body.className =
+                        "cm-mermaid-preview-body cm-mermaid-preview-body-rendered";
+                    const svg = parseMermaidSvg(result.svg);
+                    if (svg) {
+                        body.appendChild(svg);
+                    } else {
+                        renderMermaidError(
+                            body,
+                            "Unable to read Mermaid SVG output.",
+                        );
+                    }
+                    return;
+                }
+
+                renderMermaidError(body, result.message);
+            },
+        );
+
+        return outer;
+    }
+
+    ignoreEvent() {
+        return true;
+    }
+}
+
 const codeBlockFenceHidden = Decoration.line({
     class: "cm-code-block-fence-hidden",
 });
@@ -929,11 +1000,52 @@ const codeBlockLineLast = Decoration.line({
 const codeBlockLineOnly = Decoration.line({
     class: "cm-code-block-line cm-code-block-line-first cm-code-block-line-last",
 });
+const mermaidBlockSourceHidden = Decoration.line({
+    class: "cm-code-block-fence-hidden cm-mermaid-source-hidden",
+});
+
+function parseMermaidSvg(svg: string): SVGElement | null {
+    const parsed = new DOMParser().parseFromString(svg, "image/svg+xml");
+    const root = parsed.documentElement;
+    if (root.nodeName.toLowerCase() !== "svg") return null;
+    return document.importNode(root, true) as unknown as SVGElement;
+}
+
+function renderMermaidError(container: HTMLElement, message: string) {
+    container.className = "cm-mermaid-preview-body cm-mermaid-preview-error";
+
+    const title = document.createElement("div");
+    title.className = "cm-mermaid-preview-error-title";
+    title.textContent = "Mermaid diagram error";
+
+    const detail = document.createElement("pre");
+    detail.className = "cm-mermaid-preview-error-message";
+    detail.textContent = message;
+
+    container.appendChild(title);
+    container.appendChild(detail);
+}
 
 export function getFencedCodeBlockKind(info: string): FencedCodeBlockKind {
     return info.trimStart().split(/\s+/, 1)[0]?.toLowerCase() === "mermaid"
         ? "mermaid"
         : "code";
+}
+
+function buildMermaidDiagramId(
+    previewInstanceId: number,
+    source: string,
+    from: number,
+) {
+    return `mermaid-${previewInstanceId}-${from}-${hashString(source)}`;
+}
+
+function hashString(value: string) {
+    let hash = 5381;
+    for (let index = 0; index < value.length; index++) {
+        hash = (hash * 33) ^ value.charCodeAt(index);
+    }
+    return (hash >>> 0).toString(36);
 }
 
 function getFencedCodeBlockPreview(
@@ -989,7 +1101,10 @@ function getFencedCodeBlockPreview(
     };
 }
 
-function buildCodeBlockDecorations(state: EditorState): DecorationSet {
+function buildCodeBlockDecorations(
+    state: EditorState,
+    mermaidPreviewInstanceId: number,
+): DecorationSet {
     const decos: DecoEntry[] = [];
 
     syntaxTree(state).iterate({
@@ -1008,6 +1123,42 @@ function buildCodeBlockDecorations(state: EditorState): DecorationSet {
             const showHeader = true;
 
             const openLine = state.doc.lineAt(node.from);
+
+            if (previewBlock.kind === "mermaid") {
+                decos.push({
+                    from: node.from,
+                    to: node.from,
+                    deco: Decoration.widget({
+                        widget: new MermaidDiagramWidget(
+                            previewBlock.code,
+                            buildMermaidDiagramId(
+                                mermaidPreviewInstanceId,
+                                previewBlock.code,
+                                node.from,
+                            ),
+                        ),
+                        block: true,
+                        side: -1,
+                    }),
+                });
+
+                for (
+                    let lineNum = openLine.number;
+                    lineNum <=
+                    (previewBlock.closeFrom >= 0
+                        ? state.doc.lineAt(previewBlock.closeFrom).number
+                        : previewBlock.lastContentLineNumber);
+                    lineNum++
+                ) {
+                    const line = state.doc.line(lineNum);
+                    decos.push({
+                        from: line.from,
+                        to: line.from,
+                        deco: mermaidBlockSourceHidden,
+                    });
+                }
+                return;
+            }
 
             if (showHeader) {
                 decos.push({
@@ -1130,9 +1281,11 @@ function needsSyntaxBackedBlockRebuild(tr: Transaction): boolean {
 }
 
 export function createCodeBlockLivePreviewExtension() {
+    const mermaidPreviewInstanceId = nextMermaidPreviewInstanceId++;
+
     return StateField.define<DecorationSet>({
         create(state) {
-            return buildCodeBlockDecorations(state);
+            return buildCodeBlockDecorations(state, mermaidPreviewInstanceId);
         },
         update(decorations, transaction) {
             if (!needsSyntaxBackedBlockRebuild(transaction)) {
@@ -1140,7 +1293,10 @@ export function createCodeBlockLivePreviewExtension() {
                     ? decorations.map(transaction.changes)
                     : decorations;
             }
-            return buildCodeBlockDecorations(transaction.state);
+            return buildCodeBlockDecorations(
+                transaction.state,
+                mermaidPreviewInstanceId,
+            );
         },
         provide(field) {
             return EditorView.decorations.from(field);

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -13,6 +13,7 @@ import {
     type Transaction,
 } from "@codemirror/state";
 import { syntaxTree } from "@codemirror/language";
+import type { SyntaxNode } from "@lezer/common";
 import katex from "katex";
 import {
     buildVaultPreviewUrlFromAbsolutePath,
@@ -79,6 +80,18 @@ type ParsedTableCell = {
 type ParsedTableRow = {
     cells: ParsedTableCell[];
     lineEnd: number;
+};
+type FencedCodeBlockKind = "code" | "mermaid";
+type FencedCodeBlockPreview = {
+    kind: FencedCodeBlockKind;
+    info: string;
+    language: string;
+    code: string;
+    hasContent: boolean;
+    openEnd: number;
+    closeFrom: number;
+    firstContentLineNumber: number;
+    lastContentLineNumber: number;
 };
 
 // Re-exported under its historical name; the implementation now lives in the
@@ -832,12 +845,19 @@ class NoteEmbedWidget extends WidgetType {
 }
 
 class CodeBlockHeaderWidget extends WidgetType {
+    private kind: FencedCodeBlockKind;
     private language: string;
     private code: string;
     private hasContent: boolean;
 
-    constructor(language: string, code: string, hasContent: boolean) {
+    constructor(
+        kind: FencedCodeBlockKind,
+        language: string,
+        code: string,
+        hasContent: boolean,
+    ) {
         super();
+        this.kind = kind;
         this.language = language;
         this.code = code;
         this.hasContent = hasContent;
@@ -845,6 +865,7 @@ class CodeBlockHeaderWidget extends WidgetType {
 
     eq(other: CodeBlockHeaderWidget) {
         return (
+            this.kind === other.kind &&
             this.language === other.language &&
             this.code === other.code &&
             this.hasContent === other.hasContent
@@ -863,6 +884,7 @@ class CodeBlockHeaderWidget extends WidgetType {
         bar.className = this.hasContent
             ? "cm-code-block-header"
             : "cm-code-block-header cm-code-block-header-only";
+        bar.dataset.codeBlockKind = this.kind;
         bar.setAttribute("contenteditable", "false");
 
         const lang = document.createElement("span");
@@ -908,6 +930,65 @@ const codeBlockLineOnly = Decoration.line({
     class: "cm-code-block-line cm-code-block-line-first cm-code-block-line-last",
 });
 
+export function getFencedCodeBlockKind(info: string): FencedCodeBlockKind {
+    return info.trimStart().split(/\s+/, 1)[0]?.toLowerCase() === "mermaid"
+        ? "mermaid"
+        : "code";
+}
+
+function getFencedCodeBlockPreview(
+    state: EditorState,
+    node: SyntaxNode,
+): FencedCodeBlockPreview | null {
+    const cursor = node.cursor();
+    let openEnd = -1;
+    let closeFrom = -1;
+
+    if (cursor.firstChild()) {
+        do {
+            if (cursor.name !== "CodeMark") continue;
+            if (openEnd < 0) {
+                openEnd = state.doc.lineAt(cursor.from).to;
+            } else {
+                closeFrom = cursor.from;
+            }
+        } while (cursor.nextSibling());
+    }
+
+    if (openEnd < 0) return null;
+
+    const openLine = state.doc.lineAt(node.from);
+    const firstContentLineNumber = openLine.number + 1;
+    const lastContentLineNumber =
+        closeFrom >= 0
+            ? state.doc.lineAt(closeFrom).number - 1
+            : state.doc.lineAt(node.to).number;
+    const hasContent = firstContentLineNumber <= lastContentLineNumber;
+    const infoNode = node.getChild("CodeInfo");
+    const info = infoNode
+        ? state.doc.sliceString(infoNode.from, infoNode.to).trim()
+        : "";
+    const contentStart = Math.min(openEnd + 1, node.to);
+    const contentEnd =
+        closeFrom >= 0 ? Math.max(contentStart, closeFrom) : node.to;
+    let code = state.doc.sliceString(contentStart, contentEnd);
+    if (code.endsWith("\n")) {
+        code = code.slice(0, -1);
+    }
+
+    return {
+        kind: getFencedCodeBlockKind(info),
+        info,
+        language: info,
+        code,
+        hasContent,
+        openEnd,
+        closeFrom,
+        firstContentLineNumber,
+        lastContentLineNumber,
+    };
+}
+
 function buildCodeBlockDecorations(state: EditorState): DecorationSet {
     const decos: DecoEntry[] = [];
 
@@ -915,60 +996,29 @@ function buildCodeBlockDecorations(state: EditorState): DecorationSet {
         enter(node) {
             if (node.name !== "FencedCode") return;
 
-            const cursor = node.node.cursor();
-            let openEnd = -1;
-            let closeFrom = -1;
-
-            if (cursor.firstChild()) {
-                do {
-                    if (cursor.name !== "CodeMark") continue;
-                    if (openEnd < 0) {
-                        openEnd = state.doc.lineAt(cursor.from).to;
-                    } else {
-                        closeFrom = cursor.from;
-                    }
-                } while (cursor.nextSibling());
+            const previewBlock = getFencedCodeBlockPreview(state, node.node);
+            if (!previewBlock) return;
+            if (
+                previewBlock.kind === "mermaid" &&
+                previewBlock.closeFrom < 0
+            ) {
+                return;
             }
-
-            if (openEnd < 0) return;
 
             const showHeader = true;
 
             const openLine = state.doc.lineAt(node.from);
-            const firstContentLineNum = openLine.number + 1;
-            const lastContentLineNum =
-                closeFrom >= 0
-                    ? state.doc.lineAt(closeFrom).number - 1
-                    : state.doc.lineAt(node.to).number;
-            const hasContent = firstContentLineNum <= lastContentLineNum;
 
             if (showHeader) {
-                const infoNode = node.node.getChild("CodeInfo");
-                const language = infoNode
-                    ? state.doc.sliceString(infoNode.from, infoNode.to).trim()
-                    : "";
-
-                const contentStart = Math.min(openEnd + 1, node.to);
-                const contentEnd =
-                    closeFrom >= 0
-                        ? Math.max(contentStart, closeFrom)
-                        : node.to;
-                let codeContent = state.doc.sliceString(
-                    contentStart,
-                    contentEnd,
-                );
-                if (codeContent.endsWith("\n")) {
-                    codeContent = codeContent.slice(0, -1);
-                }
-
                 decos.push({
                     from: node.from,
                     to: node.from,
                     deco: Decoration.widget({
                         widget: new CodeBlockHeaderWidget(
-                            language,
-                            codeContent,
-                            hasContent,
+                            previewBlock.kind,
+                            previewBlock.language,
+                            previewBlock.code,
+                            previewBlock.hasContent,
                         ),
                         block: true,
                         side: -1,
@@ -984,8 +1034,8 @@ function buildCodeBlockDecorations(state: EditorState): DecorationSet {
             });
 
             // Collapse the closing fence line (```) so it takes no space
-            if (closeFrom >= 0) {
-                const closeLine = state.doc.lineAt(closeFrom);
+            if (previewBlock.closeFrom >= 0) {
+                const closeLine = state.doc.lineAt(previewBlock.closeFrom);
                 decos.push({
                     from: closeLine.from,
                     to: closeLine.from,
@@ -994,13 +1044,14 @@ function buildCodeBlockDecorations(state: EditorState): DecorationSet {
             }
 
             for (
-                let lineNum = firstContentLineNum;
-                lineNum <= lastContentLineNum;
+                let lineNum = previewBlock.firstContentLineNumber;
+                lineNum <= previewBlock.lastContentLineNumber;
                 lineNum++
             ) {
                 const line = state.doc.line(lineNum);
-                const isFirst = lineNum === firstContentLineNum;
-                const isLast = lineNum === lastContentLineNum;
+                const isFirst =
+                    lineNum === previewBlock.firstContentLineNumber;
+                const isLast = lineNum === previewBlock.lastContentLineNumber;
                 const needFirst = isFirst && !showHeader;
 
                 let deco: Decoration;

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -905,17 +905,17 @@ export const livePreviewTheme = EditorView.baseTheme({
         paddingBottom: "8px !important",
     },
     ".cm-mermaid-preview": {
-        margin: "10px 0",
+        margin: "12px 0",
         maxWidth: "100%",
         overflowX: "auto",
-        border: "1px solid var(--border)",
-        borderRadius: "8px",
+        borderTop: "1px solid var(--border)",
+        borderBottom: "1px solid var(--border)",
         background:
-            "color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary))",
+            "color-mix(in srgb, var(--bg-secondary) 52%, var(--bg-primary))",
     },
     ".cm-mermaid-preview-body": {
         minHeight: "72px",
-        padding: "14px",
+        padding: "16px 10px",
         color: "var(--text-secondary)",
         fontSize: "0.9em",
     },
@@ -930,8 +930,7 @@ export const livePreviewTheme = EditorView.baseTheme({
     },
     ".cm-mermaid-preview-error": {
         color: "var(--text-secondary)",
-        background:
-            "color-mix(in srgb, #ef4444 9%, var(--bg-secondary))",
+        background: "transparent",
     },
     ".cm-mermaid-preview-error-title": {
         marginBottom: "6px",
@@ -940,11 +939,17 @@ export const livePreviewTheme = EditorView.baseTheme({
     },
     ".cm-mermaid-preview-error-message": {
         margin: "0",
+        padding: "8px 10px",
         whiteSpace: "pre-wrap",
         overflowWrap: "anywhere",
         fontFamily:
             "ui-monospace, 'SF Mono', Monaco, 'Cascadia Code', monospace",
         fontSize: "0.86em",
+        color: "var(--text-primary)",
+        background:
+            "color-mix(in srgb, #ef4444 8%, var(--bg-secondary))",
+        border: "1px solid color-mix(in srgb, #ef4444 24%, var(--border))",
+        borderRadius: "6px",
     },
     ".cm-link-tooltip": {
         position: "fixed",

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -904,6 +904,48 @@ export const livePreviewTheme = EditorView.baseTheme({
         borderRadius: "0 0 8px 8px",
         paddingBottom: "8px !important",
     },
+    ".cm-mermaid-preview": {
+        margin: "10px 0",
+        maxWidth: "100%",
+        overflowX: "auto",
+        border: "1px solid var(--border)",
+        borderRadius: "8px",
+        background:
+            "color-mix(in srgb, var(--bg-secondary) 72%, var(--bg-primary))",
+    },
+    ".cm-mermaid-preview-body": {
+        minHeight: "72px",
+        padding: "14px",
+        color: "var(--text-secondary)",
+        fontSize: "0.9em",
+    },
+    ".cm-mermaid-preview-body-rendered": {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+    },
+    ".cm-mermaid-preview svg": {
+        maxWidth: "100%",
+        height: "auto",
+    },
+    ".cm-mermaid-preview-error": {
+        color: "var(--text-secondary)",
+        background:
+            "color-mix(in srgb, #ef4444 9%, var(--bg-secondary))",
+    },
+    ".cm-mermaid-preview-error-title": {
+        marginBottom: "6px",
+        color: "#ef4444",
+        fontWeight: "700",
+    },
+    ".cm-mermaid-preview-error-message": {
+        margin: "0",
+        whiteSpace: "pre-wrap",
+        overflowWrap: "anywhere",
+        fontFamily:
+            "ui-monospace, 'SF Mono', Monaco, 'Cascadia Code', monospace",
+        fontSize: "0.86em",
+    },
     ".cm-link-tooltip": {
         position: "fixed",
         zIndex: "1000",

--- a/apps/desktop/src/features/editor/mermaid/mermaidRenderer.test.ts
+++ b/apps/desktop/src/features/editor/mermaid/mermaidRenderer.test.ts
@@ -11,6 +11,10 @@ describe("mermaidRenderer", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.clearAllMocks();
+        document.documentElement.style.setProperty("--bg-primary", "#101014");
+        document.documentElement.style.setProperty("--bg-secondary", "#181820");
+        document.documentElement.style.setProperty("--text-primary", "#f4f4f5");
+        document.documentElement.style.setProperty("--accent", "#60a5fa");
     });
 
     it("initializes Mermaid with safe preview defaults once", async () => {
@@ -49,6 +53,19 @@ describe("mermaidRenderer", () => {
         expect(mockedMermaid.render).toHaveBeenCalledWith(
             "mermaid-test",
             "flowchart TD\nA --> B",
+        );
+        expect(mockedMermaid.initialize).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+                startOnLoad: false,
+                securityLevel: "strict",
+                theme: "base",
+                themeVariables: expect.objectContaining({
+                    background: "#101014",
+                    primaryColor: "#181820",
+                    primaryTextColor: "#f4f4f5",
+                    c0: "#60a5fa",
+                }),
+            }),
         );
     });
 

--- a/apps/desktop/src/features/editor/mermaid/mermaidRenderer.test.ts
+++ b/apps/desktop/src/features/editor/mermaid/mermaidRenderer.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("mermaid", () => ({
+    default: {
+        initialize: vi.fn(),
+        render: vi.fn(),
+    },
+}));
+
+describe("mermaidRenderer", () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+    });
+
+    it("initializes Mermaid with safe preview defaults once", async () => {
+        const { initializeMermaidRenderer } = await import("./mermaidRenderer");
+        const { default: mermaid } = await import("mermaid");
+        const mockedMermaid = vi.mocked(mermaid);
+
+        await initializeMermaidRenderer();
+        await initializeMermaidRenderer();
+
+        expect(mockedMermaid.initialize).toHaveBeenCalledTimes(1);
+        expect(mockedMermaid.initialize).toHaveBeenCalledWith({
+            startOnLoad: false,
+            securityLevel: "strict",
+            theme: "base",
+        });
+    });
+
+    it("renders a diagram as SVG", async () => {
+        const { renderMermaidDiagram } = await import("./mermaidRenderer");
+        const { default: mermaid } = await import("mermaid");
+        const mockedMermaid = vi.mocked(mermaid);
+
+        mockedMermaid.render.mockResolvedValueOnce({
+            svg: "<svg>diagram</svg>",
+            bindFunctions: undefined,
+            diagramType: "flowchart",
+        });
+
+        await expect(
+            renderMermaidDiagram("flowchart TD\nA --> B", "mermaid-test"),
+        ).resolves.toEqual({
+            status: "ok",
+            svg: "<svg>diagram</svg>",
+        });
+        expect(mockedMermaid.render).toHaveBeenCalledWith(
+            "mermaid-test",
+            "flowchart TD\nA --> B",
+        );
+    });
+
+    it("returns a render error message without throwing", async () => {
+        const { renderMermaidDiagram } = await import("./mermaidRenderer");
+        const { default: mermaid } = await import("mermaid");
+        const mockedMermaid = vi.mocked(mermaid);
+
+        mockedMermaid.render.mockRejectedValueOnce(new Error("Parse error"));
+
+        await expect(
+            renderMermaidDiagram("not a diagram", "mermaid-error"),
+        ).resolves.toEqual({
+            status: "error",
+            message: "Parse error",
+        });
+    });
+});

--- a/apps/desktop/src/features/editor/mermaid/mermaidRenderer.ts
+++ b/apps/desktop/src/features/editor/mermaid/mermaidRenderer.ts
@@ -1,0 +1,60 @@
+import type mermaid from "mermaid";
+
+export type MermaidRenderResult =
+    | {
+          status: "ok";
+          svg: string;
+      }
+    | {
+          status: "error";
+          message: string;
+      };
+
+let mermaidInitialized = false;
+let mermaidModulePromise: Promise<typeof mermaid> | null = null;
+
+export async function initializeMermaidRenderer(): Promise<typeof mermaid> {
+    const mermaidModule = await loadMermaidModule();
+    if (mermaidInitialized) return mermaidModule;
+
+    mermaidModule.initialize({
+        startOnLoad: false,
+        securityLevel: "strict",
+        theme: "base",
+    });
+    mermaidInitialized = true;
+    return mermaidModule;
+}
+
+export async function renderMermaidDiagram(
+    source: string,
+    id: string,
+): Promise<MermaidRenderResult> {
+    try {
+        const mermaidModule = await initializeMermaidRenderer();
+        const { svg } = await mermaidModule.render(id, source);
+        return { status: "ok", svg };
+    } catch (error) {
+        return {
+            status: "error",
+            message: getMermaidErrorMessage(error),
+        };
+    }
+}
+
+async function loadMermaidModule(): Promise<typeof mermaid> {
+    if (!mermaidModulePromise) {
+        mermaidModulePromise = import("mermaid").then((module) => module.default);
+    }
+    return mermaidModulePromise;
+}
+
+function getMermaidErrorMessage(error: unknown): string {
+    if (error instanceof Error && error.message.trim()) {
+        return error.message;
+    }
+    if (typeof error === "string" && error.trim()) {
+        return error;
+    }
+    return "Unable to render Mermaid diagram.";
+}

--- a/apps/desktop/src/features/editor/mermaid/mermaidRenderer.ts
+++ b/apps/desktop/src/features/editor/mermaid/mermaidRenderer.ts
@@ -13,15 +13,17 @@ export type MermaidRenderResult =
 let mermaidInitialized = false;
 let mermaidModulePromise: Promise<typeof mermaid> | null = null;
 
+const BASE_MERMAID_CONFIG = {
+    startOnLoad: false,
+    securityLevel: "strict",
+    theme: "base",
+} as const;
+
 export async function initializeMermaidRenderer(): Promise<typeof mermaid> {
     const mermaidModule = await loadMermaidModule();
     if (mermaidInitialized) return mermaidModule;
 
-    mermaidModule.initialize({
-        startOnLoad: false,
-        securityLevel: "strict",
-        theme: "base",
-    });
+    mermaidModule.initialize(BASE_MERMAID_CONFIG);
     mermaidInitialized = true;
     return mermaidModule;
 }
@@ -32,6 +34,10 @@ export async function renderMermaidDiagram(
 ): Promise<MermaidRenderResult> {
     try {
         const mermaidModule = await initializeMermaidRenderer();
+        mermaidModule.initialize({
+            ...BASE_MERMAID_CONFIG,
+            themeVariables: getMermaidThemeVariables(),
+        });
         const { svg } = await mermaidModule.render(id, source);
         return { status: "ok", svg };
     } catch (error) {
@@ -57,4 +63,63 @@ function getMermaidErrorMessage(error: unknown): string {
         return error;
     }
     return "Unable to render Mermaid diagram.";
+}
+
+function getMermaidThemeVariables() {
+    if (typeof document === "undefined") return undefined;
+
+    const styles = getComputedStyle(document.documentElement);
+    const value = (name: string, fallback: string) =>
+        styles.getPropertyValue(name).trim() || fallback;
+
+    const bgPrimary = value("--bg-primary", "#ffffff");
+    const bgSecondary = value("--bg-secondary", "#f8fafc");
+    const bgTertiary = value("--bg-tertiary", "#f1f5f9");
+    const textPrimary = value("--text-primary", "#111827");
+    const textSecondary = value("--text-secondary", "#4b5563");
+    const border = value("--border", "#d1d5db");
+    const accent = value("--accent", "#3b82f6");
+
+    return {
+        background: bgPrimary,
+        mainBkg: bgSecondary,
+        secondBkg: bgTertiary,
+        primaryColor: bgSecondary,
+        primaryTextColor: textPrimary,
+        primaryBorderColor: border,
+        secondaryColor: bgTertiary,
+        secondaryTextColor: textPrimary,
+        secondaryBorderColor: border,
+        tertiaryColor: bgPrimary,
+        tertiaryTextColor: textPrimary,
+        tertiaryBorderColor: border,
+        lineColor: textSecondary,
+        textColor: textPrimary,
+        nodeTextColor: textPrimary,
+        edgeLabelBackground: bgPrimary,
+        clusterBkg: bgSecondary,
+        clusterBorder: border,
+        noteBkgColor: bgTertiary,
+        noteTextColor: textPrimary,
+        noteBorderColor: border,
+        actorBkg: bgSecondary,
+        actorTextColor: textPrimary,
+        actorBorder: border,
+        actorLineColor: border,
+        signalColor: textSecondary,
+        signalTextColor: textPrimary,
+        labelBoxBkgColor: bgSecondary,
+        labelBoxBorderColor: border,
+        labelTextColor: textPrimary,
+        loopTextColor: textPrimary,
+        activationBkgColor: bgTertiary,
+        activationBorderColor: border,
+        sequenceNumberColor: bgPrimary,
+        sectionBkgColor: bgTertiary,
+        altSectionBkgColor: bgSecondary,
+        gridColor: border,
+        c0: accent,
+        c1: textSecondary,
+        c2: bgTertiary,
+    };
 }

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3713,7 +3713,7 @@ function FileTreeSettings({
                 searchQuery={searchQuery}
                 section="File Tree"
                 label="Show all vault files"
-                description="Display every vault file, beyond the curated writing and media set. With this off, Markdown, PDFs, images, Excalidraw, CSV, TXT, and HTML files are shown."
+                description="Display every vault file, beyond the curated writing and media set. With this off, Markdown, Mermaid, PDFs, images, Excalidraw, CSV, TXT, and HTML files are shown."
                 keywords={[
                     "File-oriented search is active",
                     "Search Files & Notes",

--- a/crates/index/src/search.rs
+++ b/crates/index/src/search.rs
@@ -637,7 +637,8 @@ fn score_file_search_fields(
     best
 }
 
-const CURATED_SEARCH_ENTRY_EXTENSIONS: &[&str] = &["csv", "excalidraw", "txt", "html", "htm"];
+const CURATED_SEARCH_ENTRY_EXTENSIONS: &[&str] =
+    &["csv", "excalidraw", "txt", "html", "htm", "mmd", "mermaid"];
 const CURATED_SEARCH_PDF_EXTENSION: &str = "pdf";
 
 #[derive(Clone, Copy, PartialEq, Eq)]

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -689,6 +689,12 @@ fn is_html_path(path: &Path) -> bool {
         .is_some_and(|ext| ext.eq_ignore_ascii_case("html") || ext.eq_ignore_ascii_case("htm"))
 }
 
+fn is_mermaid_path(path: &Path) -> bool {
+    path.extension()
+        .and_then(|ext| ext.to_str())
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("mmd") || ext.eq_ignore_ascii_case("mermaid"))
+}
+
 fn is_text_like_mime_type(mime_type: &str) -> bool {
     mime_type.starts_with("text/")
         || matches!(
@@ -719,6 +725,7 @@ fn classify_vault_entry_path(path: &Path, kind: &str) -> VaultEntryClassificatio
         "pdf" => (true, "pdf"),
         _ if is_excalidraw_path(path) => (true, "map"),
         _ if is_html_path(path) => (true, "html"),
+        _ if is_mermaid_path(path) => (true, "mermaid"),
         _ if is_image_like => (true, "image"),
         _ if is_text_like => (true, "text"),
         _ => (false, "external"),
@@ -980,6 +987,7 @@ fn guess_mime_type(path: &Path) -> Option<String> {
                 "html" | "htm" => "text/html",
                 "css" => "text/css",
                 "csv" => "text/csv",
+                "mmd" | "mermaid" => "text/plain",
                 "astro" | "bat" | "bash" | "c" | "cc" | "clj" | "cljs" | "cmake" | "cpp" | "cs"
                 | "d" | "dart" | "diff" | "elm" | "env" | "erl" | "ex" | "exs" | "fish" | "go"
                 | "gradle" | "graphql" | "groovy" | "h" | "hpp" | "hs" | "java" | "jl"

--- a/crates/vault/tests/integration.rs
+++ b/crates/vault/tests/integration.rs
@@ -638,6 +638,33 @@ fn discover_vault_entries_guesses_text_mime_types_for_common_config_files() {
 }
 
 #[test]
+fn discover_vault_entries_classifies_mermaid_files_as_in_app_diagrams() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("flow.mmd"), "flowchart TD\nA --> B\n").unwrap();
+    fs::write(
+        dir.path().join("sequence.mermaid"),
+        "sequenceDiagram\nA->>B: hello\n",
+    )
+    .unwrap();
+
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    let entries = vault.discover_vault_entries().unwrap();
+
+    for file_name in ["flow.mmd", "sequence.mermaid"] {
+        let entry = entries
+            .iter()
+            .find(|entry| entry.file_name == file_name)
+            .unwrap();
+
+        assert_eq!(entry.kind, "file");
+        assert_eq!(entry.mime_type.as_deref(), Some("text/plain"));
+        assert_eq!(entry.is_text_like, Some(true));
+        assert_eq!(entry.open_in_app, Some(true));
+        assert_eq!(entry.viewer_kind.as_deref(), Some("mermaid"));
+    }
+}
+
+#[test]
 fn discover_vault_entries_uses_file_name_as_title_for_dotfiles_without_stem() {
     let dir = TempDir::new().unwrap();
     fs::write(dir.path().join(".gitignore"), "target/\n").unwrap();

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ remain reviewable.
 
 ## Editor And Workspace
 
-- [Editor Architecture](editor-architecture.md): CodeMirror, live preview, wikilinks, frontmatter/properties, autosave, dirty tabs, merge view, inline review overlays, and power-user invariants.
+- [Editor Architecture](editor-architecture.md): CodeMirror, live preview, Mermaid rendering, wikilinks, frontmatter/properties, autosave, dirty tabs, merge view, inline review overlays, and power-user invariants.
 - [Terminal Architecture](terminal-integration.md): PTY sidecar boundary, xterm rendering, terminal persistence, Claude Code integration, and validation notes.
 - [Subagents Working State Map](concept-maps/codex-subagents-working-state-map.excalidraw): visual working map for subagent state and coordination.
 
@@ -52,4 +52,4 @@ tokens, provider credentials, or personally sensitive paths.
 These currently live next to their implementation/release artifacts because
 they are tightly coupled to package-specific workflows.
 
-Last updated: June 2, 2026.
+Last updated: July 3, 2026.

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -45,12 +45,12 @@ run outside Electron, its fallback app data path is platform-dependent.
 
 The vault is the user's source of truth. NeverWrite reads and writes normal files
 inside the selected vault, including Markdown notes, text/code files, CSV files,
-PDFs, images, and `.excalidraw` concept maps.
+Mermaid diagram files, PDFs, images, and `.excalidraw` concept maps.
 
 Vault content is stored in the original file formats. It is plaintext when the
-file format is plaintext, for example Markdown, CSV, JSON, source code, and
-Excalidraw JSON. Binary files such as PDFs and images remain their original
-binary files. NeverWrite does not add encryption to vault files.
+file format is plaintext, for example Markdown, CSV, JSON, source code,
+Mermaid source, or Excalidraw JSON. Binary files such as PDFs and images remain
+their original binary files. NeverWrite does not add encryption to vault files.
 
 Vault file paths, titles, tags, links, and content can be shown in the UI,
 indexed for search, sent to AI providers when attached or included as context,

--- a/docs/editor-architecture.md
+++ b/docs/editor-architecture.md
@@ -2,8 +2,9 @@
 
 This document is a maintainer guide for changing NeverWrite's editor without
 breaking the power-user experience. It focuses on the desktop editor stack:
-CodeMirror 6, live preview, wikilinks, frontmatter/properties, autosave/dirty
-state, inline review/merge view, and workspace tab boundaries.
+CodeMirror 6, live preview, Mermaid rendering, wikilinks,
+frontmatter/properties, autosave/dirty state, inline review/merge view, and
+workspace tab boundaries.
 
 For test-command conventions, also see [Testing and Validation](./testing.md).
 
@@ -25,7 +26,7 @@ The main renderer boundary is
 
 Notes and text-like files are intentionally different editor surfaces. Do not
 assume behavior added to `Editor.tsx` automatically applies to arbitrary files,
-CSV files, PDFs, or images.
+CSV files, Mermaid diagram files, PDFs, or images.
 
 ## Tab Model
 
@@ -35,7 +36,7 @@ resource-backed tab kinds are:
 
 - `NoteTab`: Markdown note content keyed by `noteId`.
 - `FileTab`: vault file content keyed by `relativePath`, with `viewer` set to
-  `text`, `csv`, or `image`.
+  `text`, `csv`, `mermaid`, or `image`.
 - `PdfTab`: PDF state, including page, zoom, view mode, and scroll position.
 
 Only `note`, `pdf`, `file`, and `map` participate in the history-tab registry
@@ -48,6 +49,9 @@ history model.
 - `viewer === "image"` uses a custom image viewer. Image tabs do not need text
   content and use vault preview URLs.
 - `viewer === "csv"` uses [`CsvFileTabView.tsx`](../apps/desktop/src/features/editor/CsvFileTabView.tsx).
+- `viewer === "mermaid"` uses [`FileTextTabView.tsx`](../apps/desktop/src/features/editor/FileTextTabView.tsx)
+  with a Source/Preview switch and [`MermaidFilePreview.tsx`](../apps/desktop/src/features/editor/MermaidFilePreview.tsx)
+  for rendered diagrams.
 - other text-like file viewers use [`FileTextTabView.tsx`](../apps/desktop/src/features/editor/FileTextTabView.tsx).
 
 `fileViewerNeedsTextContent(viewer)` returns `viewer !== "image"`, so adding a
@@ -93,7 +97,7 @@ The live preview system is split by concern:
   builds inline and line decorations for Markdown presentation.
 - [`livePreviewBlocks.ts`](../apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts)
   handles heavier block widgets such as code blocks, images, tables, math,
-  embeds, and note previews.
+  Mermaid diagrams, embeds, and note previews.
 - [`livePreviewHelpers.ts`](../apps/desktop/src/features/editor/extensions/livePreviewHelpers.ts)
   centralizes cursor-awareness and Markdown parsing helpers.
 - [`livePreviewTheme.ts`](../apps/desktop/src/features/editor/extensions/livePreviewTheme.ts)
@@ -113,6 +117,11 @@ the user is editing an ambiguous Markdown structure.
 Leading frontmatter and the leading H1 are collapsed by
 `createLeadingContentCollapseField()` in live preview, but only when the
 selection is not on those lines. Source mode keeps raw Markdown visible.
+
+Mermaid rendering is shared between Markdown fences and standalone Mermaid
+files through [`mermaidRenderer.ts`](../apps/desktop/src/features/editor/mermaid/mermaidRenderer.ts).
+Keep asynchronous render calls stale-safe so older renders cannot replace newer
+diagram source after quick edits.
 
 ## Wikilinks
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -298,7 +298,7 @@ If a vault appears corrupt or a file cannot be opened/saved:
   case-insensitive filesystems.
 - Look for permission errors in `native-backend.log`.
 - If the issue involves a specific file type, include the file extension and
-  whether it is Markdown, CSV, PDF, image, text/code, or `.excalidraw`.
+  whether it is Markdown, Mermaid, CSV, PDF, image, text/code, or `.excalidraw`.
 
 ## AI Session History And Recovery
 


### PR DESCRIPTION
## Summary

Adds first-class Mermaid rendering across the editor:

- renders Mermaid fences inside Markdown preview
- adds a reusable Mermaid rendering boundary with stale-render protection
- recognizes `.mmd` and `.mermaid` files as in-app diagram files
- adds a Mermaid file preview mode with a Source/Preview switch
- classifies Mermaid files correctly in the Rust vault backend and Electron fallback
- updates curated file/search behavior, icons, settings copy, and tests
- polishes the Mermaid toolbar button states so they read as real controls

## Why

Mermaid diagrams are common in writing-heavy technical vaults, and `.mmd` files should behave like readable/editable project files instead of opening externally or failing drag/drop insertion.

## Validation

- `npm run lint`
- `npm run build`
- `cargo clippy --all-targets --all-features`
- targeted Vitest coverage for Mermaid rendering, live preview, file icons, vault entries, editor session, and Mermaid file preview
- targeted Rust/Electron backend tests for Mermaid file classification

Note: the Vite build still reports the existing `::highlight(...)` CSS warnings.