### PR TITLE
Prepare 0.4.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.4.5] - 2026-07-06
+
+### Added
+
+- Added OKF v0.1 document status support, including status indicators in the file tree, editor header status and type badges, trust banners for non-published documents, and a Settings toggle for file tree status dots.
+- Added quick document status changes from the editor header, preserving existing frontmatter and recording the local user in `status_by` when available. Thanks to @spamsch
+- Added `neverwrite://open` deep links for opening and revealing files inside the current vault, including optional line fragments such as `#L10` and `#L10-L20`. Thanks to @spamsch
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.56.0`.
+
 ## [0.4.4] - 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.4.4",
+            "version": "0.4.5",
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",
                 "@codemirror/lang-cpp": "^6.0.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.4.4",
+    "version": "0.4.5",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.4.4",
+    "version": "0.4.5",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.4.5 changelog entry from the changes since v0.4.4
- Align desktop, native backend, Cargo lock, and web clipper versions to 0.4.5
- Keep release metadata ready for the v0.4.5 tag-driven workflow

## Validation

- `cargo check -p neverwrite-native-backend`
- `node scripts/validate-release-metadata.mjs --tag v0.4.5`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`