### PR TITLE
fix(activity): deduplicate turn item activity projection

### DIFF
--- a/Copyright.md
+++ b/Copyright.md
@@ -171,7 +171,7 @@ The Fliege Mono license text is included at
 
 | Crate                      | License               |
 | -------------------------- | --------------------- |
-| agent-client-protocol      | Apache-2.0            |
+| agent-client-protocol, codex-extension-items | Apache-2.0            |
 | serde, serde_json          | MIT OR Apache-2.0     |
 | tokio                      | MIT                   |
 | tokio-util                 | MIT                   |
@@ -279,7 +279,7 @@ Original source: https://github.com/zed-industries/codex
 | File                  | Nature of changes                                              |
 | --------------------- | -------------------------------------------------------------- |
 | `src/thread.rs`       | Extended to support AI review flow, multi-vault sessions, and custom diff streaming |
-| `src/codex_agent.rs`  | Adapted for Agent Client Protocol 0.11.1 compatibility        |
+| `src/codex_agent.rs`  | Adapted for Agent Client Protocol 0.14 compatibility and session configuration |
 
 ### `vendor/Claude-agent-acp-upstream` — Anthropic (Apache-2.0)
 
@@ -309,4 +309,4 @@ Original source: https://github.com/zed-industries/codex
 
 ---
 
-*This file is maintained from project dependency metadata. Last updated: 2026-04-24.*
+*This file is maintained from project dependency metadata. Last updated: 2026-07-11.*

--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -9,6 +9,7 @@ export default defineConfig([
     globalIgnores([
         "dist",
         "dist-electron/**",
+        "dist-electron-testing/**",
         "out/**",
         "embedded/**",
         "src/features/ai/store/wasm/*.d.ts",

--- a/crates/ai/src/tool_diffs.rs
+++ b/crates/ai/src/tool_diffs.rs
@@ -40,9 +40,15 @@ impl ToolDiffState {
 
     pub fn upsert_tool_call(&self, session_id: &str, tool_call: ToolCall) -> ToolCall {
         let key = call_key(session_id, &tool_call.tool_call_id.0);
-        if let Ok(mut guard) = self.calls.lock() {
+        let became_completed = if let Ok(mut guard) = self.calls.lock() {
+            let was_completed = guard
+                .get(&key)
+                .is_some_and(|existing| existing.status == ToolCallStatus::Completed);
             guard.insert(key, tool_call.clone());
-        }
+            tool_call.status == ToolCallStatus::Completed && !was_completed
+        } else {
+            false
+        };
 
         self.cache_read_baseline(session_id, &tool_call);
         self.capture_write_diff(
@@ -51,7 +57,7 @@ impl ToolDiffState {
             tool_call.raw_input.as_ref(),
         );
         self.cache_content_diffs(session_id, &tool_call);
-        if tool_call.status == ToolCallStatus::Completed {
+        if became_completed {
             self.advance_baseline_after_success(session_id, tool_call.raw_input.as_ref());
         }
 
@@ -69,21 +75,28 @@ impl ToolDiffState {
         let update_meta = update.meta.clone();
         let mut guard = self.calls.lock().ok()?;
         let tool_call = if let Some(existing) = guard.get_mut(&key) {
+            let was_completed = existing.status == ToolCallStatus::Completed;
             existing.update(update.fields);
             if let Some(update_meta) = update_meta {
                 merge_tool_call_meta(existing, update_meta);
             }
-            existing.clone()
+            (
+                existing.clone(),
+                !was_completed && existing.status == ToolCallStatus::Completed,
+            )
         } else {
             let tool_call = ToolCall::try_from(update).ok()?;
             guard.insert(key, tool_call.clone());
-            tool_call
+            let became_completed = tool_call.status == ToolCallStatus::Completed;
+            (tool_call, became_completed)
         };
         drop(guard);
 
+        let (tool_call, became_completed) = tool_call;
+
         self.cache_content_diffs(session_id, &tool_call);
         self.cache_read_baseline(session_id, &tool_call);
-        if tool_call.status == ToolCallStatus::Completed {
+        if became_completed {
             self.advance_baseline_after_success(session_id, tool_call.raw_input.as_ref());
         }
 

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -1800,6 +1800,7 @@ dependencies = [
  "codex-core",
  "codex-exec-server",
  "codex-extension-api",
+ "codex-extension-items",
  "codex-features",
  "codex-http-client",
  "codex-login",

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -32,6 +32,7 @@ codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" 
 codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
+codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
 codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -527,11 +527,7 @@ impl CodexAgent {
         config: &mut Config,
         session_configured: &SessionConfiguredEvent,
     ) -> Result<(), Error> {
-        config.cwd = session_configured
-            .cwd
-            .clone()
-            .try_into()
-            .map_err(Error::into_internal_error)?;
+        config.cwd = session_configured.cwd.clone();
         config.model = Some(session_configured.model.clone());
         config.model_provider_id = session_configured.model_provider_id.clone();
         config.model_reasoning_effort = session_configured.reasoning_effort.clone();

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -29,6 +29,7 @@ use codex_core::{
     config::{Config, PermissionProfileSnapshot, set_project_trust_level},
     review_prompts::user_facing_hint,
 };
+use codex_extension_items::ExtensionItem;
 use codex_features::Feature;
 use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
 use codex_login::auth::AuthManager;
@@ -1104,6 +1105,7 @@ fn turn_item_projection(item: &TurnItem) -> TurnItemProjection {
         }
         TurnItem::Plan(..)
         | TurnItem::ImageGeneration(..)
+        | TurnItem::Extension(ExtensionItem::ImageGeneration(..))
         | TurnItem::EnteredReviewMode(..)
         | TurnItem::ExitedReviewMode(..) => TurnItemProjection::Dedicated,
         TurnItem::HookPrompt(..) | TurnItem::Sleep(..) | TurnItem::ContextCompaction(..) => {
@@ -1115,7 +1117,7 @@ fn turn_item_projection(item: &TurnItem) -> TurnItemProjection {
         | TurnItem::SubAgentActivity(..)
         | TurnItem::WebSearch(..)
         | TurnItem::ImageView(..)
-        | TurnItem::Extension(..)
+        | TurnItem::Extension(ExtensionItem::WebSearch(..))
         | TurnItem::FileChange(..)
         | TurnItem::McpToolCall(..) => TurnItemProjection::Tool,
     }
@@ -1127,9 +1129,8 @@ fn turn_item_tool_kind(item: &TurnItem) -> ToolKind {
         TurnItem::WebSearch(..) => ToolKind::Fetch,
         TurnItem::ImageView(..) => ToolKind::Read,
         TurnItem::FileChange(..) => ToolKind::Edit,
-        // Extension items are deliberately kept explicit at their handler
-        // boundary; their generic fallback is safe but cannot assume a kind.
-        TurnItem::Extension(..)
+        TurnItem::Extension(ExtensionItem::WebSearch(..)) => ToolKind::Fetch,
+        TurnItem::Extension(ExtensionItem::ImageGeneration(..))
         | TurnItem::DynamicToolCall(..)
         | TurnItem::CollabAgentToolCall(..)
         | TurnItem::SubAgentActivity(..)
@@ -1207,6 +1208,16 @@ fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
                 .or_else(|| item.raw_content.first().cloned()),
         ),
         TurnItem::WebSearch(item) => ("Web search", Some(item.query.clone())),
+        TurnItem::Extension(ExtensionItem::WebSearch(item)) => {
+            ("Searching the Web", Some(item.query.clone()))
+        }
+        TurnItem::Extension(ExtensionItem::ImageGeneration(item)) => (
+            "Generating image",
+            item.saved_path
+                .as_ref()
+                .map(|path| path.display().to_string())
+                .or_else(|| Some(item.result.clone())),
+        ),
         TurnItem::ImageView(item) => (
             "Viewing image",
             Some(item.path.inferred_native_path_string()),
@@ -1227,7 +1238,6 @@ fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
         }
         TurnItem::SubAgentActivity(item) => ("Subagent activity", Some(format!("{:?}", item.kind))),
         TurnItem::Sleep(item) => ("Waiting", Some(format!("{}ms", item.duration_ms))),
-        TurnItem::Extension(item) => ("Extension", Some(format!("{item:?}"))),
         TurnItem::EnteredReviewMode(..) => ("Review mode active", None),
         TurnItem::ExitedReviewMode(..) => ("Review mode complete", None),
         TurnItem::FileChange(..) => ("Editing files", None),
@@ -1898,7 +1908,7 @@ impl PromptState {
         if state.canonical_terminal_seen || state.terminal.is_some() {
             return;
         }
-        state.terminal = Some(terminal.clone());
+        state.terminal = Some(terminal);
         let emitted = state.emitted;
         let canonical_seen = state.canonical_seen;
         state.emitted = true;
@@ -1951,7 +1961,7 @@ impl PromptState {
                     return;
                 }
                 state.canonical_terminal_seen = true;
-                state.terminal = Some(tool_call.status.clone());
+                state.terminal = Some(tool_call.status);
             }
             let emitted = state.emitted;
             state.emitted = true;
@@ -2006,7 +2016,7 @@ impl PromptState {
                     return;
                 }
                 state.canonical_terminal_seen = true;
-                state.terminal = update.fields.status.clone();
+                state.terminal = update.fields.status;
             }
             let preserve_terminal = state.terminal.is_some() && !terminal;
             let emitted = state.emitted;
@@ -2017,13 +2027,7 @@ impl PromptState {
         if !emitted {
             let mut tool_call = ToolCall::new(call_id, title_if_unmaterialized)
                 .kind(kind_if_unmaterialized)
-                .status(
-                    update
-                        .fields
-                        .status
-                        .clone()
-                        .unwrap_or(ToolCallStatus::InProgress),
-                );
+                .status(update.fields.status.unwrap_or(ToolCallStatus::InProgress));
             tool_call.update(update.fields);
             tool_call.meta = update.meta;
             client.send_tool_call(tool_call).await;
@@ -2180,6 +2184,15 @@ impl PromptState {
                 info!("Item started with thread_id: {thread_id}, turn_id: {turn_id}, item: {item:?}");
                 match item {
                     TurnItem::ImageGeneration(image_item) => {
+                        self.send_image_generation_started(
+                            client,
+                            ImageGenerationBeginEvent {
+                                call_id: image_item.id,
+                            },
+                        )
+                        .await;
+                    }
+                    TurnItem::Extension(ExtensionItem::ImageGeneration(image_item)) => {
                         self.send_image_generation_started(
                             client,
                             ImageGenerationBeginEvent {
@@ -2447,6 +2460,19 @@ impl PromptState {
                 }
                 match item {
                     TurnItem::ImageGeneration(image_item) => {
+                        self.send_image_generation_completed(
+                            client,
+                            ImageGenerationEndEvent {
+                                call_id: image_item.id,
+                                status: image_item.status,
+                                revised_prompt: image_item.revised_prompt,
+                                result: image_item.result,
+                                saved_path: image_item.saved_path,
+                            },
+                        )
+                        .await;
+                    }
+                    TurnItem::Extension(ExtensionItem::ImageGeneration(image_item)) => {
                         self.send_image_generation_completed(
                             client,
                             ImageGenerationEndEvent {
@@ -3290,7 +3316,7 @@ impl PromptState {
         self.send_canonical_tool_call(
             client,
             ToolCall::new(tool_call_id.clone(), title.clone())
-                .kind(kind.clone())
+                .kind(kind)
                 .status(ToolCallStatus::Pending)
                 .raw_input(raw_input.clone())
                 .content(content.clone().unwrap_or_default())

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -43,11 +43,12 @@ use codex_protocol::protocol::{
     ImageGenerationBeginEvent, ImageGenerationEndEvent, ItemCompletedEvent, ItemStartedEvent,
     McpInvocation, McpStartupCompleteEvent, McpStartupUpdateEvent, McpToolCallBeginEvent,
     McpToolCallEndEvent, ModelRerouteEvent, Op, PatchApplyBeginEvent, PatchApplyEndEvent,
-    PatchApplyStatus, PlanDeltaEvent, ReasoningContentDeltaEvent, ReasoningRawContentDeltaEvent,
-    ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget, StreamErrorEvent,
-    TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent, ThreadSettingsOverrides,
-    TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent, TurnStartedEvent, UserMessageEvent,
-    ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent, WebSearchEndEvent,
+    PatchApplyStatus, PatchApplyUpdatedEvent, PlanDeltaEvent, ReasoningContentDeltaEvent,
+    ReasoningRawContentDeltaEvent, ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget,
+    StreamErrorEvent, TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
+    ThreadSettingsOverrides, TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent,
+    TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent,
+    WebSearchEndEvent,
 };
 use codex_protocol::review_format::format_review_findings_block;
 use codex_protocol::{
@@ -128,6 +129,7 @@ const NEVERWRITE_DIFF_HUNKS_KEY: &str = "neverwriteHunks";
 const NEVERWRITE_STATUS_EVENT_ID_PREFIX: &str = "neverwrite:status:";
 const NEVERWRITE_IMAGE_EVENT_ID_PREFIX: &str = "neverwrite:image:";
 const FILE_DELETED_PLACEHOLDER: &str = "[file deleted]";
+const MAX_PENDING_COMMAND_OUTPUT_BYTES: usize = 1024 * 1024;
 const CODEX_ACP_EVENT_TYPE_KEY: &str = "codexAcpEventType";
 const CODEX_ACP_TURN_EVENT_TYPE_KEY: &str = "codexAcpTurnEventType";
 const CODEX_ACP_TURN_ID_KEY: &str = "codexAcpTurnId";
@@ -1192,6 +1194,24 @@ fn turn_item_terminal_status(item: &TurnItem) -> ToolCallStatus {
 
 fn is_terminal_tool_status(status: &ToolCallStatus) -> bool {
     matches!(status, ToolCallStatus::Completed | ToolCallStatus::Failed)
+}
+
+fn append_bounded_output(buffer: &mut String, chunk: &str) {
+    let remaining = MAX_PENDING_COMMAND_OUTPUT_BYTES.saturating_sub(buffer.len());
+    if remaining == 0 {
+        return;
+    }
+    if chunk.len() <= remaining {
+        buffer.push_str(chunk);
+        return;
+    }
+    let end = chunk
+        .char_indices()
+        .take_while(|(index, _)| *index < remaining)
+        .map(|(index, character)| index + character.len_utf8())
+        .last()
+        .unwrap_or_default();
+    buffer.push_str(&chunk[..end]);
 }
 
 fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
@@ -2435,6 +2455,14 @@ impl PromptState {
                 );
                 self.start_patch_apply(client, event).await;
             }
+            EventMsg::PatchApplyUpdated(event) => {
+                info!(
+                    "Patch apply updated: call_id={}, changed_files={}",
+                    event.call_id,
+                    event.changes.len()
+                );
+                self.update_patch_apply(client, event).await;
+            }
             EventMsg::PatchApplyEnd(event) => {
                 info!(
                     "Patch apply end: call_id={}, success={}",
@@ -2736,8 +2764,7 @@ impl PromptState {
             | EventMsg::ModelVerification(..)
             | EventMsg::GuardianWarning(..)
             | EventMsg::HookStarted(..)
-            | EventMsg::HookCompleted(..)
-            | EventMsg::PatchApplyUpdated(..) => {}
+            | EventMsg::HookCompleted(..) => {}
             e @ (EventMsg::RealtimeConversationListVoicesResponse(..)
             | EventMsg::DeprecationNotice(..)) => {
                 warn!("Unexpected event: {:?}", e);
@@ -3046,6 +3073,30 @@ impl PromptState {
                 .locations(locations)
                 .content(content.collect())
                 .raw_input(raw_input),
+        )
+        .await;
+    }
+
+    async fn update_patch_apply(&mut self, client: &SessionClient, event: PatchApplyUpdatedEvent) {
+        let raw_input = serde_json::json!(&event);
+        let PatchApplyUpdatedEvent { call_id, changes } = event;
+        if changes.is_empty() {
+            return;
+        }
+
+        let (title, locations, content) = extract_tool_call_content_from_changes(changes);
+        self.send_canonical_tool_update(
+            client,
+            ToolCallUpdate::new(
+                call_id,
+                ToolCallUpdateFields::new()
+                    .title(title)
+                    .locations(locations)
+                    .content(content.collect::<Vec<_>>())
+                    .raw_input(raw_input),
+            ),
+            "Updating files",
+            ToolKind::Edit,
         )
         .await;
     }
@@ -3462,10 +3513,8 @@ impl PromptState {
         } else {
             // Codex can race an output delta ahead of its begin event. Keep it
             // scoped to the call ID so it can never attach to another command.
-            self.pending_command_output
-                .entry(call_id)
-                .or_default()
-                .push_str(&data_str);
+            let buffer = self.pending_command_output.entry(call_id).or_default();
+            append_bounded_output(buffer, &data_str);
         }
     }
 
@@ -3554,6 +3603,24 @@ impl PromptState {
                             }),
                         )])
                     }),
+                ),
+                "Running command",
+                ToolKind::Execute,
+            )
+            .await;
+        } else {
+            let status = match status {
+                ExecCommandStatus::Completed if exit_code == 0 => ToolCallStatus::Completed,
+                ExecCommandStatus::Completed => ToolCallStatus::Failed,
+                ExecCommandStatus::Failed | ExecCommandStatus::Declined => ToolCallStatus::Failed,
+            };
+            self.send_canonical_tool_update(
+                client,
+                ToolCallUpdate::new(
+                    call_id,
+                    ToolCallUpdateFields::new()
+                        .status(status)
+                        .raw_output(raw_output),
                 ),
                 "Running command",
                 ToolKind::Execute,

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -3506,6 +3506,17 @@ impl PromptState {
             process_id: _,
             ..
         } = event;
+        // Events can arrive out of order. Once an end event has made this
+        // command terminal, a late begin must not recreate active state.
+        if self
+            .projected_tool_calls
+            .get(&call_id)
+            .is_some_and(|state| state.terminal.is_some())
+        {
+            self.pending_command_output.remove(&call_id);
+            return;
+        }
+
         // Create a new tool call for the command execution
         let tool_call_id = ToolCallId::new(call_id.clone());
         let ParseCommandToolCall {
@@ -8351,6 +8362,28 @@ mod tests {
             .await;
 
         assert!(!state.pending_command_output.contains_key("exec-1"));
+
+        state
+            .exec_command_begin(
+                &session_client,
+                ExecCommandBeginEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    started_at_ms: 0,
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo".to_string()],
+                    cwd: codex_utils_path_uri::PathUri::from_host_native_path(&cwd)
+                        .expect("current dir should be representable as a path URI"),
+                    parsed_cmd: vec![ParsedCommand::Unknown {
+                        cmd: "sh".to_string(),
+                    }],
+                    source: Default::default(),
+                    interaction_input: None,
+                },
+            )
+            .await;
+        assert!(!state.active_commands.contains_key("exec-1"));
+
         state
             .exec_command_output_delta(
                 &session_client,

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -875,6 +875,7 @@ struct PromptState {
     active_web_search: Option<String>,
     active_guardian_assessments: HashSet<String>,
     active_plan_text: HashMap<String, String>,
+    projected_tool_calls: HashMap<String, ProjectedToolCallState>,
     thread: Arc<dyn CodexThreadImpl>,
     resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
     pending_permission_interactions: HashMap<String, PendingPermissionInteraction>,
@@ -884,6 +885,14 @@ struct PromptState {
     seen_message_deltas: bool,
     seen_reasoning_deltas: bool,
     project_user_messages: bool,
+}
+
+#[derive(Default)]
+struct ProjectedToolCallState {
+    emitted: bool,
+    canonical_seen: bool,
+    canonical_terminal_seen: bool,
+    terminal: Option<ToolCallStatus>,
 }
 #[derive(Debug, serde::Deserialize)]
 struct NeverWriteUserInputAnswerPayload {
@@ -1134,6 +1143,48 @@ fn turn_item_tool_kind(item: &TurnItem) -> ToolKind {
         | TurnItem::ImageGeneration(..)
         | TurnItem::EnteredReviewMode(..)
         | TurnItem::ExitedReviewMode(..) => ToolKind::Other,
+    }
+}
+
+fn turn_item_call_id(item: &TurnItem, projection: TurnItemProjection) -> String {
+    match projection {
+        TurnItemProjection::Status => format!(
+            "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}item:{}",
+            turn_item_id(item)
+        ),
+        TurnItemProjection::Hidden | TurnItemProjection::Dedicated | TurnItemProjection::Tool => {
+            turn_item_id(item).to_string()
+        }
+    }
+}
+
+fn turn_item_terminal_status(item: &TurnItem) -> ToolCallStatus {
+    use codex_protocol::items::{
+        CollabAgentToolCallStatus, CommandExecutionStatus, DynamicToolCallStatus, McpToolCallStatus,
+    };
+
+    let failed = match item {
+        TurnItem::CommandExecution(item) => {
+            matches!(
+                item.status,
+                CommandExecutionStatus::Failed | CommandExecutionStatus::Declined
+            )
+        }
+        TurnItem::DynamicToolCall(item) => matches!(item.status, DynamicToolCallStatus::Failed),
+        TurnItem::CollabAgentToolCall(item) => {
+            matches!(item.status, CollabAgentToolCallStatus::Failed)
+        }
+        TurnItem::FileChange(item) => matches!(
+            item.status,
+            Some(PatchApplyStatus::Failed | PatchApplyStatus::Declined)
+        ),
+        TurnItem::McpToolCall(item) => matches!(item.status, McpToolCallStatus::Failed),
+        _ => false,
+    };
+    if failed {
+        ToolCallStatus::Failed
+    } else {
+        ToolCallStatus::Completed
     }
 }
 
@@ -1523,6 +1574,7 @@ impl PromptState {
             active_web_search: None,
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
+            projected_tool_calls: HashMap::new(),
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
@@ -1546,6 +1598,7 @@ impl PromptState {
             active_web_search: None,
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
+            projected_tool_calls: HashMap::new(),
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
@@ -1804,6 +1857,96 @@ impl PromptState {
             .await;
     }
 
+    async fn start_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
+        let projection = turn_item_projection(item);
+        if matches!(
+            projection,
+            TurnItemProjection::Hidden | TurnItemProjection::Dedicated
+        ) {
+            return;
+        }
+
+        let call_id = turn_item_call_id(item, projection);
+        let state = self
+            .projected_tool_calls
+            .entry(call_id.clone())
+            .or_default();
+        if state.emitted || state.terminal.is_some() {
+            return;
+        }
+        state.emitted = true;
+
+        let (title, detail) = describe_turn_item(item);
+        let mut tool_call = ToolCall::new(call_id, title)
+            .kind(if projection == TurnItemProjection::Status {
+                ToolKind::Other
+            } else {
+                turn_item_tool_kind(item)
+            })
+            .status(ToolCallStatus::InProgress)
+            .raw_input(serde_json::json!(item));
+        if let Some(detail) = detail {
+            tool_call = tool_call.content(vec![ToolCallContent::Content(Content::new(detail))]);
+        }
+        if projection == TurnItemProjection::Status {
+            tool_call = tool_call.meta(neverwrite_status_meta("item_activity", "neutral"));
+        }
+        client.send_tool_call(tool_call).await;
+    }
+
+    async fn complete_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
+        let projection = turn_item_projection(item);
+        if matches!(
+            projection,
+            TurnItemProjection::Hidden | TurnItemProjection::Dedicated
+        ) {
+            return;
+        }
+
+        let call_id = turn_item_call_id(item, projection);
+        let terminal = turn_item_terminal_status(item);
+        let state = self
+            .projected_tool_calls
+            .entry(call_id.clone())
+            .or_default();
+        if state.canonical_terminal_seen || state.terminal.is_some() {
+            return;
+        }
+        state.terminal = Some(terminal.clone());
+        let emitted = state.emitted;
+        state.emitted = true;
+
+        let (title, detail) = describe_turn_item(item);
+        if emitted {
+            let mut fields = ToolCallUpdateFields::new()
+                .title(title.to_string())
+                .status(terminal)
+                .raw_output(serde_json::json!(item));
+            if let Some(detail) = detail {
+                fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
+            }
+            client
+                .send_tool_call_update(ToolCallUpdate::new(call_id, fields))
+                .await;
+        } else {
+            let mut tool_call = ToolCall::new(call_id, title)
+                .kind(if projection == TurnItemProjection::Status {
+                    ToolKind::Other
+                } else {
+                    turn_item_tool_kind(item)
+                })
+                .status(terminal)
+                .raw_input(serde_json::json!(item));
+            if let Some(detail) = detail {
+                tool_call = tool_call.content(vec![ToolCallContent::Content(Content::new(detail))]);
+            }
+            if projection == TurnItemProjection::Status {
+                tool_call = tool_call.meta(neverwrite_status_meta("item_activity", "neutral"));
+            }
+            client.send_tool_call(tool_call).await;
+        }
+    }
+
     async fn send_image_generation_started(
         &self,
         client: &SessionClient,
@@ -1955,30 +2098,7 @@ impl PromptState {
                         )
                         .await;
                     }
-                    TurnItem::CommandExecution(..)
-                    | TurnItem::DynamicToolCall(..)
-                    | TurnItem::CollabAgentToolCall(..)
-                    | TurnItem::SubAgentActivity(..)
-                    | TurnItem::Sleep(..)
-                    | TurnItem::Extension(..)
-                    | TurnItem::EnteredReviewMode(..)
-                    | TurnItem::ExitedReviewMode(..) => {}
-                    other_item => {
-                        let (title, detail) = describe_turn_item(&other_item);
-                        self.send_status_tool_call(
-                            client,
-                            format!(
-                                "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}item:{}",
-                                turn_item_id(&other_item)
-                            ),
-                            "item_activity",
-                            title,
-                            detail,
-                            "neutral",
-                            ToolCallStatus::InProgress,
-                        )
-                        .await;
-                    }
+                    other_item => self.start_turn_item(client, &other_item).await,
                 }
             }
             EventMsg::UserMessage(UserMessageEvent {
@@ -2249,27 +2369,8 @@ impl PromptState {
                         )
                         .await;
                     }
-                    TurnItem::CommandExecution(..)
-                    | TurnItem::DynamicToolCall(..)
-                    | TurnItem::CollabAgentToolCall(..)
-                    | TurnItem::SubAgentActivity(..)
-                    | TurnItem::Sleep(..)
-                    | TurnItem::Extension(..)
-                    | TurnItem::EnteredReviewMode(..)
-                    | TurnItem::ExitedReviewMode(..) => {}
                     other_item => {
-                        let (title, detail) = describe_turn_item(&other_item);
-                        self.send_status_tool_call_update(
-                            client,
-                            format!(
-                                "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}item:{}",
-                                turn_item_id(&other_item)
-                            ),
-                            title,
-                            detail,
-                            ToolCallStatus::Completed,
-                        )
-                        .await;
+                        self.complete_turn_item(client, &other_item).await;
                         // Notify the client when context compaction completes so users see
                         // a status message rather than silence during /compact.
                         if matches!(other_item, TurnItem::ContextCompaction(..)) {

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -872,6 +872,7 @@ fn format_mcp_tool_approval_value(value: &serde_json::Value) -> String {
 struct PromptState {
     submission_id: String,
     active_commands: HashMap<String, ActiveCommand>,
+    pending_command_output: HashMap<String, String>,
     active_web_search: Option<String>,
     active_guardian_assessments: HashSet<String>,
     active_plan_text: HashMap<String, String>,
@@ -1186,6 +1187,10 @@ fn turn_item_terminal_status(item: &TurnItem) -> ToolCallStatus {
     } else {
         ToolCallStatus::Completed
     }
+}
+
+fn is_terminal_tool_status(status: &ToolCallStatus) -> bool {
+    matches!(status, ToolCallStatus::Completed | ToolCallStatus::Failed)
 }
 
 fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
@@ -1571,6 +1576,7 @@ impl PromptState {
         Self {
             submission_id,
             active_commands: HashMap::new(),
+            pending_command_output: HashMap::new(),
             active_web_search: None,
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
@@ -1595,6 +1601,7 @@ impl PromptState {
         Self {
             submission_id,
             active_commands: HashMap::new(),
+            pending_command_output: HashMap::new(),
             active_web_search: None,
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
@@ -1836,27 +1843,6 @@ impl PromptState {
         client.send_tool_call(tool_call).await;
     }
 
-    async fn send_status_tool_call_update(
-        &self,
-        client: &SessionClient,
-        call_id: impl Into<ToolCallId>,
-        title: impl Into<String>,
-        detail: Option<String>,
-        status: ToolCallStatus,
-    ) {
-        let mut fields = ToolCallUpdateFields::new()
-            .title(title.into())
-            .status(status);
-
-        if let Some(detail) = detail {
-            fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
-        }
-
-        client
-            .send_tool_call_update(ToolCallUpdate::new(call_id, fields))
-            .await;
-    }
-
     async fn start_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
         let projection = turn_item_projection(item);
         if matches!(
@@ -1914,16 +1900,19 @@ impl PromptState {
         }
         state.terminal = Some(terminal.clone());
         let emitted = state.emitted;
+        let canonical_seen = state.canonical_seen;
         state.emitted = true;
 
         let (title, detail) = describe_turn_item(item);
         if emitted {
-            let mut fields = ToolCallUpdateFields::new()
-                .title(title.to_string())
-                .status(terminal)
-                .raw_output(serde_json::json!(item));
-            if let Some(detail) = detail {
-                fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
+            let mut fields = ToolCallUpdateFields::new().status(terminal);
+            if !canonical_seen {
+                fields = fields
+                    .title(title.to_string())
+                    .raw_output(serde_json::json!(item));
+                if let Some(detail) = detail {
+                    fields = fields.content(vec![ToolCallContent::Content(Content::new(detail))]);
+                }
             }
             client
                 .send_tool_call_update(ToolCallUpdate::new(call_id, fields))
@@ -1945,6 +1934,107 @@ impl PromptState {
             }
             client.send_tool_call(tool_call).await;
         }
+    }
+
+    async fn send_canonical_tool_call(&mut self, client: &SessionClient, tool_call: ToolCall) {
+        let call_id = tool_call.tool_call_id.to_string();
+        let terminal = is_terminal_tool_status(&tool_call.status);
+        let (emitted, preserve_terminal) = {
+            let state = self
+                .projected_tool_calls
+                .entry(call_id.clone())
+                .or_default();
+            state.canonical_seen = true;
+            let preserve_terminal = state.terminal.is_some() && !terminal;
+            if terminal {
+                if state.canonical_terminal_seen {
+                    return;
+                }
+                state.canonical_terminal_seen = true;
+                state.terminal = Some(tool_call.status.clone());
+            }
+            let emitted = state.emitted;
+            state.emitted = true;
+            (emitted, preserve_terminal)
+        };
+
+        if !emitted {
+            client.send_tool_call(tool_call).await;
+            return;
+        }
+
+        let mut fields = ToolCallUpdateFields::new()
+            .kind(tool_call.kind)
+            .title(tool_call.title)
+            .raw_input(tool_call.raw_input)
+            .raw_output(tool_call.raw_output);
+        if !tool_call.content.is_empty() {
+            fields = fields.content(tool_call.content);
+        }
+        if !tool_call.locations.is_empty() {
+            fields = fields.locations(tool_call.locations);
+        }
+        if !preserve_terminal {
+            fields = fields.status(tool_call.status);
+        }
+        client
+            .send_tool_call_update(ToolCallUpdate::new(call_id, fields).meta(tool_call.meta))
+            .await;
+    }
+
+    async fn send_canonical_tool_update(
+        &mut self,
+        client: &SessionClient,
+        update: ToolCallUpdate,
+        title_if_unmaterialized: impl Into<String>,
+        kind_if_unmaterialized: ToolKind,
+    ) {
+        let call_id = update.tool_call_id.to_string();
+        let terminal = update
+            .fields
+            .status
+            .as_ref()
+            .is_some_and(is_terminal_tool_status);
+        let (emitted, preserve_terminal) = {
+            let state = self
+                .projected_tool_calls
+                .entry(call_id.clone())
+                .or_default();
+            state.canonical_seen = true;
+            if terminal {
+                if state.canonical_terminal_seen {
+                    return;
+                }
+                state.canonical_terminal_seen = true;
+                state.terminal = update.fields.status.clone();
+            }
+            let preserve_terminal = state.terminal.is_some() && !terminal;
+            let emitted = state.emitted;
+            state.emitted = true;
+            (emitted, preserve_terminal)
+        };
+
+        if !emitted {
+            let mut tool_call = ToolCall::new(call_id, title_if_unmaterialized)
+                .kind(kind_if_unmaterialized)
+                .status(
+                    update
+                        .fields
+                        .status
+                        .clone()
+                        .unwrap_or(ToolCallStatus::InProgress),
+                );
+            tool_call.update(update.fields);
+            tool_call.meta = update.meta;
+            client.send_tool_call(tool_call).await;
+            return;
+        }
+
+        let mut update = update;
+        if preserve_terminal {
+            update.fields.status = None;
+        }
+        client.send_tool_call_update(update).await;
     }
 
     async fn send_image_generation_started(
@@ -2863,6 +2953,20 @@ impl PromptState {
             ..
         } = event;
         let (title, locations, content) = extract_tool_call_content_from_changes(changes);
+        let mut content = content.collect::<Vec<_>>();
+        if let Some(reason) = reason.as_ref() {
+            content.push(reason.clone().into());
+        }
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(call_id.clone(), title.clone())
+                .kind(ToolKind::Edit)
+                .status(ToolCallStatus::Pending)
+                .locations(locations.clone())
+                .content(content.clone())
+                .raw_input(raw_input.clone()),
+        )
+        .await;
         let request_key = patch_request_key(&call_id);
         let options = vec![
             PermissionOption::new("approved", "Yes", PermissionOptionKind::AllowOnce),
@@ -2889,7 +2993,7 @@ impl PromptState {
                     .status(ToolCallStatus::Pending)
                     .title(title)
                     .locations(locations)
-                    .content(content.chain(reason.map(|r| r.into())).collect::<Vec<_>>())
+                    .content(content)
                     .raw_input(raw_input),
             ),
             options,
@@ -2897,7 +3001,7 @@ impl PromptState {
         Ok(())
     }
 
-    async fn start_patch_apply(&self, client: &SessionClient, event: PatchApplyBeginEvent) {
+    async fn start_patch_apply(&mut self, client: &SessionClient, event: PatchApplyBeginEvent) {
         let raw_input = serde_json::json!(&event);
         let PatchApplyBeginEvent {
             call_id,
@@ -2908,19 +3012,19 @@ impl PromptState {
 
         let (title, locations, content) = extract_tool_call_content_from_changes(changes);
 
-        client
-            .send_tool_call(
-                ToolCall::new(call_id, title)
-                    .kind(ToolKind::Edit)
-                    .status(ToolCallStatus::InProgress)
-                    .locations(locations)
-                    .content(content.collect())
-                    .raw_input(raw_input),
-            )
-            .await;
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(call_id, title)
+                .kind(ToolKind::Edit)
+                .status(ToolCallStatus::InProgress)
+                .locations(locations)
+                .content(content.collect())
+                .raw_input(raw_input),
+        )
+        .await;
     }
 
-    async fn end_patch_apply(&self, client: &SessionClient, event: PatchApplyEndEvent) {
+    async fn end_patch_apply(&mut self, client: &SessionClient, event: PatchApplyEndEvent) {
         let raw_output = serde_json::json!(&event);
         let PatchApplyEndEvent {
             call_id,
@@ -2945,8 +3049,9 @@ impl PromptState {
             PatchApplyStatus::Failed | PatchApplyStatus::Declined => ToolCallStatus::Failed,
         };
 
-        client
-            .send_tool_call_update(ToolCallUpdate::new(
+        self.send_canonical_tool_update(
+            client,
+            ToolCallUpdate::new(
                 call_id,
                 ToolCallUpdateFields::new()
                     .status(status)
@@ -2954,44 +3059,47 @@ impl PromptState {
                     .title(title)
                     .locations(locations)
                     .content(content),
-            ))
-            .await;
+            ),
+            "Updating files",
+            ToolKind::Edit,
+        )
+        .await;
     }
 
     async fn start_dynamic_tool_call(
-        &self,
+        &mut self,
         client: &SessionClient,
         call_id: String,
         tool: String,
         arguments: serde_json::Value,
     ) {
-        client
-            .send_tool_call(
-                ToolCall::new(call_id, format!("Tool: {tool}"))
-                    .status(ToolCallStatus::InProgress)
-                    .raw_input(serde_json::json!(&arguments)),
-            )
-            .await;
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(call_id, format!("Tool: {tool}"))
+                .status(ToolCallStatus::InProgress)
+                .raw_input(serde_json::json!(&arguments)),
+        )
+        .await;
     }
 
     async fn start_mcp_tool_call(
-        &self,
+        &mut self,
         client: &SessionClient,
         call_id: String,
         invocation: McpInvocation,
     ) {
         let title = format!("Tool: {}/{}", invocation.server, invocation.tool);
-        client
-            .send_tool_call(
-                ToolCall::new(call_id, title)
-                    .status(ToolCallStatus::InProgress)
-                    .raw_input(serde_json::json!(&invocation)),
-            )
-            .await;
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(call_id, title)
+                .status(ToolCallStatus::InProgress)
+                .raw_input(serde_json::json!(&invocation)),
+        )
+        .await;
     }
 
     async fn end_dynamic_tool_call(
-        &self,
+        &mut self,
         client: &SessionClient,
         event: DynamicToolCallResponseEvent,
     ) {
@@ -3008,8 +3116,9 @@ impl PromptState {
             ..
         } = event;
 
-        client
-            .send_tool_call_update(ToolCallUpdate::new(
+        self.send_canonical_tool_update(
+            client,
+            ToolCallUpdate::new(
                 call_id,
                 ToolCallUpdateFields::new()
                     .status(if success {
@@ -3037,12 +3146,15 @@ impl PromptState {
                             .chain(error.map(|e| ToolCallContent::Content(Content::new(e))))
                             .collect::<Vec<_>>(),
                     ),
-            ))
-            .await;
+            ),
+            "Tool call",
+            ToolKind::Other,
+        )
+        .await;
     }
 
     async fn end_mcp_tool_call(
-        &self,
+        &mut self,
         client: &SessionClient,
         call_id: String,
         result: Result<CallToolResult, String>,
@@ -3056,8 +3168,9 @@ impl PromptState {
             Err(err) => serde_json::json!(err),
         };
 
-        client
-            .send_tool_call_update(ToolCallUpdate::new(
+        self.send_canonical_tool_update(
+            client,
+            ToolCallUpdate::new(
                 call_id,
                 ToolCallUpdateFields::new()
                     .status(if is_error {
@@ -3078,8 +3191,11 @@ impl PromptState {
                                 .collect()
                         },
                     )),
-            ))
-            .await;
+            ),
+            "MCP tool call",
+            ToolKind::Other,
+        )
+        .await;
     }
 
     async fn exec_approval(
@@ -3171,6 +3287,17 @@ impl PromptState {
             additional_permissions.as_ref(),
         );
 
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(tool_call_id.clone(), title.clone())
+                .kind(kind.clone())
+                .status(ToolCallStatus::Pending)
+                .raw_input(raw_input.clone())
+                .content(content.clone().unwrap_or_default())
+                .locations(locations.clone()),
+        )
+        .await;
+
         self.spawn_permission_request(
             client,
             exec_request_key(&call_id),
@@ -3237,7 +3364,10 @@ impl PromptState {
 
         let active_command = ActiveCommand {
             tool_call_id: tool_call_id.clone(),
-            output: String::new(),
+            output: self
+                .pending_command_output
+                .remove(&call_id)
+                .unwrap_or_default(),
             file_extension,
             terminal_output,
             file_snapshots,
@@ -3258,17 +3388,17 @@ impl PromptState {
 
         self.active_commands.insert(call_id.clone(), active_command);
 
-        client
-            .send_tool_call(
-                ToolCall::new(tool_call_id, title)
-                    .kind(kind)
-                    .status(ToolCallStatus::InProgress)
-                    .locations(locations)
-                    .raw_input(raw_input)
-                    .content(content)
-                    .meta(meta),
-            )
-            .await;
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(tool_call_id, title)
+                .kind(kind)
+                .status(ToolCallStatus::InProgress)
+                .locations(locations)
+                .raw_input(raw_input)
+                .content(content)
+                .meta(meta),
+        )
+        .await;
     }
 
     async fn exec_command_output_delta(
@@ -3282,9 +3412,8 @@ impl PromptState {
             stream: _,
         } = event;
         // Stream output bytes to the display-only terminal via ToolCallUpdate meta.
+        let data_str = String::from_utf8_lossy(&chunk).to_string();
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
-            let data_str = String::from_utf8_lossy(&chunk).to_string();
-
             if client.supports_terminal_output(active_command) {
                 let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
@@ -3304,6 +3433,13 @@ impl PromptState {
                 // and can exhaust memory for commands with long output.
                 active_command.output.push_str(&data_str);
             }
+        } else {
+            // Codex can race an output delta ahead of its begin event. Keep it
+            // scoped to the call ID so it can never attach to another command.
+            self.pending_command_output
+                .entry(call_id)
+                .or_default()
+                .push_str(&data_str);
         }
     }
 
@@ -3379,22 +3515,24 @@ impl PromptState {
                 .raw_output(raw_output)
                 .content(content);
 
-            client
-                .send_tool_call_update(
-                    ToolCallUpdate::new(active_command.tool_call_id.clone(), fields).meta(
-                        client.supports_terminal_output(&active_command).then(|| {
-                            Meta::from_iter([(
-                                "terminal_exit".into(),
-                                serde_json::json!({
-                                    "terminal_id": call_id,
-                                    "exit_code": exit_code,
-                                    "signal": null
-                                }),
-                            )])
-                        }),
-                    ),
-                )
-                .await;
+            self.send_canonical_tool_update(
+                client,
+                ToolCallUpdate::new(active_command.tool_call_id.clone(), fields).meta(
+                    client.supports_terminal_output(&active_command).then(|| {
+                        Meta::from_iter([(
+                            "terminal_exit".into(),
+                            serde_json::json!({
+                                "terminal_id": call_id,
+                                "exit_code": exit_code,
+                                "signal": null
+                            }),
+                        )])
+                    }),
+                ),
+                "Running command",
+                ToolKind::Execute,
+            )
+            .await;
         }
     }
 
@@ -3435,13 +3573,17 @@ impl PromptState {
 
     async fn start_web_search(&mut self, client: &SessionClient, call_id: String) {
         self.active_web_search = Some(call_id.clone());
-        client
-            .send_tool_call(ToolCall::new(call_id, "Searching the Web").kind(ToolKind::Fetch))
-            .await;
+        self.send_canonical_tool_call(
+            client,
+            ToolCall::new(call_id, "Searching the Web")
+                .kind(ToolKind::Fetch)
+                .status(ToolCallStatus::InProgress),
+        )
+        .await;
     }
 
     async fn update_web_search_query(
-        &self,
+        &mut self,
         client: &SessionClient,
         call_id: String,
         query: String,
@@ -3466,8 +3608,9 @@ impl PromptState {
             WebSearchAction::Other => "Web search".to_string(),
         };
 
-        client
-            .send_tool_call_update(ToolCallUpdate::new(
+        self.send_canonical_tool_update(
+            client,
+            ToolCallUpdate::new(
                 call_id,
                 ToolCallUpdateFields::new()
                     .status(ToolCallStatus::InProgress)
@@ -3476,18 +3619,25 @@ impl PromptState {
                         "query": query,
                         "action": action
                     })),
-            ))
-            .await;
+            ),
+            "Searching the Web",
+            ToolKind::Fetch,
+        )
+        .await;
     }
 
     async fn complete_web_search(&mut self, client: &SessionClient) {
         if let Some(call_id) = self.active_web_search.take() {
-            client
-                .send_tool_call_update(ToolCallUpdate::new(
+            self.send_canonical_tool_update(
+                client,
+                ToolCallUpdate::new(
                     call_id,
                     ToolCallUpdateFields::new().status(ToolCallStatus::Completed),
-                ))
-                .await;
+                ),
+                "Searching the Web",
+                ToolKind::Fetch,
+            )
+            .await;
         }
     }
 }

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -3523,17 +3523,25 @@ impl PromptState {
             file_snapshots.insert(path.clone(), read_text_snapshot(&path));
         }
 
-        let active_command = ActiveCommand {
+        let pending_output = self
+            .pending_command_output
+            .remove(&call_id)
+            .unwrap_or_default();
+        let mut active_command = ActiveCommand {
             tool_call_id: tool_call_id.clone(),
-            output: self
-                .pending_command_output
-                .remove(&call_id)
-                .unwrap_or_default(),
+            output: pending_output,
             file_extension,
             terminal_output,
             file_snapshots,
         };
-        let (content, meta) = if client.supports_terminal_output(&active_command) {
+        let supports_terminal_output = client.supports_terminal_output(&active_command);
+        // Output can arrive before the command begin event. A terminal client
+        // needs that buffered output replayed as a terminal update, not kept in
+        // the fallback content buffer.
+        let pending_terminal_output = supports_terminal_output
+            .then(|| std::mem::take(&mut active_command.output))
+            .filter(|output| !output.is_empty());
+        let (content, meta) = if supports_terminal_output {
             let content = vec![ToolCallContent::Terminal(Terminal::new(call_id.clone()))];
             let meta = Some(Meta::from_iter([(
                 "terminal_info".to_owned(),
@@ -3551,7 +3559,7 @@ impl PromptState {
 
         self.send_canonical_tool_call(
             client,
-            ToolCall::new(tool_call_id, title)
+            ToolCall::new(tool_call_id.clone(), title)
                 .kind(kind)
                 .status(ToolCallStatus::InProgress)
                 .locations(locations)
@@ -3560,6 +3568,22 @@ impl PromptState {
                 .meta(meta),
         )
         .await;
+
+        if let Some(data) = pending_terminal_output {
+            client
+                .send_tool_call_update(
+                    ToolCallUpdate::new(tool_call_id, ToolCallUpdateFields::new()).meta(
+                        Meta::from_iter([(
+                            "terminal_output".to_owned(),
+                            serde_json::json!({
+                                "terminal_id": call_id,
+                                "data": data,
+                            }),
+                        )]),
+                    ),
+                )
+                .await;
+        }
     }
 
     async fn exec_command_output_delta(
@@ -3597,6 +3621,13 @@ impl PromptState {
         } else {
             // Codex can race an output delta ahead of its begin event. Keep it
             // scoped to the call ID so it can never attach to another command.
+            if self
+                .projected_tool_calls
+                .get(&call_id)
+                .is_some_and(|state| state.terminal.is_some())
+            {
+                return;
+            }
             let buffer = self.pending_command_output.entry(call_id).or_default();
             append_bounded_output(buffer, &data_str);
         }
@@ -3693,6 +3724,8 @@ impl PromptState {
             )
             .await;
         } else {
+            // No later event can consume this buffer once the command has ended.
+            self.pending_command_output.remove(&call_id);
             let status = match status {
                 ExecCommandStatus::Completed if exit_code == 0 => ToolCallStatus::Completed,
                 ExecCommandStatus::Completed => ToolCallStatus::Failed,
@@ -8110,6 +8143,139 @@ mod tests {
         assert!(text.contains("typed input"));
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn early_command_output_is_replayed_to_terminal_clients() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let capabilities = Arc::new(std::sync::Mutex::new(ClientCapabilities::new().meta(
+            Meta::from_iter([("terminal_output".to_string(), json!(true))]),
+        )));
+        let session_client = SessionClient::with_client(session_id, client.clone(), capabilities);
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+        let cwd = std::env::current_dir().expect("current dir should be available");
+
+        state
+            .exec_command_output_delta(
+                &session_client,
+                ExecCommandOutputDeltaEvent {
+                    call_id: "exec-1".to_string(),
+                    stream: codex_protocol::protocol::ExecOutputStream::Stdout,
+                    chunk: b"output before begin".to_vec(),
+                },
+            )
+            .await;
+        state
+            .exec_command_begin(
+                &session_client,
+                ExecCommandBeginEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    started_at_ms: 0,
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo".to_string()],
+                    cwd: codex_utils_path_uri::PathUri::from_host_native_path(&cwd)
+                        .expect("current dir should be representable as a path URI"),
+                    parsed_cmd: vec![ParsedCommand::Unknown {
+                        cmd: "sh".to_string(),
+                    }],
+                    source: Default::default(),
+                    interaction_input: None,
+                },
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let replay = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => update
+                    .meta
+                    .as_ref()
+                    .and_then(|meta| meta.get("terminal_output")),
+                _ => None,
+            })
+            .expect("early output should be replayed to the terminal");
+        assert_eq!(replay.get("terminal_id"), Some(&json!("exec-1")));
+        assert_eq!(replay.get("data"), Some(&json!("output before begin")));
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn command_end_discards_output_without_a_begin_event() {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client, Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+        let cwd = std::env::current_dir().expect("current dir should be available");
+
+        state
+            .exec_command_output_delta(
+                &session_client,
+                ExecCommandOutputDeltaEvent {
+                    call_id: "exec-1".to_string(),
+                    stream: codex_protocol::protocol::ExecOutputStream::Stdout,
+                    chunk: b"orphaned output".to_vec(),
+                },
+            )
+            .await;
+        assert!(state.pending_command_output.contains_key("exec-1"));
+
+        state
+            .exec_command_end(
+                &session_client,
+                ExecCommandEndEvent {
+                    call_id: "exec-1".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    completed_at_ms: 0,
+                    command: vec!["sh".to_string(), "-c".to_string(), "echo".to_string()],
+                    cwd: codex_utils_path_uri::PathUri::from_host_native_path(&cwd)
+                        .expect("current dir should be representable as a path URI"),
+                    parsed_cmd: vec![],
+                    source: Default::default(),
+                    interaction_input: None,
+                    stdout: String::new(),
+                    stderr: String::new(),
+                    aggregated_output: String::new(),
+                    exit_code: 0,
+                    duration: std::time::Duration::from_millis(1),
+                    formatted_output: String::new(),
+                    status: ExecCommandStatus::Completed,
+                },
+            )
+            .await;
+
+        assert!(!state.pending_command_output.contains_key("exec-1"));
+        state
+            .exec_command_output_delta(
+                &session_client,
+                ExecCommandOutputDeltaEvent {
+                    call_id: "exec-1".to_string(),
+                    stream: codex_protocol::protocol::ExecOutputStream::Stdout,
+                    chunk: b"late output".to_vec(),
+                },
+            )
+            .await;
+        assert!(!state.pending_command_output.contains_key("exec-1"));
     }
 
     async fn setup(

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -897,6 +897,8 @@ struct ProjectedToolCallState {
     canonical_seen: bool,
     canonical_terminal_seen: bool,
     terminal: Option<ToolCallStatus>,
+    pending_canonical_fields: Option<ToolCallUpdateFields>,
+    pending_canonical_meta: Option<Meta>,
 }
 #[derive(Debug, serde::Deserialize)]
 struct NeverWriteUserInputAnswerPayload {
@@ -1212,6 +1214,47 @@ fn append_bounded_output(buffer: &mut String, chunk: &str) {
         .last()
         .unwrap_or_default();
     buffer.push_str(&chunk[..end]);
+}
+
+fn merge_tool_call_update_fields(into: &mut ToolCallUpdateFields, fields: ToolCallUpdateFields) {
+    if fields.kind.is_some() {
+        into.kind = fields.kind;
+    }
+    if fields.status.is_some() {
+        into.status = fields.status;
+    }
+    if fields.title.is_some() {
+        into.title = fields.title;
+    }
+    if fields.content.is_some() {
+        into.content = fields.content;
+    }
+    if fields.locations.is_some() {
+        into.locations = fields.locations;
+    }
+    if fields.raw_input.is_some() {
+        into.raw_input = fields.raw_input;
+    }
+    if fields.raw_output.is_some() {
+        into.raw_output = fields.raw_output;
+    }
+}
+
+fn merge_tool_call_meta(into: &mut Option<Meta>, meta: Option<Meta>) {
+    let Some(meta) = meta else {
+        return;
+    };
+    into.get_or_insert_with(Meta::new).extend(meta);
+}
+
+fn canonical_update_can_materialize(update: &ToolCallUpdate) -> bool {
+    is_terminal_tool_status(&update.fields.status.unwrap_or(ToolCallStatus::InProgress))
+        || update.fields.title.is_some()
+        || update.fields.kind.is_some()
+        || update.fields.content.is_some()
+        || update.fields.locations.is_some()
+        || update.fields.raw_input.is_some()
+        || update.fields.raw_output.is_some()
 }
 
 fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
@@ -1891,6 +1934,8 @@ impl PromptState {
             return;
         }
         state.emitted = true;
+        let pending_fields = state.pending_canonical_fields.take();
+        let pending_meta = state.pending_canonical_meta.take();
 
         let (title, detail) = describe_turn_item(item);
         let mut tool_call = ToolCall::new(call_id, title)
@@ -1907,6 +1952,10 @@ impl PromptState {
         if projection == TurnItemProjection::Status {
             tool_call = tool_call.meta(neverwrite_status_meta("item_activity", "neutral"));
         }
+        if let Some(fields) = pending_fields {
+            tool_call.update(fields);
+        }
+        merge_tool_call_meta(&mut tool_call.meta, pending_meta);
         client.send_tool_call(tool_call).await;
     }
 
@@ -1966,10 +2015,10 @@ impl PromptState {
         }
     }
 
-    async fn send_canonical_tool_call(&mut self, client: &SessionClient, tool_call: ToolCall) {
+    async fn send_canonical_tool_call(&mut self, client: &SessionClient, mut tool_call: ToolCall) {
         let call_id = tool_call.tool_call_id.to_string();
         let terminal = is_terminal_tool_status(&tool_call.status);
-        let (emitted, preserve_terminal) = {
+        let (emitted, preserve_terminal, pending_fields, pending_meta) = {
             let state = self
                 .projected_tool_calls
                 .entry(call_id.clone())
@@ -1985,8 +2034,18 @@ impl PromptState {
             }
             let emitted = state.emitted;
             state.emitted = true;
-            (emitted, preserve_terminal)
+            (
+                emitted,
+                preserve_terminal,
+                state.pending_canonical_fields.take(),
+                state.pending_canonical_meta.take(),
+            )
         };
+
+        if let Some(fields) = pending_fields {
+            tool_call.update(fields);
+        }
+        merge_tool_call_meta(&mut tool_call.meta, pending_meta);
 
         if !emitted {
             client.send_tool_call(tool_call).await;
@@ -2015,17 +2074,31 @@ impl PromptState {
     async fn send_canonical_tool_update(
         &mut self,
         client: &SessionClient,
-        update: ToolCallUpdate,
+        mut update: ToolCallUpdate,
         title_if_unmaterialized: impl Into<String>,
         kind_if_unmaterialized: ToolKind,
     ) {
         let call_id = update.tool_call_id.to_string();
+        if !canonical_update_can_materialize(&update)
+            && !self
+                .projected_tool_calls
+                .get(&call_id)
+                .is_some_and(|state| state.emitted)
+        {
+            let state = self.projected_tool_calls.entry(call_id).or_default();
+            state.canonical_seen = true;
+            let pending_fields = state.pending_canonical_fields.get_or_insert_default();
+            merge_tool_call_update_fields(pending_fields, update.fields);
+            merge_tool_call_meta(&mut state.pending_canonical_meta, update.meta);
+            return;
+        }
+
         let terminal = update
             .fields
             .status
             .as_ref()
             .is_some_and(is_terminal_tool_status);
-        let (emitted, preserve_terminal) = {
+        let (emitted, preserve_terminal, pending_fields, pending_meta) = {
             let state = self
                 .projected_tool_calls
                 .entry(call_id.clone())
@@ -2041,8 +2114,20 @@ impl PromptState {
             let preserve_terminal = state.terminal.is_some() && !terminal;
             let emitted = state.emitted;
             state.emitted = true;
-            (emitted, preserve_terminal)
+            (
+                emitted,
+                preserve_terminal,
+                state.pending_canonical_fields.take(),
+                state.pending_canonical_meta.take(),
+            )
         };
+
+        if let Some(pending_fields) = pending_fields {
+            let mut merged = pending_fields;
+            merge_tool_call_update_fields(&mut merged, update.fields);
+            update.fields = merged;
+        }
+        merge_tool_call_meta(&mut update.meta, pending_meta);
 
         if !emitted {
             let mut tool_call = ToolCall::new(call_id, title_if_unmaterialized)
@@ -2054,7 +2139,6 @@ impl PromptState {
             return;
         }
 
-        let mut update = update;
         if preserve_terminal {
             update.fields.status = None;
         }
@@ -7136,6 +7220,109 @@ mod tests {
         );
         assert_eq!(parsed.entries.len(), 1);
         assert_eq!(parsed.entries[0].step, "Inspect current state");
+    }
+
+    #[tokio::test]
+    async fn canonical_metadata_waits_for_a_materializing_turn_item() {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new("submission-1".into(), thread, resolution_tx, response_tx);
+
+        state
+            .send_canonical_tool_update(
+                &session_client,
+                ToolCallUpdate::new("web-1", ToolCallUpdateFields::new()).meta(Meta::from_iter([
+                    ("query_source".into(), json!("canonical")),
+                ])),
+                "Searching the Web",
+                ToolKind::Fetch,
+            )
+            .await;
+        assert!(client.notifications.lock().unwrap().is_empty());
+
+        state
+            .start_turn_item(
+                &session_client,
+                &TurnItem::WebSearch(codex_protocol::items::WebSearchItem {
+                    id: "web-1".into(),
+                    query: "Rust ACP".into(),
+                    action: WebSearchAction::Other,
+                }),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let calls = notifications
+            .iter()
+            .filter_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(call) => Some(call),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].tool_call_id.0.as_ref(), "web-1");
+        assert_eq!(
+            calls[0]
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get("query_source")),
+            Some(&json!("canonical"))
+        );
+    }
+
+    #[tokio::test]
+    async fn fallback_and_canonical_turn_item_share_one_tool_call() {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new("submission-1".into(), thread, resolution_tx, response_tx);
+        let item = TurnItem::WebSearch(codex_protocol::items::WebSearchItem {
+            id: "web-1".into(),
+            query: "Rust ACP".into(),
+            action: WebSearchAction::Other,
+        });
+
+        state.start_turn_item(&session_client, &item).await;
+        state
+            .send_canonical_tool_call(
+                &session_client,
+                ToolCall::new("web-1", "Searching the Web")
+                    .kind(ToolKind::Fetch)
+                    .status(ToolCallStatus::InProgress)
+                    .content(vec![ToolCallContent::Content(Content::new("Rust ACP"))]),
+            )
+            .await;
+        state.complete_turn_item(&session_client, &item).await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let call_count = notifications
+            .iter()
+            .filter(|notification| matches!(notification.update, SessionUpdate::ToolCall(_)))
+            .count();
+        let updates = notifications
+            .iter()
+            .filter_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(call_count, 1);
+        assert_eq!(updates.len(), 2);
+        assert!(
+            updates
+                .iter()
+                .all(|update| update.tool_call_id.0.as_ref() == "web-1")
+        );
+        assert_eq!(updates[0].fields.content.as_ref().map(Vec::len), Some(1));
+        assert_eq!(updates[1].fields.status, Some(ToolCallStatus::Completed));
+        assert!(updates[1].fields.content.is_none());
     }
 
     #[tokio::test]

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -1103,6 +1103,15 @@ enum TurnItemProjection {
     Tool,
 }
 
+struct StatusToolCall {
+    call_id: ToolCallId,
+    kind: &'static str,
+    title: String,
+    detail: Option<String>,
+    emphasis: &'static str,
+    status: ToolCallStatus,
+}
+
 fn turn_item_projection(item: &TurnItem) -> TurnItemProjection {
     match item {
         TurnItem::UserMessage(..) | TurnItem::AgentMessage(..) | TurnItem::Reasoning(..) => {
@@ -1895,22 +1904,16 @@ impl PromptState {
         Ok(())
     }
 
-    async fn send_status_tool_call(
-        &self,
-        client: &SessionClient,
-        call_id: impl Into<ToolCallId>,
-        kind: &str,
-        title: impl Into<String>,
-        detail: Option<String>,
-        emphasis: &str,
-        status: ToolCallStatus,
-    ) {
-        let mut tool_call = ToolCall::new(call_id, title)
+    async fn send_status_tool_call(&self, client: &SessionClient, status_call: StatusToolCall) {
+        let mut tool_call = ToolCall::new(status_call.call_id, status_call.title)
             .kind(ToolKind::Other)
-            .status(status)
-            .meta(neverwrite_status_meta(kind, emphasis));
+            .status(status_call.status)
+            .meta(neverwrite_status_meta(
+                status_call.kind,
+                status_call.emphasis,
+            ));
 
-        if let Some(detail) = detail {
+        if let Some(detail) = status_call.detail {
             tool_call = tool_call.content(vec![ToolCallContent::Content(Content::new(detail))]);
         }
 
@@ -2257,15 +2260,14 @@ impl PromptState {
                     .send_turn_lifecycle(CODEX_ACP_TURN_STARTED_EVENT_TYPE, Some(&turn_id))
                     .await;
                 let detail = model_context_window.map(|size| format!("Context window: {size}"));
-                self.send_status_tool_call(
-                    client,
-                    format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}turn:{turn_id}"),
-                    "turn_started",
-                    "New turn",
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}turn:{turn_id}").into(),
+                    kind: "turn_started",
+                    title: "New turn".to_string(),
                     detail,
-                    "neutral",
-                    ToolCallStatus::Completed,
-                )
+                    emphasis: "neutral",
+                    status: ToolCallStatus::Completed,
+                })
                 .await;
             }
             EventMsg::TokenCount(TokenCountEvent { info, .. }) => {
@@ -2636,15 +2638,14 @@ impl PromptState {
                 let detail = additional_details
                     .filter(|details| !details.trim().is_empty())
                     .unwrap_or_else(|| message.clone());
-                self.send_status_tool_call(
-                    client,
-                    format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}stream_error:{}", self.event_count),
-                    "stream_error",
-                    "Streaming interrupted",
-                    Some(detail),
-                    "error",
-                    ToolCallStatus::Failed,
-                )
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}stream_error:{}", self.event_count).into(),
+                    kind: "stream_error",
+                    title: "Streaming interrupted".to_string(),
+                    detail: Some(detail),
+                    emphasis: "error",
+                    status: ToolCallStatus::Failed,
+                })
                 .await;
             }
             EventMsg::Error(ErrorEvent {
@@ -2701,15 +2702,14 @@ impl PromptState {
             }
             EventMsg::EnteredReviewMode(review_request) => {
                 info!("Review begin: request={review_request:?}");
-                self.send_status_tool_call(
-                    client,
-                    format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}review:{}", self.event_count),
-                    "review_mode",
-                    "Review mode active",
-                    Some(format_review_target(&review_request.target)),
-                    "info",
-                    ToolCallStatus::Completed,
-                )
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}review:{}", self.event_count).into(),
+                    kind: "review_mode",
+                    title: "Review mode active".to_string(),
+                    detail: Some(format_review_target(&review_request.target)),
+                    emphasis: "info",
+                    status: ToolCallStatus::Completed,
+                })
                 .await;
             }
             EventMsg::ExitedReviewMode(event) => {
@@ -2761,15 +2761,14 @@ impl PromptState {
                 let detail = reason
                     .map(|reason| format!("{from_model} -> {to_model}. {reason}"))
                     .or_else(|| Some(format!("{from_model} -> {to_model}")));
-                self.send_status_tool_call(
-                    client,
-                    format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}model_reroute:{}", self.event_count),
-                    "model_reroute",
-                    format!("Switched to {to_model}"),
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!("{NEVERWRITE_STATUS_EVENT_ID_PREFIX}model_reroute:{}", self.event_count).into(),
+                    kind: "model_reroute",
+                    title: format!("Switched to {to_model}"),
                     detail,
-                    "info",
-                    ToolCallStatus::Completed,
-                )
+                    emphasis: "info",
+                    status: ToolCallStatus::Completed,
+                })
                 .await;
             }
             EventMsg::RequestUserInput(event) => {
@@ -2947,7 +2946,7 @@ impl PromptState {
             permissions_request_key(&call_id),
             PendingPermissionRequest::RequestPermissions {
                 call_id: call_id.clone(),
-                permissions: permissions.into(),
+                permissions,
             },
             ToolCallUpdate::new(
                 call_id,

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{HashMap, HashSet, VecDeque},
     future::Future,
     path::{Path, PathBuf},
     pin::Pin,
@@ -130,6 +130,7 @@ const NEVERWRITE_STATUS_EVENT_ID_PREFIX: &str = "neverwrite:status:";
 const NEVERWRITE_IMAGE_EVENT_ID_PREFIX: &str = "neverwrite:image:";
 const FILE_DELETED_PLACEHOLDER: &str = "[file deleted]";
 const MAX_PENDING_COMMAND_OUTPUT_BYTES: usize = 1024 * 1024;
+const MAX_CLOSED_EVENT_PROJECTIONS: usize = 256;
 const CODEX_ACP_EVENT_TYPE_KEY: &str = "codexAcpEventType";
 const CODEX_ACP_TURN_EVENT_TYPE_KEY: &str = "codexAcpTurnEventType";
 const CODEX_ACP_TURN_ID_KEY: &str = "codexAcpTurnId";
@@ -4295,6 +4296,10 @@ struct ThreadActor<A> {
     submissions: HashMap<String, SubmissionState>,
     /// Drain-only projections for Codex turns created outside ACP prompt calls.
     event_projections: HashMap<String, PromptState>,
+    /// Recently closed external turns. This lifecycle-only tombstone prevents
+    /// late events from recreating activities after their projection ended.
+    closed_event_projections: HashSet<String>,
+    closed_event_projection_order: VecDeque<String>,
     /// A receiver for incoming thread messages.
     message_rx: mpsc::UnboundedReceiver<ThreadMessage>,
     /// A receiver for spawned interaction results.
@@ -4325,6 +4330,8 @@ impl<A: Auth> ThreadActor<A> {
             resolution_tx,
             submissions: HashMap::new(),
             event_projections: HashMap::new(),
+            closed_event_projections: HashSet::new(),
+            closed_event_projection_order: VecDeque::new(),
             message_rx,
             resolution_rx,
             last_sent_config_options: None,
@@ -5565,6 +5572,9 @@ impl<A: Auth> ThreadActor<A> {
         if let Some(submission) = self.submissions.get_mut(&id) {
             submission.handle_event(&self.client, msg).await;
         } else {
+            if self.closed_event_projections.contains(&id) {
+                return;
+            }
             let is_terminal = is_projection_terminal_event(&msg);
             let thread = self.thread.clone();
             let resolution_tx = self.resolution_tx.clone();
@@ -5575,6 +5585,18 @@ impl<A: Auth> ThreadActor<A> {
             projection.handle_event(&self.client, msg).await;
             if is_terminal {
                 self.event_projections.remove(&id);
+                self.remember_closed_event_projection(id);
+            }
+        }
+    }
+
+    fn remember_closed_event_projection(&mut self, id: String) {
+        if self.closed_event_projections.insert(id.clone()) {
+            self.closed_event_projection_order.push_back(id);
+        }
+        while self.closed_event_projection_order.len() > MAX_CLOSED_EVENT_PROJECTIONS {
+            if let Some(expired) = self.closed_event_projection_order.pop_front() {
+                self.closed_event_projections.remove(&expired);
             }
         }
     }
@@ -7704,6 +7726,29 @@ mod tests {
             .await;
         assert!(!actor.event_projections.contains_key(&submission_id));
 
+        let notification_count_after_close = client.notifications.lock().unwrap().len();
+        actor
+            .handle_event(Event {
+                id: submission_id.clone(),
+                msg: EventMsg::ItemStarted(ItemStartedEvent {
+                    thread_id: codex_protocol::ThreadId::new(),
+                    turn_id: "turn-1".to_string(),
+                    started_at_ms: 0,
+                    item: TurnItem::WebSearch(codex_protocol::items::WebSearchItem {
+                        id: "late-web-1".to_string(),
+                        query: "late event".to_string(),
+                        action: WebSearchAction::Other,
+                    }),
+                }),
+            })
+            .await;
+        assert!(!actor.event_projections.contains_key(&submission_id));
+        assert_eq!(
+            client.notifications.lock().unwrap().len(),
+            notification_count_after_close,
+            "late events must not recreate a closed external projection"
+        );
+
         let notifications = client.notifications.lock().unwrap();
         assert!(matches!(
             notifications.first().map(|notification| &notification.update),
@@ -7716,6 +7761,48 @@ mod tests {
                     == Some("subagent_breadcrumb")
         ));
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn closed_event_projection_tombstones_are_bounded() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client, Arc::default());
+        let conversation = Arc::new(StubCodexThread::new());
+        let models_manager = Arc::new(StubModelsManager);
+        let config = Config::load_with_cli_overrides_and_harness_overrides(
+            vec![],
+            ConfigOverrides::default(),
+        )
+        .await?;
+        let (_message_tx, message_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (resolution_tx, resolution_rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut actor = ThreadActor::new(
+            StubAuth,
+            session_client,
+            conversation,
+            models_manager,
+            config,
+            message_rx,
+            resolution_tx,
+            resolution_rx,
+        );
+
+        for index in 0..=MAX_CLOSED_EVENT_PROJECTIONS {
+            actor.remember_closed_event_projection(format!("submission-{index}"));
+        }
+
+        assert_eq!(
+            actor.closed_event_projections.len(),
+            MAX_CLOSED_EVENT_PROJECTIONS
+        );
+        assert!(!actor.closed_event_projections.contains("submission-0"));
+        assert!(
+            actor
+                .closed_event_projections
+                .contains(&format!("submission-{MAX_CLOSED_EVENT_PROJECTIONS}"))
+        );
         Ok(())
     }
 

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -1077,6 +1077,66 @@ fn turn_item_id(item: &TurnItem) -> &str {
     }
 }
 
+/// Items that already have a dedicated ACP projection stay out of the generic
+/// lifecycle. Messages and reasoning are streamed through their own channels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TurnItemProjection {
+    Hidden,
+    Dedicated,
+    Status,
+    Tool,
+}
+
+fn turn_item_projection(item: &TurnItem) -> TurnItemProjection {
+    match item {
+        TurnItem::UserMessage(..) | TurnItem::AgentMessage(..) | TurnItem::Reasoning(..) => {
+            TurnItemProjection::Hidden
+        }
+        TurnItem::Plan(..)
+        | TurnItem::ImageGeneration(..)
+        | TurnItem::EnteredReviewMode(..)
+        | TurnItem::ExitedReviewMode(..) => TurnItemProjection::Dedicated,
+        TurnItem::HookPrompt(..) | TurnItem::Sleep(..) | TurnItem::ContextCompaction(..) => {
+            TurnItemProjection::Status
+        }
+        TurnItem::CommandExecution(..)
+        | TurnItem::DynamicToolCall(..)
+        | TurnItem::CollabAgentToolCall(..)
+        | TurnItem::SubAgentActivity(..)
+        | TurnItem::WebSearch(..)
+        | TurnItem::ImageView(..)
+        | TurnItem::Extension(..)
+        | TurnItem::FileChange(..)
+        | TurnItem::McpToolCall(..) => TurnItemProjection::Tool,
+    }
+}
+
+fn turn_item_tool_kind(item: &TurnItem) -> ToolKind {
+    match item {
+        TurnItem::CommandExecution(..) => ToolKind::Execute,
+        TurnItem::WebSearch(..) => ToolKind::Fetch,
+        TurnItem::ImageView(..) => ToolKind::Read,
+        TurnItem::FileChange(..) => ToolKind::Edit,
+        // Extension items are deliberately kept explicit at their handler
+        // boundary; their generic fallback is safe but cannot assume a kind.
+        TurnItem::Extension(..)
+        | TurnItem::DynamicToolCall(..)
+        | TurnItem::CollabAgentToolCall(..)
+        | TurnItem::SubAgentActivity(..)
+        | TurnItem::McpToolCall(..)
+        | TurnItem::HookPrompt(..)
+        | TurnItem::Sleep(..)
+        | TurnItem::ContextCompaction(..)
+        | TurnItem::UserMessage(..)
+        | TurnItem::AgentMessage(..)
+        | TurnItem::Plan(..)
+        | TurnItem::Reasoning(..)
+        | TurnItem::ImageGeneration(..)
+        | TurnItem::EnteredReviewMode(..)
+        | TurnItem::ExitedReviewMode(..) => ToolKind::Other,
+    }
+}
+
 fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
     match item {
         TurnItem::UserMessage(..) => ("Preparing input", None),


### PR DESCRIPTION
## Summary

- Project fallback `TurnItem` activity into ACP tool calls for commands, file changes, web searches, tool calls, and status-only activities.
- Reconcile fallback activity with canonical tool-call events so each operation retains one stable tool call and terminal status.
- Preserve patch updates, command output that arrives before command start, and canonical file-diff baselines.
- Add explicit handling for extension web search and image generation items.

## Why

Codex can emit both generic turn-item lifecycle events and canonical tool-call events for the same operation. Previously this caused missing activity, duplicated entries, or incomplete patch and terminal-command details.

## Validation

- `rustup run 1.96.0 cargo test --lib` (vendor/codex-acp)
- `git diff --check origin/main...HEAD`

## Notes

- The change keeps fallback activity as a display-safe projection while canonical events remain the source of richer tool-call details and diffs.