### PR TITLE
Add neverwrite://open deep link to open a vault file

### DIFF
--- a/apps/desktop/src-electron/main/deepLink.test.ts
+++ b/apps/desktop/src-electron/main/deepLink.test.ts
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { handleWebClipperDeepLink } = vi.hoisted(() => ({
+    handleWebClipperDeepLink: vi.fn(),
+}));
+vi.mock("./webClipper", () => ({ handleWebClipperDeepLink }));
+
+import {
+    extractDeepLinksFromArgv,
+    handleDeepLink,
+    installDeepLinkRuntime,
+    parseOpenDeepLink,
+} from "./deepLink";
+
+describe("parseOpenDeepLink", () => {
+    it("parses a plain relative path", () => {
+        expect(parseOpenDeepLink("neverwrite://open?path=notes/todo.md")).toEqual(
+            { path: "notes/todo.md", line: null, endLine: null },
+        );
+    });
+
+    it("accepts the authority-less form (neverwrite:open)", () => {
+        expect(
+            parseOpenDeepLink("neverwrite:open?path=Allgemein/ABOUT.md#L5"),
+        ).toEqual({ path: "Allgemein/ABOUT.md", line: 5, endLine: null });
+    });
+
+    it("decodes url-encoded paths", () => {
+        expect(
+            parseOpenDeepLink(
+                "neverwrite://open?path=Daily%20Notes%2F2026-07-06.md",
+            ),
+        ).toEqual({
+            path: "Daily Notes/2026-07-06.md",
+            line: null,
+            endLine: null,
+        });
+    });
+
+    it("reads a single-line fragment", () => {
+        expect(
+            parseOpenDeepLink("neverwrite://open?path=a.md#L12"),
+        ).toEqual({ path: "a.md", line: 12, endLine: null });
+    });
+
+    it("reads a line range fragment (L-prefixed and bare end)", () => {
+        expect(parseOpenDeepLink("neverwrite://open?path=a.md#L10-L20")).toEqual({
+            path: "a.md",
+            line: 10,
+            endLine: 20,
+        });
+        expect(parseOpenDeepLink("neverwrite://open?path=a.md#L10-20")).toEqual({
+            path: "a.md",
+            line: 10,
+            endLine: 20,
+        });
+    });
+
+    it("tolerates a fragment percent-encoded into the path value", () => {
+        expect(
+            parseOpenDeepLink("neverwrite://open?path=a.md%23L5"),
+        ).toEqual({ path: "a.md", line: 5, endLine: null });
+    });
+
+    it("does not truncate a filename that merely contains #L<digit>", () => {
+        expect(
+            parseOpenDeepLink(
+                "neverwrite://open?path=Report%23L2%20draft.md",
+            ),
+        ).toEqual({ path: "Report#L2 draft.md", line: null, endLine: null });
+    });
+
+    it("ignores a non-line fragment", () => {
+        expect(
+            parseOpenDeepLink("neverwrite://open?path=a.md#section"),
+        ).toEqual({ path: "a.md", line: null, endLine: null });
+    });
+
+    it("rejects zero/negative line numbers", () => {
+        expect(parseOpenDeepLink("neverwrite://open?path=a.md#L0")).toEqual({
+            path: "a.md",
+            line: null,
+            endLine: null,
+        });
+    });
+
+    it("returns null for a missing path", () => {
+        expect(parseOpenDeepLink("neverwrite://open")).toBeNull();
+        expect(parseOpenDeepLink("neverwrite://open?path=")).toBeNull();
+    });
+
+    it("returns null for a different action or scheme", () => {
+        expect(parseOpenDeepLink("neverwrite://clip?path=a.md")).toBeNull();
+        expect(parseOpenDeepLink("https://example.com/open?path=a.md")).toBeNull();
+        expect(parseOpenDeepLink("not a url")).toBeNull();
+    });
+});
+
+describe("extractDeepLinksFromArgv", () => {
+    it("keeps only neverwrite deep links", () => {
+        expect(
+            extractDeepLinksFromArgv([
+                "/Applications/NeverWrite.app",
+                "--flag",
+                "neverwrite://open?path=a.md",
+                "neverwrite://clip?requestId=1",
+                "https://example.com",
+            ]),
+        ).toEqual([
+            "neverwrite://open?path=a.md",
+            "neverwrite://clip?requestId=1",
+        ]);
+    });
+});
+
+describe("handleDeepLink", () => {
+    beforeEach(() => {
+        handleWebClipperDeepLink.mockClear();
+    });
+
+    it("routes clip links to the web clipper unchanged", () => {
+        const url = "neverwrite://clip?requestId=1&title=t&folder=f&mode=inline";
+        handleDeepLink(url);
+        expect(handleWebClipperDeepLink).toHaveBeenCalledWith(url);
+    });
+
+    it("routes the authority-less open form", () => {
+        const emit = vi.fn();
+        installDeepLinkRuntime(emit);
+        handleDeepLink("neverwrite:open?path=Allgemein/ABOUT.md");
+        expect(emit).toHaveBeenCalledWith("neverwrite:deep-link/open-file", {
+            path: "Allgemein/ABOUT.md",
+            line: null,
+            endLine: null,
+        });
+    });
+
+    it("does not route unknown actions anywhere", () => {
+        handleDeepLink("neverwrite://frobnicate?path=a.md");
+        expect(handleWebClipperDeepLink).not.toHaveBeenCalled();
+    });
+
+    it("emits the open-file event once a runtime is installed", () => {
+        const emit = vi.fn();
+        installDeepLinkRuntime(emit);
+        handleDeepLink("neverwrite://open?path=notes/a.md#L3-L4");
+        expect(emit).toHaveBeenCalledWith("neverwrite:deep-link/open-file", {
+            path: "notes/a.md",
+            line: 3,
+            endLine: 4,
+        });
+    });
+});
+
+describe("deep-link open queueing", () => {
+    it("flushes links received before the runtime is ready", async () => {
+        vi.resetModules();
+        const { handleDeepLink: freshHandle, installDeepLinkRuntime: freshInstall } =
+            await import("./deepLink");
+
+        freshHandle("neverwrite://open?path=queued.md");
+        const emit = vi.fn();
+        freshInstall(emit);
+        expect(emit).toHaveBeenCalledWith("neverwrite:deep-link/open-file", {
+            path: "queued.md",
+            line: null,
+            endLine: null,
+        });
+    });
+});

--- a/apps/desktop/src-electron/main/deepLink.ts
+++ b/apps/desktop/src-electron/main/deepLink.ts
@@ -1,0 +1,145 @@
+import { handleWebClipperDeepLink } from "./webClipper";
+
+const DEEP_LINK_OPEN_FILE_EVENT = "neverwrite:deep-link/open-file";
+
+export interface DeepLinkOpenFileRequest {
+    path: string;
+    line: number | null;
+    endLine: number | null;
+}
+
+type EmitEvent = (eventName: string, payload: unknown) => void;
+
+const pendingOpenLinks: string[] = [];
+let emitEvent: EmitEvent | null = null;
+
+/**
+ * Wire the deep-link runtime to the renderer event bus. `neverwrite://open`
+ * links that arrived before the runtime was installed are flushed here. This
+ * mirrors the web-clipper runtime; on a true cold launch the renderer may still
+ * be mounting, so guaranteed cold-start delivery would need a renderer-pull
+ * handshake (tracked as follow-up).
+ */
+export function installDeepLinkRuntime(emit: EmitEvent) {
+    emitEvent = emit;
+    const queued = pendingOpenLinks.splice(0);
+    for (const rawUrl of queued) {
+        dispatchOpenDeepLink(rawUrl);
+    }
+}
+
+/**
+ * Pick out every NeverWrite deep link from a process argv list. Windows and
+ * Linux deliver the URL as a command-line argument via `second-instance`.
+ */
+export function extractDeepLinksFromArgv(argv: string[]) {
+    return argv.filter((arg) => arg.startsWith("neverwrite://"));
+}
+
+/**
+ * Generic dispatcher for `neverwrite://` deep links. Keeps the existing
+ * `neverwrite://clip` web-clipper flow untouched and adds `neverwrite://open`.
+ */
+export function handleDeepLink(rawUrl: string) {
+    let url: URL;
+    try {
+        url = new URL(rawUrl);
+    } catch {
+        console.warn(`[deep-link] Ignoring malformed deep link: ${rawUrl}`);
+        return;
+    }
+
+    if (url.protocol !== "neverwrite:") return;
+
+    switch (deepLinkAction(url)) {
+        case "clip":
+            handleWebClipperDeepLink(rawUrl);
+            return;
+        case "open":
+            dispatchOpenDeepLink(rawUrl);
+            return;
+        default:
+            console.warn(
+                `[deep-link] Unsupported deep link action: ${deepLinkAction(url)}`,
+            );
+    }
+}
+
+/**
+ * The action is normally the URL authority (`neverwrite://open?...`), but also
+ * accept the authority-less form `neverwrite:open?...`, where the action lands
+ * in the (opaque) path instead. Both are common in hand-written links.
+ */
+function deepLinkAction(url: URL): string {
+    if (url.hostname) return url.hostname;
+    return url.pathname.replace(/^\/+/, "").split("/")[0] ?? "";
+}
+
+function dispatchOpenDeepLink(rawUrl: string) {
+    const request = parseOpenDeepLink(rawUrl);
+    if (!request) {
+        console.warn(`[deep-link] Ignoring invalid open deep link: ${rawUrl}`);
+        return;
+    }
+    if (!emitEvent) {
+        pendingOpenLinks.push(rawUrl);
+        return;
+    }
+    emitEvent(DEEP_LINK_OPEN_FILE_EVENT, request);
+}
+
+/**
+ * Parse `neverwrite://open?path=<url-encoded-path>` with an optional
+ * `#L10` / `#L10-L20` line fragment. The path is validated and resolved
+ * against the open vault later, in the renderer.
+ */
+export function parseOpenDeepLink(rawUrl: string): DeepLinkOpenFileRequest | null {
+    let url: URL;
+    try {
+        url = new URL(rawUrl);
+    } catch {
+        return null;
+    }
+
+    if (url.protocol !== "neverwrite:" || deepLinkAction(url) !== "open") {
+        return null;
+    }
+
+    let path = url.searchParams.get("path")?.trim();
+    if (!path) return null;
+
+    // Line info is normally the URL fragment (`...?path=x#L10`), but tolerate a
+    // fragment that was percent-encoded into the `path` value itself. Only peel
+    // off a suffix that is a complete line fragment, so filenames that legitimately
+    // contain `#L<digit>` (e.g. `Report#L2 draft.md`) are left intact.
+    let fragment = url.hash;
+    if (!fragment) {
+        const inlineFragment = /#L\d+(?:-L?\d+)?$/.exec(path);
+        if (inlineFragment) {
+            fragment = inlineFragment[0];
+            path = path.slice(0, inlineFragment.index).trim();
+            if (!path) return null;
+        }
+    }
+
+    const { line, endLine } = parseLineFragment(fragment);
+    return { path, line, endLine };
+}
+
+function parseLineFragment(fragment: string): {
+    line: number | null;
+    endLine: number | null;
+} {
+    // Accepts `#L10`, `#L10-L20`, and `#L10-20`.
+    const match = /^#L(\d+)(?:-L?(\d+))?$/.exec(fragment);
+    if (!match) return { line: null, endLine: null };
+
+    const line = toPositiveInt(match[1]);
+    const endLine = match[2] ? toPositiveInt(match[2]) : null;
+    return { line, endLine };
+}
+
+function toPositiveInt(value: string): number | null {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}

--- a/apps/desktop/src-electron/main/index.ts
+++ b/apps/desktop/src-electron/main/index.ts
@@ -1,10 +1,7 @@
 import { app, BrowserWindow, protocol, session } from "electron";
 import { installNativeMenus, refreshDockMenu } from "./menu";
 import { createAppWindow, getWindowByLabel } from "./window";
-import {
-    extractWebClipperDeepLinksFromArgv,
-    handleWebClipperDeepLink,
-} from "./webClipper";
+import { extractDeepLinksFromArgv, handleDeepLink } from "./deepLink";
 import {
     registerIpcHandlers,
     registerPreviewProtocolHandler,
@@ -67,7 +64,7 @@ app.on("child-process-gone", (_event, details) => {
 app.on("open-url", (event, url) => {
     event.preventDefault();
     focusOrCreateMainWindow();
-    handleWebClipperDeepLink(url);
+    handleDeepLink(url);
 });
 
 function focusOrCreateMainWindow() {
@@ -93,8 +90,8 @@ if (!hasLock) {
 } else {
     app.on("second-instance", (_event, argv) => {
         focusOrCreateMainWindow();
-        for (const url of extractWebClipperDeepLinksFromArgv(argv)) {
-            handleWebClipperDeepLink(url);
+        for (const url of extractDeepLinksFromArgv(argv)) {
+            handleDeepLink(url);
         }
     });
 
@@ -105,8 +102,8 @@ if (!hasLock) {
         registerIpcHandlers();
         void installNativeMenus();
         createAppWindow("main");
-        for (const url of extractWebClipperDeepLinksFromArgv(process.argv)) {
-            handleWebClipperDeepLink(url);
+        for (const url of extractDeepLinksFromArgv(process.argv)) {
+            handleDeepLink(url);
         }
 
         app.on("activate", () => {

--- a/apps/desktop/src-electron/main/ipc.ts
+++ b/apps/desktop/src-electron/main/ipc.ts
@@ -26,6 +26,7 @@ import {
 import { createNativeBackendSidecar } from "./nativeBackend";
 import { ElectronAppUpdater } from "./updater";
 import { installWebClipperRuntime } from "./webClipper";
+import { installDeepLinkRuntime } from "./deepLink";
 
 function asRecord(value: unknown): Record<string, unknown> {
     return value && typeof value === "object"
@@ -215,6 +216,7 @@ function registerInvokeHandler() {
         nativeBackend,
     );
     installWebClipperRuntime(backend, emitRuntimeEvent);
+    installDeepLinkRuntime(emitRuntimeEvent);
 
     ipcMain.handle(ELECTRON_IPC.invoke, async (_event, rawEnvelope) => {
         const envelope = asRecord(rawEnvelope) as Partial<IpcInvokeEnvelope>;

--- a/apps/desktop/src-electron/main/webClipper.ts
+++ b/apps/desktop/src-electron/main/webClipper.ts
@@ -53,10 +53,6 @@ export function installWebClipperRuntime(
     }
 }
 
-export function extractWebClipperDeepLinksFromArgv(argv: string[]) {
-    return argv.filter((arg) => arg.startsWith("neverwrite://clip"));
-}
-
 export function handleWebClipperDeepLink(rawUrl: string) {
     if (!runtime) {
         pendingDeepLinks.push(rawUrl);

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -111,6 +111,10 @@ import { shouldAllowNativeContextMenu } from "./features/spellcheck/contextMenu"
 import { YouTubeModalHost } from "./features/editor/YouTubeModalHost";
 import { ClipNotification } from "./features/clip/ClipNotification";
 import { useClipImportStore } from "./features/clip/clipImportStore";
+import {
+    openDeepLinkFile,
+    type DeepLinkOpenFilePayload,
+} from "./features/deep-link/openDeepLinkFile";
 import { useAppUpdateStore } from "./features/updates/store";
 import {
     buildWindowOperationalState,
@@ -130,6 +134,7 @@ interface WebClipperSavedPayload {
 
 const WEB_CLIPPER_CLIP_SAVED_EVENT = "neverwrite:web-clipper/clip-saved";
 const WEB_CLIPPER_ROUTE_CLIP_EVENT = "neverwrite:web-clipper/route-clip";
+const DEEP_LINK_OPEN_FILE_EVENT = "neverwrite:deep-link/open-file";
 const MENU_ACTION_EVENT = "menu-action";
 const DOCK_OPEN_VAULT_EVENT = "dock-open-vault";
 const EXCALIDRAW_RUNTIME_SUPPORTED = canUseExcalidrawRuntime();
@@ -1408,6 +1413,30 @@ export default function App() {
         [showWebClipperSavedNotice],
     );
 
+    const handleDeepLinkOpenFile = useCallback(
+        async (payload: DeepLinkOpenFilePayload) => {
+            const result = await openDeepLinkFile(payload);
+            if (result === "opened") return;
+
+            const message =
+                result === "no-vault"
+                    ? "Open a vault first, then try the link again."
+                    : result === "outside-vault"
+                      ? "This file is outside the currently open vault."
+                      : result === "invalid"
+                        ? "The link is missing a valid file path."
+                        : "That file could not be found in the current vault.";
+
+            useClipImportStore.getState().showNotice({
+                id: crypto.randomUUID(),
+                heading: "Couldn't open link",
+                title: payload.path,
+                message,
+            });
+        },
+        [],
+    );
+
     useRegisterCommands(openSettings, windowMode === "main");
     useGlobalShortcuts(openSettings);
     useAppWebviewZoom();
@@ -2131,6 +2160,34 @@ export default function App() {
             unlisten?.();
         };
     }, [routeWebClipperClip, windowMode]);
+
+    useEffect(() => {
+        if (windowMode !== "main") return;
+
+        let disposed = false;
+        let unlisten: (() => void) | null = null;
+
+        resolveDeferredUnlisten(
+            listen<DeepLinkOpenFilePayload>(
+                DEEP_LINK_OPEN_FILE_EVENT,
+                (event) => {
+                    if (disposed) return;
+                    void handleDeepLinkOpenFile(event.payload);
+                },
+            ),
+            {
+                isDisposed: () => disposed,
+                onResolved: (cleanup) => {
+                    unlisten = cleanup;
+                },
+            },
+        );
+
+        return () => {
+            disposed = true;
+            unlisten?.();
+        };
+    }, [handleDeepLinkOpenFile, windowMode]);
 
     if (windowMode === "ghost") {
         const title = readSearchParam("title") ?? "Tab";

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -98,6 +98,12 @@ export interface PendingSelectionReveal {
     head: number;
 }
 
+export interface PendingLineReveal {
+    noteId: string;
+    line: number;
+    endLine: number | null;
+}
+
 export interface EditorSelectionContext {
     noteId: string | null;
     path: string | null;
@@ -111,11 +117,14 @@ export interface EditorSelectionContext {
 export interface EditorStore extends EditorWorkspaceStore {
     pendingReveal: PendingReveal | null;
     pendingSelectionReveal: PendingSelectionReveal | null;
+    pendingLineReveal: PendingLineReveal | null;
     currentSelection: EditorSelectionContext | null;
     queueReveal: (reveal: PendingReveal) => void;
     clearPendingReveal: () => void;
     queueSelectionReveal: (reveal: PendingSelectionReveal) => void;
     clearPendingSelectionReveal: () => void;
+    queueLineReveal: (reveal: PendingLineReveal) => void;
+    clearPendingLineReveal: () => void;
     setCurrentSelection: (selection: EditorSelectionContext) => void;
     clearCurrentSelection: () => void;
 }
@@ -124,6 +133,7 @@ export const useEditorStore = create<EditorStore>((set, get, api) => ({
     ...createEditorWorkspaceSlice<EditorStore>(set, get, api),
     pendingReveal: null,
     pendingSelectionReveal: null,
+    pendingLineReveal: null,
     currentSelection: null,
 
     queueReveal: (pendingReveal) => set({ pendingReveal }),
@@ -134,6 +144,10 @@ export const useEditorStore = create<EditorStore>((set, get, api) => ({
         set({ pendingSelectionReveal }),
 
     clearPendingSelectionReveal: () => set({ pendingSelectionReveal: null }),
+
+    queueLineReveal: (pendingLineReveal) => set({ pendingLineReveal }),
+
+    clearPendingLineReveal: () => set({ pendingLineReveal: null }),
 
     setCurrentSelection: (currentSelection) => set({ currentSelection }),
 

--- a/apps/desktop/src/features/clip/ClipNotification.tsx
+++ b/apps/desktop/src/features/clip/ClipNotification.tsx
@@ -46,7 +46,7 @@ export function ClipNotification() {
                     color: "var(--text-secondary)",
                 }}
             >
-                Web clip saved
+                {notice.heading ?? "Web clip saved"}
             </div>
             <div
                 style={{
@@ -68,17 +68,19 @@ export function ClipNotification() {
             >
                 {notice.message}
             </div>
-            <div
-                style={{
-                    marginTop: 8,
-                    fontSize: 12,
-                    lineHeight: 1.4,
-                    color: "var(--text-secondary)",
-                    wordBreak: "break-word",
-                }}
-            >
-                {notice.relativePath}
-            </div>
+            {notice.relativePath ? (
+                <div
+                    style={{
+                        marginTop: 8,
+                        fontSize: 12,
+                        lineHeight: 1.4,
+                        color: "var(--text-secondary)",
+                        wordBreak: "break-word",
+                    }}
+                >
+                    {notice.relativePath}
+                </div>
+            ) : null}
         </div>
     );
 }

--- a/apps/desktop/src/features/clip/clipImportStore.ts
+++ b/apps/desktop/src/features/clip/clipImportStore.ts
@@ -4,7 +4,10 @@ export interface ClipImportNotice {
     id: string;
     title: string;
     message: string;
-    relativePath: string;
+    // Optional uppercase eyebrow shown above the title. Defaults to the
+    // web-clipper wording so existing callers keep their look.
+    heading?: string;
+    relativePath?: string;
 }
 
 interface ClipImportStore {

--- a/apps/desktop/src/features/deep-link/openDeepLinkFile.test.ts
+++ b/apps/desktop/src/features/deep-link/openDeepLinkFile.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openAiEditedFileByAbsolutePath } = vi.hoisted(() => ({
+    openAiEditedFileByAbsolutePath: vi.fn(),
+}));
+vi.mock("../ai/chatFileNavigation", () => ({
+    openAiEditedFileByAbsolutePath,
+}));
+
+import { useEditorStore } from "../../app/store/editorStore";
+import { useVaultStore, type NoteDto } from "../../app/store/vaultStore";
+import { openDeepLinkFile } from "./openDeepLinkFile";
+
+function setNotes(notes: Array<{ id: string; path: string }>) {
+    useVaultStore.setState({ notes: notes as unknown as NoteDto[] });
+}
+
+beforeEach(() => {
+    useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+    useEditorStore.getState().clearPendingLineReveal();
+    openAiEditedFileByAbsolutePath.mockReset().mockResolvedValue(true);
+});
+
+describe("openDeepLinkFile", () => {
+    it("rejects an empty path", async () => {
+        expect(
+            await openDeepLinkFile({ path: " ", line: null, endLine: null }),
+        ).toBe("invalid");
+        expect(openAiEditedFileByAbsolutePath).not.toHaveBeenCalled();
+    });
+
+    it("reports when no vault is open", async () => {
+        useVaultStore.setState({ vaultPath: null });
+        expect(
+            await openDeepLinkFile({ path: "a.md", line: null, endLine: null }),
+        ).toBe("no-vault");
+        expect(openAiEditedFileByAbsolutePath).not.toHaveBeenCalled();
+    });
+
+    it("rejects absolute paths outside the vault", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "/etc/passwd",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("outside-vault");
+        expect(openAiEditedFileByAbsolutePath).not.toHaveBeenCalled();
+    });
+
+    it("rejects relative traversal that escapes the vault", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "../secret.txt",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("outside-vault");
+        expect(openAiEditedFileByAbsolutePath).not.toHaveBeenCalled();
+    });
+
+    it("rejects absolute traversal that escapes the vault", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "/vault/../etc/passwd",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("outside-vault");
+        expect(openAiEditedFileByAbsolutePath).not.toHaveBeenCalled();
+    });
+
+    it("collapses harmless . / .. segments that stay inside the vault", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "notes/../a.md",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("opened");
+        expect(openAiEditedFileByAbsolutePath).toHaveBeenCalledWith("/vault/a.md");
+    });
+
+    it("resolves a relative path against the vault root and opens it", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "notes/a.md",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("opened");
+        expect(openAiEditedFileByAbsolutePath).toHaveBeenCalledWith(
+            "/vault/notes/a.md",
+        );
+    });
+
+    it("accepts an absolute path inside the vault", async () => {
+        expect(
+            await openDeepLinkFile({
+                path: "/vault/sub/x.md",
+                line: null,
+                endLine: null,
+            }),
+        ).toBe("opened");
+        expect(openAiEditedFileByAbsolutePath).toHaveBeenCalledWith(
+            "/vault/sub/x.md",
+        );
+    });
+
+    it("reports not-found when the file cannot be opened", async () => {
+        openAiEditedFileByAbsolutePath.mockResolvedValue(false);
+        expect(
+            await openDeepLinkFile({ path: "gone.md", line: null, endLine: null }),
+        ).toBe("not-found");
+    });
+
+    it("queues a line reveal for notes when a line is given", async () => {
+        setNotes([{ id: "note-1", path: "/vault/a.md" }]);
+        expect(
+            await openDeepLinkFile({ path: "a.md", line: 10, endLine: 20 }),
+        ).toBe("opened");
+        expect(useEditorStore.getState().pendingLineReveal).toEqual({
+            noteId: "note-1",
+            line: 10,
+            endLine: 20,
+        });
+    });
+
+    it("does not queue a line reveal without a line", async () => {
+        setNotes([{ id: "note-1", path: "/vault/a.md" }]);
+        await openDeepLinkFile({ path: "a.md", line: null, endLine: null });
+        expect(useEditorStore.getState().pendingLineReveal).toBeNull();
+    });
+
+    it("does not queue a line reveal for a non-note file", async () => {
+        // `a.txt` is not in the notes list, so a line fragment is a no-op.
+        await openDeepLinkFile({ path: "a.txt", line: 10, endLine: null });
+        expect(useEditorStore.getState().pendingLineReveal).toBeNull();
+    });
+});

--- a/apps/desktop/src/features/deep-link/openDeepLinkFile.ts
+++ b/apps/desktop/src/features/deep-link/openDeepLinkFile.ts
@@ -1,0 +1,85 @@
+import { useEditorStore } from "../../app/store/editorStore";
+import { useVaultStore } from "../../app/store/vaultStore";
+import {
+    normalizeVaultPath,
+    resolveVaultAbsolutePath,
+    toVaultRelativePath,
+} from "../../app/utils/vaultPaths";
+import { openAiEditedFileByAbsolutePath } from "../ai/chatFileNavigation";
+
+/**
+ * Collapse `.` and `..` segments so the vault-boundary check below cannot be
+ * fooled by traversal like `../secret.txt` (which would otherwise keep the
+ * `/vault/` prefix and slip past a plain string comparison).
+ */
+function collapseTraversal(path: string): string {
+    const normalized = normalizeVaultPath(path);
+    const isAbsolute = normalized.startsWith("/");
+    const out: string[] = [];
+    for (const segment of normalized.split("/")) {
+        if (segment === "" || segment === ".") continue;
+        if (segment === "..") {
+            out.pop();
+            continue;
+        }
+        out.push(segment);
+    }
+    return (isAbsolute ? "/" : "") + out.join("/");
+}
+
+export interface DeepLinkOpenFilePayload {
+    path: string;
+    line: number | null;
+    endLine: number | null;
+}
+
+export type DeepLinkOpenResult =
+    | "opened"
+    | "invalid"
+    | "no-vault"
+    | "outside-vault"
+    | "not-found";
+
+/**
+ * Resolve a `neverwrite://open?path=...` deep link against the open vault and
+ * open the file if it is a legitimate vault member.
+ *
+ * Security boundary (see issue #289): this only opens or reveals an existing
+ * file inside the current vault. Absolute paths are accepted only when they
+ * resolve inside the vault root; relative paths resolve against that root.
+ * No writes, no shell/open-external behavior.
+ */
+export async function openDeepLinkFile(
+    payload: DeepLinkOpenFilePayload,
+): Promise<DeepLinkOpenResult> {
+    const path = payload.path?.trim();
+    if (!path) return "invalid";
+
+    const vaultPath = useVaultStore.getState().vaultPath;
+    if (!vaultPath) return "no-vault";
+
+    const absPath = collapseTraversal(resolveVaultAbsolutePath(path, vaultPath));
+    if (toVaultRelativePath(absPath, vaultPath) === null) {
+        return "outside-vault";
+    }
+
+    // Capture the note (if any) before opening so we can queue a line reveal
+    // once the tab is active. Match on the normalized path so notes resolve on
+    // Windows too, where `note.path` uses backslashes.
+    const note = useVaultStore
+        .getState()
+        .notes.find((entry) => normalizeVaultPath(entry.path) === absPath);
+
+    const opened = await openAiEditedFileByAbsolutePath(absPath);
+    if (!opened) return "not-found";
+
+    if (note && payload.line) {
+        useEditorStore.getState().queueLineReveal({
+            noteId: note.id,
+            line: payload.line,
+            endLine: payload.endLine ?? null,
+        });
+    }
+
+    return "opened";
+}

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -486,6 +486,10 @@ export function Editor({
     const clearPendingSelectionReveal = useEditorStore(
         (s) => s.clearPendingSelectionReveal,
     );
+    const pendingLineReveal = useEditorStore((s) => s.pendingLineReveal);
+    const clearPendingLineReveal = useEditorStore(
+        (s) => s.clearPendingLineReveal,
+    );
     const updateTabContent = useEditorStore((s) => s.updateTabContent);
     const updateTabTitle = useEditorStore((s) => s.updateTabTitle);
     const clearNoteExternalConflict = useEditorStore(
@@ -3881,6 +3885,34 @@ export function Editor({
         view.focus();
         clearPendingSelectionReveal();
     }, [activeTab, pendingSelectionReveal, clearPendingSelectionReveal]);
+
+    // Jump to a 1-based line (optionally selecting through an end line) after a
+    // deep link like `neverwrite://open?path=note.md#L10-L20` opens the note.
+    useEffect(() => {
+        const view = viewRef.current;
+        if (!view || !activeTab || !pendingLineReveal) return;
+        if (pendingLineReveal.noteId !== activeTab.noteId) return;
+
+        const lineCount = view.state.doc.lines;
+        const startLineNumber = Math.max(
+            1,
+            Math.min(pendingLineReveal.line, lineCount),
+        );
+        const endLineNumber = Math.max(
+            startLineNumber,
+            Math.min(pendingLineReveal.endLine ?? startLineNumber, lineCount),
+        );
+        const startLine = view.state.doc.line(startLineNumber);
+        const endLine = view.state.doc.line(endLineNumber);
+
+        view.dispatch({
+            selection: { anchor: startLine.from, head: endLine.to },
+            effects: EditorView.scrollIntoView(startLine.from, { y: "center" }),
+        });
+        flashLine(view, startLine.from);
+        view.focus();
+        clearPendingLineReveal();
+    }, [activeTab, pendingLineReveal, clearPendingLineReveal]);
 
     // Keyboard shortcuts
     useEffect(() => {

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ polish and hardening.
 - [Contributing](../CONTRIBUTING.md): contributor workflow, code style, testing expectations, versioning, and release preparation.
 - [Project Architecture](project-architecture.md): high-level map of the monorepo, Electron runtime, IPC boundaries, Rust sidecar, shared crates, web clipper, ACP runtimes, and major data flows.
 - [Testing and Validation](testing.md): the command matrix for Rust, desktop, Electron smoke tests, web clipper checks, CI parity, and area-specific validation.
+- [Deep Links](deep-links.md): `neverwrite://open` and `neverwrite://clip` behavior, path safety boundaries, line fragments, platform delivery, and manual QA notes.
 - [Settings Scope](settings-scope.md): inventory of global, per-vault, and mixed-scope settings, preferences, local UI state, migrations, and storage keys.
 
 ## AI And Change Control
@@ -52,4 +53,4 @@ tokens, provider credentials, or personally sensitive paths.
 These currently live next to their implementation/release artifacts because
 they are tightly coupled to package-specific workflows.
 
-Last updated: July 3, 2026.
+Last updated: July 6, 2026.

--- a/docs/deep-links.md
+++ b/docs/deep-links.md
@@ -1,0 +1,135 @@
+# Deep Links
+
+NeverWrite registers the `neverwrite` custom URI scheme in packaged desktop
+builds. Deep links are handled by Electron main, then routed through renderer
+runtime events so vault-aware behavior remains inside the app UI.
+
+## Supported Actions
+
+### `neverwrite://open`
+
+Open an existing file in the currently open vault:
+
+```text
+neverwrite://open?path=<url-encoded-vault-path>
+```
+
+NeverWrite also accepts the authority-less form:
+
+```text
+neverwrite:open?path=<url-encoded-vault-path>
+```
+
+The `path` parameter can be:
+
+- A path relative to the current vault root.
+- An absolute path, only if it resolves inside the current vault root.
+
+This action is open/reveal only. It must not create files, write to the vault,
+launch shell commands, or open arbitrary external paths.
+
+### `neverwrite://clip`
+
+The web clipper fallback uses `neverwrite://clip` when the loopback desktop API
+is unavailable. The clipper flow keeps its existing required parameters and
+runtime behavior. Prefer the direct desktop API while debugging clip saving; use
+deep links to isolate fallback and OS registration issues.
+
+## Line Fragments
+
+`neverwrite://open` supports optional line fragments for text notes:
+
+```text
+#L10
+#L10-L20
+#L10-20
+```
+
+When the target is a note, NeverWrite opens the note, centers the start line,
+selects the requested range when present, focuses the editor, and briefly
+flashes the line. Non-note files can still open, but line fragments are ignored.
+
+Line fragments are normally URL fragments:
+
+```bash
+open 'neverwrite://open?path=notes/todo.md#L10-L20'
+```
+
+NeverWrite also tolerates a fragment percent-encoded into the `path` value:
+
+```bash
+open 'neverwrite://open?path=notes%2Ftodo.md%23L10'
+```
+
+Filenames that merely contain `#L<digit>` are not truncated unless the suffix is
+a complete line fragment.
+
+## Security Boundary
+
+Deep-link open requests are resolved against the currently open vault:
+
+- Relative paths resolve under the current vault root.
+- Absolute paths are accepted only when they are inside the current vault root.
+- `.` and `..` traversal segments are collapsed before the vault-boundary check.
+- Requests with no open vault, missing paths, paths outside the vault, or files
+  that cannot be found show a notice instead of opening anything.
+
+Examples that should be blocked:
+
+```bash
+open 'neverwrite://open?path=../secret.txt'
+open 'neverwrite://open?path=/etc/passwd'
+open 'neverwrite://open?path=/path/outside/vault/outside.md'
+```
+
+Examples that can be valid when the resulting file stays inside the vault:
+
+```bash
+open 'neverwrite://open?path=notes/../todo.md'
+open 'neverwrite://open?path=/path/to/vault/notes/todo.md#L5'
+```
+
+## Platform Delivery
+
+macOS delivers custom URI activations through Electron's `open-url` event.
+Windows and Linux deliver activations through a second app instance and command
+line arguments. Both paths route through the same dispatcher.
+
+Packaged builds register the scheme with the OS. Pure development sessions do
+not reliably validate OS-level scheme handling on macOS because Launch Services
+may point `neverwrite://` at another installed build or at Electron itself. For
+manual QA of a local packaged app, force the target app:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md'
+```
+
+If Launch Services has stale registration data, re-register the build:
+
+```bash
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /path/to/NeverWrite.app
+```
+
+## Manual Examples
+
+With a vault open:
+
+```bash
+open 'neverwrite://open?path=notes/todo.md'
+open 'neverwrite://open?path=Daily%20Notes%2F2026-07-06.md'
+open 'neverwrite://open?path=notes/todo.md#L20'
+open 'neverwrite://open?path=notes/todo.md#L10-L20'
+open 'neverwrite:open?path=notes/todo.md'
+```
+
+For a local QA build, prefer:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md#L10-L20'
+```
+
+When a command succeeds, there is no success toast. The expected result is that
+the target tab opens or becomes active, and line fragments reveal the requested
+line or range.
+
+Last updated: July 6, 2026.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -126,6 +126,62 @@ NEVERWRITE_ELECTRON_DIST_ARCH=x64
 
 For custom paths, use `NEVERWRITE_PACKAGED_APP_EXECUTABLE` or `NEVERWRITE_PACKAGED_SIDECAR_PATH`.
 
+## Deep Link QA
+
+Use this checklist when changing Electron app identity, URI registration,
+deep-link dispatch, web clipper fallback behavior, vault path resolution, or
+editor reveal behavior. See [Deep Links](deep-links.md) for the full contract.
+
+Deep-link QA should use a packaged app, not a pure `npm run dev` session. On
+macOS, Launch Services can keep stale `neverwrite://` registrations, so force
+the exact app under test:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md'
+```
+
+If the wrong app opens, re-register the app:
+
+```bash
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /path/to/NeverWrite.app
+```
+
+With a known test vault open, validate successful opens:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=Daily%20Notes%2F2026-07-06.md'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=projects/spec.md'
+open -a /path/to/NeverWrite.app 'neverwrite:open?path=notes/todo.md'
+```
+
+Validate line reveal and range selection:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md#L20'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md#L10-L20'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=projects/spec.md#L30-L45'
+```
+
+Validate absolute paths inside the vault and traversal that stays inside:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=/path/to/vault/notes/todo.md'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=projects/drafts/../../notes/todo.md#L5'
+```
+
+Validate blocked requests. These should show a notice and must not open
+external files:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=missing.md'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=../secret.txt'
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=/etc/passwd'
+```
+
+Also verify that `neverwrite://clip` still routes to the existing web clipper
+fallback flow when the extension cannot use the loopback desktop API.
+
 ## Web Clipper
 
 The web clipper is an isolated WXT app. Do not run `npm install` here.
@@ -209,4 +265,4 @@ Desktop release validation lives in [`.github/workflows/release-desktop.yml`](..
 - If a packaged sidecar smoke fails after packaging changes, verify that the native backend was staged into the expected `resources/native-backend` location and has executable permissions on macOS/Linux.
 - If local web clipper requests are blocked, confirm the desktop app is running, the extension is calling `127.0.0.1:32145`, and `NEVERWRITE_WEB_CLIPPER_DEV_ORIGINS` contains the exact unpacked extension origin.
 
-Last updated: June 12, 2026.
+Last updated: July 6, 2026.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -9,6 +9,7 @@ or updater.
 Related references:
 
 - [App logs](app-logs.md)
+- [Deep Links](deep-links.md)
 - [AI runtime setup](ai-runtime-setup.md)
 - [AI session history and crash recovery](ai-session-history.md)
 - [Data and privacy](data-and-privacy.md)
@@ -246,20 +247,58 @@ pnpm run check
 
 ## Custom URI And Deep Links
 
-When the desktop API is unavailable, the extension can fall back to
-`neverwrite://clip` deep links. Current limitations:
+NeverWrite supports `neverwrite://clip` for web clipper fallback and
+`neverwrite://open?path=...` for opening an existing file in the currently open
+vault. See [Deep Links](deep-links.md) for the full behavior and security
+boundary.
 
-- Deep links require the installed app to have registered the `neverwrite://`
-  scheme with the OS.
-- On macOS, `npm run dev` does not register custom URI schemes, so browser
-  fallback cannot be validated end-to-end against a pure dev session there.
-- The desktop handler only supports `neverwrite://clip` with required
-  `requestId`, `title`, `folder`, and `mode` parameters.
-- Supported modes are `inline` and `clipboard`.
-- Clipboard mode uses the system clipboard as a temporary handoff, so clipped
-  content may briefly be visible to clipboard managers.
+Deep links require the installed app to have registered the `neverwrite://`
+scheme with the OS. On macOS, `npm run dev` does not reliably validate custom
+URI handling because Launch Services may route `neverwrite://` to another
+installed build or to Electron itself.
 
-Prefer the direct desktop API while debugging save behavior; use deep links only
+If a deep link opens Electron's default welcome screen, the scheme is registered
+to the generic Electron binary or another stale handler. Re-register the
+packaged app:
+
+```bash
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -f /path/to/NeverWrite.app
+```
+
+For local QA, force the app explicitly:
+
+```bash
+open -a /path/to/NeverWrite.app 'neverwrite://open?path=notes/todo.md'
+```
+
+If the app shows:
+
+```text
+That file could not be found in the current vault.
+```
+
+the deep link reached NeverWrite, but the currently open vault does not contain
+that path or the vault index cannot resolve it yet. Confirm that the intended
+vault is open, wait for indexing to finish, then try a path visible in the file
+tree.
+
+If the app shows:
+
+```text
+This file is outside the currently open vault.
+```
+
+the safety boundary is working. The path resolved outside the active vault root,
+usually because the link used an absolute path for another vault or a `..`
+traversal escaped the vault.
+
+For `neverwrite://clip`, the handler still expects the web clipper fallback
+parameters, including `requestId`, `title`, `folder`, and `mode`. Supported
+modes are `inline` and `clipboard`. Clipboard mode uses the system clipboard as
+a temporary handoff, so clipped content may briefly be visible to clipboard
+managers.
+
+Prefer the direct desktop API while debugging clip-save behavior; use deep links
 to isolate fallback and OS registration issues.
 
 ## Vault Opening, Indexing, And Filesystem Issues


### PR DESCRIPTION
Closes #289.

## What

Adds a generic `neverwrite://` deep-link dispatcher and a new `neverwrite://open?path=<url-encoded-path>` action to open a specific vault file. The existing `neverwrite://clip` web-clipper flow is routed through the dispatcher **unchanged**.

The authority-less form `neverwrite:open?path=...` is also accepted (common in hand-written links).

## Security boundary

Open/reveal only, as requested in the issue. No writes, no shell/open-external.

- Relative paths resolve against the currently open vault.
- Absolute paths are accepted **only** when they resolve inside the vault root.
- `.`/`..` traversal is collapsed and rejected if it escapes the vault.
- A notice is shown when no vault is open, the path is outside the vault, or the file can't be found.

## Line fragments

Optional `#L10` / `#L10-L20` (and `#L10-20`) fragments jump to, select, center, and briefly flash the line(s) for notes, consistent with the AI attachment URI shape.

## Platforms

Handled via macOS `open-url` and Windows/Linux `second-instance` argv, both routed through the same dispatcher.

## Tests

- Parser/dispatcher unit tests (`deepLink.test.ts`): both scheme forms, line fragments (single/range/L-prefixed), fragment percent-encoded into the path, filename that merely contains `#L<digit>` (not truncated), rejection of missing path / wrong action / wrong scheme, argv extraction, clip routing, and the pending-queue flush.
- Renderer resolution unit tests (`openDeepLinkFile.test.ts`): no-vault, outside-vault, relative/absolute traversal escapes, harmless `..` collapse, relative + absolute inside-vault open, not-found, and line-reveal queuing (notes only).

## Known follow-ups (out of scope)

Documented in code as edge cases matching existing shared patterns:
- Guaranteed cold-start delivery (renderer-pull handshake) — the web clipper has the same limitation today.
- Windows drive-letter case sensitivity in the boundary check.
- Delivery when only a non-main window is focused.

## Manual test

With a vault open:

```
open 'neverwrite://open?path=notes/todo.md#L10-L20'   # opens + jumps
open 'neverwrite:open?path=notes/todo.md'             # authority-less form
open 'neverwrite://open?path=/etc/passwd'             # notice: outside vault
open 'neverwrite://open?path=../secret.txt'           # notice: traversal blocked
open 'neverwrite://open?path=notes/missing.md'        # notice: not found
```
With no vault open, any `open` link shows an "Open a vault first" notice. The web-clipper flow is unchanged.