### PR TITLE
Add OKF document status support in file tree and editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NeverWrite is a local-first knowledge workspace for people who need to handle wo
 Today the repository combines:
 
 - An Electron desktop app with a Rust sidecar that opens a local vault and keeps working state on disk.
-- A Markdown, CSV, Mermaid, and text/code editing workflow with wikilinks, live preview, frontmatter editing, spellcheck, and grammar checking.
+- A Markdown, CSV, Mermaid, and text/code editing workflow with wikilinks, live preview, frontmatter editing, OKF document status hints, spellcheck, and grammar checking.
 - Knowledge navigation tools such as backlinks, tags, advanced search, bookmarks, concept maps, and a 2D/3D graph view.
 - An ACP-based AI layer with Codex, Claude, Grok, Kilo, and OpenCode runtimes.
 - An explicit AI change-review system with inline review inside the editor and a dedicated surface in chat and a tab with changes pending approval.
@@ -39,6 +39,7 @@ The current product already includes:
 Saved AI conversations are stored locally under each vault's hidden `.neverwrite/sessions/` directory.
 See [AI session history and crash recovery](docs/ai-session-history.md) for the disk layout and recovery flow.
 NeverWrite also writes local diagnostic logs under the app data `logs/` directory; see [App logs](docs/app-logs.md) for platform-specific paths and privacy notes.
+NeverWrite has partial Open Knowledge Format support for `status`, `type`, and vault-level `okf_version`; see [Open Knowledge Format (OKF)](docs/okf.md).
 
 ## Why It Is Different
 
@@ -68,6 +69,7 @@ NeverWrite also writes local diagnostic logs under the app data `logs/` director
 - Wikilink suggestions, resolution, and navigation
 - Live preview with tasks, tables, embeds, math, Mermaid diagrams, and YouTube previews
 - Frontmatter/properties editing
+- OKF-style document status support with editor badges, trust banners, and file tree dots
 - Mermaid diagram files with source editing and preview switching
 - CSV editing with table and raw fallback views
 - Editable text/code files with syntax highlighting and autosave

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -25,7 +25,8 @@ use neverwrite_types::{
     VaultOpenStateDto, WikilinkSuggestionDto,
 };
 use neverwrite_vault::{
-    normalize_existing_vault_path, start_watcher, ScopedPathIntent, Vault, VaultEvent, WriteTracker,
+    normalize_existing_vault_path, parser::frontmatter_string_field, start_watcher,
+    ScopedPathIntent, Vault, VaultEvent, WriteTracker,
 };
 use notify::RecommendedWatcher;
 use serde::{Deserialize, Serialize};
@@ -1339,6 +1340,7 @@ impl NativeBackend {
         let scan_ms = now_ms().saturating_sub(scan_started_at);
         let note_count = index.metadata.len();
         let entry_count = entries.len();
+        let okf_version = vault.detect_okf_version();
         let write_tracker = WriteTracker::new();
         let watcher = start_vault_watcher(&root, write_tracker.clone(), backend_ref)?;
 
@@ -1367,6 +1369,7 @@ impl NativeBackend {
                         snapshot_save_ms: 0,
                     },
                     error: None,
+                    okf_version,
                 },
                 graph_revision: 1,
                 note_revisions: HashMap::new(),
@@ -2475,6 +2478,7 @@ fn cancelled_placeholder_state(root: String) -> VaultRuntimeState {
             finished_at_ms: Some(now_ms()),
             metrics: empty_metrics(),
             error: None,
+            okf_version: None,
         },
         graph_revision: 1,
         note_revisions: HashMap::new(),
@@ -2498,6 +2502,7 @@ fn idle_open_state() -> VaultOpenStateDto {
         finished_at_ms: None,
         metrics: empty_metrics(),
         error: None,
+        okf_version: None,
     }
 }
 
@@ -2782,6 +2787,8 @@ fn note_to_dto(note: &NoteMetadata) -> NoteDto {
         title: note.title.clone(),
         modified_at: note.modified_at,
         created_at: note.created_at,
+        status: note.status.clone(),
+        okf_type: note.okf_type.clone(),
     }
 }
 
@@ -2793,6 +2800,8 @@ fn note_document_to_dto(note: &NoteDocument) -> NoteDto {
         title: note.title.clone(),
         modified_at,
         created_at,
+        status: frontmatter_string_field(note.frontmatter.as_ref(), "status"),
+        okf_type: frontmatter_string_field(note.frontmatter.as_ref(), "type"),
     }
 }
 
@@ -2961,6 +2970,10 @@ impl VaultNoteChangeInput {
 }
 
 fn build_vault_note_change(input: VaultNoteChangeInput) -> VaultNoteChangeDto {
+    // Mirror the changed note's frontmatter-derived fields at the top level so
+    // the file tree can react to status/type changes without inspecting `note`.
+    let status = input.note.as_ref().and_then(|note| note.status.clone());
+    let okf_type = input.note.as_ref().and_then(|note| note.okf_type.clone());
     VaultNoteChangeDto {
         vault_path: input.vault_path,
         kind: input.kind,
@@ -2968,6 +2981,8 @@ fn build_vault_note_change(input: VaultNoteChangeInput) -> VaultNoteChangeDto {
         note_id: input.note_id,
         entry: input.entry,
         relative_path: input.relative_path,
+        status,
+        okf_type,
         origin: input.origin,
         op_id: input.op_id,
         revision: input.revision,
@@ -3491,6 +3506,7 @@ mod tests {
                     finished_at_ms: None,
                     metrics: empty_metrics(),
                     error: None,
+                    okf_version: None,
                 },
                 graph_revision: 1,
                 note_revisions: HashMap::new(),
@@ -3524,6 +3540,74 @@ mod tests {
         assert_eq!(
             text_change.get("content_hash").and_then(Value::as_str),
             Some(expected_text_hash.as_str())
+        );
+    }
+
+    #[test]
+    fn exposes_status_okf_type_and_okf_version() {
+        let (event_tx, event_rx) = mpsc::channel::<RpcOutput>();
+        let backend = Arc::new(Mutex::new(NativeBackend::new(event_tx)));
+        let vault_dir = tempfile::tempdir().unwrap();
+        // Bundle-root index.md declaring the OKF version.
+        fs::write(
+            vault_dir.path().join("index.md"),
+            "---\nokf_version: \"0.1\"\n---\n# Root\n",
+        )
+        .unwrap();
+        let notes_dir = vault_dir.path().join("Notes");
+        fs::create_dir_all(&notes_dir).unwrap();
+        fs::write(
+            notes_dir.join("A.md"),
+            "---\nstatus: draft\ntype: article\n---\n# Alpha\n",
+        )
+        .unwrap();
+
+        let vault_path = vault_dir.path().to_string_lossy().to_string();
+        invoke(&backend, "start_open_vault", json!({ "path": vault_path })).unwrap();
+
+        // okf_version surfaces on the vault-open state DTO.
+        let open_state = invoke(
+            &backend,
+            "get_vault_open_state",
+            json!({ "vaultPath": vault_path }),
+        )
+        .unwrap();
+        assert_eq!(
+            open_state.get("okf_version").and_then(Value::as_str),
+            Some("0.1")
+        );
+
+        // list_notes carries status + okf_type per note.
+        let notes = invoke(&backend, "list_notes", json!({ "vaultPath": vault_path })).unwrap();
+        let note_a = notes
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|note| note.get("id").and_then(Value::as_str) == Some("Notes/A"))
+            .expect("note A present");
+        assert_eq!(note_a.get("status").and_then(Value::as_str), Some("draft"));
+        assert_eq!(note_a.get("okf_type").and_then(Value::as_str), Some("article"));
+
+        // Editing the status produces a change event carrying the new value.
+        invoke(
+            &backend,
+            "save_note",
+            json!({
+                "vaultPath": vault_path,
+                "noteId": "Notes/A",
+                "content": "---\nstatus: published\ntype: article\n---\n# Alpha\n",
+            }),
+        )
+        .unwrap();
+        let change = recv_vault_change(&event_rx);
+        assert_eq!(change.get("status").and_then(Value::as_str), Some("published"));
+        assert_eq!(change.get("okf_type").and_then(Value::as_str), Some("article"));
+        assert_eq!(
+            change
+                .get("note")
+                .and_then(|note| note.get("status"))
+                .and_then(Value::as_str),
+            Some("published")
         );
     }
 }

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -2814,6 +2814,8 @@ fn note_to_detail(note: &NoteDocument) -> NoteDetailDto {
         tags: note.tags.clone(),
         links: note.links.iter().map(|link| link.target.clone()).collect(),
         frontmatter: note.frontmatter.clone(),
+        status: frontmatter_string_field(note.frontmatter.as_ref(), "status"),
+        okf_type: frontmatter_string_field(note.frontmatter.as_ref(), "type"),
     }
 }
 
@@ -3588,8 +3590,11 @@ mod tests {
         assert_eq!(note_a.get("status").and_then(Value::as_str), Some("draft"));
         assert_eq!(note_a.get("okf_type").and_then(Value::as_str), Some("article"));
 
-        // Editing the status produces a change event carrying the new value.
-        invoke(
+        // Editing the status produces a change event carrying the new value,
+        // and the save_note RESPONSE carries it too. The response matters
+        // because the renderer ignores user-origin change events and updates
+        // its store from the response instead (Editor.tsx saveNow).
+        let detail = invoke(
             &backend,
             "save_note",
             json!({
@@ -3599,6 +3604,14 @@ mod tests {
             }),
         )
         .unwrap();
+        assert_eq!(
+            detail.get("status").and_then(Value::as_str),
+            Some("published")
+        );
+        assert_eq!(
+            detail.get("okf_type").and_then(Value::as_str),
+            Some("article")
+        );
         let change = recv_vault_change(&event_rx);
         assert_eq!(change.get("status").and_then(Value::as_str), Some("published"));
         assert_eq!(change.get("okf_type").and_then(Value::as_str), Some("article"));

--- a/apps/desktop/src-electron/main/ipc.ts
+++ b/apps/desktop/src-electron/main/ipc.ts
@@ -24,6 +24,7 @@ import {
     resolvePreviewFilePath,
 } from "./vaultBackend";
 import { createNativeBackendSidecar } from "./nativeBackend";
+import { getSystemUsername } from "./systemUser";
 import { ElectronAppUpdater } from "./updater";
 import { installWebClipperRuntime } from "./webClipper";
 
@@ -220,6 +221,12 @@ function registerInvokeHandler() {
         const envelope = asRecord(rawEnvelope) as Partial<IpcInvokeEnvelope>;
         if (typeof envelope.command !== "string" || !envelope.command) {
             throw new Error("Invalid invoke envelope.");
+        }
+        // System info commands are answered here at the IPC layer so they
+        // work identically whether a vault uses the native sidecar or the
+        // pure TS backend.
+        if (envelope.command === "get_system_username") {
+            return getSystemUsername();
         }
         return backend.invoke(envelope.command, asRecord(envelope.args));
     });

--- a/apps/desktop/src-electron/main/systemUser.test.ts
+++ b/apps/desktop/src-electron/main/systemUser.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+    getSystemUsername,
+    resetSystemUsernameCacheForTests,
+    resolveSystemUsername,
+} from "./systemUser";
+
+describe("resolveSystemUsername", () => {
+    it("prefers os.userInfo().username", () => {
+        expect(
+            resolveSystemUsername({ USER: "envuser" }, () => ({
+                username: "osuser",
+            })),
+        ).toBe("osuser");
+    });
+
+    it("trims the os username", () => {
+        expect(
+            resolveSystemUsername({}, () => ({ username: "  simon  " })),
+        ).toBe("simon");
+    });
+
+    it("falls back to USER when userInfo throws", () => {
+        expect(
+            resolveSystemUsername({ USER: "posixuser" }, () => {
+                throw new Error("no passwd entry");
+            }),
+        ).toBe("posixuser");
+    });
+
+    it("falls back to USERNAME (Windows) when USER is absent", () => {
+        expect(
+            resolveSystemUsername({ USERNAME: "winuser" }, () => {
+                throw new Error("no passwd entry");
+            }),
+        ).toBe("winuser");
+    });
+
+    it("falls back to env when the os username is empty", () => {
+        expect(
+            resolveSystemUsername({ USER: "envuser" }, () => ({
+                username: "   ",
+            })),
+        ).toBe("envuser");
+    });
+
+    it("returns null when nothing is available", () => {
+        expect(
+            resolveSystemUsername({}, () => {
+                throw new Error("no passwd entry");
+            }),
+        ).toBeNull();
+        expect(
+            resolveSystemUsername({ USER: "  " }, () => ({ username: "" })),
+        ).toBeNull();
+    });
+});
+
+describe("getSystemUsername", () => {
+    afterEach(() => {
+        resetSystemUsernameCacheForTests();
+    });
+
+    it("returns a stable value across calls", () => {
+        const first = getSystemUsername();
+        expect(getSystemUsername()).toBe(first);
+        // On any real machine running the test suite this resolves.
+        expect(typeof first === "string" || first === null).toBe(true);
+    });
+});

--- a/apps/desktop/src-electron/main/systemUser.ts
+++ b/apps/desktop/src-electron/main/systemUser.ts
@@ -1,0 +1,45 @@
+import os from "node:os";
+
+/**
+ * Resolve the OS account name of the current user.
+ *
+ * Chain: `os.userInfo().username`, then the `USER` (POSIX) / `USERNAME`
+ * (Windows) environment variables, then `null`. `os.userInfo()` can throw on
+ * some systems (e.g. no entry in the password database), so the env fallback
+ * matters. Callers must treat `null` as "unknown" and omit the value rather
+ * than writing a placeholder.
+ */
+export function resolveSystemUsername(
+    env: Record<string, string | undefined> = process.env,
+    userInfo: () => { username: string } = () => os.userInfo(),
+): string | null {
+    try {
+        const name = userInfo().username;
+        if (typeof name === "string" && name.trim()) {
+            return name.trim();
+        }
+    } catch {
+        // Fall through to the environment variables.
+    }
+
+    const fallback = env.USER ?? env.USERNAME;
+    if (typeof fallback === "string" && fallback.trim()) {
+        return fallback.trim();
+    }
+
+    return null;
+}
+
+let cachedUsername: string | null | undefined;
+
+/** Cached variant used by the IPC layer; the username cannot change mid-run. */
+export function getSystemUsername(): string | null {
+    if (cachedUsername === undefined) {
+        cachedUsername = resolveSystemUsername();
+    }
+    return cachedUsername;
+}
+
+export function resetSystemUsernameCacheForTests() {
+    cachedUsername = undefined;
+}

--- a/apps/desktop/src-electron/main/vaultBackend.test.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.test.ts
@@ -226,4 +226,74 @@ describe("ElectronVaultBackend OKF frontmatter", () => {
         expect(saved.status).toBe("archived");
         expect(saved.okf_type).toBe("runbook");
     });
+
+    it("reads status and type from CRLF frontmatter", async () => {
+        const vaultPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), "neverwrite-okf-crlf-"),
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "crlf.md"),
+            "---\r\ntitle: Alpha\r\nstatus: published\r\ntype: runbook\r\n---\r\n\r\nBody\r\n",
+            "utf8",
+        );
+
+        const backend = new ElectronVaultBackend(vi.fn(), createUpdater(), null);
+        await backend.invoke("start_open_vault", { path: vaultPath });
+
+        const notes = (await backend.invoke("list_notes", {
+            vaultPath,
+        })) as Array<{
+            id: string;
+            title: string;
+            status: string | null;
+            okf_type: string | null;
+        }>;
+
+        const note = notes.find((candidate) => candidate.id === "crlf");
+        expect(note).toMatchObject({
+            title: "Alpha",
+            status: "published",
+            okf_type: "runbook",
+        });
+    });
+
+    it("detects okf_version from the vault-root index.md on open", async () => {
+        const vaultPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), "neverwrite-okf-version-"),
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "index.md"),
+            "---\nokf_version: \"0.1\"\n---\n\n# Bundle\n",
+            "utf8",
+        );
+
+        const backend = new ElectronVaultBackend(vi.fn(), createUpdater(), null);
+        await backend.invoke("start_open_vault", { path: vaultPath });
+
+        const openState = (await backend.invoke("get_vault_open_state", {
+            vaultPath,
+        })) as { stage: string; okf_version: string | null };
+        expect(openState.stage).toBe("ready");
+        expect(openState.okf_version).toBe("0.1");
+    });
+
+    it("reports a null okf_version for vaults without a root index.md declaration", async () => {
+        const vaultPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), "neverwrite-okf-none-"),
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "note.md"),
+            "# Plain vault\n",
+            "utf8",
+        );
+
+        const backend = new ElectronVaultBackend(vi.fn(), createUpdater(), null);
+        await backend.invoke("start_open_vault", { path: vaultPath });
+
+        const openState = (await backend.invoke("get_vault_open_state", {
+            vaultPath,
+        })) as { stage: string; okf_version: string | null };
+        expect(openState.stage).toBe("ready");
+        expect(openState.okf_version).toBeNull();
+    });
 });

--- a/apps/desktop/src-electron/main/vaultBackend.test.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.test.ts
@@ -166,3 +166,52 @@ describe("ElectronVaultBackend vault classification", () => {
         }
     });
 });
+
+describe("ElectronVaultBackend OKF frontmatter", () => {
+    it("reads status and type from note frontmatter for list_notes and read_note", async () => {
+        const vaultPath = await fs.mkdtemp(
+            path.join(os.tmpdir(), "neverwrite-okf-"),
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "with-meta.md"),
+            "---\ntitle: Alpha\nstatus: published\ntype: runbook\n---\n\nBody\n",
+            "utf8",
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "blank-status.md"),
+            "---\ntitle: Beta\nstatus:   \n---\n\nBody\n",
+            "utf8",
+        );
+        await fs.writeFile(
+            path.join(vaultPath, "no-meta.md"),
+            "# Gamma\n\nBody\n",
+            "utf8",
+        );
+
+        const backend = new ElectronVaultBackend(vi.fn(), createUpdater(), null);
+        await backend.invoke("start_open_vault", { path: vaultPath });
+
+        const notes = (await backend.invoke("list_notes", {
+            vaultPath,
+        })) as Array<{ id: string; status: string | null; okf_type: string | null }>;
+
+        const withMeta = notes.find((note) => note.id === "with-meta");
+        expect(withMeta).toMatchObject({
+            status: "published",
+            okf_type: "runbook",
+        });
+
+        const blank = notes.find((note) => note.id === "blank-status");
+        expect(blank).toMatchObject({ status: null, okf_type: null });
+
+        const noMeta = notes.find((note) => note.id === "no-meta");
+        expect(noMeta).toMatchObject({ status: null, okf_type: null });
+
+        const detail = (await backend.invoke("read_note", {
+            vaultPath,
+            noteId: "with-meta",
+        })) as { status: string | null; okf_type: string | null };
+        expect(detail.status).toBe("published");
+        expect(detail.okf_type).toBe("runbook");
+    });
+});

--- a/apps/desktop/src-electron/main/vaultBackend.test.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.test.ts
@@ -213,5 +213,17 @@ describe("ElectronVaultBackend OKF frontmatter", () => {
         })) as { status: string | null; okf_type: string | null };
         expect(detail.status).toBe("published");
         expect(detail.okf_type).toBe("runbook");
+
+        // The save_note response must carry the updated status too: the
+        // renderer ignores user-origin change events and syncs its store
+        // from this response.
+        const saved = (await backend.invoke("save_note", {
+            vaultPath,
+            noteId: "with-meta",
+            content:
+                "---\ntitle: Alpha\nstatus: archived\ntype: runbook\n---\n\nBody\n",
+        })) as { status: string | null; okf_type: string | null };
+        expect(saved.status).toBe("archived");
+        expect(saved.okf_type).toBe("runbook");
     });
 });

--- a/apps/desktop/src-electron/main/vaultBackend.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.ts
@@ -467,9 +467,9 @@ function entryKind(fileName: string, isDirectory: boolean): VaultEntryKind {
 }
 
 function deriveTitle(filePath: string, content: string) {
-    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-    if (frontmatterMatch) {
-        const titleMatch = frontmatterMatch[1]?.match(/^title:\s*(.+)$/m);
+    const frontmatter = extractFrontmatterBlock(content);
+    if (frontmatter !== null) {
+        const titleMatch = frontmatter.match(/^title:\s*(.+)$/m);
         const title = titleMatch?.[1]?.trim().replace(/^["']|["']$/g, "");
         if (title) return title;
     }
@@ -483,34 +483,55 @@ function deriveTitle(filePath: string, content: string) {
     return path.basename(filePath, path.extname(filePath)) || "Untitled";
 }
 
+// Accepts both LF and CRLF newlines around the `---` delimiters, matching the
+// Rust backend which parses CRLF frontmatter via serde_yaml.
+function extractFrontmatterBlock(content: string): string | null {
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    return match ? (match[1] ?? "") : null;
+}
+
 /**
- * Extract the OKF `status` and `type` frontmatter fields, mirroring the Rust
- * backend rules: only plain string scalars are accepted, values are trimmed,
- * and empty strings resolve to `null`. Non-scalar YAML (lists/maps/block
- * scalars) is treated as absent.
+ * Read a frontmatter field, mirroring the Rust backend rules: only plain
+ * string scalars are accepted, values are trimmed, and empty strings resolve
+ * to `null`. Non-scalar YAML (lists/maps/block scalars) is treated as absent.
  */
+function readFrontmatterStringField(body: string, key: string): string | null {
+    const match = body.match(new RegExp(`^${key}:[ \\t]*(.*)$`, "m"));
+    if (!match) return null;
+    let value = (match[1] ?? "").trim();
+    // Reject YAML non-scalar indicators (lists, maps, block scalars).
+    if (/^[[{|>&*!]/.test(value)) return null;
+    // Strip a single pair of surrounding quotes.
+    value = value.replace(/^["'](.*)["']$/, "$1").trim();
+    return value === "" ? null : value;
+}
+
+/** Extract the OKF `status` and `type` frontmatter fields. */
 function extractOkfMeta(content: string): {
     status: string | null;
     okf_type: string | null;
 } {
-    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
-    if (!frontmatterMatch) return { status: null, okf_type: null };
-
-    const body = frontmatterMatch[1] ?? "";
-    const readField = (key: string): string | null => {
-        const match = body.match(
-            new RegExp(`^${key}:[ \\t]*(.*)$`, "m"),
-        );
-        if (!match) return null;
-        let value = (match[1] ?? "").trim();
-        // Reject YAML non-scalar indicators (lists, maps, block scalars).
-        if (/^[[{|>&*!]/.test(value)) return null;
-        // Strip a single pair of surrounding quotes.
-        value = value.replace(/^["'](.*)["']$/, "$1").trim();
-        return value === "" ? null : value;
+    const body = extractFrontmatterBlock(content);
+    if (body === null) return { status: null, okf_type: null };
+    return {
+        status: readFrontmatterStringField(body, "status"),
+        okf_type: readFrontmatterStringField(body, "type"),
     };
+}
 
-    return { status: readField("status"), okf_type: readField("type") };
+/**
+ * Detect the OKF version declared by the vault-root `index.md`, mirroring the
+ * Rust `Vault::detect_okf_version`: only the root file is inspected, and only
+ * a non-empty string scalar counts.
+ */
+async function detectOkfVersion(root: string): Promise<string | null> {
+    const content = await fs
+        .readFile(path.join(root, "index.md"), "utf8")
+        .catch(() => null);
+    if (content === null) return null;
+    const body = extractFrontmatterBlock(content);
+    if (body === null) return null;
+    return readFrontmatterStringField(body, "okf_version");
 }
 
 function extractTags(content: string) {
@@ -1149,7 +1170,10 @@ export class ElectronVaultBackend {
         });
 
         try {
-            const snapshot = await scanVault(vaultPath);
+            const [snapshot, okfVersion] = await Promise.all([
+                scanVault(vaultPath),
+                detectOkfVersion(vaultPath),
+            ]);
             snapshots.set(vaultPath, snapshot);
             openStates.set(vaultPath, {
                 ...idleOpenState,
@@ -1159,6 +1183,7 @@ export class ElectronVaultBackend {
                 processed: snapshot.entries.length,
                 total: snapshot.entries.length,
                 note_count: snapshot.notes.length,
+                okf_version: okfVersion,
                 started_at_ms: started,
                 finished_at_ms: Date.now(),
                 metrics: {

--- a/apps/desktop/src-electron/main/vaultBackend.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.ts
@@ -18,6 +18,8 @@ interface NoteDto {
     title: string;
     modified_at: number;
     created_at: number;
+    status: string | null;
+    okf_type: string | null;
 }
 
 interface NoteDetailDto extends NoteDto {
@@ -72,6 +74,7 @@ interface VaultOpenState {
         snapshot_save_ms: number;
     };
     error: string | null;
+    okf_version: string | null;
 }
 
 interface SearchResultDto {
@@ -107,6 +110,8 @@ interface VaultNoteChange {
     revision: number;
     content_hash: string | null;
     graph_revision: number;
+    status: string | null;
+    okf_type: string | null;
 }
 
 const ignoredDirNames = new Set([
@@ -197,6 +202,7 @@ const idleOpenState: VaultOpenState = {
         snapshot_save_ms: 0,
     },
     error: null,
+    okf_version: null,
 };
 
 function normalizePathForDto(value: string) {
@@ -477,6 +483,36 @@ function deriveTitle(filePath: string, content: string) {
     return path.basename(filePath, path.extname(filePath)) || "Untitled";
 }
 
+/**
+ * Extract the OKF `status` and `type` frontmatter fields, mirroring the Rust
+ * backend rules: only plain string scalars are accepted, values are trimmed,
+ * and empty strings resolve to `null`. Non-scalar YAML (lists/maps/block
+ * scalars) is treated as absent.
+ */
+function extractOkfMeta(content: string): {
+    status: string | null;
+    okf_type: string | null;
+} {
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!frontmatterMatch) return { status: null, okf_type: null };
+
+    const body = frontmatterMatch[1] ?? "";
+    const readField = (key: string): string | null => {
+        const match = body.match(
+            new RegExp(`^${key}:[ \\t]*(.*)$`, "m"),
+        );
+        if (!match) return null;
+        let value = (match[1] ?? "").trim();
+        // Reject YAML non-scalar indicators (lists, maps, block scalars).
+        if (/^[[{|>&*!]/.test(value)) return null;
+        // Strip a single pair of surrounding quotes.
+        value = value.replace(/^["'](.*)["']$/, "$1").trim();
+        return value === "" ? null : value;
+    };
+
+    return { status: readField("status"), okf_type: readField("type") };
+}
+
 function extractTags(content: string) {
     return [
         ...new Set(
@@ -553,12 +589,15 @@ async function walkVault(root: string, dir = root): Promise<VaultEntryDto[]> {
 
 async function noteFromEntry(entry: VaultEntryDto): Promise<NoteDto> {
     const content = await fs.readFile(entry.path, "utf8").catch(() => "");
+    const okf = extractOkfMeta(content);
     return {
         id: entry.id,
         path: entry.path,
         title: deriveTitle(entry.path, content),
         modified_at: entry.modified_at,
         created_at: entry.created_at,
+        status: okf.status,
+        okf_type: okf.okf_type,
     };
 }
 
@@ -607,12 +646,15 @@ async function readNoteDetail(vaultPath: string, noteId: string): Promise<NoteDe
     const { absolutePath } = resolveVaultScopedPath(vaultPath, noteIdToRelativePath(noteId));
     const content = await fs.readFile(absolutePath, "utf8");
     const stat = await fs.stat(absolutePath);
+    const okf = extractOkfMeta(content);
     return {
         id: withoutExtension(normalizePathForDto(path.relative(toAbsoluteVaultPath(vaultPath), absolutePath))),
         path: absolutePath,
         title: deriveTitle(absolutePath, content),
         modified_at: Math.floor(stat.mtimeMs / 1000),
         created_at: Math.floor(stat.birthtimeMs / 1000),
+        status: okf.status,
+        okf_type: okf.okf_type,
         content,
         tags: extractTags(content),
         links: extractLinks(content),
@@ -658,6 +700,8 @@ function buildChange(args: {
         revision: nextRevision(args.vaultPath),
         content_hash: args.content == null ? null : contentHash(args.content),
         graph_revision: 1,
+        status: args.note?.status ?? null,
+        okf_type: args.note?.okf_type ?? null,
     };
 }
 

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -45,6 +45,9 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().fileTreeScale).toBe(114);
         expect(useSettingsStore.getState().agentsSidebarScale).toBe(100);
         expect(useSettingsStore.getState().fileTreeStickyFolders).toBe(true);
+        expect(useSettingsStore.getState().fileTreeShowDocumentStatus).toBe(
+            true,
+        );
         expect(useSettingsStore.getState().editorAutosaveDelayMs).toBe(300);
         expect(useSettingsStore.getState().fileTreeExtensionFilter).toEqual([]);
         expect(useSettingsStore.getState().vimModeEnabled).toBe(false);
@@ -149,6 +152,25 @@ describe("settingsStore", () => {
                 agentsSidebarScale: 125,
                 editorAutosaveDelayMs: 750,
             },
+        });
+    });
+
+    it("persists the document status toggle per vault", () => {
+        useVaultStore.setState({ vaultPath: "/vaults/okf" });
+
+        useSettingsStore
+            .getState()
+            .setSetting("fileTreeShowDocumentStatus", false);
+
+        expect(
+            useSettingsStore.getState().fileTreeShowDocumentStatus,
+        ).toBe(false);
+        expect(
+            JSON.parse(
+                localStorage.getItem("neverwrite:settings:/vaults/okf") ?? "",
+            ),
+        ).toMatchObject({
+            state: { fileTreeShowDocumentStatus: false },
         });
     });
 

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -52,6 +52,7 @@ export interface Settings {
     // Developers
     fileTreeContentMode: "notes_only" | "all_files";
     fileTreeShowExtensions: boolean;
+    fileTreeShowDocumentStatus: boolean;
     fileTreeExtensionFilter: string[];
 }
 
@@ -218,6 +219,7 @@ const defaults: Settings = {
     claudeCodeContinueSession: false,
     fileTreeContentMode: "notes_only",
     fileTreeShowExtensions: false,
+    fileTreeShowDocumentStatus: true,
     fileTreeExtensionFilter: [],
 };
 
@@ -561,6 +563,9 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             fileTreeShowExtensions:
                 parsed.state.fileTreeShowExtensions ??
                 defaults.fileTreeShowExtensions,
+            fileTreeShowDocumentStatus:
+                parsed.state.fileTreeShowDocumentStatus ??
+                defaults.fileTreeShowDocumentStatus,
             fileTreeExtensionFilter: normalizeFileTreeExtensionFilter(
                 parsed.state.fileTreeExtensionFilter,
             ),
@@ -640,6 +645,7 @@ function pickSettings(state: SettingsStore): Settings {
         claudeCodeContinueSession: state.claudeCodeContinueSession,
         fileTreeContentMode: state.fileTreeContentMode,
         fileTreeShowExtensions: state.fileTreeShowExtensions,
+        fileTreeShowDocumentStatus: state.fileTreeShowDocumentStatus,
         fileTreeExtensionFilter: state.fileTreeExtensionFilter,
     };
 }

--- a/apps/desktop/src/app/store/vaultStore.test.ts
+++ b/apps/desktop/src/app/store/vaultStore.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from "vitest";
 import { mockInvoke, setEditorTabs } from "../../test/test-utils";
 import { useBookmarkStore } from "./bookmarkStore";
 import { useEditorStore } from "./editorStore";
-import { useVaultStore, type VaultEntryDto } from "./vaultStore";
+import {
+    useVaultStore,
+    type VaultEntryDto,
+    type VaultNoteChange,
+} from "./vaultStore";
 
 function folderEntry(path: string): VaultEntryDto {
     const name = path.split("/").pop() ?? path;
@@ -39,7 +43,101 @@ function fileEntry(path: string): VaultEntryDto {
     };
 }
 
+function upsertChange(
+    note: {
+        id: string;
+        path: string;
+        title: string;
+        status?: string | null;
+        okf_type?: string | null;
+    },
+): VaultNoteChange {
+    return {
+        vault_path: "/vault",
+        kind: "upsert",
+        note: {
+            modified_at: 1,
+            created_at: 1,
+            ...note,
+        },
+        note_id: note.id,
+        entry: null,
+        relative_path: `${note.id}.md`,
+        origin: "external",
+        op_id: null,
+        revision: 1,
+        content_hash: null,
+        graph_revision: 0,
+        status: note.status ?? null,
+        okf_type: note.okf_type ?? null,
+    };
+}
+
 describe("vaultStore", () => {
+    it("updates a note's status and okf_type when a change event arrives", () => {
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [
+                {
+                    id: "notes/alpha",
+                    path: "/vault/notes/alpha.md",
+                    title: "Alpha",
+                    modified_at: 1,
+                    created_at: 1,
+                },
+            ],
+        });
+
+        const before = useVaultStore.getState().structureRevision;
+
+        useVaultStore.getState().applyVaultNoteChange(
+            upsertChange({
+                id: "notes/alpha",
+                path: "/vault/notes/alpha.md",
+                title: "Alpha",
+                status: "published",
+                okf_type: "runbook",
+            }),
+        );
+
+        const note = useVaultStore
+            .getState()
+            .notes.find((n) => n.id === "notes/alpha");
+        expect(note?.status).toBe("published");
+        expect(note?.okf_type).toBe("runbook");
+        // A status/type change must bump structureRevision so the tree
+        // rebuilds and its status dot updates live.
+        expect(useVaultStore.getState().structureRevision).toBe(before + 1);
+    });
+
+    it("sets okfVersion from the open state and resets it when switching vaults", async () => {
+        const invokeMock = mockInvoke();
+
+        const openStateFor = (okfVersion: string | null) =>
+            async (command: string) => {
+                if (command === "start_open_vault") return null;
+                if (command === "get_vault_open_state") {
+                    return {
+                        stage: "ready",
+                        message: "Vault ready",
+                        okf_version: okfVersion,
+                    };
+                }
+                if (command === "list_notes") return [];
+                if (command === "list_vault_entries") return [];
+                if (command === "get_graph_revision") return 1;
+                throw new Error(`Unexpected command: ${command}`);
+            };
+
+        invokeMock.mockImplementation(openStateFor("0.1.0"));
+        await useVaultStore.getState().openVault("/vault-okf");
+        expect(useVaultStore.getState().okfVersion).toBe("0.1.0");
+
+        invokeMock.mockImplementation(openStateFor(null));
+        await useVaultStore.getState().openVault("/vault-plain");
+        expect(useVaultStore.getState().okfVersion).toBeNull();
+    });
+
     it("normalizes Windows-style vault DTO paths when opening a vault", async () => {
         const invokeMock = mockInvoke();
 

--- a/apps/desktop/src/app/store/vaultStore.test.ts
+++ b/apps/desktop/src/app/store/vaultStore.test.ts
@@ -110,6 +110,55 @@ describe("vaultStore", () => {
         expect(useVaultStore.getState().structureRevision).toBe(before + 1);
     });
 
+    it("updates status via updateNoteMetadata and bumps only the structure revision", () => {
+        // Runtime sequence for an app-initiated save: the backend's change
+        // event has origin "user" and is ignored by the renderer, so the
+        // editor pushes status/okf_type from the save_note response through
+        // updateNoteMetadata. The tree rebuild is keyed on structureRevision;
+        // resolver/graph revisions must stay untouched for a status-only edit.
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [
+                {
+                    id: "notes/alpha",
+                    path: "/vault/notes/alpha.md",
+                    title: "Alpha",
+                    modified_at: 1,
+                    created_at: 1,
+                    status: "draft",
+                    okf_type: "runbook",
+                },
+            ],
+        });
+
+        const before = useVaultStore.getState();
+
+        useVaultStore.getState().updateNoteMetadata("notes/alpha", {
+            title: "Alpha",
+            path: "/vault/notes/alpha.md",
+            modified_at: 2,
+            status: "published",
+            okf_type: "runbook",
+        });
+
+        const after = useVaultStore.getState();
+        const note = after.notes.find((n) => n.id === "notes/alpha");
+        expect(note?.status).toBe("published");
+        expect(after.structureRevision).toBe(before.structureRevision + 1);
+        expect(after.resolverRevision).toBe(before.resolverRevision);
+        expect(after.graphRevision).toBe(before.graphRevision);
+
+        // Unchanged status must not churn the structure revision.
+        useVaultStore.getState().updateNoteMetadata("notes/alpha", {
+            modified_at: 3,
+            status: "published",
+            okf_type: "runbook",
+        });
+        expect(useVaultStore.getState().structureRevision).toBe(
+            before.structureRevision + 1,
+        );
+    });
+
     it("sets okfVersion from the open state and resets it when switching vaults", async () => {
         const invokeMock = mockInvoke();
 

--- a/apps/desktop/src/app/store/vaultStore.ts
+++ b/apps/desktop/src/app/store/vaultStore.ts
@@ -142,6 +142,22 @@ function didStructureMetadataChange(
     );
 }
 
+function didMetadataStatusOrTypeChange(
+    previousNotes: NoteDto[],
+    noteId: string,
+    patch: Partial<Pick<NoteDto, "status" | "okf_type">>,
+) {
+    const previous = previousNotes.find((note) => note.id === noteId);
+    if (!previous) return false;
+
+    return (
+        (patch.status !== undefined &&
+            (patch.status ?? null) !== (previous.status ?? null)) ||
+        (patch.okf_type !== undefined &&
+            (patch.okf_type ?? null) !== (previous.okf_type ?? null))
+    );
+}
+
 function didNoteStatusOrTypeChange(
     previousNotes: NoteDto[],
     change: VaultNoteChange,
@@ -469,7 +485,15 @@ interface VaultStore {
     updateNoteMetadata: (
         noteId: string,
         patch: Partial<
-            Pick<NoteDto, "title" | "path" | "modified_at" | "created_at">
+            Pick<
+                NoteDto,
+                | "title"
+                | "path"
+                | "modified_at"
+                | "created_at"
+                | "status"
+                | "okf_type"
+            >
         >,
     ) => void;
 }
@@ -1083,14 +1107,23 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
                 noteId,
                 patch,
             );
+            // Status/type changes only affect presentation (file tree dot),
+            // so they bump structureRevision — which the tree rebuild is keyed
+            // on — but not the resolver/graph revisions.
+            const statusOrTypeChanged = didMetadataStatusOrTypeChange(
+                s.notes,
+                noteId,
+                patch,
+            );
 
             return {
                 notes: s.notes.map((n) =>
                     n.id === noteId ? { ...n, ...patch } : n,
                 ),
-                structureRevision: structureChanged
-                    ? s.structureRevision + 1
-                    : s.structureRevision,
+                structureRevision:
+                    structureChanged || statusOrTypeChanged
+                        ? s.structureRevision + 1
+                        : s.structureRevision,
                 resolverRevision: structureChanged
                     ? s.resolverRevision + 1
                     : s.resolverRevision,

--- a/apps/desktop/src/app/store/vaultStore.ts
+++ b/apps/desktop/src/app/store/vaultStore.ts
@@ -23,6 +23,10 @@ export interface NoteDto {
     title: string;
     modified_at: number;
     created_at: number;
+    /** OKF document status from frontmatter (`status`), verbatim string or null. */
+    status?: string | null;
+    /** OKF document type from frontmatter (`type`), verbatim string or null. */
+    okf_type?: string | null;
 }
 
 export interface VaultEntryDto {
@@ -80,6 +84,8 @@ export interface VaultOpenState {
     finished_at_ms: number | null;
     metrics: VaultOpenMetrics;
     error: string | null;
+    /** OKF version detected in the vault root index.md (null when not an OKF vault). */
+    okf_version: string | null;
 }
 
 export type VaultChangeOrigin =
@@ -101,6 +107,8 @@ export interface VaultNoteChange {
     revision: number;
     content_hash: string | null;
     graph_revision: number;
+    status?: string | null;
+    okf_type?: string | null;
 }
 
 function didResolverStructureChange(
@@ -134,6 +142,21 @@ function didStructureMetadataChange(
     );
 }
 
+function didNoteStatusOrTypeChange(
+    previousNotes: NoteDto[],
+    change: VaultNoteChange,
+) {
+    if (change.kind === "delete" || !change.note) return false;
+
+    const previous = previousNotes.find((note) => note.id === change.note!.id);
+    if (!previous) return change.note.status != null || change.note.okf_type != null;
+
+    return (
+        (previous.status ?? null) !== (change.note.status ?? null) ||
+        (previous.okf_type ?? null) !== (change.note.okf_type ?? null)
+    );
+}
+
 function hasMarkdownExtension(path: string) {
     return path.toLowerCase().endsWith(".md");
 }
@@ -162,6 +185,7 @@ const IDLE_OPEN_STATE: VaultOpenState = {
         snapshot_save_ms: 0,
     },
     error: null,
+    okf_version: null,
 };
 
 let openVaultSequence = 0;
@@ -303,6 +327,7 @@ function normalizeOpenState(
             snapshot_save_ms: state?.metrics?.snapshot_save_ms ?? 0,
         },
         error: state?.error ?? null,
+        okf_version: state?.okf_version ?? null,
     };
 }
 
@@ -410,6 +435,8 @@ interface VaultStore {
     vaultPath: string | null;
     notes: NoteDto[];
     entries: VaultEntryDto[];
+    /** OKF version detected in the vault root index.md; null for non-OKF vaults. */
+    okfVersion: string | null;
     vaultRevision: number;
     contentRevision: number;
     structureRevision: number;
@@ -451,6 +478,7 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
     vaultPath: null,
     notes: [],
     entries: [],
+    okfVersion: null,
     vaultRevision: 0,
     contentRevision: 0,
     structureRevision: 0,
@@ -467,6 +495,7 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
         set({
             isLoading: true,
             error: null,
+            okfVersion: null,
             vaultOpenState: {
                 ...IDLE_OPEN_STATE,
                 path,
@@ -513,6 +542,7 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
                         vaultPath: path,
                         notes: normalizeVaultNotes(notes),
                         entries: normalizeVaultEntries(entries),
+                        okfVersion: openState.okf_version,
                         isLoading: false,
                         error: null,
                         vaultOpenState: openState,
@@ -650,6 +680,13 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
                 state.notes,
                 normalizedChange,
             );
+            // A status/type-only change is not a resolver/graph structure
+            // change, but the file tree still needs to rebuild so its status
+            // dot updates live. Fold it into the structure revision only.
+            const statusOrTypeChanged = didNoteStatusOrTypeChange(
+                state.notes,
+                normalizedChange,
+            );
             perfCount(`vault.applyNoteChange.${normalizedChange.kind}`);
             perfMeasure(
                 `vault.applyNoteChange.${normalizedChange.kind}.duration`,
@@ -669,9 +706,10 @@ export const useVaultStore = create<VaultStore>((set, get) => ({
                     change.kind === "upsert"
                         ? state.contentRevision + 1
                         : state.contentRevision,
-                structureRevision: structureChanged
-                    ? state.structureRevision + 1
-                    : state.structureRevision,
+                structureRevision:
+                    structureChanged || statusOrTypeChanged
+                        ? state.structureRevision + 1
+                        : state.structureRevision,
                 resolverRevision: structureChanged
                     ? state.resolverRevision + 1
                     : state.resolverRevision,

--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -8,6 +8,7 @@ import { EditorView, keymap } from "@codemirror/view";
 import { describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../app/store/editorStore";
 import { useSettingsStore } from "../../app/store/settingsStore";
+import { useVaultStore } from "../../app/store/vaultStore";
 import { useCommandStore } from "../command-palette/store/commandStore";
 import { useChatStore } from "../ai/store/chatStore";
 import {
@@ -1827,6 +1828,96 @@ describe("Editor", () => {
                 vaultPath: "/vault",
                 opId: expect.any(String),
             }),
+        );
+    });
+
+    it("updates the note's status in the vault store from the save_note response", async () => {
+        // App-initiated saves emit a `vault://note-changed` event with origin
+        // "user", which the renderer ignores by design (vaultChangeSync). The
+        // only live path into the vault store for a user save is therefore the
+        // save_note response, so it must carry status/okf_type through to the
+        // store or the file tree's status dot goes stale.
+        mockInvoke().mockImplementation(async (command) => {
+            if (command === "save_note") {
+                return {
+                    id: "notes/current",
+                    path: "/vault/notes/current.md",
+                    title: "Current",
+                    content:
+                        "---\nstatus: published\ntype: runbook\n---\nBody",
+                    status: "published",
+                    okf_type: "runbook",
+                };
+            }
+            return undefined;
+        });
+
+        setEditorTabs(
+            [
+                {
+                    id: "tab-1",
+                    noteId: "notes/current",
+                    title: "Current",
+                    content: "---\nstatus: draft\ntype: runbook\n---\nBody",
+                },
+                {
+                    id: "tab-2",
+                    noteId: "notes/other",
+                    title: "Other",
+                    content: "Other body",
+                },
+            ],
+            "tab-1",
+        );
+        setVaultNotes([
+            {
+                id: "notes/current",
+                title: "Current",
+                path: "/vault/notes/current.md",
+                modified_at: 0,
+                created_at: 0,
+                status: "draft",
+                okf_type: "runbook",
+            },
+            {
+                id: "notes/other",
+                title: "Other",
+                path: "/vault/notes/other.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+
+        const structureRevisionBefore =
+            useVaultStore.getState().structureRevision;
+
+        renderComponent(<Editor />);
+        const view = getEditorView();
+
+        await act(async () => {
+            view.dispatch({
+                changes: {
+                    from: 0,
+                    to: view.state.doc.length,
+                    insert: "---\nstatus: published\ntype: runbook\n---\nBody",
+                },
+            });
+        });
+
+        await act(async () => {
+            useEditorStore.getState().switchTab("tab-2");
+        });
+        await flushPromises();
+
+        const note = useVaultStore
+            .getState()
+            .notes.find((candidate) => candidate.id === "notes/current");
+        expect(note?.status).toBe("published");
+        expect(note?.okf_type).toBe("runbook");
+        // The file tree rebuilds on structureRevision; a stale revision means
+        // the dot keeps its old color even though the note changed.
+        expect(useVaultStore.getState().structureRevision).toBeGreaterThan(
+            structureRevisionBefore,
         );
     });
 

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -220,6 +220,10 @@ type SavedNoteDetail = {
     path: string;
     title: string;
     content: string;
+    // Optional so older backends that don't emit the fields still type-check;
+    // absent means "no status/type".
+    status?: string | null;
+    okf_type?: string | null;
 };
 type ReloadedNoteMetadata = {
     origin?: "user" | "agent" | "external" | "system" | "unknown";
@@ -804,6 +808,11 @@ export function Editor({
                     title: detail.title,
                     path: detail.path,
                     modified_at: Math.floor(Date.now() / 1000),
+                    // User-origin change events are ignored by the renderer
+                    // (vaultChangeSync), so the save response is the only live
+                    // path for status/type into the vault store and file tree.
+                    status: detail.status ?? null,
+                    okf_type: detail.okf_type ?? null,
                 });
                 if (activeTabRef.current?.id === tab.id) {
                     setActiveFrontmatter(

--- a/apps/desktop/src/features/editor/EditorHeader.tsx
+++ b/apps/desktop/src/features/editor/EditorHeader.tsx
@@ -9,9 +9,17 @@ import {
 export function MetaBadge({
     label,
     tone = "muted",
+    leading,
+    onClick,
+    title,
 }: {
     label: string;
-    tone?: "muted" | "accent" | "success";
+    tone?: "muted" | "accent" | "success" | "warning";
+    /** Optional element rendered before the label (e.g. a status dot). */
+    leading?: React.ReactNode;
+    /** When provided, the badge renders as a button. */
+    onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+    title?: string;
 }) {
     const palette =
         tone === "accent"
@@ -28,15 +36,58 @@ export function MetaBadge({
                         "color-mix(in srgb, #22c55e 10%, var(--bg-primary))",
                     border: "color-mix(in srgb, #22c55e 22%, var(--border))",
                 }
-              : {
-                    color: "var(--text-secondary)",
-                    background:
-                        "color-mix(in srgb, var(--bg-secondary) 82%, transparent)",
-                    border: "var(--border)",
-                };
+              : tone === "warning"
+                ? {
+                      color: "#b45309",
+                      background:
+                          "color-mix(in srgb, #f97316 12%, var(--bg-primary))",
+                      border: "color-mix(in srgb, #f97316 26%, var(--border))",
+                  }
+                : {
+                      color: "var(--text-secondary)",
+                      background:
+                          "color-mix(in srgb, var(--bg-secondary) 82%, transparent)",
+                      border: "var(--border)",
+                  };
+
+    const content = (
+        <>
+            {leading}
+            {label}
+        </>
+    );
+
+    if (onClick) {
+        return (
+            <button
+                type="button"
+                onClick={onClick}
+                title={title}
+                style={{
+                    display: "inline-flex",
+                    alignItems: "center",
+                    gap: 6,
+                    maxWidth: "100%",
+                    height: 24,
+                    padding: "0 8px",
+                    borderRadius: 2,
+                    border: `1px solid ${palette.border}`,
+                    background: palette.background,
+                    color: palette.color,
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.04em",
+                    cursor: "pointer",
+                }}
+            >
+                {content}
+            </button>
+        );
+    }
 
     return (
         <span
+            title={title}
             style={{
                 display: "inline-flex",
                 alignItems: "center",
@@ -53,7 +104,7 @@ export function MetaBadge({
                 letterSpacing: "0.04em",
             }}
         >
-            {label}
+            {content}
         </span>
     );
 }

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
@@ -1,6 +1,28 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
-import { MarkdownNoteHeader } from "./MarkdownNoteHeader";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    MarkdownNoteHeader,
+    type MarkdownNoteHeaderProps,
+} from "./MarkdownNoteHeader";
+import { useVaultStore } from "../../app/store/vaultStore";
+
+function renderWith(overrides: Partial<MarkdownNoteHeaderProps> = {}) {
+    const props: MarkdownNoteHeaderProps = {
+        editableTitle: "Example note",
+        lineWrapping: true,
+        onTitleChange: () => {},
+        titleInputRef: { current: null },
+        locationParent: "Notes",
+        frontmatterRaw: null,
+        onFrontmatterChange: vi.fn(),
+        propertiesExpanded: false,
+        onToggleProperties: vi.fn(),
+        onSearchClick: vi.fn(),
+        ...overrides,
+    };
+    render(<MarkdownNoteHeader {...props} />);
+    return props;
+}
 
 function renderHeader(lineWrapping: boolean) {
     render(
@@ -185,5 +207,195 @@ describe("MarkdownNoteHeader", () => {
                 ).scrollHeight;
             }
         }
+    });
+});
+
+const fm = (body: string) => `---\n${body}\n---\n`;
+
+describe("MarkdownNoteHeader — OKF status", () => {
+    // Earlier tests in this file leave `document.fonts` defined-but-undefined,
+    // which makes EditableNoteTitle's `document.fonts.ready` throw. Ensure a
+    // usable stub so these renders don't crash on that unrelated effect.
+    beforeEach(() => {
+        Object.defineProperty(document, "fonts", {
+            configurable: true,
+            value: { ready: Promise.resolve() },
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("renders a status badge for each canonical status", () => {
+        const cases: Array<[string, string]> = [
+            ["draft", "Draft"],
+            ["in_review", "In review"],
+            ["published", "Published"],
+            ["deprecated", "Deprecated"],
+            ["archived", "Archived"],
+        ];
+        for (const [raw, label] of cases) {
+            const { unmount } = render(
+                <MarkdownNoteHeader
+                    editableTitle="Example note"
+                    lineWrapping
+                    onTitleChange={() => {}}
+                    titleInputRef={{ current: null }}
+                    locationParent="Notes"
+                    frontmatterRaw={fm(`status: ${raw}`)}
+                    onFrontmatterChange={vi.fn()}
+                    propertiesExpanded={false}
+                    onToggleProperties={vi.fn()}
+                    onSearchClick={vi.fn()}
+                />,
+            );
+            expect(
+                screen.getByRole("button", { name: label }),
+            ).toBeInTheDocument();
+            unmount();
+        }
+    });
+
+    it("shows a subtle 'Set status' affordance and no banner when status is absent", () => {
+        renderWith({ frontmatterRaw: null });
+        expect(
+            screen.getByRole("button", { name: "Set status" }),
+        ).toBeInTheDocument();
+        expect(document.querySelector("[data-status-banner]")).toBeNull();
+        expect(
+            screen.queryByRole("button", { name: "Draft" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("renders a type badge showing the raw type value", () => {
+        renderWith({ frontmatterRaw: fm("type: runbook") });
+        expect(screen.getByText("runbook")).toBeInTheDocument();
+    });
+
+    it.each([
+        ["draft", "Draft — this document has not been published."],
+        ["in_review", "In review — content may change before publication."],
+        ["deprecated", "Deprecated — this document is outdated."],
+        ["archived", "Archived — kept for reference only."],
+    ])("renders the trust banner for %s", (raw, copy) => {
+        renderWith({ frontmatterRaw: fm(`status: ${raw}`) });
+        const banner = document.querySelector("[data-status-banner]");
+        expect(banner).not.toBeNull();
+        expect(banner).toHaveTextContent(copy);
+    });
+
+    it("renders no banner for published", () => {
+        renderWith({ frontmatterRaw: fm("status: published") });
+        expect(document.querySelector("[data-status-banner]")).toBeNull();
+    });
+
+    it("shows an unknown status verbatim with no banner", () => {
+        renderWith({ frontmatterRaw: fm("status: needs work") });
+        expect(
+            screen.getByRole("button", { name: "needs work" }),
+        ).toBeInTheDocument();
+        expect(document.querySelector("[data-status-banner]")).toBeNull();
+    });
+
+    it("updates the status via the dropdown while preserving other keys and order", async () => {
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello\nstatus: draft\ntype: note"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "Published" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Hello");
+        expect(next).toContain("status: published");
+        expect(next).toContain("type: note");
+        // Order preserved: title before status before type.
+        expect(next.indexOf("title")).toBeLessThan(next.indexOf("status"));
+        expect(next.indexOf("status")).toBeLessThan(next.indexOf("type"));
+    });
+
+    it("removes the status key when 'No status' is chosen", async () => {
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello\nstatus: draft"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "No status" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Hello");
+        expect(next).not.toContain("status:");
+    });
+
+    it("adds a status when none exists via 'Set status'", async () => {
+        const props = renderWith({ frontmatterRaw: fm("title: Hello") });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "In review" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Hello");
+        expect(next).toContain("status: in_review");
+    });
+});
+
+describe("MarkdownNoteHeader — OKF conformance hint", () => {
+    beforeEach(() => {
+        Object.defineProperty(document, "fonts", {
+            configurable: true,
+            value: { ready: Promise.resolve() },
+        });
+    });
+
+    afterEach(() => {
+        useVaultStore.setState({ okfVersion: null });
+        vi.restoreAllMocks();
+    });
+
+    it("shows the hint when the vault is OKF and the note has no type", () => {
+        useVaultStore.setState({ okfVersion: "0.1.0" });
+        renderWith({ frontmatterRaw: fm("title: Hello") });
+        expect(
+            screen.getByRole("button", { name: "No OKF type" }),
+        ).toBeInTheDocument();
+    });
+
+    it("hides the hint when the note already has a type", () => {
+        useVaultStore.setState({ okfVersion: "0.1.0" });
+        renderWith({ frontmatterRaw: fm("type: runbook") });
+        expect(
+            screen.queryByRole("button", { name: "No OKF type" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("hides the hint when the vault is not an OKF vault", () => {
+        useVaultStore.setState({ okfVersion: null });
+        renderWith({ frontmatterRaw: fm("title: Hello") });
+        expect(
+            screen.queryByRole("button", { name: "No OKF type" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("opens the Properties panel when the hint is clicked", () => {
+        useVaultStore.setState({ okfVersion: "0.1.0" });
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello"),
+            propertiesExpanded: false,
+        });
+        fireEvent.click(screen.getByRole("button", { name: "No OKF type" }));
+        expect(props.onToggleProperties).toHaveBeenCalledTimes(1);
     });
 });

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
 import { invoke } from "@neverwrite/runtime";
 import {
     MarkdownNoteHeader,
@@ -481,6 +482,136 @@ describe("MarkdownNoteHeader — OKF status", () => {
             .calls[0][0] as string;
         expect(next).toContain("status: draft");
         expect(next).not.toContain("status_by:");
+    });
+
+    it("preserves the title across two consecutive status changes with live prop flow", async () => {
+        vi.mocked(invoke).mockResolvedValue("simon");
+        const changes: Array<string | null> = [];
+
+        // Model Editor.tsx's real delivery: applyFrontmatterChange calls
+        // setActiveFrontmatter(nextRaw), which re-renders the header with the
+        // new frontmatterRaw prop.
+        function Harness() {
+            const [raw, setRaw] = useState<string | null>(null);
+            return (
+                <MarkdownNoteHeader
+                    editableTitle="Example note"
+                    lineWrapping
+                    onTitleChange={() => {}}
+                    titleInputRef={{ current: null }}
+                    locationParent="Notes"
+                    frontmatterRaw={raw}
+                    onFrontmatterChange={(next) => {
+                        changes.push(next);
+                        setRaw(next);
+                    }}
+                    propertiesExpanded={false}
+                    onToggleProperties={vi.fn()}
+                    onSearchClick={vi.fn()}
+                />
+            );
+        }
+        render(<Harness />);
+
+        // First change: create frontmatter from scratch.
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        await waitFor(() => expect(changes).toHaveLength(1));
+        expect(changes[0]).toContain("title: Example note");
+        expect(changes[0]).toContain("status: draft");
+        expect(changes[0]).toContain("status_by: simon");
+
+        // Second change: badge now shows Draft; switch to Published.
+        await waitFor(() =>
+            expect(
+                screen.getByRole("button", { name: "Draft" }),
+            ).toBeInTheDocument(),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "Published" }));
+        await waitFor(() => expect(changes).toHaveLength(2));
+
+        expect(changes[1]).toContain("title: Example note");
+        expect(changes[1]).toContain("status: published");
+        expect(changes[1]).toContain("status_by: simon");
+    });
+
+    it("preserves an existing title when only the status changes", async () => {
+        vi.mocked(invoke).mockResolvedValue("simon");
+        const props = renderWith({
+            frontmatterRaw: fm("title: My Runbook\nstatus: draft"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "Archived" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: My Runbook");
+        expect(next).toContain("status: archived");
+    });
+
+    it("builds the change from the freshest frontmatter when the raw updates mid-await", async () => {
+        // Regression: the username fetch awaits an IPC round-trip. If a newer
+        // frontmatter raw lands during that await (save response, external
+        // sync), the write must be computed from the fresh raw, not from the
+        // entries captured at click time - otherwise keys that only exist in
+        // the fresh raw (like a just-added title) are silently dropped.
+        let resolveUsername: (value: string) => void = () => {};
+        vi.mocked(invoke).mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveUsername = resolve as (value: string) => void;
+                }),
+        );
+
+        const onFrontmatterChange = vi.fn();
+        const baseProps: MarkdownNoteHeaderProps = {
+            editableTitle: "Example note",
+            lineWrapping: true,
+            onTitleChange: () => {},
+            titleInputRef: { current: null },
+            locationParent: "Notes",
+            frontmatterRaw: fm("status: draft\nstatus_by: simon"),
+            onFrontmatterChange,
+            propertiesExpanded: false,
+            onToggleProperties: vi.fn(),
+            onSearchClick: vi.fn(),
+        };
+        const { rerender } = render(<MarkdownNoteHeader {...baseProps} />);
+
+        // Click Published; setStatus is now parked on the username fetch.
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "Published" }));
+        // Flush the queued menu action so setStatus starts and the fetch is
+        // actually pending.
+        await act(async () => {});
+        expect(invoke).toHaveBeenCalledWith("get_system_username");
+
+        // A newer raw (title added elsewhere) arrives while the fetch is
+        // pending.
+        rerender(
+            <MarkdownNoteHeader
+                {...baseProps}
+                frontmatterRaw={fm(
+                    "title: My Runbook\nstatus: draft\nstatus_by: simon",
+                )}
+            />,
+        );
+
+        await act(async () => {
+            resolveUsername("simon");
+            await Promise.resolve();
+        });
+
+        await waitFor(() => expect(onFrontmatterChange).toHaveBeenCalled());
+        const next = onFrontmatterChange.mock.calls[0][0] as string;
+        expect(next).toContain("title: My Runbook");
+        expect(next).toContain("status: published");
+        expect(next).toContain("status_by: simon");
     });
 
     it("does not crash and omits status_by when the username fetch fails", async () => {

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
@@ -1,9 +1,11 @@
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { invoke } from "@neverwrite/runtime";
 import {
     MarkdownNoteHeader,
     type MarkdownNoteHeaderProps,
 } from "./MarkdownNoteHeader";
+import { resetSystemUsernameCacheForTests } from "../okf/systemUsername";
 import { useVaultStore } from "../../app/store/vaultStore";
 
 function renderWith(overrides: Partial<MarkdownNoteHeaderProps> = {}) {
@@ -221,6 +223,10 @@ describe("MarkdownNoteHeader — OKF status", () => {
             configurable: true,
             value: { ready: Promise.resolve() },
         });
+        // The system username is cached module-wide; isolate tests. The
+        // global setup resets the `invoke` mock, so unless a test provides
+        // one, the username resolves to null (no `status_by` written).
+        resetSystemUsernameCacheForTests();
     });
 
     afterEach(() => {
@@ -349,6 +355,150 @@ describe("MarkdownNoteHeader — OKF status", () => {
             .calls[0][0] as string;
         expect(next).toContain("title: Hello");
         expect(next).toContain("status: in_review");
+    });
+
+    it("seeds the new frontmatter block with the note title when created from scratch", async () => {
+        const props = renderWith({
+            editableTitle: "Example note",
+            frontmatterRaw: null,
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Example note");
+        expect(next).toContain("status: draft");
+        // Title first, then status.
+        expect(next.indexOf("title:")).toBeLessThan(next.indexOf("status:"));
+    });
+
+    it("does not inject a title into existing frontmatter that lacks one", async () => {
+        const props = renderWith({
+            editableTitle: "Example note",
+            frontmatterRaw: fm("type: note"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("type: note");
+        expect(next).toContain("status: draft");
+        expect(next).not.toContain("title:");
+    });
+
+    it("records status_by with the system username on status change", async () => {
+        vi.mocked(invoke).mockResolvedValue("simon");
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello\nstatus: draft\ntype: note"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "Published" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        expect(invoke).toHaveBeenCalledWith("get_system_username");
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("status: published");
+        expect(next).toContain("status_by: simon");
+        expect(next).toContain("type: note");
+        // status_by sits directly after status, before the other keys.
+        expect(next.indexOf("status:")).toBeLessThan(
+            next.indexOf("status_by:"),
+        );
+        expect(next.indexOf("status_by:")).toBeLessThan(
+            next.indexOf("type:"),
+        );
+    });
+
+    it("creates frontmatter from scratch as title, status, status_by", async () => {
+        vi.mocked(invoke).mockResolvedValue("simon");
+        const props = renderWith({
+            editableTitle: "Example note",
+            frontmatterRaw: null,
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Example note");
+        expect(next).toContain("status: draft");
+        expect(next).toContain("status_by: simon");
+        expect(next.indexOf("title:")).toBeLessThan(next.indexOf("status:"));
+        expect(next.indexOf("status:")).toBeLessThan(
+            next.indexOf("status_by:"),
+        );
+    });
+
+    it("removes status_by along with status when 'No status' is chosen", async () => {
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello\nstatus: draft\nstatus_by: bob"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+        fireEvent.click(screen.getByRole("button", { name: "No status" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("title: Hello");
+        expect(next).not.toContain("status:");
+        expect(next).not.toContain("status_by:");
+    });
+
+    it("omits status_by when the username is unavailable", async () => {
+        vi.mocked(invoke).mockResolvedValue(null);
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("status: draft");
+        expect(next).not.toContain("status_by:");
+    });
+
+    it("does not crash and omits status_by when the username fetch fails", async () => {
+        vi.mocked(invoke).mockRejectedValue(new Error("ipc unavailable"));
+        const props = renderWith({
+            frontmatterRaw: fm("title: Hello"),
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: "Set status" }));
+        fireEvent.click(screen.getByRole("button", { name: "Draft" }));
+
+        await waitFor(() =>
+            expect(props.onFrontmatterChange).toHaveBeenCalled(),
+        );
+        const next = (props.onFrontmatterChange as ReturnType<typeof vi.fn>).mock
+            .calls[0][0] as string;
+        expect(next).toContain("status: draft");
+        expect(next).not.toContain("status_by:");
     });
 });
 

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
@@ -17,7 +17,9 @@ import {
     statusLabel,
     statusTone,
 } from "../okf/status";
+import { fetchSystemUsername } from "../okf/systemUsername";
 import { useVaultStore } from "../../app/store/vaultStore";
+import { upsertFrontmatterTitle } from "./noteTitleHelpers";
 
 /** Statuses that warrant a trust banner, with their banner copy. */
 const BANNER_COPY: Record<string, string> = {
@@ -98,21 +100,64 @@ export function MarkdownNoteHeader({
         setStatusMenu({ x: rect.left, y: rect.bottom + 4, payload: undefined });
     };
 
-    const setStatus = (next: string | null) => {
-        // Preserve every other key and its order. Only touch `status`.
+    const setStatus = async (next: string | null) => {
+        // Preserve every other key and its order. Only touch `status` and
+        // its attribution key `status_by`.
         let nextEntries: FrontmatterEntry[];
         if (next === null) {
-            nextEntries = entries.filter(
-                (e) => e.key.toLowerCase() !== "status",
-            );
-        } else if (entries.some((e) => e.key.toLowerCase() === "status")) {
-            nextEntries = entries.map((e) =>
-                e.key.toLowerCase() === "status" ? { ...e, value: next } : e,
-            );
+            // Removing the status also removes its attribution.
+            nextEntries = entries.filter((e) => {
+                const key = e.key.toLowerCase();
+                return key !== "status" && key !== "status_by";
+            });
         } else {
-            nextEntries = [...entries, { key: "status", value: next }];
+            if (entries.some((e) => e.key.toLowerCase() === "status")) {
+                nextEntries = entries.map((e) =>
+                    e.key.toLowerCase() === "status"
+                        ? { ...e, value: next }
+                        : e,
+                );
+            } else {
+                nextEntries = [...entries, { key: "status", value: next }];
+            }
+
+            // Record who changed the status. When the username cannot be
+            // determined, omit the field instead of writing a junk value
+            // (any existing attribution is left untouched).
+            const username = await fetchSystemUsername();
+            if (username) {
+                if (
+                    nextEntries.some((e) => e.key.toLowerCase() === "status_by")
+                ) {
+                    nextEntries = nextEntries.map((e) =>
+                        e.key.toLowerCase() === "status_by"
+                            ? { ...e, value: username }
+                            : e,
+                    );
+                } else {
+                    const statusIndex = nextEntries.findIndex(
+                        (e) => e.key.toLowerCase() === "status",
+                    );
+                    nextEntries = [
+                        ...nextEntries.slice(0, statusIndex + 1),
+                        { key: "status_by", value: username },
+                        ...nextEntries.slice(statusIndex + 1),
+                    ];
+                }
+            }
         }
-        onFrontmatterChange(serializeFrontmatterRaw(nextEntries));
+        const nextRaw = serializeFrontmatterRaw(nextEntries);
+
+        // When this status change creates the frontmatter block from scratch,
+        // seed it with the note's title (the same derived title the header
+        // shows) so the new block is `title` + `status`, not `status` alone.
+        // Existing frontmatter is left untouched beyond the status key.
+        if (!frontmatterRaw && next !== null && nextRaw) {
+            onFrontmatterChange(upsertFrontmatterTitle(nextRaw, editableTitle));
+            return;
+        }
+
+        onFrontmatterChange(nextRaw);
     };
 
     const bannerCopy = status ? BANNER_COPY[status] : undefined;
@@ -235,12 +280,12 @@ export function MarkdownNoteHeader({
                     entries={[
                         ...KNOWN_STATUSES.map((s) => ({
                             label: statusLabel(s),
-                            action: () => setStatus(s),
+                            action: () => void setStatus(s),
                         })),
                         { type: "separator" as const },
                         {
                             label: "No status",
-                            action: () => setStatus(null),
+                            action: () => void setStatus(null),
                             danger: true,
                         },
                     ]}

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
@@ -1,6 +1,31 @@
-import { type RefObject } from "react";
+import { useMemo, useState, type RefObject } from "react";
 import { MetaBadge, EditableNoteTitle } from "./EditorHeader";
-import { FrontmatterBody } from "./FrontmatterPanel";
+import {
+    FrontmatterBody,
+    parseFrontmatterRaw,
+    serializeFrontmatterRaw,
+    type FrontmatterEntry,
+} from "./FrontmatterPanel";
+import {
+    ContextMenu,
+    type ContextMenuState,
+} from "../../components/context-menu/ContextMenu";
+import {
+    KNOWN_STATUSES,
+    normalizeDocumentStatus,
+    statusDotColor,
+    statusLabel,
+    statusTone,
+} from "../okf/status";
+import { useVaultStore } from "../../app/store/vaultStore";
+
+/** Statuses that warrant a trust banner, with their banner copy. */
+const BANNER_COPY: Record<string, string> = {
+    draft: "Draft — this document has not been published.",
+    in_review: "In review — content may change before publication.",
+    deprecated: "Deprecated — this document is outdated.",
+    archived: "Archived — kept for reference only.",
+};
 
 export interface MarkdownNoteHeaderProps {
     /** Current editable title text */
@@ -40,6 +65,58 @@ export function MarkdownNoteHeader({
     onToggleProperties,
     onSearchClick,
 }: MarkdownNoteHeaderProps) {
+    const entries = useMemo<FrontmatterEntry[]>(
+        () => (frontmatterRaw ? parseFrontmatterRaw(frontmatterRaw) : []),
+        [frontmatterRaw],
+    );
+
+    const rawStatus = useMemo(() => {
+        const entry = entries.find((e) => e.key.toLowerCase() === "status");
+        return entry && typeof entry.value === "string" ? entry.value : null;
+    }, [entries]);
+    const status = useMemo(
+        () => normalizeDocumentStatus(rawStatus),
+        [rawStatus],
+    );
+
+    const typeValue = useMemo(() => {
+        const entry = entries.find((e) => e.key.toLowerCase() === "type");
+        const value =
+            entry && typeof entry.value === "string" ? entry.value.trim() : "";
+        return value || null;
+    }, [entries]);
+
+    const okfVersion = useVaultStore((s) => s.okfVersion);
+    // Conformance hint: OKF vaults expect a `type` field. Only nudge when we
+    // know this is an OKF vault and the note is missing a non-empty type.
+    const showMissingTypeHint = okfVersion !== null && typeValue === null;
+
+    const [statusMenu, setStatusMenu] = useState<ContextMenuState | null>(null);
+
+    const openStatusMenu = (event: React.MouseEvent<HTMLElement>) => {
+        const rect = event.currentTarget.getBoundingClientRect();
+        setStatusMenu({ x: rect.left, y: rect.bottom + 4, payload: undefined });
+    };
+
+    const setStatus = (next: string | null) => {
+        // Preserve every other key and its order. Only touch `status`.
+        let nextEntries: FrontmatterEntry[];
+        if (next === null) {
+            nextEntries = entries.filter(
+                (e) => e.key.toLowerCase() !== "status",
+            );
+        } else if (entries.some((e) => e.key.toLowerCase() === "status")) {
+            nextEntries = entries.map((e) =>
+                e.key.toLowerCase() === "status" ? { ...e, value: next } : e,
+            );
+        } else {
+            nextEntries = [...entries, { key: "status", value: next }];
+        }
+        onFrontmatterChange(serializeFrontmatterRaw(nextEntries));
+    };
+
+    const bannerCopy = status ? BANNER_COPY[status] : undefined;
+
     return (
         <div
             data-editor-note-header="true"
@@ -63,21 +140,43 @@ export function MarkdownNoteHeader({
                     margin: lineWrapping ? "0 auto" : "0",
                 }}
             >
-                {/* Location breadcrumb */}
-                {locationParent && (
-                    <div
-                        style={{
-                            display: "flex",
-                            alignItems: "center",
-                            gap: 8,
-                            flexWrap: "wrap",
-                            minWidth: 0,
-                            marginBottom: 14,
-                        }}
-                    >
-                        <MetaBadge label={locationParent} />
-                    </div>
-                )}
+                {/* Location breadcrumb + OKF status / type badges */}
+                <div
+                    style={{
+                        display: "flex",
+                        alignItems: "center",
+                        gap: 8,
+                        flexWrap: "wrap",
+                        minWidth: 0,
+                        marginBottom: 14,
+                    }}
+                >
+                    {locationParent && <MetaBadge label={locationParent} />}
+                    {status ? (
+                        <MetaBadge
+                            label={statusLabel(status)}
+                            tone={statusTone(status)}
+                            title="Change status"
+                            onClick={openStatusMenu}
+                            leading={
+                                <StatusDot color={statusDotColor(status)} />
+                            }
+                        />
+                    ) : (
+                        <SetStatusButton onClick={openStatusMenu} />
+                    )}
+                    {typeValue && <MetaBadge label={typeValue} tone="muted" />}
+                    {showMissingTypeHint && (
+                        <MetaBadge
+                            label="No OKF type"
+                            tone="muted"
+                            title="OKF vaults expect a type field in frontmatter"
+                            onClick={() => {
+                                if (!propertiesExpanded) onToggleProperties();
+                            }}
+                        />
+                    )}
+                </div>
 
                 {/* Title row */}
                 <EditableNoteTitle
@@ -112,6 +211,11 @@ export function MarkdownNoteHeader({
                     />
                 </div>
 
+                {/* Trust banner (draft / in_review / deprecated / archived) */}
+                {status && bannerCopy && (
+                    <TrustBanner status={status} copy={bannerCopy} />
+                )}
+
                 {/* Properties body (expanded below toolbar) */}
                 {propertiesExpanded && (
                     <div style={{ minWidth: 0, marginBottom: 8 }}>
@@ -122,6 +226,105 @@ export function MarkdownNoteHeader({
                     </div>
                 )}
             </div>
+
+            {statusMenu && (
+                <ContextMenu
+                    menu={statusMenu}
+                    onClose={() => setStatusMenu(null)}
+                    minWidth={160}
+                    entries={[
+                        ...KNOWN_STATUSES.map((s) => ({
+                            label: statusLabel(s),
+                            action: () => setStatus(s),
+                        })),
+                        { type: "separator" as const },
+                        {
+                            label: "No status",
+                            action: () => setStatus(null),
+                            danger: true,
+                        },
+                    ]}
+                />
+            )}
+        </div>
+    );
+}
+
+/* ── OKF status UI ─────────────────────────────────────────── */
+
+function StatusDot({ color }: { color: string }) {
+    return (
+        <span
+            aria-hidden="true"
+            style={{
+                width: 7,
+                height: 7,
+                borderRadius: "50%",
+                background: color,
+                flexShrink: 0,
+            }}
+        />
+    );
+}
+
+function SetStatusButton({
+    onClick,
+}: {
+    onClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
+}) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            title="Set status"
+            style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: 5,
+                height: 24,
+                padding: "0 8px",
+                borderRadius: 2,
+                border: "1px dashed color-mix(in srgb, var(--border) 90%, transparent)",
+                background: "transparent",
+                color: "var(--text-secondary)",
+                fontSize: 11,
+                fontWeight: 600,
+                letterSpacing: "0.04em",
+                cursor: "pointer",
+                opacity: 0.7,
+            }}
+        >
+            <StatusDot color="var(--text-secondary)" />
+            Set status
+        </button>
+    );
+}
+
+function TrustBanner({ status, copy }: { status: string; copy: string }) {
+    const base = statusDotColor(status);
+    return (
+        <div
+            role="note"
+            data-status-banner={status}
+            style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                width: "100%",
+                boxSizing: "border-box",
+                padding: "6px 10px",
+                marginBottom: 8,
+                borderRadius: 4,
+                border: `1px solid color-mix(in srgb, ${base} 22%, var(--border))`,
+                background: `color-mix(in srgb, ${base} 10%, transparent)`,
+                color: "var(--text-secondary)",
+                fontSize: 12,
+                fontWeight: 500,
+                lineHeight: 1.4,
+            }}
+        >
+            <StatusDot color={base} />
+            <span>{copy}</span>
         </div>
     );
 }

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, type RefObject } from "react";
+import { useMemo, useRef, useState, type RefObject } from "react";
 import { MetaBadge, EditableNoteTitle } from "./EditorHeader";
 import {
     FrontmatterBody,
@@ -95,36 +95,51 @@ export function MarkdownNoteHeader({
 
     const [statusMenu, setStatusMenu] = useState<ContextMenuState | null>(null);
 
+    // Latest-prop mirror so async handlers (setStatus awaits the username
+    // IPC) always read the freshest frontmatter, never a stale render
+    // capture. Assigned during render on purpose; it is a pure mirror.
+    const frontmatterRawRef = useRef(frontmatterRaw);
+    frontmatterRawRef.current = frontmatterRaw;
+
     const openStatusMenu = (event: React.MouseEvent<HTMLElement>) => {
         const rect = event.currentTarget.getBoundingClientRect();
         setStatusMenu({ x: rect.left, y: rect.bottom + 4, payload: undefined });
     };
 
     const setStatus = async (next: string | null) => {
+        // Resolve attribution BEFORE reading the frontmatter. The username
+        // fetch awaits an IPC round-trip, and a newer raw can land during
+        // that await (autosave response, external sync). Computing the change
+        // from render-captured entries here used to clobber keys that only
+        // existed in the fresher raw, e.g. a just-added title.
+        const username = next === null ? null : await fetchSystemUsername();
+
+        const currentRaw = frontmatterRawRef.current;
+        const current = currentRaw ? parseFrontmatterRaw(currentRaw) : [];
+
         // Preserve every other key and its order. Only touch `status` and
         // its attribution key `status_by`.
         let nextEntries: FrontmatterEntry[];
         if (next === null) {
             // Removing the status also removes its attribution.
-            nextEntries = entries.filter((e) => {
+            nextEntries = current.filter((e) => {
                 const key = e.key.toLowerCase();
                 return key !== "status" && key !== "status_by";
             });
         } else {
-            if (entries.some((e) => e.key.toLowerCase() === "status")) {
-                nextEntries = entries.map((e) =>
+            if (current.some((e) => e.key.toLowerCase() === "status")) {
+                nextEntries = current.map((e) =>
                     e.key.toLowerCase() === "status"
                         ? { ...e, value: next }
                         : e,
                 );
             } else {
-                nextEntries = [...entries, { key: "status", value: next }];
+                nextEntries = [...current, { key: "status", value: next }];
             }
 
-            // Record who changed the status. When the username cannot be
-            // determined, omit the field instead of writing a junk value
-            // (any existing attribution is left untouched).
-            const username = await fetchSystemUsername();
+            // When the username cannot be determined, omit the field instead
+            // of writing a junk value (any existing attribution is left
+            // untouched).
             if (username) {
                 if (
                     nextEntries.some((e) => e.key.toLowerCase() === "status_by")
@@ -152,7 +167,7 @@ export function MarkdownNoteHeader({
         // seed it with the note's title (the same derived title the header
         // shows) so the new block is `title` + `status`, not `status` alone.
         // Existing frontmatter is left untouched beyond the status key.
-        if (!frontmatterRaw && next !== null && nextRaw) {
+        if (!currentRaw && next !== null && nextRaw) {
             onFrontmatterChange(upsertFrontmatterTitle(nextRaw, editableTitle));
             return;
         }

--- a/apps/desktop/src/features/okf/status.test.ts
+++ b/apps/desktop/src/features/okf/status.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from "vitest";
+import {
+    KNOWN_STATUSES,
+    isKnownStatus,
+    normalizeDocumentStatus,
+    statusDotColor,
+    statusLabel,
+    statusTone,
+} from "./status";
+
+describe("normalizeDocumentStatus", () => {
+    it("returns null for non-string input", () => {
+        expect(normalizeDocumentStatus(null)).toBeNull();
+        expect(normalizeDocumentStatus(undefined)).toBeNull();
+        expect(normalizeDocumentStatus(42)).toBeNull();
+        expect(normalizeDocumentStatus(["draft"])).toBeNull();
+        expect(normalizeDocumentStatus({})).toBeNull();
+    });
+
+    it("returns null for empty or whitespace-only input", () => {
+        expect(normalizeDocumentStatus("")).toBeNull();
+        expect(normalizeDocumentStatus("   ")).toBeNull();
+        expect(normalizeDocumentStatus("\t\n")).toBeNull();
+    });
+
+    it("trims and lowercases", () => {
+        expect(normalizeDocumentStatus("  Draft  ")).toBe("draft");
+        expect(normalizeDocumentStatus("PUBLISHED")).toBe("published");
+    });
+
+    it("collapses spaces and hyphens to underscores", () => {
+        expect(normalizeDocumentStatus("in review")).toBe("in_review");
+        expect(normalizeDocumentStatus("in-review")).toBe("in_review");
+        expect(normalizeDocumentStatus("in   review")).toBe("in_review");
+        expect(normalizeDocumentStatus("in - review")).toBe("in_review");
+        expect(normalizeDocumentStatus("In Review")).toBe("in_review");
+    });
+
+    it("aliases 'review' to 'in_review'", () => {
+        expect(normalizeDocumentStatus("review")).toBe("in_review");
+        expect(normalizeDocumentStatus("  Review ")).toBe("in_review");
+    });
+
+    it("returns unknown values normalized rather than dropping them", () => {
+        expect(normalizeDocumentStatus("Needs Work")).toBe("needs_work");
+        expect(normalizeDocumentStatus("custom-status")).toBe("custom_status");
+    });
+});
+
+describe("isKnownStatus", () => {
+    it("recognizes the canonical statuses", () => {
+        for (const s of KNOWN_STATUSES) {
+            expect(isKnownStatus(s)).toBe(true);
+        }
+    });
+
+    it("rejects unknown values", () => {
+        expect(isKnownStatus("needs_work")).toBe(false);
+        expect(isKnownStatus("review")).toBe(false);
+    });
+});
+
+describe("statusLabel", () => {
+    it("labels known statuses", () => {
+        expect(statusLabel("draft")).toBe("Draft");
+        expect(statusLabel("in_review")).toBe("In review");
+        expect(statusLabel("published")).toBe("Published");
+        expect(statusLabel("deprecated")).toBe("Deprecated");
+        expect(statusLabel("archived")).toBe("Archived");
+    });
+
+    it("renders unknown statuses with underscores as spaces", () => {
+        expect(statusLabel("needs_work")).toBe("needs work");
+        expect(statusLabel("custom")).toBe("custom");
+    });
+});
+
+describe("statusTone", () => {
+    it("maps known statuses to tones", () => {
+        expect(statusTone("draft")).toBe("muted");
+        expect(statusTone("in_review")).toBe("accent");
+        expect(statusTone("published")).toBe("success");
+        expect(statusTone("deprecated")).toBe("warning");
+        expect(statusTone("archived")).toBe("muted");
+    });
+
+    it("falls back to muted for unknown statuses", () => {
+        expect(statusTone("needs_work")).toBe("muted");
+    });
+});
+
+describe("statusDotColor", () => {
+    it("returns a color for each known status", () => {
+        for (const s of KNOWN_STATUSES) {
+            expect(statusDotColor(s)).toBeTruthy();
+        }
+    });
+
+    it("uses green for published and accent for in_review", () => {
+        expect(statusDotColor("published")).toBe("#22c55e");
+        expect(statusDotColor("in_review")).toBe("var(--accent)");
+    });
+
+    it("falls back to a muted color for unknown statuses", () => {
+        expect(statusDotColor("mystery")).toBe("var(--text-secondary)");
+    });
+});

--- a/apps/desktop/src/features/okf/status.ts
+++ b/apps/desktop/src/features/okf/status.ts
@@ -1,0 +1,111 @@
+/**
+ * OKF (Open Knowledge Format) document status.
+ *
+ * NeverWrite defines a `status` extension field in OKF frontmatter to signal
+ * a document's publication/trust state. OKF is permissive on consumption:
+ * unknown status values are normalized and shown, never rejected.
+ *
+ * This module is shared between the editor header and the file tree, so the
+ * public API here is intentionally stable.
+ */
+
+export const KNOWN_STATUSES = [
+    "draft",
+    "in_review",
+    "published",
+    "deprecated",
+    "archived",
+] as const;
+
+export type KnownDocumentStatus = (typeof KNOWN_STATUSES)[number];
+
+export type StatusTone = "muted" | "accent" | "success" | "warning";
+
+/**
+ * Normalize a raw frontmatter status value.
+ *
+ * - Non-string or empty/whitespace-only input returns `null`.
+ * - Otherwise the value is trimmed, lowercased, and any run of spaces or
+ *   hyphens is collapsed to a single underscore.
+ * - The alias `"review"` maps to `"in_review"`.
+ *
+ * Unknown values are still returned (normalized) rather than dropped, so the
+ * UI can surface them verbatim.
+ */
+export function normalizeDocumentStatus(raw: unknown): string | null {
+    if (typeof raw !== "string") return null;
+
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+
+    const normalized = trimmed
+        .toLowerCase()
+        .replace(/[\s-]+/g, "_")
+        .replace(/_+/g, "_")
+        .replace(/^_+|_+$/g, "");
+
+    if (!normalized) return null;
+    if (normalized === "review") return "in_review";
+
+    return normalized;
+}
+
+export function isKnownStatus(s: string): s is KnownDocumentStatus {
+    return (KNOWN_STATUSES as readonly string[]).includes(s);
+}
+
+const STATUS_LABELS: Record<KnownDocumentStatus, string> = {
+    draft: "Draft",
+    in_review: "In review",
+    published: "Published",
+    deprecated: "Deprecated",
+    archived: "Archived",
+};
+
+/**
+ * Human-readable label for a normalized status. Known statuses use a fixed
+ * label; unknown statuses render their normalized value with underscores
+ * turned back into spaces.
+ */
+export function statusLabel(s: string): string {
+    if (isKnownStatus(s)) return STATUS_LABELS[s];
+    return s.replace(/_/g, " ");
+}
+
+const STATUS_TONES: Record<KnownDocumentStatus, StatusTone> = {
+    draft: "muted",
+    in_review: "accent",
+    published: "success",
+    deprecated: "warning",
+    archived: "muted",
+};
+
+/** Badge tone for a normalized status. Unknown statuses fall back to muted. */
+export function statusTone(s: string): StatusTone {
+    if (isKnownStatus(s)) return STATUS_TONES[s];
+    return "muted";
+}
+
+/**
+ * CSS color for the leading status dot. Uses the app's CSS variables and the
+ * `color-mix` idiom so it reads correctly in both light and dark themes.
+ */
+export function statusDotColor(s: string): string {
+    switch (s) {
+        case "published":
+            // Green, matching the success badge palette.
+            return "#22c55e";
+        case "in_review":
+            return "var(--accent)";
+        case "draft":
+            // Amber.
+            return "#f59e0b";
+        case "deprecated":
+            // Orange.
+            return "#f97316";
+        case "archived":
+            return "var(--text-secondary)";
+        default:
+            return "var(--text-secondary)";
+    }
+}

--- a/apps/desktop/src/features/okf/systemUsername.ts
+++ b/apps/desktop/src/features/okf/systemUsername.ts
@@ -1,0 +1,28 @@
+import { invoke } from "@neverwrite/runtime";
+
+let cached: string | null | undefined;
+
+/**
+ * OS account name of the current user, fetched once from the Electron main
+ * process (`get_system_username`) and cached for the session. Returns `null`
+ * when the username cannot be determined; callers must then omit
+ * attribution fields (e.g. `status_by`) rather than write a placeholder.
+ *
+ * Failures are not cached, so a transient IPC error does not permanently
+ * disable attribution.
+ */
+export async function fetchSystemUsername(): Promise<string | null> {
+    if (cached !== undefined) return cached;
+    try {
+        const value = await invoke<unknown>("get_system_username");
+        cached =
+            typeof value === "string" && value.trim() ? value.trim() : null;
+        return cached;
+    } catch {
+        return null;
+    }
+}
+
+export function resetSystemUsernameCacheForTests() {
+    cached = undefined;
+}

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3674,6 +3674,7 @@ function FileTreeSettings({
     const {
         fileTreeContentMode,
         fileTreeShowExtensions,
+        fileTreeShowDocumentStatus,
         fileTreeExtensionFilter,
         setSetting,
     } = useSettingsStore();
@@ -3692,6 +3693,10 @@ function FileTreeSettings({
             [
                 "Show file extensions",
                 "Display full file names with their extensions in the vault tree.",
+            ],
+            [
+                "Show document status",
+                "Show a colored dot for the frontmatter status of each note.",
             ],
             [
                 "File extension filter",
@@ -3742,6 +3747,20 @@ function FileTreeSettings({
                         value={fileTreeShowExtensions}
                         onChange={(value) =>
                             setSetting("fileTreeShowExtensions", value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="File Tree"
+                label="Show document status"
+                description="Show a colored dot for the frontmatter status of each note."
+                control={
+                    <Toggle
+                        value={fileTreeShowDocumentStatus}
+                        onChange={(value) =>
+                            setSetting("fileTreeShowDocumentStatus", value)
                         }
                     />
                 }

--- a/apps/desktop/src/features/vault/FileTree.test.tsx
+++ b/apps/desktop/src/features/vault/FileTree.test.tsx
@@ -3776,3 +3776,102 @@ describe("FileTree", () => {
         expect(elementsFromPoint).toHaveBeenCalled();
     });
 });
+
+describe("FileTree — document status dot", () => {
+    function statusNote(
+        overrides: Partial<{
+            status: string | null;
+            okf_type: string | null;
+        }> = {},
+    ) {
+        return {
+            id: "notes/alpha",
+            path: "/vault/notes/alpha.md",
+            title: "Alpha",
+            modified_at: 1,
+            created_at: 1,
+            status: null,
+            okf_type: null,
+            ...overrides,
+        };
+    }
+
+    it("renders a colored status dot with a tooltip that includes the type", async () => {
+        const user = userEvent.setup();
+        act(() => {
+            useSettingsStore.getState().reset();
+            useSettingsStore.setState({ fileTreeShowDocumentStatus: true });
+        });
+        setVaultNotes([statusNote({ status: "published", okf_type: "Runbook" })]);
+
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "notes");
+
+            const row = getNoteRow("Alpha");
+            const dot = row.querySelector("[data-document-status]");
+            expect(dot).not.toBeNull();
+            expect(dot).toHaveAttribute("data-document-status", "published");
+            expect(dot).toHaveAttribute("title", "Published · Runbook");
+        } finally {
+            act(() => useSettingsStore.getState().reset());
+        }
+    });
+
+    it("does not render a dot when the setting is off", async () => {
+        const user = userEvent.setup();
+        act(() => {
+            useSettingsStore.getState().reset();
+            useSettingsStore.setState({ fileTreeShowDocumentStatus: false });
+        });
+        setVaultNotes([statusNote({ status: "published" })]);
+
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "notes");
+            expect(
+                getNoteRow("Alpha").querySelector("[data-document-status]"),
+            ).toBeNull();
+        } finally {
+            act(() => useSettingsStore.getState().reset());
+        }
+    });
+
+    it("does not render a dot when the note has no status", async () => {
+        const user = userEvent.setup();
+        act(() => {
+            useSettingsStore.getState().reset();
+            useSettingsStore.setState({ fileTreeShowDocumentStatus: true });
+        });
+        setVaultNotes([statusNote()]);
+
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "notes");
+            expect(
+                getNoteRow("Alpha").querySelector("[data-document-status]"),
+            ).toBeNull();
+        } finally {
+            act(() => useSettingsStore.getState().reset());
+        }
+    });
+
+    it("dims the label for archived notes", async () => {
+        const user = userEvent.setup();
+        act(() => {
+            useSettingsStore.getState().reset();
+            useSettingsStore.setState({ fileTreeShowDocumentStatus: true });
+        });
+        setVaultNotes([statusNote({ status: "archived" })]);
+
+        try {
+            renderComponent(<FileTree />);
+            await expandFolder(user, "notes");
+
+            const label = screen.getByText("Alpha");
+            expect(label).toHaveStyle({ opacity: "0.55" });
+        } finally {
+            act(() => useSettingsStore.getState().reset());
+        }
+    });
+});

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -65,6 +65,11 @@ import {
 import { FileTypeIcon } from "../../components/icons/FileTypeIcon";
 import { FolderTypeIcon } from "../../components/icons/FolderTypeIcon";
 import {
+    normalizeDocumentStatus,
+    statusDotColor,
+    statusLabel,
+} from "../okf/status";
+import {
     EXTERNAL_FILE_TREE_DRAG_EVENT,
     emitFileTreeAttachToNewChat,
     emitFileTreeNoteDrag,
@@ -938,6 +943,7 @@ interface FlatTreeRowViewProps {
     onRenameEntryConfirm: (entry: VaultEntryDto, newName: string) => void;
     onRenameCancel: () => void;
     showExtensions: boolean;
+    showDocumentStatus: boolean;
     stickyContentOffsetX?: number;
 }
 
@@ -984,6 +990,7 @@ const FlatTreeRowView = memo(
         onRenameEntryConfirm,
         onRenameCancel,
         showExtensions,
+        showDocumentStatus,
         stickyContentOffsetX = 0,
     }: FlatTreeRowViewProps) {
         const renameInputRef = useRef<HTMLInputElement>(null);
@@ -1440,6 +1447,16 @@ const FlatTreeRowView = memo(
         const isActive = note.id === activeNoteId;
         const isSelected = selectedNoteIds.has(note.id);
         const isDraggingThis = draggingNoteIds.has(note.id);
+        const documentStatus = showDocumentStatus
+            ? normalizeDocumentStatus(note.status)
+            : null;
+        const statusIsDimmed =
+            documentStatus === "archived" || documentStatus === "deprecated";
+        const statusDotTitle = documentStatus
+            ? note.okf_type
+                ? `${statusLabel(documentStatus)} · ${note.okf_type}`
+                : statusLabel(documentStatus)
+            : undefined;
 
         if (isRenamingNote) {
             return (
@@ -1555,9 +1572,26 @@ const FlatTreeRowView = memo(
                     kind="note"
                     size={metrics.smallIcon}
                 />
-                <span className={TREE_LABEL_CLASSNAME}>
+                <span
+                    className={TREE_LABEL_CLASSNAME}
+                    style={statusIsDimmed ? { opacity: 0.55 } : undefined}
+                >
                     {getNoteDisplayName(note, showExtensions)}
                 </span>
+                {documentStatus && (
+                    <span
+                        data-document-status={documentStatus}
+                        title={statusDotTitle}
+                        style={{
+                            flexShrink: 0,
+                            width: 6,
+                            height: 6,
+                            marginLeft: 2,
+                            borderRadius: "50%",
+                            background: statusDotColor(documentStatus),
+                        }}
+                    />
+                )}
             </div>
         );
     },
@@ -1581,6 +1615,7 @@ const FlatTreeRowView = memo(
         if (prev.creatingMode !== next.creatingMode) return false;
         if (prev.newItemName !== next.newItemName) return false;
         if (prev.showExtensions !== next.showExtensions) return false;
+        if (prev.showDocumentStatus !== next.showDocumentStatus) return false;
 
         const path = prev.row.path;
 
@@ -2106,6 +2141,9 @@ export function FileTree() {
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
     const fileTreeShowExtensions = useSettingsStore(
         (s) => s.fileTreeShowExtensions,
+    );
+    const fileTreeShowDocumentStatus = useSettingsStore(
+        (s) => s.fileTreeShowDocumentStatus,
     );
     const fileTreeExtensionFilter = useSettingsStore(
         (s) => s.fileTreeExtensionFilter,
@@ -5806,6 +5844,9 @@ export function FileTree() {
                                             showExtensions={
                                                 fileTreeShowExtensions
                                             }
+                                            showDocumentStatus={
+                                                fileTreeShowDocumentStatus
+                                            }
                                         />
                                     </div>
                                 ))}
@@ -5938,6 +5979,9 @@ export function FileTree() {
                                             onRenameCancel={handleRenameCancel}
                                             showExtensions={
                                                 fileTreeShowExtensions
+                                            }
+                                            showDocumentStatus={
+                                                fileTreeShowDocumentStatus
                                             }
                                         />
                                     );

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -4020,6 +4020,8 @@ export function FileTree() {
             const detail = await vaultInvoke<{
                 title: string;
                 path: string;
+                status?: string | null;
+                okf_type?: string | null;
             }>("save_note", {
                 noteId: created.id,
                 content,
@@ -4029,6 +4031,8 @@ export function FileTree() {
                 title: detail.title,
                 path: detail.path,
                 modified_at: Math.floor(Date.now() / 1000),
+                status: detail.status ?? null,
+                okf_type: detail.okf_type ?? null,
             });
             touchContent();
             return created;
@@ -4398,6 +4402,8 @@ export function FileTree() {
                 const detail = await vaultInvoke<{
                     title: string;
                     path: string;
+                    status?: string | null;
+                    okf_type?: string | null;
                 }>("save_note", {
                     noteId: created.id,
                     content,
@@ -4407,6 +4413,8 @@ export function FileTree() {
                     title: detail.title,
                     path: detail.path,
                     modified_at: Math.floor(Date.now() / 1000),
+                    status: detail.status ?? null,
+                    okf_type: detail.okf_type ?? null,
                 });
                 touchContent();
             } catch (error) {

--- a/crates/index/src/index.rs
+++ b/crates/index/src/index.rs
@@ -6,6 +6,7 @@ use std::sync::{
 use std::thread;
 
 use neverwrite_types::{IndexedNote, NoteDocument, NoteId, NoteMetadata, PdfDocument, PdfMetadata};
+use neverwrite_vault::parser::frontmatter_string_field;
 
 const PROGRESS_REPORT_EVERY: usize = 256;
 const MAX_SUGGESTION_PREFIX_CHARS: usize = 64;
@@ -458,6 +459,8 @@ impl VaultIndex {
                 modified_at: note.modified_at,
                 created_at: note.created_at,
                 size: note.size,
+                status: note.status.clone(),
+                okf_type: note.okf_type.clone(),
             },
         );
     }
@@ -889,6 +892,8 @@ struct PreparedNote {
     modified_at: u64,
     created_at: u64,
     size: u64,
+    status: Option<String>,
+    okf_type: Option<String>,
 }
 
 impl PreparedNote {
@@ -906,6 +911,8 @@ impl PreparedNote {
             .unwrap_or_default()
             .to_string();
         let (modified_at, created_at, size) = read_note_file_stats(&note.path.0);
+        let status = frontmatter_string_field(note.frontmatter.as_ref(), "status");
+        let okf_type = frontmatter_string_field(note.frontmatter.as_ref(), "type");
 
         Self {
             normalized_id: normalize_alias(&note.id.0),
@@ -922,6 +929,8 @@ impl PreparedNote {
             modified_at,
             created_at,
             size,
+            status,
+            okf_type,
         }
     }
 }

--- a/crates/index/tests/integration.rs
+++ b/crates/index/tests/integration.rs
@@ -829,3 +829,87 @@ fn pdf_metadata_empty_by_default() {
     assert!(index.pdf_metadata.is_empty());
     assert!(index.pdf_search_index.is_empty());
 }
+
+fn make_note_with_frontmatter(
+    id: &str,
+    title: &str,
+    frontmatter: serde_json::Value,
+) -> NoteDocument {
+    NoteDocument {
+        id: NoteId(id.to_string()),
+        path: NotePath(PathBuf::from(format!("{}.md", id))),
+        title: title.to_string(),
+        raw_markdown: String::new(),
+        links: Vec::new(),
+        tags: Vec::new(),
+        frontmatter: Some(frontmatter),
+    }
+}
+
+#[test]
+fn build_populates_status_and_okf_type() {
+    let index = VaultIndex::build(vec![
+        make_note_with_frontmatter(
+            "a",
+            "Note A",
+            serde_json::json!({ "status": "draft", "type": "article" }),
+        ),
+        make_note_with_frontmatter("b", "Note B", serde_json::json!({ "title": "Note B" })),
+        make_note_with_frontmatter(
+            "c",
+            "Note C",
+            // Non-string values must be ignored.
+            serde_json::json!({ "status": ["x", "y"], "type": 42 }),
+        ),
+    ]);
+
+    let a = &index.metadata[&NoteId("a".into())];
+    assert_eq!(a.status.as_deref(), Some("draft"));
+    assert_eq!(a.okf_type.as_deref(), Some("article"));
+
+    let b = &index.metadata[&NoteId("b".into())];
+    assert_eq!(b.status, None);
+    assert_eq!(b.okf_type, None);
+
+    let c = &index.metadata[&NoteId("c".into())];
+    assert_eq!(c.status, None);
+    assert_eq!(c.okf_type, None);
+}
+
+#[test]
+fn reindex_updates_status() {
+    let mut index = VaultIndex::build(vec![make_note_with_frontmatter(
+        "a",
+        "Note A",
+        serde_json::json!({ "status": "draft", "type": "article" }),
+    )]);
+    assert_eq!(index.metadata[&NoteId("a".into())].status.as_deref(), Some("draft"));
+
+    index.reindex_note(make_note_with_frontmatter(
+        "a",
+        "Note A",
+        serde_json::json!({ "status": "published", "type": "article" }),
+    ));
+
+    let a = &index.metadata[&NoteId("a".into())];
+    assert_eq!(a.status.as_deref(), Some("published"));
+    assert_eq!(a.okf_type.as_deref(), Some("article"));
+}
+
+#[test]
+fn reindex_clears_removed_status() {
+    let mut index = VaultIndex::build(vec![make_note_with_frontmatter(
+        "a",
+        "Note A",
+        serde_json::json!({ "status": "draft" }),
+    )]);
+    assert_eq!(index.metadata[&NoteId("a".into())].status.as_deref(), Some("draft"));
+
+    index.reindex_note(make_note_with_frontmatter(
+        "a",
+        "Note A",
+        serde_json::json!({ "title": "Note A" }),
+    ));
+
+    assert_eq!(index.metadata[&NoteId("a".into())].status, None);
+}

--- a/crates/types/src/domain.rs
+++ b/crates/types/src/domain.rs
@@ -44,6 +44,12 @@ pub struct NoteMetadata {
     pub modified_at: u64,
     pub created_at: u64,
     pub size: u64,
+    /// Raw `status` frontmatter extension field (trimmed non-empty string, else None).
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Raw OKF `type` frontmatter field (trimmed non-empty string, else None).
+    #[serde(default)]
+    pub okf_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/types/src/dto.rs
+++ b/crates/types/src/dto.rs
@@ -81,6 +81,12 @@ pub struct NoteDto {
     pub title: String,
     pub modified_at: u64,
     pub created_at: u64,
+    /// Raw `status` frontmatter extension field (trimmed string, else null).
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Raw OKF `type` frontmatter field (trimmed string, else null).
+    #[serde(default)]
+    pub okf_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -133,6 +139,11 @@ pub struct VaultOpenStateDto {
     pub finished_at_ms: Option<u64>,
     pub metrics: VaultOpenMetricsDto,
     pub error: Option<String>,
+    /// OKF version declared by the vault-root `index.md` frontmatter, if any.
+    /// Computed at vault-open time only (may go stale if the root index.md is
+    /// edited while the vault stays open).
+    #[serde(default)]
+    pub okf_version: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -143,6 +154,12 @@ pub struct VaultNoteChangeDto {
     pub note_id: Option<String>,
     pub entry: Option<VaultEntryDto>,
     pub relative_path: Option<String>,
+    /// Raw `status` frontmatter extension field for the changed note, if any.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Raw OKF `type` frontmatter field for the changed note, if any.
+    #[serde(default)]
+    pub okf_type: Option<String>,
     #[serde(default = "default_vault_change_origin")]
     pub origin: String,
     #[serde(default)]

--- a/crates/types/src/dto.rs
+++ b/crates/types/src/dto.rs
@@ -98,6 +98,15 @@ pub struct NoteDetailDto {
     pub tags: Vec<String>,
     pub links: Vec<String>,
     pub frontmatter: Option<serde_json::Value>,
+    /// Raw `status` frontmatter extension field (trimmed string, else null).
+    /// Carried on the save/read response because app-initiated saves emit a
+    /// user-origin change event that the renderer intentionally ignores; the
+    /// response is the only live path for status into the renderer store.
+    #[serde(default)]
+    pub status: Option<String>,
+    /// Raw OKF `type` frontmatter field (trimmed string, else null).
+    #[serde(default)]
+    pub okf_type: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/vault/src/parser/frontmatter.rs
+++ b/crates/vault/src/parser/frontmatter.rs
@@ -16,6 +16,20 @@ pub fn extract_frontmatter(text: &str) -> Option<Value> {
     serde_json::to_value(yaml_value).ok()
 }
 
+/// Reads a frontmatter field as a trimmed, non-empty string.
+///
+/// Returns `None` when the frontmatter is absent, the key is missing, the value
+/// is not a YAML string, or the value is empty/whitespace-only after trimming.
+pub fn frontmatter_string_field(frontmatter: Option<&Value>, key: &str) -> Option<String> {
+    let value = frontmatter?.get(key)?.as_str()?;
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -48,5 +62,64 @@ mod tests {
         let text = "---\ndate: 2024-01-15\ndraft: true\n---\nContenido";
         let fm = extract_frontmatter(text).unwrap();
         assert_eq!(fm["draft"], true);
+    }
+
+    #[test]
+    fn string_field_present() {
+        let text = "---\nstatus: draft\ntype: article\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(
+            frontmatter_string_field(fm.as_ref(), "status"),
+            Some("draft".to_string())
+        );
+        assert_eq!(
+            frontmatter_string_field(fm.as_ref(), "type"),
+            Some("article".to_string())
+        );
+    }
+
+    #[test]
+    fn string_field_missing() {
+        let text = "---\ntitle: Only Title\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "status"), None);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "type"), None);
+    }
+
+    #[test]
+    fn string_field_no_frontmatter() {
+        assert_eq!(frontmatter_string_field(None, "status"), None);
+    }
+
+    #[test]
+    fn string_field_non_string() {
+        let text = "---\nstatus:\n  - a\n  - b\ntype: 42\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "status"), None);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "type"), None);
+    }
+
+    #[test]
+    fn string_field_empty_string() {
+        let text = "---\nstatus: \"\"\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "status"), None);
+    }
+
+    #[test]
+    fn string_field_whitespace_only_is_trimmed_to_none() {
+        let text = "---\nstatus: \"   \"\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(frontmatter_string_field(fm.as_ref(), "status"), None);
+    }
+
+    #[test]
+    fn string_field_trims_surrounding_whitespace() {
+        let text = "---\nstatus: \"  in_review  \"\n---\n# Body";
+        let fm = extract_frontmatter(text);
+        assert_eq!(
+            frontmatter_string_field(fm.as_ref(), "status"),
+            Some("in_review".to_string())
+        );
     }
 }

--- a/crates/vault/src/parser/mod.rs
+++ b/crates/vault/src/parser/mod.rs
@@ -5,7 +5,7 @@ pub mod wikilinks;
 
 use neverwrite_types::NoteDocument;
 
-pub use frontmatter::extract_frontmatter;
+pub use frontmatter::{extract_frontmatter, frontmatter_string_field};
 pub use tags::extract_tags;
 pub use wikilinks::extract_wikilinks;
 

--- a/crates/vault/src/vault.rs
+++ b/crates/vault/src/vault.rs
@@ -62,6 +62,20 @@ impl Vault {
         Ok(Vault { root: path })
     }
 
+    /// Detects the OKF (Open Knowledge Format) version declared by the vault-root
+    /// `index.md`. Per the OKF spec the bundle-root `index.md` may declare
+    /// `okf_version` in its frontmatter. Only the vault-root file is inspected;
+    /// nested `index.md` files are ignored.
+    ///
+    /// Returns `None` when the root `index.md` is missing, has no parseable
+    /// frontmatter, or `okf_version` is absent / not a string.
+    pub fn detect_okf_version(&self) -> Option<String> {
+        let index_path = self.root.join("index.md");
+        let content = std::fs::read_to_string(&index_path).ok()?;
+        let frontmatter = crate::parser::extract_frontmatter(&content);
+        crate::parser::frontmatter_string_field(frontmatter.as_ref(), "okf_version")
+    }
+
     /// Discovers all `.md` files in the vault and returns lightweight metadata for each file.
     pub fn discover_markdown_files(&self) -> Result<Vec<DiscoveredNoteFile>, VaultError> {
         let mut discovered = Vec::new();

--- a/crates/vault/tests/integration.rs
+++ b/crates/vault/tests/integration.rs
@@ -766,3 +766,55 @@ fn pdf_cache_works_on_second_extraction() {
     }
     // If extraction failed (minimal PDF not parseable), that's OK — we tested error path above
 }
+
+#[test]
+fn detect_okf_version_present() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "---\nokf_version: \"0.1\"\ntype: bundle\n---\n# Root\n",
+    )
+    .unwrap();
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    assert_eq!(vault.detect_okf_version().as_deref(), Some("0.1"));
+}
+
+#[test]
+fn detect_okf_version_absent_key() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "---\ntype: bundle\n---\n# Root\n",
+    )
+    .unwrap();
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    assert_eq!(vault.detect_okf_version(), None);
+}
+
+#[test]
+fn detect_okf_version_missing_index() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("other.md"), "# No index\n").unwrap();
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    assert_eq!(vault.detect_okf_version(), None);
+}
+
+#[test]
+fn detect_okf_version_non_string() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("index.md"),
+        "---\nokf_version: [0.1]\n---\n# Root\n",
+    )
+    .unwrap();
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    assert_eq!(vault.detect_okf_version(), None);
+}
+
+#[test]
+fn detect_okf_version_no_frontmatter() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("index.md"), "# Plain index, no frontmatter\n").unwrap();
+    let vault = Vault::open(dir.path().to_path_buf()).unwrap();
+    assert_eq!(vault.detect_okf_version(), None);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ remain reviewable.
 ## Editor And Workspace
 
 - [Editor Architecture](editor-architecture.md): CodeMirror, live preview, Mermaid rendering, wikilinks, frontmatter/properties, autosave, dirty tabs, merge view, inline review overlays, and power-user invariants.
+- [Open Knowledge Format (OKF)](okf.md): the `status` and `type` frontmatter fields, canonical status values, where status appears (file tree dot, editor badge/banner), the "Show document status" setting, and `okf_version` vault detection.
 - [Terminal Architecture](terminal-integration.md): PTY sidecar boundary, xterm rendering, terminal persistence, Claude Code integration, and validation notes.
 - [Subagents Working State Map](concept-maps/codex-subagents-working-state-map.excalidraw): visual working map for subagent state and coordination.
 

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -1,0 +1,95 @@
+# Open Knowledge Format (OKF)
+
+NeverWrite has partial support for the [Open Knowledge Format
+(OKF)](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md),
+a convention for describing knowledge documents through Markdown frontmatter.
+This page documents the parts NeverWrite reads and surfaces: the `status`
+extension field, the `type` field, and OKF vault detection.
+
+OKF is permissive on consumption. NeverWrite never rejects a note for having an
+unknown or missing field. Everything below is additive: notes without OKF
+frontmatter render exactly as before.
+
+## The `status` field
+
+`status` is a NeverWrite extension to OKF frontmatter that signals a document's
+publication and trust state. It is a single string value:
+
+```markdown
+---
+title: Incident runbook
+type: runbook
+status: published
+---
+```
+
+### Canonical values
+
+| Value | Meaning |
+| --- | --- |
+| `draft` | Not yet published. |
+| `in_review` | Under review; may change before publication. |
+| `published` | Published and current. |
+| `deprecated` | Outdated; kept but no longer authoritative. |
+| `archived` | Kept for reference only. |
+
+Values are normalized before display: they are trimmed, lowercased, and runs of
+spaces or hyphens collapse to a single underscore (so `In Review` and
+`in-review` both become `in_review`; the alias `review` also maps to
+`in_review`). Unknown values are not dropped. They are shown verbatim (with
+underscores rendered as spaces) using a neutral style, so a vault can use its
+own status vocabulary without losing information.
+
+Empty or whitespace-only values, and any non-string value, are treated as no
+status.
+
+## Where status appears
+
+- **File tree dot.** When "Show document status" is enabled (see below), each
+  note with a status shows a small colored dot to the right of its label. The
+  dot color maps to the status (green for `published`, amber for `draft`, and so
+  on). Its tooltip shows the status label, plus the note's `type` when present,
+  for example `Published · Runbook`. Notes whose status is `archived` or
+  `deprecated` are dimmed in the tree.
+- **Editor status badge.** The Markdown editor header shows a status badge in
+  the breadcrumb row. Clicking it opens a menu to change or clear the status;
+  the change is written back to frontmatter, preserving the order and content of
+  every other key.
+- **Editor trust banner.** For `draft`, `in_review`, `deprecated`, and
+  `archived`, the editor shows a short banner under the toolbar explaining the
+  state. `published` shows no banner.
+
+## The `type` field
+
+`type` is the standard OKF field describing the kind of document (for example
+`runbook`, `reference`, `guide`). NeverWrite reads it as a plain string and
+shows it as a muted badge in the editor header, and in the file tree status
+dot's tooltip. Same string rules as `status`: only string scalars, trimmed;
+empty resolves to absent.
+
+## Settings
+
+The file tree dot is controlled by a single toggle:
+
+- **Settings → File Tree → Show document status** (`fileTreeShowDocumentStatus`),
+  default on. This is a per-vault setting, scoped the same way as the other file
+  tree settings.
+
+Turning it off hides all status dots in the tree. It does not affect the editor
+badge or banner.
+
+## OKF vault detection (`okf_version`)
+
+A vault is treated as an OKF vault when its root `index.md` declares an OKF
+version in frontmatter. When detected, NeverWrite records the version
+(`okf_version`) and uses it for conformance hints. For example, in an OKF vault a
+note whose frontmatter has no non-empty `type` shows a muted "No OKF type" hint
+in the editor header; clicking it opens the Properties panel so the field can be
+added.
+
+### Limitation
+
+`okf_version` is computed once, when the vault is opened. It is not recomputed
+while the vault is open. Editing the root `index.md` to add, change, or remove
+the OKF version does not update detection live. Close and reopen the vault to
+refresh it.

--- a/docs/okf.md
+++ b/docs/okf.md
@@ -43,6 +43,16 @@ own status vocabulary without losing information.
 Empty or whitespace-only values, and any non-string value, are treated as no
 status.
 
+### Status attribution (`status_by`)
+
+When a status is set or changed through the editor's status menu, NeverWrite
+also writes `status_by: <username>` directly after `status`, recording the
+operating system account name of the person who made the change. The username
+comes from the desktop session on macOS, Windows, and Linux alike; if it cannot
+be determined, the field is omitted rather than filled with a placeholder.
+Choosing "No status" removes both `status` and `status_by`. All other
+frontmatter keys keep their order and content.
+
 ## Where status appears
 
 - **File tree dot.** When "Show document status" is enabled (see below), each


### PR DESCRIPTION
Closes #293

Adopts [OKF v0.1](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) as the recognized frontmatter convention and adds a `status` extension field so users can see at a glance whether a document is published and can be trusted. Canonical values: `draft`, `in_review`, `published`, `deprecated`, `archived`. Unknown values and unknown frontmatter keys are tolerated and preserved, per the OKF permissive consumption model.

## Backend (Rust)

- `status` and OKF `type` are extracted from frontmatter and cached in the vault index at build and reindex time (same pattern as `tags`), so the file tree renders from memory with no per-row disk reads.
- Both fields are exposed on `NoteDto` and `VaultNoteChangeDto`; the existing watcher path delivers live updates to the UI.
- `okf_version` is detected in the vault-root `index.md` at open and exposed on `VaultOpenStateDto`. Limitation: computed at open time only; editing it requires a vault reopen to refresh.
- The pure-TS fallback backend (`vaultBackend.ts`) mirrors the extraction rules (string scalars only, trimmed, empty means absent).

## UI

- **File tree**: colored status dot per note row with a `statusLabel · type` tooltip; `archived`/`deprecated` rows are dimmed. Behind a new `fileTreeShowDocumentStatus` setting (default on). Notes without `status` render unchanged, so non-OKF vaults see no visual noise.
- **Editor header**: status badge with a dropdown to change status through the existing frontmatter write-back path (autosave, undo, and conflict handling unchanged); a muted OKF `type` badge; a thin trust banner for any non-`published` status.
- **Conformance hint**: a "No OKF type" badge appears only in vaults that declare `okf_version`, and opens the Properties panel on click.
- Shared status normalization lives in `apps/desktop/src/features/okf/status.ts`.

## Docs

`docs/okf.md` documents the format, the status field, and the settings toggle; linked from `docs/README.md`.

## Testing

- Full desktop Vitest suite: 172 files, 1975 passed.
- `cargo test --workspace`: all green; `cargo clippy --workspace --all-targets` clean.
- `tsc --noEmit` clean for app, vitest, and electron tsconfig projects.
- New tests cover frontmatter extraction edge cases (non-string, empty, whitespace), index build/reindex propagation, change events, `okf_version` detection, tree dot/tooltip/dimming/setting, store wiring, badge/banner/dropdown behavior, and round-trip key preservation.