### PR TITLE
Fix sticky file tree folders at top

### DIFF
--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -339,6 +339,60 @@ describe("FileTree", () => {
         );
     });
 
+    it("does not render sticky folders while the tree is scrolled to the top", async () => {
+        const user = userEvent.setup();
+
+        setVaultNotes([
+            {
+                id: "root/folder/alpha",
+                path: "/vault/root/folder/alpha.md",
+                title: "Alpha",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "root/folder/beta",
+                path: "/vault/root/folder/beta.md",
+                title: "Beta",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "root/folder/gamma",
+                path: "/vault/root/folder/gamma.md",
+                title: "Gamma",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+
+        renderComponent(<FileTree />);
+        await expandFolder(user, "root");
+        await expandFolder(user, "folder");
+
+        const viewport = screen.getByTestId("file-tree-viewport");
+        Object.defineProperty(viewport, "clientHeight", {
+            configurable: true,
+            value: 48,
+        });
+
+        viewport.scrollTop = 0;
+        fireEvent.scroll(viewport);
+        fireEvent(window, new Event("resize"));
+        expect(screen.queryByTestId("file-tree-sticky-layer")).toBeNull();
+
+        viewport.scrollTop = 1;
+        fireEvent.scroll(viewport);
+        expect(
+            await screen.findByTestId("file-tree-sticky-layer"),
+        ).toBeInTheDocument();
+        expect(
+            within(screen.getByTestId("file-tree-sticky-layer")).getByText(
+                "root",
+            ),
+        ).toBeInTheDocument();
+    });
+
     it("does not render sticky folders when the appearance setting is disabled", async () => {
         const user = userEvent.setup();
 

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -2450,7 +2450,7 @@ export function FileTree() {
                 if (row.kind !== "folder" || row.depth !== depth) continue;
 
                 const rowTop = i * metrics.rowHeight;
-                if (rowTop > scrollTop + stickyPosition) break;
+                if (rowTop >= scrollTop + stickyPosition) break;
 
                 const lastIdx = folderLastDescendant.get(i) ?? i;
                 const sectionBottom = (lastIdx + 1) * metrics.rowHeight;


### PR DESCRIPTION
## Summary

- Fixes sticky file tree folders appearing while the tree is still scrolled to the very top.
- Updates the sticky threshold so folders only move into the overlay after their natural row has crossed the sticky position.
- Adds a regression test for the top-of-tree case.

## Root Cause

The sticky folder calculation treated equality as already sticky. At `scrollTop = 0`, the first folder row has `rowTop = 0`, so it was immediately duplicated into the sticky overlay and hidden from the normal row layer.

## Validation

- `npm test -- src/features/vault/FileTree.test.tsx`
