### PR TITLE
Prepare 0.4.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.4] - 2026-07-05
+
+### Added
+
+- Added Mermaid diagram previews for Markdown code fences and standalone Mermaid diagram files, including a source/preview toggle for diagram tabs.
+
+### Fixed
+
+- Fixed sticky folders in the file tree so nested directories stay aligned with their parent scope instead of sticking to the top of the entire tree.
+
 ## [0.4.3] - 2026-07-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.4.3",
+            "version": "0.4.4",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.4.3",
+    "version": "0.4.4",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.4.3",
+    "version": "0.4.4",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Adds the 0.4.4 changelog entry for Mermaid previews and the file tree sticky-folder fix.
- Bumps the desktop app, native backend, Cargo lock entry, and Web Clipper metadata to 0.4.4.

## Validation

- `cargo check -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.4.4`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`