### PR TITLE
Package Codex code-mode host with desktop runtime

### DIFF
--- a/.github/workflows/electron-package-smoke.yml
+++ b/.github/workflows/electron-package-smoke.yml
@@ -60,8 +60,8 @@ jobs:
               run: |
                   cargo build -p neverwrite-native-backend --quiet --release --target aarch64-apple-darwin
                   cargo build -p neverwrite-native-backend --quiet --release --target x86_64-apple-darwin
-                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin
-                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin --bins
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin --bins
 
             - name: Download embedded Node runtimes
               shell: bash
@@ -87,6 +87,8 @@ jobs:
                   echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/target/x86_64-apple-darwin/release/neverwrite-native-backend" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-code-mode-host" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-code-mode-host" >> "$GITHUB_ENV"
 
             - name: Package unsigned Electron app
               working-directory: apps/desktop
@@ -127,7 +129,7 @@ jobs:
                     local archs
                     archs="$(lipo -archs "$binary_path")"
                     echo "$binary_path: $archs"
-                    if [[ "$archs" != *"arm64"* || "$archs" != *"x86_64"* ]]; then
+                    if [[ "$archs" != "arm64 x86_64" && "$archs" != "x86_64 arm64" ]]; then
                       echo "Expected universal arm64/x86_64 binary: $binary_path" >&2
                       exit 1
                     fi
@@ -135,6 +137,7 @@ jobs:
 
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/neverwrite-native-backend"
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/binaries/codex-acp"
+                  verify_universal "$APP_PATH/Contents/Resources/native-backend/binaries/codex-code-mode-host"
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/embedded/node/bin/node"
 
     windows-x64:
@@ -169,7 +172,7 @@ jobs:
               shell: bash
               run: |
                   cargo build -p neverwrite-native-backend --quiet --release --target x86_64-pc-windows-msvc
-                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-pc-windows-msvc
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-pc-windows-msvc --bins
 
             - name: Download embedded Node runtime
               shell: bash
@@ -188,8 +191,10 @@ jobs:
               run: |
                   NATIVE_BACKEND_BIN="$GITHUB_WORKSPACE/target/x86_64-pc-windows-msvc/release/neverwrite-native-backend.exe"
                   CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-pc-windows-msvc/release/codex-acp.exe"
+                  CODEX_CODE_MODE_HOST_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-pc-windows-msvc/release/codex-code-mode-host.exe"
                   echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN=$NATIVE_BACKEND_BIN" >> "$GITHUB_ENV"
                   echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN=$CODEX_CODE_MODE_HOST_BIN" >> "$GITHUB_ENV"
 
             - name: Package unsigned Electron app
               working-directory: apps/desktop
@@ -202,6 +207,18 @@ jobs:
               env:
                   NEVERWRITE_ELECTRON_DIST_ARCH: x64
               run: npm run electron:sidecar:smoke:packaged
+
+            - name: Verify packaged Codex runtime files
+              shell: bash
+              run: |
+                  for binary in codex-acp.exe codex-code-mode-host.exe; do
+                    mapfile -t matches < <(find "$NEVERWRITE_ELECTRON_OUTPUT_DIR" -type f -path "*/resources/native-backend/binaries/$binary")
+                    if [[ "${#matches[@]}" -ne 1 ]]; then
+                      echo "Expected one packaged $binary, found ${#matches[@]}." >&2
+                      exit 1
+                    fi
+                    echo "Packaged $binary: ${matches[0]}"
+                  done
 
     linux:
         name: ${{ matrix.name }}
@@ -276,6 +293,22 @@ jobs:
               working-directory: apps/desktop
               run: npm ci
 
+            - name: Build target-specific sidecars
+              shell: bash
+              run: |
+                  cargo build -p neverwrite-native-backend --quiet --release --target ${{ matrix.target }}
+                  cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target ${{ matrix.target }} --bins
+
+            - name: Export sidecar environment
+              shell: bash
+              run: |
+                  NATIVE_BACKEND_BIN="$GITHUB_WORKSPACE/target/${{ matrix.target }}/release/neverwrite-native-backend"
+                  CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-acp"
+                  CODEX_CODE_MODE_HOST_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-code-mode-host"
+                  echo "NEVERWRITE_NATIVE_BACKEND_BUNDLE_BIN=$NATIVE_BACKEND_BIN" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
+                  echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN=$CODEX_CODE_MODE_HOST_BIN" >> "$GITHUB_ENV"
+
             - name: Package unsigned Electron app
               working-directory: apps/desktop
               env:
@@ -298,6 +331,24 @@ jobs:
                   NEVERWRITE_ELECTRON_OUTPUT_DIR: ${{ runner.temp }}/electron-dist
                   NEVERWRITE_ELECTRON_DIST_ARCH: ${{ matrix.arch }}
               run: npm run electron:app:smoke:packaged
+
+            - name: Verify packaged Codex runtime files
+              shell: bash
+              env:
+                  NEVERWRITE_ELECTRON_OUTPUT_DIR: ${{ runner.temp }}/electron-dist
+              run: |
+                  for binary in codex-acp codex-code-mode-host; do
+                    mapfile -t matches < <(find "$NEVERWRITE_ELECTRON_OUTPUT_DIR" -type f -path "*/resources/native-backend/binaries/$binary")
+                    if [[ "${#matches[@]}" -ne 1 ]]; then
+                      echo "Expected one packaged $binary, found ${#matches[@]}." >&2
+                      exit 1
+                    fi
+                    if [[ ! -x "${matches[0]}" ]]; then
+                      echo "Packaged $binary is not executable: ${matches[0]}" >&2
+                      exit 1
+                    fi
+                    echo "Packaged $binary: ${matches[0]}"
+                  done
 
             - name: Stage release assets and feed metadata
               shell: bash

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -185,10 +185,10 @@ jobs:
               shell: bash
               run: |
                   if [[ "${{ matrix.target }}" == "universal-apple-darwin" ]]; then
-                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin
-                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin
+                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target aarch64-apple-darwin --bins
+                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target x86_64-apple-darwin --bins
                   else
-                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target ${{ matrix.target }}
+                    cargo build --quiet --manifest-path vendor/codex-acp/Cargo.toml --release --target ${{ matrix.target }} --bins
                   fi
 
             - name: Download embedded Node runtime
@@ -224,12 +224,18 @@ jobs:
                   if [[ "${{ matrix.target }}" == "universal-apple-darwin" ]]; then
                     echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
                     echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-acp" >> "$GITHUB_ENV"
+                    echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64=$GITHUB_WORKSPACE/vendor/codex-acp/target/aarch64-apple-darwin/release/codex-code-mode-host" >> "$GITHUB_ENV"
+                    echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_X64=$GITHUB_WORKSPACE/vendor/codex-acp/target/x86_64-apple-darwin/release/codex-code-mode-host" >> "$GITHUB_ENV"
                   elif [[ "${{ runner.os }}" == "Windows" ]]; then
                     CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-acp.exe"
+                    CODEX_CODE_MODE_HOST_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-code-mode-host.exe"
                     echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
+                    echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN=$CODEX_CODE_MODE_HOST_BIN" >> "$GITHUB_ENV"
                   else
                     CODEX_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-acp"
+                    CODEX_CODE_MODE_HOST_BIN="$GITHUB_WORKSPACE/vendor/codex-acp/target/${{ matrix.target }}/release/codex-code-mode-host"
                     echo "NEVERWRITE_CODEX_ACP_BUNDLE_BIN=$CODEX_BIN" >> "$GITHUB_ENV"
+                    echo "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN=$CODEX_CODE_MODE_HOST_BIN" >> "$GITHUB_ENV"
                   fi
 
                   echo "NEVERWRITE_ELECTRON_OUTPUT_DIR=$RUNNER_TEMP/electron-dist" >> "$GITHUB_ENV"
@@ -312,6 +318,33 @@ jobs:
                   NEVERWRITE_ELECTRON_DIST_ARCH: ${{ matrix.arch }}
               run: npm run electron:app:smoke:packaged
 
+            - name: Verify signed macOS Codex runtime
+              if: matrix.target == 'universal-apple-darwin'
+              shell: bash
+              env:
+                  NEVERWRITE_ELECTRON_OUTPUT_DIR: ${{ runner.temp }}/electron-dist
+              run: |
+                  APP_PATH=""
+                  for candidate in \
+                    "$NEVERWRITE_ELECTRON_OUTPUT_DIR/mac-universal/NeverWrite.app" \
+                    "$NEVERWRITE_ELECTRON_OUTPUT_DIR/mac/NeverWrite.app"; do
+                    if [[ -d "$candidate" ]]; then
+                      APP_PATH="$candidate"
+                      break
+                    fi
+                  done
+
+                  if [[ -z "$APP_PATH" ]]; then
+                    echo "Could not find packaged NeverWrite.app in $NEVERWRITE_ELECTRON_OUTPUT_DIR." >&2
+                    exit 1
+                  fi
+
+                  for binary in codex-acp codex-code-mode-host; do
+                    codesign --verify --strict --verbose=2 \
+                      "$APP_PATH/Contents/Resources/native-backend/binaries/$binary"
+                  done
+                  codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
             - name: Verify macOS universal runtime binaries
               if: matrix.target == 'universal-apple-darwin'
               shell: bash
@@ -338,7 +371,7 @@ jobs:
                     local archs
                     archs="$(lipo -archs "$binary_path")"
                     echo "$binary_path: $archs"
-                    if [[ "$archs" != *"arm64"* || "$archs" != *"x86_64"* ]]; then
+                    if [[ "$archs" != "arm64 x86_64" && "$archs" != "x86_64 arm64" ]]; then
                       echo "Expected universal arm64/x86_64 binary: $binary_path" >&2
                       exit 1
                     fi
@@ -346,6 +379,7 @@ jobs:
 
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/neverwrite-native-backend"
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/binaries/codex-acp"
+                  verify_universal "$APP_PATH/Contents/Resources/native-backend/binaries/codex-code-mode-host"
                   verify_universal "$APP_PATH/Contents/Resources/native-backend/embedded/node/bin/node"
 
             - name: Sign Linux RPM package

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -18,6 +18,7 @@ const MAC_ADDITIONAL_BINARY_MAGIC_NUMBERS = new Set([
 const DEFAULT_MAC_BINARY_RELATIVE_PATHS = [
     "neverwrite-native-backend",
     "binaries/codex-acp",
+    "binaries/codex-code-mode-host",
     "embedded/node/bin/node",
 ];
 

--- a/apps/desktop/scripts/electron-builder-config.test.mjs
+++ b/apps/desktop/scripts/electron-builder-config.test.mjs
@@ -1,9 +1,16 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import config from "../electron-builder.config.mjs";
 import packageJson from "../package.json" with { type: "json" };
+import verifyElectronBundle, {
+    REQUIRED_RESOURCE_PATHS,
+    verifyPackagedResources,
+} from "./verify-electron-bundle.mjs";
 
 const require = createRequire(import.meta.url);
 const minimatch = require("minimatch");
@@ -21,6 +28,19 @@ test("macOS universal x64ArchFiles covers packaged native binaries", () => {
         minimatch(
             "Contents/Resources/native-backend/binaries/codex-acp",
             pattern,
+        ),
+        true,
+    );
+    assert.equal(
+        minimatch(
+            "Contents/Resources/native-backend/binaries/codex-code-mode-host",
+            pattern,
+        ),
+        true,
+    );
+    assert.equal(
+        config.mac.binaries.includes(
+            "Contents/Resources/native-backend/binaries/codex-code-mode-host",
         ),
         true,
     );
@@ -45,6 +65,74 @@ test("macOS universal x64ArchFiles covers packaged native binaries", () => {
         ),
         false,
     );
+});
+
+test("Codex runtime resources remain outside app.asar", () => {
+    assert.deepEqual(config.files, ["out/electron/**/*", "package.json"]);
+    assert.deepEqual(config.extraResources[0], {
+        from: "out/native-backend",
+        to: "native-backend",
+        filter: ["**/*"],
+    });
+});
+
+async function writeResourceFixture(
+    platform,
+    missingRelativePath = null,
+    resourcesDir = null,
+) {
+    if (!resourcesDir) {
+        resourcesDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), `neverwrite-${platform}-resources-`),
+        );
+    }
+    for (const relativePath of REQUIRED_RESOURCE_PATHS[platform]) {
+        if (relativePath === missingRelativePath) continue;
+        const absolutePath = path.join(resourcesDir, relativePath);
+        await fs.mkdir(path.dirname(absolutePath), { recursive: true });
+        await fs.writeFile(absolutePath, "fixture");
+        await fs.chmod(absolutePath, 0o755);
+    }
+    return resourcesDir;
+}
+
+test("resource verification accepts complete Codex runtime fixtures on every platform", async () => {
+    for (const platform of ["darwin", "win32", "linux"]) {
+        const resourcesDir = await writeResourceFixture(platform);
+        try {
+            assert.doesNotThrow(() =>
+                verifyPackagedResources(
+                    { electronPlatformName: platform },
+                    resourcesDir,
+                ),
+            );
+        } finally {
+            await fs.rm(resourcesDir, { recursive: true, force: true });
+        }
+    }
+});
+
+test("resource verification fails when only the code-mode host is missing", async () => {
+    const missingPath = "native-backend/binaries/codex-code-mode-host";
+    const appOutDir = await fs.mkdtemp(
+        path.join(os.tmpdir(), "neverwrite-linux-package-"),
+    );
+    const resourcesDir = await writeResourceFixture(
+        "linux",
+        missingPath,
+        path.join(appOutDir, "resources"),
+    );
+    try {
+        await assert.rejects(
+            verifyElectronBundle({
+                electronPlatformName: "linux",
+                appOutDir,
+            }),
+            /codex-code-mode-host/,
+        );
+    } finally {
+        await fs.rm(appOutDir, { recursive: true, force: true });
+    }
 });
 
 test("desktop app icons are wired for all packaged platforms", () => {

--- a/apps/desktop/scripts/postprocess-macos-dmg.mjs
+++ b/apps/desktop/scripts/postprocess-macos-dmg.mjs
@@ -119,6 +119,24 @@ function assertElectronFrameworkBinary(appPath) {
     }
 }
 
+function assertCodexRuntimeSignatures(appPath) {
+    const binariesDir = path.join(
+        appPath,
+        "Contents",
+        "Resources",
+        "native-backend",
+        "binaries",
+    );
+    for (const binaryName of ["codex-acp", "codex-code-mode-host"]) {
+        run("codesign", [
+            "--verify",
+            "--strict",
+            "--verbose=2",
+            path.join(binariesDir, binaryName),
+        ]);
+    }
+}
+
 function attachDmg(dmgPath, mountPoint) {
     fs.mkdirSync(mountPoint, { recursive: true });
     run("hdiutil", [
@@ -147,6 +165,7 @@ function detachDmg(mountPoint) {
 
 function validateMountedApp(appPath, requireNotarization) {
     assertElectronFrameworkBinary(appPath);
+    assertCodexRuntimeSignatures(appPath);
     run("codesign", [
         "--verify",
         "--deep",

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -99,11 +99,79 @@ async function findSidecarPath() {
     );
 }
 
-function assertExecutableMode(stats, sidecarPath) {
+function assertExecutableMode(stats, executablePath, description) {
     if (process.platform === "win32") return;
     if ((stats.mode & 0o111) === 0) {
-        throw new Error(`Packaged sidecar is not executable: ${sidecarPath}`);
+        throw new Error(`Packaged ${description} is not executable: ${executablePath}`);
     }
+}
+
+async function findCodeModeHostPath(sidecarPath) {
+    const hostName =
+        process.platform === "win32"
+            ? "codex-code-mode-host.exe"
+            : "codex-code-mode-host";
+    const hostPath = path.join(path.dirname(sidecarPath), "binaries", hostName);
+
+    let stats;
+    try {
+        stats = await fs.stat(hostPath);
+    } catch (error) {
+        if (error?.code === "ENOENT") {
+            throw new Error(`Packaged Codex code-mode host is missing: ${hostPath}`);
+        }
+        throw new Error(
+            `Could not inspect packaged Codex code-mode host: ${hostPath}`,
+            { cause: error },
+        );
+    }
+    if (!stats.isFile()) {
+        throw new Error(`Packaged Codex code-mode host is not a file: ${hostPath}`);
+    }
+    assertExecutableMode(stats, hostPath, "Codex code-mode host");
+    return hostPath;
+}
+
+async function smokeCodeModeHost(hostPath) {
+    const child = spawn(hostPath, [], { stdio: ["pipe", "ignore", "pipe"] });
+    const stderrChunks = [];
+    let settled = false;
+
+    child.stderr.on("data", (chunk) => stderrChunks.push(String(chunk)));
+
+    await new Promise((resolve, reject) => {
+        const startupTimer = setTimeout(() => {
+            cleanup();
+            resolve();
+        }, Math.min(smokeTimeoutMs, 1_000));
+
+        function cleanup() {
+            if (settled) return;
+            settled = true;
+            clearTimeout(startupTimer);
+            child.stdin.end();
+            if (!child.killed) child.kill("SIGTERM");
+        }
+
+        child.on("error", (error) => {
+            if (settled) return;
+            cleanup();
+            reject(
+                new Error(`Packaged Codex code-mode host could not start: ${hostPath}`, {
+                    cause: error,
+                }),
+            );
+        });
+        child.on("exit", (code, signal) => {
+            if (settled) return;
+            cleanup();
+            reject(
+                new Error(
+                    `Packaged Codex code-mode host exited before startup (${code ?? signal ?? "unknown"}).${formatStderr(stderrChunks)}`,
+                ),
+            );
+        });
+    });
 }
 
 async function smokePing(sidecarPath) {
@@ -193,7 +261,10 @@ if (!stats.isFile()) {
     throw new Error(`Packaged sidecar path is not a file: ${sidecarPath}`);
 }
 
-assertExecutableMode(stats, sidecarPath);
+assertExecutableMode(stats, sidecarPath, "sidecar");
+const codeModeHostPath = await findCodeModeHostPath(sidecarPath);
+await smokeCodeModeHost(codeModeHostPath);
 await smokePing(sidecarPath);
 
+console.log(`Packaged Codex code-mode host started: ${codeModeHostPath}`);
 console.log(`Packaged native backend sidecar responded to ping: ${sidecarPath}`);

--- a/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
@@ -1,0 +1,241 @@
+import path from "node:path";
+
+export const MAC_UNIVERSAL_TARGET = "universal-apple-darwin";
+export const MAC_UNIVERSAL_COMPONENT_TARGETS = [
+    "aarch64-apple-darwin",
+    "x86_64-apple-darwin",
+];
+
+export const CODEX_RUNTIME_COMPONENTS = [
+    {
+        baseName: "codex-acp",
+        description: "Codex ACP",
+        baseEnvKey: "NEVERWRITE_CODEX_ACP_BUNDLE_BIN",
+    },
+    {
+        baseName: "codex-code-mode-host",
+        description: "Codex code-mode host",
+        baseEnvKey: "NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN",
+    },
+];
+
+export function executableNameForTarget(baseName, targetTriple) {
+    return targetTriple.includes("windows") ? `${baseName}.exe` : baseName;
+}
+
+export function envSuffixForTarget(targetTriple) {
+    if (targetTriple === "aarch64-apple-darwin") return "ARM64";
+    if (targetTriple === "x86_64-apple-darwin") return "X64";
+    if (targetTriple === "aarch64-pc-windows-msvc") return "ARM64";
+    if (targetTriple === "x86_64-pc-windows-msvc") return "X64";
+    if (targetTriple === "aarch64-unknown-linux-gnu") return "ARM64";
+    if (targetTriple === "x86_64-unknown-linux-gnu") return "X64";
+    throw new Error(
+        `Unsupported target for environment suffix: ${targetTriple}`,
+    );
+}
+
+export function targetSpecificEnvKey(baseEnvKey, targetTriple) {
+    return `${baseEnvKey}_${envSuffixForTarget(targetTriple)}`;
+}
+
+export function codexRuntimePathForTarget(
+    workspaceRoot,
+    baseName,
+    targetTriple,
+) {
+    return path.join(
+        workspaceRoot,
+        "vendor",
+        "codex-acp",
+        "target",
+        targetTriple,
+        "release",
+        executableNameForTarget(baseName, targetTriple),
+    );
+}
+
+function configuredValue(env, envKey) {
+    return env[envKey]?.trim() || null;
+}
+
+function assertExpectedBinaryName(filePath, component, targetTriple, envKey) {
+    const expectedName = executableNameForTarget(
+        component.baseName,
+        targetTriple,
+    );
+    if (path.basename(filePath) !== expectedName) {
+        throw new Error(
+            `${component.description} override from ${envKey} must point to ${expectedName}: ${filePath}`,
+        );
+    }
+}
+
+function pairedOverridesForTarget(env, targetTriple) {
+    const overrides = CODEX_RUNTIME_COMPONENTS.map((component) => {
+        const envKey = targetSpecificEnvKey(component.baseEnvKey, targetTriple);
+        return {
+            component,
+            envKey,
+            value: configuredValue(env, envKey),
+        };
+    });
+    const configured = overrides.filter((override) => override.value);
+    if (configured.length > 0 && configured.length !== overrides.length) {
+        const missing = overrides
+            .filter((override) => !override.value)
+            .map((override) => override.envKey)
+            .join(", ");
+        throw new Error(
+            `Codex runtime overrides for ${targetTriple} must cover both binaries; missing: ${missing}`,
+        );
+    }
+    for (const override of configured) {
+        assertExpectedBinaryName(
+            override.value,
+            override.component,
+            targetTriple,
+            override.envKey,
+        );
+    }
+    return overrides;
+}
+
+function genericOverrides(env, targetTriple) {
+    const overrides = CODEX_RUNTIME_COMPONENTS.map((component) => ({
+        component,
+        envKey: component.baseEnvKey,
+        value: configuredValue(env, component.baseEnvKey),
+    }));
+    const configured = overrides.filter((override) => override.value);
+    if (configured.length > 0 && configured.length !== overrides.length) {
+        const missing = overrides
+            .filter((override) => !override.value)
+            .map((override) => override.envKey)
+            .join(", ");
+        throw new Error(
+            `Codex runtime overrides must cover both binaries; missing: ${missing}`,
+        );
+    }
+    for (const override of configured) {
+        assertExpectedBinaryName(
+            override.value,
+            override.component,
+            targetTriple,
+            override.envKey,
+        );
+    }
+    return overrides;
+}
+
+function binaryPlan(component, targetTriple, inputPaths) {
+    return {
+        ...component,
+        outputName: executableNameForTarget(component.baseName, targetTriple),
+        inputPaths,
+    };
+}
+
+export function createCodexRuntimeBundlePlan({
+    targetTriple,
+    workspaceRoot,
+    env = process.env,
+    skipBuild = false,
+}) {
+    if (targetTriple === MAC_UNIVERSAL_TARGET) {
+        const generic = genericOverrides(env, targetTriple);
+        if (generic.every((override) => override.value)) {
+            return {
+                buildTargets: [],
+                binaries: generic.map((override) =>
+                    binaryPlan(override.component, targetTriple, [
+                        override.value,
+                    ]),
+                ),
+            };
+        }
+
+        const inputPathsByComponent = new Map(
+            CODEX_RUNTIME_COMPONENTS.map((component) => [
+                component.baseName,
+                [],
+            ]),
+        );
+        const buildTargets = [];
+        for (const componentTarget of MAC_UNIVERSAL_COMPONENT_TARGETS) {
+            const overrides = pairedOverridesForTarget(env, componentTarget);
+            const hasOverrides = overrides.every((override) => override.value);
+            if (!hasOverrides && !skipBuild) {
+                buildTargets.push(componentTarget);
+            }
+            for (const override of overrides) {
+                inputPathsByComponent
+                    .get(override.component.baseName)
+                    .push(
+                        override.value ||
+                            codexRuntimePathForTarget(
+                                workspaceRoot,
+                                override.component.baseName,
+                                componentTarget,
+                            ),
+                    );
+            }
+        }
+
+        return {
+            buildTargets,
+            binaries: CODEX_RUNTIME_COMPONENTS.map((component) =>
+                binaryPlan(
+                    component,
+                    targetTriple,
+                    inputPathsByComponent.get(component.baseName),
+                ),
+            ),
+        };
+    }
+
+    const specific = pairedOverridesForTarget(env, targetTriple);
+    const hasSpecificOverrides = specific.every((override) => override.value);
+    const generic = genericOverrides(env, targetTriple);
+    const hasGenericOverrides = generic.every((override) => override.value);
+    if (hasSpecificOverrides && hasGenericOverrides) {
+        throw new Error(
+            `Codex runtime overrides for ${targetTriple} cannot mix target-specific and generic bundle paths`,
+        );
+    }
+
+    const selectedOverrides = hasSpecificOverrides
+        ? specific
+        : hasGenericOverrides
+          ? generic
+          : null;
+    return {
+        buildTargets: selectedOverrides || skipBuild ? [] : [targetTriple],
+        binaries: CODEX_RUNTIME_COMPONENTS.map((component) => {
+            const override = selectedOverrides?.find(
+                (candidate) =>
+                    candidate.component.baseName === component.baseName,
+            );
+            return binaryPlan(component, targetTriple, [
+                override?.value ||
+                    codexRuntimePathForTarget(
+                        workspaceRoot,
+                        component.baseName,
+                        targetTriple,
+                    ),
+            ]);
+        }),
+    };
+}
+
+export async function validateCodexRuntimeBundleInputs(plan, exists) {
+    for (const binary of plan.binaries) {
+        for (const inputPath of binary.inputPaths) {
+            if (!(await exists(inputPath))) {
+                throw new Error(
+                    `${binary.description} binary was not found: ${inputPath}`,
+                );
+            }
+        }
+    }
+}

--- a/apps/desktop/scripts/stage-electron-sidecar.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.mjs
@@ -4,6 +4,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+    MAC_UNIVERSAL_COMPONENT_TARGETS,
+    MAC_UNIVERSAL_TARGET,
+    createCodexRuntimeBundlePlan,
+    envSuffixForTarget,
+    executableNameForTarget,
+    validateCodexRuntimeBundleInputs,
+} from "./stage-electron-sidecar-helpers.mjs";
+
 const appRoot = fileURLToPath(new URL("..", import.meta.url));
 const workspaceRoot = path.resolve(appRoot, "..", "..");
 const stagedDir = path.join(appRoot, "out", "native-backend");
@@ -16,11 +25,6 @@ const vendorClaudeEmbeddedDir = path.join(
     "vendor",
     "Claude-agent-acp-upstream",
 );
-const MAC_UNIVERSAL_TARGET = "universal-apple-darwin";
-const MAC_UNIVERSAL_COMPONENT_TARGETS = [
-    "aarch64-apple-darwin",
-    "x86_64-apple-darwin",
-];
 const CLAUDE_RUNTIME_DEPENDENCIES = [
     "@agentclientprotocol/sdk",
     "@anthropic-ai/claude-agent-sdk",
@@ -252,24 +256,8 @@ function resolveHostRustTarget() {
     );
 }
 
-function executableNameForTarget(baseName, targetTriple) {
-    return targetTriple.includes("windows") ? `${baseName}.exe` : baseName;
-}
-
 function isMacUniversalTarget(targetTriple) {
     return targetTriple === MAC_UNIVERSAL_TARGET;
-}
-
-function envSuffixForTarget(targetTriple) {
-    if (targetTriple === "aarch64-apple-darwin") return "ARM64";
-    if (targetTriple === "x86_64-apple-darwin") return "X64";
-    if (targetTriple === "aarch64-pc-windows-msvc") return "ARM64";
-    if (targetTriple === "x86_64-pc-windows-msvc") return "X64";
-    if (targetTriple === "aarch64-unknown-linux-gnu") return "ARM64";
-    if (targetTriple === "x86_64-unknown-linux-gnu") return "X64";
-    throw new Error(
-        `Unsupported target for environment suffix: ${targetTriple}`,
-    );
 }
 
 function embeddedNodeVersion() {
@@ -516,6 +504,21 @@ async function lipoCreate(inputPaths, outputPath) {
     );
 }
 
+async function verifyUniversalBinary(filePath, description) {
+    try {
+        await run(
+            "lipo",
+            ["-verify_arch", "arm64", "x86_64", filePath],
+            appRoot,
+        );
+    } catch (error) {
+        throw new Error(
+            `${description} universal override must contain arm64 and x86_64: ${filePath}`,
+            { cause: error },
+        );
+    }
+}
+
 async function stageUniversalEmbeddedNodeRuntime(nodeSource) {
     const destinationNodeRoot = path.join(embeddedDir, "node");
     await fs.cp(nodeSource.sourcePath, destinationNodeRoot, {
@@ -594,18 +597,6 @@ function nativeBackendPathForTarget(targetTriple) {
     );
 }
 
-function codexPathForTarget(targetTriple) {
-    return path.join(
-        workspaceRoot,
-        "vendor",
-        "codex-acp",
-        "target",
-        targetTriple,
-        "release",
-        executableNameForTarget("codex-acp", targetTriple),
-    );
-}
-
 function targetSpecificEnvKey(baseEnvKey, targetTriple) {
     return `${baseEnvKey}_${envSuffixForTarget(targetTriple)}`;
 }
@@ -636,6 +627,7 @@ async function buildCodexForTarget(targetTriple) {
             "--release",
             "--target",
             targetTriple,
+            "--bins",
             "--quiet",
         ],
         workspaceRoot,
@@ -695,12 +687,15 @@ const nativeBackendName = executableNameForTarget(
     "neverwrite-native-backend",
     targetTriple,
 );
-const codexBinaryName = executableNameForTarget("codex-acp", targetTriple);
 const stagedPath = path.join(stagedDir, nativeBackendName);
 const isUniversalMac = isMacUniversalTarget(targetTriple);
+const codexRuntimePlan = createCodexRuntimeBundlePlan({
+    targetTriple,
+    workspaceRoot,
+    skipBuild: args.skipBuild,
+});
 
 let stagingNativeBackendPath;
-let stagingCodexPath;
 
 if (isUniversalMac) {
     stagingNativeBackendPath = await buildOrResolveUniversalRuntimeBinary({
@@ -708,12 +703,6 @@ if (isUniversalMac) {
         description: "Native backend",
         fallbackPathForTarget: nativeBackendPathForTarget,
         buildForTarget: buildNativeBackendForTarget,
-    });
-    stagingCodexPath = await buildOrResolveUniversalRuntimeBinary({
-        baseEnvKey: "NEVERWRITE_CODEX_ACP_BUNDLE_BIN",
-        description: "Codex ACP",
-        fallbackPathForTarget: codexPathForTarget,
-        buildForTarget: buildCodexForTarget,
     });
 } else {
     if (
@@ -729,19 +718,6 @@ if (isUniversalMac) {
         await buildNativeBackendForTarget(targetTriple);
     }
 
-    if (
-        !args.skipBuild &&
-        !process.env.NEVERWRITE_CODEX_ACP_BUNDLE_BIN?.trim() &&
-        !process.env[
-            targetSpecificEnvKey(
-                "NEVERWRITE_CODEX_ACP_BUNDLE_BIN",
-                targetTriple,
-            )
-        ]?.trim()
-    ) {
-        await buildCodexForTarget(targetTriple);
-    }
-
     stagingNativeBackendPath = await materializeStagingSource(
         await resolveSingleTargetRuntimeBinary({
             targetTriple,
@@ -750,15 +726,33 @@ if (isUniversalMac) {
             description: "Native backend",
         }),
     );
-    stagingCodexPath = await materializeStagingSource(
-        await resolveSingleTargetRuntimeBinary({
-            targetTriple,
-            baseEnvKey: "NEVERWRITE_CODEX_ACP_BUNDLE_BIN",
-            fallbackPath: codexPathForTarget(targetTriple),
-            description: "Codex ACP",
-        }),
-    );
 }
+
+// Both companion binaries come from one Cargo invocation for each target.
+for (const buildTarget of codexRuntimePlan.buildTargets) {
+    await buildCodexForTarget(buildTarget);
+}
+
+// Resolve and validate the complete pair before replacing the existing staging tree.
+await validateCodexRuntimeBundleInputs(codexRuntimePlan, pathExists);
+if (isUniversalMac) {
+    for (const binary of codexRuntimePlan.binaries) {
+        if (binary.inputPaths.length === 1) {
+            await verifyUniversalBinary(
+                binary.inputPaths[0],
+                binary.description,
+            );
+        }
+    }
+}
+const stagingCodexRuntime = await Promise.all(
+    codexRuntimePlan.binaries.map(async (binary) => ({
+        ...binary,
+        inputPaths: await Promise.all(
+            binary.inputPaths.map(materializeStagingSource),
+        ),
+    })),
+);
 
 const nodeSource = await resolveEmbeddedNodeSource(targetTriple);
 const claudeEmbeddedSource = await resolveClaudeEmbeddedSource();
@@ -774,13 +768,13 @@ if (Array.isArray(stagingNativeBackendPath)) {
     await fs.copyFile(stagingNativeBackendPath, stagedPath);
 }
 await fs.mkdir(binariesDir, { recursive: true });
-if (Array.isArray(stagingCodexPath)) {
-    await lipoCreate(stagingCodexPath, path.join(binariesDir, codexBinaryName));
-} else {
-    await fs.copyFile(
-        stagingCodexPath,
-        path.join(binariesDir, codexBinaryName),
-    );
+for (const binary of stagingCodexRuntime) {
+    const outputPath = path.join(binariesDir, binary.outputName);
+    if (binary.inputPaths.length > 1) {
+        await lipoCreate(binary.inputPaths, outputPath);
+    } else {
+        await fs.copyFile(binary.inputPaths[0], outputPath);
+    }
 }
 await fs.mkdir(embeddedDir, { recursive: true });
 if (nodeSource.kind === "universal-directory") {
@@ -794,7 +788,9 @@ await fs.cp(claudeEmbeddedSource, path.join(embeddedDir, "claude-agent-acp"), {
 });
 
 await ensureExecutableIfNeeded(stagedPath);
-await ensureExecutableIfNeeded(path.join(binariesDir, codexBinaryName));
+for (const binary of stagingCodexRuntime) {
+    await ensureExecutableIfNeeded(path.join(binariesDir, binary.outputName));
+}
 
 const stagedNodeBinary = path.join(
     embeddedDir,

--- a/apps/desktop/scripts/stage-electron-sidecar.test.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.test.mjs
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import {
+    createCodexRuntimeBundlePlan,
+    executableNameForTarget,
+    validateCodexRuntimeBundleInputs,
+} from "./stage-electron-sidecar-helpers.mjs";
+
+const workspaceRoot = path.resolve("/workspace");
+
+function existingPaths(...paths) {
+    const existing = new Set(paths);
+    return async (filePath) => existing.has(filePath);
+}
+
+test("derives runtime binary names from the target platform", () => {
+    assert.equal(
+        executableNameForTarget("codex-acp", "aarch64-apple-darwin"),
+        "codex-acp",
+    );
+    assert.equal(
+        executableNameForTarget(
+            "codex-code-mode-host",
+            "x86_64-pc-windows-msvc",
+        ),
+        "codex-code-mode-host.exe",
+    );
+});
+
+test("uses paired target-specific overrides without scheduling a build", () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "aarch64-apple-darwin",
+        workspaceRoot,
+        env: {
+            NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64: "/inputs/codex-acp",
+            NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64:
+                "/inputs/codex-code-mode-host",
+        },
+    });
+
+    assert.deepEqual(plan.buildTargets, []);
+    assert.deepEqual(
+        plan.binaries.map((binary) => binary.inputPaths[0]),
+        ["/inputs/codex-acp", "/inputs/codex-code-mode-host"],
+    );
+});
+
+test("uses paired Windows overrides with executable names", () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "x86_64-pc-windows-msvc",
+        workspaceRoot,
+        env: {
+            NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64: "/inputs/codex-acp.exe",
+            NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_X64:
+                "/inputs/codex-code-mode-host.exe",
+        },
+    });
+
+    assert.deepEqual(plan.buildTargets, []);
+    assert.deepEqual(
+        plan.binaries.map((binary) => binary.outputName),
+        ["codex-acp.exe", "codex-code-mode-host.exe"],
+    );
+    assert.deepEqual(
+        plan.binaries.map((binary) => binary.inputPaths[0]),
+        ["/inputs/codex-acp.exe", "/inputs/codex-code-mode-host.exe"],
+    );
+});
+
+test("uses paired generic overrides without scheduling a build", () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "aarch64-unknown-linux-gnu",
+        workspaceRoot,
+        env: {
+            NEVERWRITE_CODEX_ACP_BUNDLE_BIN: "/inputs/codex-acp",
+            NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN:
+                "/inputs/codex-code-mode-host",
+        },
+    });
+
+    assert.deepEqual(plan.buildTargets, []);
+    assert.deepEqual(
+        plan.binaries.map((binary) => binary.inputPaths[0]),
+        ["/inputs/codex-acp", "/inputs/codex-code-mode-host"],
+    );
+});
+
+test("rejects mixing generic and target-specific runtime overrides", () => {
+    assert.throws(
+        () =>
+            createCodexRuntimeBundlePlan({
+                targetTriple: "aarch64-apple-darwin",
+                workspaceRoot,
+                env: {
+                    NEVERWRITE_CODEX_ACP_BUNDLE_BIN: "/inputs/codex-acp",
+                    NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN:
+                        "/inputs/codex-code-mode-host",
+                    NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64:
+                        "/arm64/codex-acp",
+                    NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64:
+                        "/arm64/codex-code-mode-host",
+                },
+            }),
+        /cannot mix target-specific and generic bundle paths/,
+    );
+});
+
+test("rejects a bundle missing only the code-mode host", async () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "aarch64-apple-darwin",
+        workspaceRoot,
+        env: {},
+        skipBuild: true,
+    });
+    const acpPath = plan.binaries.find(
+        (binary) => binary.baseName === "codex-acp",
+    ).inputPaths[0];
+
+    await assert.rejects(
+        validateCodexRuntimeBundleInputs(plan, existingPaths(acpPath)),
+        /Codex code-mode host binary was not found/,
+    );
+});
+
+test("rejects a bundle missing only the ACP binary", async () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "aarch64-apple-darwin",
+        workspaceRoot,
+        env: {},
+        skipBuild: true,
+    });
+    const hostPath = plan.binaries.find(
+        (binary) => binary.baseName === "codex-code-mode-host",
+    ).inputPaths[0];
+
+    await assert.rejects(
+        validateCodexRuntimeBundleInputs(plan, existingPaths(hostPath)),
+        /Codex ACP binary was not found/,
+    );
+});
+
+test("does not reuse an arm64 host override for an x64 target", () => {
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "x86_64-apple-darwin",
+        workspaceRoot,
+        env: {
+            NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64:
+                "/inputs/codex-code-mode-host",
+        },
+    });
+
+    assert.deepEqual(plan.buildTargets, ["x86_64-apple-darwin"]);
+    assert.match(
+        plan.binaries.find(
+            (binary) => binary.baseName === "codex-code-mode-host",
+        ).inputPaths[0],
+        /x86_64-apple-darwin/,
+    );
+});
+
+test("universal staging requires four inputs and produces two outputs", async () => {
+    const env = {
+        NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64: "/arm64/codex-acp",
+        NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64:
+            "/arm64/codex-code-mode-host",
+        NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64: "/x64/codex-acp",
+        NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_X64:
+            "/x64/codex-code-mode-host",
+    };
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "universal-apple-darwin",
+        workspaceRoot,
+        env,
+    });
+
+    assert.deepEqual(plan.buildTargets, []);
+    assert.equal(plan.binaries.length, 2);
+    assert.deepEqual(
+        plan.binaries.map((binary) => binary.inputPaths.length),
+        [2, 2],
+    );
+    await validateCodexRuntimeBundleInputs(
+        plan,
+        existingPaths(...Object.values(env)),
+    );
+});
+
+test("universal staging rejects a missing component slice", () => {
+    assert.throws(
+        () =>
+            createCodexRuntimeBundlePlan({
+                targetTriple: "universal-apple-darwin",
+                workspaceRoot,
+                env: {
+                    NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64: "/arm64/codex-acp",
+                },
+            }),
+        /must cover both binaries/,
+    );
+});
+
+test("universal staging rejects one missing binary input", async () => {
+    const env = {
+        NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64: "/arm64/codex-acp",
+        NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64:
+            "/arm64/codex-code-mode-host",
+        NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64: "/x64/codex-acp",
+        NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_X64:
+            "/x64/codex-code-mode-host",
+    };
+    const plan = createCodexRuntimeBundlePlan({
+        targetTriple: "universal-apple-darwin",
+        workspaceRoot,
+        env,
+    });
+
+    await assert.rejects(
+        validateCodexRuntimeBundleInputs(
+            plan,
+            existingPaths(
+                env.NEVERWRITE_CODEX_ACP_BUNDLE_BIN_ARM64,
+                env.NEVERWRITE_CODEX_CODE_MODE_HOST_BUNDLE_BIN_ARM64,
+                env.NEVERWRITE_CODEX_ACP_BUNDLE_BIN_X64,
+            ),
+        ),
+        /Codex code-mode host binary was not found.*x64/,
+    );
+});

--- a/apps/desktop/scripts/validate-linux-deb-package.mjs
+++ b/apps/desktop/scripts/validate-linux-deb-package.mjs
@@ -8,6 +8,10 @@ import {
 } from "../../../scripts/electron-release-lib.mjs";
 
 const LARGE_COMMAND_OUTPUT_MAX_BUFFER = 64 * 1024 * 1024;
+const REQUIRED_CODEX_RUNTIME_PATHS = [
+    "/native-backend/binaries/codex-acp",
+    "/native-backend/binaries/codex-code-mode-host",
+];
 
 function parseArgs(argv) {
     const args = {
@@ -125,6 +129,16 @@ function validatePackageMetadata({ debPath, debArch, version }) {
         /\/usr\/share\/icons\/|\/usr\/share\/pixmaps\//m,
         "desktop icon is missing",
     );
+    for (const runtimePath of REQUIRED_CODEX_RUNTIME_PATHS) {
+        assertMatches(
+            contents,
+            new RegExp(
+                `^-rwx\\S*\\s+.*${escapeRegex(runtimePath)}$`,
+                "m",
+            ),
+            `Codex runtime binary is missing or not executable: ${runtimePath}`,
+        );
+    }
 }
 
 function queryInstalledPackage() {

--- a/apps/desktop/scripts/validate-linux-rpm-package.mjs
+++ b/apps/desktop/scripts/validate-linux-rpm-package.mjs
@@ -7,6 +7,11 @@ import {
     rpmArchForBuildTarget,
 } from "../../../scripts/electron-release-lib.mjs";
 
+const REQUIRED_CODEX_RUNTIME_PATHS = [
+    "/native-backend/binaries/codex-acp",
+    "/native-backend/binaries/codex-code-mode-host",
+];
+
 function parseArgs(argv) {
     const args = {
         stagedAssetsDir: null,
@@ -90,6 +95,16 @@ function assertRpmSignature(rpmPath) {
     }
 }
 
+function assertRuntimeContents(files) {
+    for (const runtimePath of REQUIRED_CODEX_RUNTIME_PATHS) {
+        if (!files.includes(runtimePath)) {
+            throw new Error(
+                `RPM package is missing required Codex runtime binary: ${runtimePath}`,
+            );
+        }
+    }
+}
+
 function main() {
     const args = parseArgs(process.argv.slice(2));
     assertRpmAvailable();
@@ -105,6 +120,7 @@ function main() {
     }
     const info = runCommand("rpm", ["-qip", rpmPath]);
     const files = runCommand("rpm", ["-qlp", rpmPath]);
+    assertRuntimeContents(files);
 
     const nameMatch = info.match(/^Name\s*:\s*(\S+)/m);
     if (!nameMatch || nameMatch[1] !== "neverwrite") {

--- a/apps/desktop/scripts/verify-electron-bundle.mjs
+++ b/apps/desktop/scripts/verify-electron-bundle.mjs
@@ -3,11 +3,12 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { rcedit } from "rcedit";
 
-const REQUIRED_RESOURCE_PATHS = {
+export const REQUIRED_RESOURCE_PATHS = {
     darwin: [
         "icons/icon.png",
         "native-backend/neverwrite-native-backend",
         "native-backend/binaries/codex-acp",
+        "native-backend/binaries/codex-code-mode-host",
         "native-backend/embedded/node/bin/node",
         "native-backend/embedded/claude-agent-acp/dist/index.js",
         "native-backend/embedded/claude-agent-acp/node_modules/@agentclientprotocol/sdk/package.json",
@@ -18,6 +19,7 @@ const REQUIRED_RESOURCE_PATHS = {
         "icons/icon.ico",
         "native-backend/neverwrite-native-backend.exe",
         "native-backend/binaries/codex-acp.exe",
+        "native-backend/binaries/codex-code-mode-host.exe",
         "native-backend/embedded/node/bin/node.exe",
         "native-backend/embedded/claude-agent-acp/dist/index.js",
         "native-backend/embedded/claude-agent-acp/node_modules/@agentclientprotocol/sdk/package.json",
@@ -28,6 +30,7 @@ const REQUIRED_RESOURCE_PATHS = {
         "icons/icon.png",
         "native-backend/neverwrite-native-backend",
         "native-backend/binaries/codex-acp",
+        "native-backend/binaries/codex-code-mode-host",
         "native-backend/embedded/node/bin/node",
         "native-backend/embedded/claude-agent-acp/dist/index.js",
         "native-backend/embedded/claude-agent-acp/node_modules/@agentclientprotocol/sdk/package.json",
@@ -127,8 +130,8 @@ async function stampWindowsExecutable(packContext) {
     });
 }
 
-function assertExecutableMode(absolutePath) {
-    if (process.platform === "win32") {
+function assertExecutableMode(absolutePath, targetPlatform) {
+    if (targetPlatform === "win32") {
         return;
     }
 
@@ -136,6 +139,19 @@ function assertExecutableMode(absolutePath) {
     if ((mode & 0o111) === 0) {
         throw new Error(`Packaged binary is not executable: ${absolutePath}`);
     }
+}
+
+function isExecutableResource(relativePath) {
+    return (
+        relativePath.endsWith("neverwrite-native-backend") ||
+        relativePath.endsWith("neverwrite-native-backend.exe") ||
+        relativePath.endsWith("/codex-acp") ||
+        relativePath.endsWith("/codex-acp.exe") ||
+        relativePath.endsWith("/codex-code-mode-host") ||
+        relativePath.endsWith("/codex-code-mode-host.exe") ||
+        relativePath.endsWith("/node") ||
+        relativePath.endsWith("/node.exe")
+    );
 }
 
 function assertEmbeddedNodeRuntime(packContext, resourcesDir) {
@@ -175,10 +191,7 @@ function assertEmbeddedNodeRuntime(packContext, resourcesDir) {
     }
 }
 
-export default async function verifyElectronBundle(packContext) {
-    await stampWindowsExecutable(packContext);
-
-    const resourcesDir = resolveResourcesDir(packContext);
+export function verifyPackagedResources(packContext, resourcesDir) {
     const requiredPaths =
         REQUIRED_RESOURCE_PATHS[packContext.electronPlatformName];
 
@@ -196,17 +209,15 @@ export default async function verifyElectronBundle(packContext) {
             );
         }
 
-        if (
-            relativePath.endsWith("neverwrite-native-backend") ||
-            relativePath.endsWith("neverwrite-native-backend.exe") ||
-            relativePath.endsWith("/codex-acp") ||
-            relativePath.endsWith("/codex-acp.exe") ||
-            relativePath.endsWith("/node") ||
-            relativePath.endsWith("/node.exe")
-        ) {
-            assertExecutableMode(absolutePath);
+        if (isExecutableResource(relativePath)) {
+            assertExecutableMode(absolutePath, packContext.electronPlatformName);
         }
     }
 
     assertEmbeddedNodeRuntime(packContext, resourcesDir);
+}
+
+export default async function verifyElectronBundle(packContext) {
+    await stampWindowsExecutable(packContext);
+    verifyPackagedResources(packContext, resolveResourcesDir(packContext));
 }

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -407,7 +407,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1795,6 +1795,7 @@ dependencies = [
  "clap",
  "codex-apply-patch",
  "codex-arg0",
+ "codex-code-mode-host",
  "codex-config",
  "codex-core",
  "codex-exec-server",
@@ -2018,6 +2019,18 @@ dependencies = [
  "tokio-util",
  "tracing",
  "v8",
+]
+
+[[package]]
+name = "codex-code-mode-host"
+version = "0.144.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+dependencies = [
+ "anyhow",
+ "codex-code-mode",
+ "codex-code-mode-protocol",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -4136,7 +4149,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4438,7 +4451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6317,7 +6330,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7587,7 +7600,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8638,7 +8651,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8677,9 +8690,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9539,7 +9552,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9598,7 +9611,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10429,7 +10442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11002,7 +11015,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11055,7 +11068,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11739,7 +11752,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12249,7 +12262,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -12,6 +12,10 @@ homepage = "https://github.com/zed-industries/codex-acp"
 name = "codex-acp"
 path = "src/main.rs"
 
+[[bin]]
+name = "codex-code-mode-host"
+path = "src/code_mode_host.rs"
+
 [lib]
 doctest = false
 name = "codex_acp"
@@ -23,6 +27,7 @@ anyhow = "1"
 clap = "4"
 codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
+codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }

--- a/vendor/codex-acp/src/code_mode_host.rs
+++ b/vendor/codex-acp/src/code_mode_host.rs
@@ -1,0 +1,4 @@
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    codex_code_mode_host::run_stdio().await
+}

--- a/vendor/codex-acp/tests/code_mode_host_smoke.rs
+++ b/vendor/codex-acp/tests/code_mode_host_smoke.rs
@@ -1,0 +1,57 @@
+use std::process::Child;
+use std::process::Command;
+use std::process::Stdio;
+use std::thread;
+use std::time::Duration;
+use std::time::Instant;
+
+struct ChildGuard(Child);
+
+impl ChildGuard {
+    fn terminate(mut self) {
+        self.0.kill().expect("code-mode host should be killable");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match self.0.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) => panic!("code-mode host did not terminate within the timeout"),
+                Err(error) => panic!("failed to wait for code-mode host: {error}"),
+            }
+        }
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        drop(self.0.kill());
+        drop(self.0.wait());
+    }
+}
+
+#[test]
+fn code_mode_host_starts_and_waits_for_stdio_handshake() {
+    let child = Command::new(env!("CARGO_BIN_EXE_codex-code-mode-host"))
+        // Keeping stdin open verifies that the host waits for its framed handshake.
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("code-mode host binary should start");
+    let mut child = ChildGuard(child);
+
+    thread::sleep(Duration::from_millis(150));
+    assert!(
+        child
+            .0
+            .try_wait()
+            .expect("host status should be readable")
+            .is_none(),
+        "code-mode host exited before receiving a stdio handshake"
+    );
+
+    child.terminate();
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
@@ -79,7 +79,7 @@ impl RawConPty {
     }
 
     pub fn pseudoconsole_handle(&self) -> RawHandle {
-        self.con.raw_handle()
+        self.con.raw_handle() as RawHandle
     }
 
     pub fn into_handles(self) -> (PsuedoCon, FileDescriptor, FileDescriptor) {


### PR DESCRIPTION
## Summary

Packages `codex-code-mode-host` alongside `codex-acp` as one atomic Codex runtime bundle. Both binaries are built from the same vendored manifest and target, staged adjacently in Electron resources, and validated before packaging.

## Changes

- Adds the `codex-code-mode-host` binary and smoke test to the vendored Codex runtime.
- Refactors Electron staging to resolve, validate, copy, and permission both Codex binaries as one bundle.
- Requires the host in Darwin, Windows, and Linux Electron bundles.
- Extends packaged smoke coverage to start and cleanly terminate the host.
- Covers universal macOS, Windows, and Linux package-smoke targets with paired build overrides.
- Aligns the release flow: macOS verifies host signature and universal slices; Debian and RPM validation require both runtime files.

## Validation

- `node --test scripts/stage-electron-sidecar.test.mjs scripts/electron-builder-config.test.mjs` (19 passing)
- `node --check` for modified packaging and release scripts
- Local staging confirms both binaries are present and executable
- Packaged sidecar smoke starts `codex-code-mode-host` and verifies sidecar ping
- Workflow YAML parses successfully

## Follow-up before merge

- [ ] Confirm `Electron Package Smoke` is green on macOS universal, Windows x64, Linux x64, and Linux ARM64.
- [ ] Run a controlled release dry run.
- [ ] Configure Windows code signing before enforcing Authenticode verification for internal runtime executables. The current release workflow intentionally creates unsigned Windows builds.

## Stable contract for follow-up work

`codex-acp` and `codex-code-mode-host` are adjacent and originate from the same manifest and target build. Missing either binary is a packaging error; follow-up work must not add download fallbacks or global binary discovery.