### PR TITLE
Subagent lifecycle and breadcrumb contract

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -3097,7 +3097,7 @@ impl NativeAcpClient {
 
     fn child_session_ids_for_terminal_subagent_breadcrumb(
         &self,
-        _parent_session_id: &str,
+        parent_session_id: &str,
         meta: &Meta,
     ) -> Vec<String> {
         let Some(subagent_event_type) = meta_string(meta, CODEX_ACP_SUBAGENT_EVENT_TYPE_KEY) else {
@@ -3106,7 +3106,7 @@ impl NativeAcpClient {
 
         if subagent_event_type == CODEX_ACP_SUBAGENT_CLOSE_END_EVENT_TYPE {
             return self
-                .child_session_id_from_breadcrumb_meta(meta)
+                .child_session_id_from_breadcrumb_meta(parent_session_id, meta)
                 .into_iter()
                 .collect();
         }
@@ -3118,7 +3118,7 @@ impl NativeAcpClient {
         ) {
             if codex_acp_agent_status_is_terminal(meta).unwrap_or(false) {
                 return self
-                    .child_session_id_from_breadcrumb_meta(meta)
+                    .child_session_id_from_breadcrumb_meta(parent_session_id, meta)
                     .into_iter()
                     .collect();
             }
@@ -3132,23 +3132,46 @@ impl NativeAcpClient {
         if let Some(runtime_child_session_id) = meta_string(meta, CODEX_ACP_CHILD_SESSION_ID_KEY) {
             if codex_acp_agent_status_is_terminal(meta).unwrap_or(false) {
                 return self
-                    .find_app_session_id(&runtime_child_session_id)
+                    .child_session_id_for_parent(parent_session_id, &runtime_child_session_id)
                     .into_iter()
                     .collect();
             }
             return vec![];
         }
 
-        self.terminal_child_session_ids_from_agent_statuses(meta)
+        self.terminal_child_session_ids_from_agent_statuses(parent_session_id, meta)
     }
 
-    fn child_session_id_from_breadcrumb_meta(&self, meta: &Meta) -> Option<String> {
+    fn child_session_id_from_breadcrumb_meta(
+        &self,
+        parent_session_id: &str,
+        meta: &Meta,
+    ) -> Option<String> {
         meta_string(meta, CODEX_ACP_CHILD_SESSION_ID_KEY).and_then(|runtime_child_session_id| {
-            self.find_app_session_id(&runtime_child_session_id)
+            self.child_session_id_for_parent(parent_session_id, &runtime_child_session_id)
         })
     }
 
-    fn terminal_child_session_ids_from_agent_statuses(&self, meta: &Meta) -> Vec<String> {
+    fn child_session_id_for_parent(
+        &self,
+        parent_session_id: &str,
+        runtime_child_session_id: &str,
+    ) -> Option<String> {
+        let state = self.session_state.lock().ok()?;
+        state.sessions.values().find_map(|managed| {
+            let matches_child = managed.session.session_id == runtime_child_session_id
+                || managed.session.runtime_session_id.as_deref() == Some(runtime_child_session_id);
+            (matches_child
+                && managed.session.parent_session_id.as_deref() == Some(parent_session_id))
+            .then(|| managed.session.session_id.clone())
+        })
+    }
+
+    fn terminal_child_session_ids_from_agent_statuses(
+        &self,
+        parent_session_id: &str,
+        meta: &Meta,
+    ) -> Vec<String> {
         meta.get(CODEX_ACP_AGENT_STATUSES_KEY)
             .and_then(Value::as_array)
             .map(|statuses| {
@@ -3165,7 +3188,10 @@ impl NativeAcpClient {
                             .get(CODEX_ACP_CHILD_SESSION_ID_KEY)
                             .and_then(Value::as_str)
                             .and_then(|runtime_child_session_id| {
-                                self.find_app_session_id(runtime_child_session_id)
+                                self.child_session_id_for_parent(
+                                    parent_session_id,
+                                    runtime_child_session_id,
+                                )
                             })
                     })
                     .collect()
@@ -10985,6 +11011,77 @@ mod tests {
         assert!(saw_closed_update);
         assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
         assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
+    }
+
+    #[test]
+    fn terminal_breadcrumb_cannot_close_child_owned_by_another_parent() {
+        const OTHER_PARENT_SESSION_ID: &str = "other-parent-session";
+
+        let (event_tx, event_rx) = mpsc::channel();
+        let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
+        insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, PARENT_RUNTIME_SESSION_ID);
+        insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, OTHER_PARENT_SESSION_ID);
+        insert_test_managed_session(&session_state, CODEX_RUNTIME_ID, CHILD_RUNTIME_SESSION_ID);
+        mark_test_session_as_child(
+            &session_state,
+            CHILD_RUNTIME_SESSION_ID,
+            CHILD_RUNTIME_SESSION_ID,
+        );
+        {
+            let mut state = session_state.lock().unwrap();
+            let child = state
+                .sessions
+                .get_mut(CHILD_RUNTIME_SESSION_ID)
+                .expect("child session should exist");
+            child.session.parent_session_id = Some(PARENT_RUNTIME_SESSION_ID.to_string());
+            child.session.status = AiSessionStatus::Streaming;
+        }
+        let client = test_client_with_state(event_tx, Arc::clone(&session_state));
+
+        let close_meta = Meta::from_iter([
+            (
+                CODEX_ACP_EVENT_TYPE_KEY.to_string(),
+                json!(CODEX_ACP_SUBAGENT_BREADCRUMB_EVENT),
+            ),
+            (
+                CODEX_ACP_CHILD_SESSION_ID_KEY.to_string(),
+                json!(CHILD_RUNTIME_SESSION_ID),
+            ),
+            (
+                CODEX_ACP_SUBAGENT_EVENT_TYPE_KEY.to_string(),
+                json!(CODEX_ACP_SUBAGENT_CLOSE_END_EVENT),
+            ),
+        ]);
+        run_client_future(
+            client.session_notification(SessionNotification::new(
+                OTHER_PARENT_SESSION_ID,
+                SessionUpdate::ToolCall(
+                    ToolCall::new(ToolCallId::from("foreign-subagent-close"), "Closed child")
+                        .kind(ToolKind::Other)
+                        .status(ToolCallStatus::Completed)
+                        .meta(close_meta),
+                ),
+            )),
+        )
+        .unwrap();
+
+        let RpcOutput::Event { event_name, .. } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("breadcrumb should still emit tool activity")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert!(event_rx.try_recv().is_err());
+
+        let state = session_state.lock().unwrap();
+        let child = &state
+            .sessions
+            .get(CHILD_RUNTIME_SESSION_ID)
+            .expect("child session should remain available")
+            .session;
+        assert_eq!(child.status, AiSessionStatus::Streaming);
+        assert!(child.closed_at.is_none());
     }
 
     #[test]

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -1352,6 +1352,115 @@ describe("AIChatMessageItem read tool targets", () => {
         });
     });
 
+    it("labels subagent breadcrumbs from the resolved child session", () => {
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                "child-session": {
+                    sessionId: "child-session",
+                    historySessionId: "child-session",
+                    status: "idle",
+                    runtimeId: "codex-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                    parentSessionId: "parent-session",
+                    persistedTitle: "Franklin",
+                    runtimeState: "live",
+                    activeWorkCycleId: null,
+                    visibleWorkCycleId: null,
+                    resumeContextPending: false,
+                },
+            },
+            sessionOrder: ["child-session"],
+        }));
+
+        renderMessage({
+            id: "tool:subagent-name",
+            role: "assistant",
+            kind: "tool",
+            title: "Started explorer",
+            content: "Agent: /root/explorer",
+            timestamp: Date.now(),
+            toolAction: {
+                kind: "open_session",
+                session_id: "child-session",
+            },
+            meta: {
+                tool: "other",
+                status: "completed",
+            },
+        });
+
+        expect(
+            screen.getByRole("button", { name: "Open Franklin" }),
+        ).toBeEnabled();
+        expect(
+            screen.queryByRole("button", { name: "Open explorer" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("updates a breadcrumb label when the child session arrives later", () => {
+        renderMessage({
+            id: "tool:subagent-late-name",
+            role: "assistant",
+            kind: "tool",
+            title: "Started explorer",
+            content: "Agent: /root/explorer",
+            timestamp: Date.now(),
+            toolAction: {
+                kind: "open_session",
+                session_id: "runtime-child",
+            },
+            meta: {
+                tool: "other",
+                status: "completed",
+            },
+        });
+
+        expect(
+            screen.getByRole("button", { name: "Open explorer" }),
+        ).toBeDisabled();
+
+        act(() => {
+            useChatStore.setState((state) => ({
+                ...state,
+                sessionsById: {
+                    ...state.sessionsById,
+                    "child-session": {
+                        sessionId: "child-session",
+                        historySessionId: "child-session",
+                        runtimeSessionId: "runtime-child",
+                        status: "idle",
+                        runtimeId: "codex-acp",
+                        modelId: "test-model",
+                        modeId: "default",
+                        models: [],
+                        modes: [],
+                        configOptions: [],
+                        messages: [],
+                        attachments: [],
+                        parentSessionId: "parent-session",
+                        persistedTitle: "Franklin",
+                        runtimeState: "live",
+                        activeWorkCycleId: null,
+                        visibleWorkCycleId: null,
+                        resumeContextPending: false,
+                    },
+                },
+                sessionOrder: [...state.sessionOrder, "child-session"],
+            }));
+        });
+
+        expect(
+            screen.getByRole("button", { name: "Open Franklin" }),
+        ).toBeEnabled();
+    });
+
     it("opens restored subagent sessions by history id from persisted breadcrumbs", async () => {
         useEditorStore.getState().hydrateWorkspace(
             [

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -527,9 +527,14 @@ function stripMarkdownBold(text: string) {
     return text.replace(/\*\*(.+?)\*\*/g, "$1");
 }
 
-function getOpenSessionActionLabel(message: AIChatMessage) {
+function getOpenSessionActionLabel(
+    message: AIChatMessage,
+    resolvedSessionTitle: string | null,
+) {
     const explicitLabel = message.toolAction?.label?.trim();
     if (explicitLabel) return explicitLabel;
+
+    if (resolvedSessionTitle) return `Open ${resolvedSessionTitle}`;
 
     const name = (message.title ?? "")
         .replace(/^(spawned|started|opened)\s+/i, "")
@@ -589,13 +594,22 @@ function OpenSessionActionButton({ message }: { message: AIChatMessage }) {
             openSessionId,
         ),
     );
+    const resolvedOpenSessionTitle = useChatStore((state) => {
+        if (!resolvedOpenSessionId) return null;
+        const session = state.sessionsById[resolvedOpenSessionId];
+        return (
+            session?.customTitle?.trim() ||
+            session?.persistedTitle?.trim() ||
+            null
+        );
+    });
     const canOpenSession = resolvedOpenSessionId !== null;
 
     if (!openSessionAction) {
         return null;
     }
 
-    const label = getOpenSessionActionLabel(message);
+    const label = getOpenSessionActionLabel(message, resolvedOpenSessionTitle);
 
     return (
         <button

--- a/apps/desktop/src/features/ai/sessionHierarchy.test.ts
+++ b/apps/desktop/src/features/ai/sessionHierarchy.test.ts
@@ -125,4 +125,33 @@ describe("buildAiSessionHierarchyGroups", () => {
             "second",
         ]);
     });
+
+    it("keeps self-parented and cyclic historical sessions visible as roots", () => {
+        const selfParented = session("self", "Self parented", {
+            parentSessionId: "self",
+            runtimeState: "persisted_only",
+        });
+        const cycleA = session("cycle-a", "Cycle A", {
+            parentSessionId: "cycle-b",
+            runtimeState: "persisted_only",
+        });
+        const cycleB = session("cycle-b", "Cycle B", {
+            parentSessionId: "cycle-a",
+            runtimeState: "persisted_only",
+        });
+
+        const result = buildAiSessionHierarchyGroups({
+            sessions: [selfParented, cycleA, cycleB],
+        });
+
+        expect(result.rootSessionIds).toEqual(["self", "cycle-a", "cycle-b"]);
+        expect(result.groups.map((group) => group.root.sessionId)).toEqual([
+            "self",
+            "cycle-a",
+            "cycle-b",
+        ]);
+        expect(result.groups.every((group) => group.children.length === 0)).toBe(
+            true,
+        );
+    });
 });

--- a/apps/desktop/src/features/ai/sessionHierarchy.ts
+++ b/apps/desktop/src/features/ai/sessionHierarchy.ts
@@ -80,6 +80,25 @@ function sessionMatchesFilter(session: AIChatSession, normalizedFilter: string) 
     return getSessionPreview(session).toLowerCase().includes(normalizedFilter);
 }
 
+function relationshipCreatesCycle(
+    session: AIChatSession,
+    parent: AIChatSession,
+    lookup: ReadonlyMap<string, AIChatSession>,
+) {
+    const visited = new Set([session.sessionId]);
+    let current: AIChatSession | null = parent;
+
+    while (current) {
+        if (visited.has(current.sessionId)) return true;
+        visited.add(current.sessionId);
+
+        const parentRef = normalizeSessionRef(current.parentSessionId);
+        current = parentRef ? (lookup.get(parentRef) ?? null) : null;
+    }
+
+    return false;
+}
+
 function compareSessionsByUpdatedAtDesc(
     left: AIChatSession,
     right: AIChatSession,
@@ -124,7 +143,11 @@ export function buildAiSessionHierarchyGroups({
     for (const session of sessions) {
         const parentRef = normalizeSessionRef(session.parentSessionId);
         const parent = parentRef ? lookup.get(parentRef) : null;
-        if (parent && parent.sessionId !== session.sessionId) {
+        if (
+            parent &&
+            parent.sessionId !== session.sessionId &&
+            !relationshipCreatesCycle(session, parent, lookup)
+        ) {
             const children = childrenByParentId.get(parent.sessionId) ?? [];
             children.push(session);
             childrenByParentId.set(parent.sessionId, children);

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -15175,6 +15175,130 @@ describe("chatStore", () => {
         });
     });
 
+    it("keeps parent and child review decisions isolated after restoring the same path and tool id", async () => {
+        const sharedPath = "/vault/src/shared.md";
+        const sharedToolMessage = {
+            id: "tool:shared-tool-call",
+            role: "assistant" as const,
+            kind: "tool" as const,
+            title: "Edit shared file",
+            content: "Updated shared.md",
+            timestamp: 10,
+            meta: {
+                tool: "edit",
+                status: "completed",
+                target: sharedPath,
+            },
+        };
+        const parentFile = createTrackedFile(
+            sharedPath,
+            "base line",
+            "parent line",
+        );
+        const childFile = createTrackedFile(
+            sharedPath,
+            "base line",
+            "child line",
+        );
+        const parent = createSessionWithTrackedFiles("parent-session", [
+            parentFile,
+        ]);
+        parent.messages = [
+            {
+                ...sharedToolMessage,
+                diffs: [
+                    {
+                        path: sharedPath,
+                        kind: "update",
+                        old_text: "base line",
+                        new_text: "parent line",
+                    },
+                ],
+            },
+        ];
+        const child = createSessionWithTrackedFiles("child-session", [childFile]);
+        child.parentSessionId = parent.sessionId;
+        child.messages = [
+            {
+                ...sharedToolMessage,
+                diffs: [
+                    {
+                        path: sharedPath,
+                        kind: "update",
+                        old_text: "base line",
+                        new_text: "child line",
+                    },
+                ],
+            },
+        ];
+
+        // A structured clone models the persisted/restored session boundary:
+        // no object identity is shared between the parent and child snapshots.
+        const restoredSessions = structuredClone({
+            [parent.sessionId]: parent,
+            [child.sessionId]: child,
+        });
+        resetChatStore();
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        useChatStore.setState({
+            sessionsById: restoredSessions,
+            sessionOrder: [parent.sessionId, child.sessionId],
+            activeSessionId: parent.sessionId,
+        });
+
+        useChatStore
+            .getState()
+            .keepEditedFile(parent.sessionId, parentFile.identityKey);
+
+        expect(getVisibleBuffer(parent.sessionId)).toHaveLength(0);
+        expect(getVisibleBuffer(child.sessionId)).toEqual([
+            expect.objectContaining({ currentText: "child line" }),
+        ]);
+
+        invokeMock.mockImplementation(async (command) => {
+            if (command === "ai_get_text_file_hash") {
+                return hashTextContent(childFile.currentText);
+            }
+            if (command === "ai_restore_text_file") {
+                return {
+                    vault_path: "/vault",
+                    kind: "upsert",
+                    note: null,
+                    note_id: null,
+                    entry: null,
+                    relative_path: "src/shared.md",
+                    origin: "agent",
+                    op_id: "child-review-reject",
+                    revision: 2,
+                    content_hash: hashTextContent(childFile.diffBase),
+                    graph_revision: 1,
+                };
+            }
+            if (
+                command === "ai_save_session_history" ||
+                command === "ai_prune_session_histories"
+            ) {
+                return undefined;
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        await useChatStore
+            .getState()
+            .rejectEditedFile(child.sessionId, childFile.identityKey);
+
+        expect(getVisibleBuffer(child.sessionId)).toHaveLength(0);
+        expect(getVisibleBuffer(parent.sessionId)).toHaveLength(0);
+        expect(
+            useChatStore.getState().sessionsById[parent.sessionId]?.messages[0]
+                ?.id,
+        ).toBe("tool:shared-tool-call");
+        expect(
+            useChatStore.getState().sessionsById[child.sessionId]?.messages[0]
+                ?.id,
+        ).toBe("tool:shared-tool-call");
+    });
+
     it("restores composer state when closing a subagent with an edited queued message", () => {
         const parent = {
             ...createSessionWithTrackedFiles("session-parent", []),

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -105,17 +105,26 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - state DB lookup plus thread-store and installation-ID wiring used by list,
   load, resume, fork, and child-thread registration
 - actor lifecycle behavior that does not keep the internal message channel alive after external senders disappear
-- subagent thread projection for collaboration events surfaced through the desktop ACP session
+- subagent sessions with typed `ThreadId` identity, descriptive `agent_path` metadata,
+  idempotent registration, and reconciliation after missed child-thread broadcasts
+- a private `codexAcp*` subagent contract for session creation, navigable activity
+  breadcrumbs, child lifecycle, and receiver-owned inter-agent transcripts
+- per-turn coalescing of equivalent subagent waits; only fully terminal status sets
+  complete the ACP activity
 - a local `codex-utils-pty` 0.144 snapshot with process-group signaling and
   Windows input/ConPTY compatibility tests
 
-The 0.144 API shapes for deferred turn items and `SubAgentActivity` are handled
-exhaustively as localized no-ops. This baseline does not add their functional
-ACP projection. Specifically deferred work is:
+The 0.144 API shapes for deferred turn items are handled as localized
+projections. `SubAgentActivity` is projected through the same canonical
+activity identity as its `TurnItem` fallback: matching protocol IDs update one
+ACP tool call, while distinct IDs remain separate rather than being correlated
+by descriptive metadata. Child `ThreadId` values remain authoritative; paths,
+nicknames, and roles are display metadata only.
+
+The deferred work is:
 
 - `codex-code-mode-host` and release packaging in PR 2
 - `ItemStarted`/`ItemCompleted` activity projection for new `TurnItem` variants in PR 3
-- the 0.144 `SubAgentActivity` ACP contract in PR 4
 - native image generation outside this PR series
 
 The current bundle must not be treated as self-contained until the companion

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -615,6 +615,7 @@ async fn register_subagent_thread(
 
     let thread = Arc::new(Thread::new(
         registration.child_session_id.clone(),
+        registration.child_thread_id,
         child_thread,
         auth_manager,
         models_manager,
@@ -797,6 +798,7 @@ impl CodexAgent {
             .insert(session_id.clone(), config.cwd.to_path_buf());
         let thread = Arc::new(Thread::new(
             session_id.clone(),
+            thread_id,
             thread,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),
@@ -897,7 +899,7 @@ impl CodexAgent {
         let mut config = self.build_session_config(&cwd, mcp_servers)?;
 
         let NewThread {
-            thread_id: _,
+            thread_id,
             thread,
             session_configured,
         } = Box::pin(self.thread_manager.resume_thread_from_rollout(
@@ -914,6 +916,7 @@ impl CodexAgent {
 
         let thread = Arc::new(Thread::new(
             session_id.clone(),
+            thread_id,
             thread,
             self.auth_manager.clone(),
             Arc::new(self.thread_manager.get_models_manager()),

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -276,8 +276,13 @@ impl CodexAgent {
                     let agent = agent.clone();
                     async move |request: PromptRequest, responder, cx: ConnectionTo<Client>| {
                         let agent = agent.clone();
+                        let session_cx = cx.clone();
                         cx.spawn(async move {
-                            responder.respond_with_result(agent.prompt(request).await)
+                            responder.respond_with_result(
+                                agent
+                                    .prompt_with_subagent_registration(request, session_cx)
+                                    .await,
+                            )
                         })?;
                         Ok(())
                     }
@@ -401,6 +406,25 @@ impl CodexAgent {
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                         warn!("Skipped {skipped} child thread creation notifications");
+                        for thread_id in thread_manager.list_thread_ids().await {
+                            if let Err(error) = register_subagent_thread(
+                                thread_id,
+                                thread_manager.clone(),
+                                sessions.clone(),
+                                session_roots.clone(),
+                                auth_manager.clone(),
+                                models_manager.clone(),
+                                client_capabilities.clone(),
+                                base_config.clone(),
+                                task_cx.clone(),
+                            )
+                            .await
+                            {
+                                warn!(
+                                    "Failed to reconcile spawned child thread {thread_id}: {error:?}"
+                                );
+                            }
+                        }
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
                 }
@@ -597,6 +621,14 @@ async fn register_subagent_thread(
         return Ok(());
     };
 
+    if is_self_referential_subagent(&registration) {
+        warn!(
+            thread_id = %registration.child_thread_id,
+            "Ignoring self-referential subagent thread registration"
+        );
+        return Ok(());
+    }
+
     if sessions
         .lock()
         .unwrap()
@@ -645,7 +677,37 @@ async fn register_subagent_thread(
     Ok(())
 }
 
+fn is_self_referential_subagent(registration: &subagents::SubagentThreadRegistration) -> bool {
+    registration.parent_thread_id == registration.child_thread_id
+}
+
 impl CodexAgent {
+    async fn prompt_with_subagent_registration(
+        &self,
+        request: PromptRequest,
+        cx: ConnectionTo<Client>,
+    ) -> Result<PromptResponse, Error> {
+        if self.get_thread(&request.session_id).is_err()
+            && let Ok(thread_id) = ThreadId::from_string(&request.session_id.0)
+            && self.thread_manager.get_thread(thread_id).await.is_ok()
+        {
+            register_subagent_thread(
+                thread_id,
+                self.thread_manager.clone(),
+                self.sessions.clone(),
+                self.session_roots.clone(),
+                self.auth_manager.clone(),
+                Arc::new(self.thread_manager.get_models_manager()),
+                self.client_capabilities.clone(),
+                self.config.clone(),
+                cx,
+            )
+            .await?;
+        }
+
+        self.prompt(request).await
+    }
+
     async fn initialize(&self, request: InitializeRequest) -> Result<InitializeResponse, Error> {
         let InitializeRequest {
             protocol_version,
@@ -1187,5 +1249,21 @@ mod tests {
             stored_session_title(Some("  "), "preview"),
             Some("preview".to_string())
         );
+    }
+
+    #[test]
+    fn self_referential_subagent_registration_is_rejected_by_typed_thread_id() {
+        let thread_id = ThreadId::new();
+        let registration = subagents::SubagentThreadRegistration {
+            parent_thread_id: thread_id,
+            parent_session_id: SessionId::new("parent-session"),
+            child_thread_id: thread_id,
+            child_session_id: SessionId::new("different-child-session-serialization"),
+            agent_path: Some("/root".to_string()),
+            nickname: None,
+            role: None,
+        };
+
+        assert!(is_self_referential_subagent(&registration));
     }
 }

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -6,7 +6,8 @@ use agent_client_protocol::schema::{
 };
 use codex_core::ThreadConfigSnapshot;
 use codex_protocol::{
-    ThreadId,
+    AgentPath, ThreadId,
+    items::SubAgentActivityItem,
     protocol::{
         AgentStatus, CollabAgentRef, CollabAgentStatusEntry, EventMsg, SessionSource,
         SubAgentActivityEvent, SubAgentActivityKind, SubAgentSource,
@@ -415,12 +416,48 @@ fn project_subagent_activity(
     current_thread_id: ThreadId,
     parent_session_id: &SessionId,
 ) -> Option<SubagentProjection> {
-    if event.agent_thread_id == current_thread_id {
+    project_subagent_activity_fields(
+        &event.event_id,
+        event.kind,
+        event.agent_thread_id,
+        &event.agent_path,
+        current_thread_id,
+        parent_session_id,
+        event,
+    )
+}
+
+pub(crate) fn projection_for_subagent_activity_item(
+    item: &SubAgentActivityItem,
+    current_thread_id: ThreadId,
+    parent_session_id: &SessionId,
+) -> Option<SubagentProjection> {
+    project_subagent_activity_fields(
+        &item.id,
+        item.kind,
+        item.agent_thread_id,
+        &item.agent_path,
+        current_thread_id,
+        parent_session_id,
+        item,
+    )
+}
+
+fn project_subagent_activity_fields(
+    activity_id: &str,
+    kind: SubAgentActivityKind,
+    agent_thread_id: ThreadId,
+    agent_path: &AgentPath,
+    current_thread_id: ThreadId,
+    parent_session_id: &SessionId,
+    raw_output: impl Serialize,
+) -> Option<SubagentProjection> {
+    if agent_thread_id == current_thread_id {
         return None;
     }
 
-    let display_name = event.agent_path.name();
-    let (event_type, title, status) = match event.kind {
+    let display_name = agent_path.name();
+    let (event_type, title, status) = match kind {
         SubAgentActivityKind::Started => (
             "activity_started",
             format!("Started {display_name}"),
@@ -457,24 +494,21 @@ fn project_subagent_activity(
     );
     meta.insert(
         CODEX_ACP_CHILD_SESSION_ID_KEY.to_string(),
-        json!(event.agent_thread_id.to_string()),
+        json!(agent_thread_id.to_string()),
     );
     meta.insert(
         CODEX_ACP_CHILD_THREAD_ID_KEY.to_string(),
-        json!(event.agent_thread_id.to_string()),
+        json!(agent_thread_id.to_string()),
     );
-    meta.insert(
-        CODEX_ACP_AGENT_PATH_KEY.to_string(),
-        json!(event.agent_path),
-    );
+    meta.insert(CODEX_ACP_AGENT_PATH_KEY.to_string(), json!(agent_path));
     meta.insert(CODEX_ACP_AGENT_STATUS_KEY.to_string(), json!(status));
 
     Some(SubagentProjection::ToolCall(
-        ToolCall::new(subagent_activity_tool_call_id(&event.event_id), title)
+        ToolCall::new(subagent_activity_tool_call_id(activity_id), title)
             .kind(ToolKind::Other)
             .status(ToolCallStatus::Completed)
-            .content(content(Some(format!("Agent: {}", event.agent_path))))
-            .raw_output(raw_event(event))
+            .content(content(Some(format!("Agent: {agent_path}"))))
+            .raw_output(raw_event(raw_output))
             .meta(meta),
     ))
 }

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -21,6 +21,7 @@ const CODEX_ACP_PARENT_SESSION_ID_KEY: &str = "codexAcpParentSessionId";
 const CODEX_ACP_PARENT_THREAD_ID_KEY: &str = "codexAcpParentThreadId";
 const CODEX_ACP_CHILD_SESSION_ID_KEY: &str = "codexAcpChildSessionId";
 const CODEX_ACP_CHILD_THREAD_ID_KEY: &str = "codexAcpChildThreadId";
+const CODEX_ACP_AGENT_PATH_KEY: &str = "codexAcpAgentPath";
 const CODEX_ACP_AGENT_NICKNAME_KEY: &str = "codexAcpAgentNickname";
 const CODEX_ACP_AGENT_ROLE_KEY: &str = "codexAcpAgentRole";
 const CODEX_ACP_AGENT_STATUS_KEY: &str = "codexAcpAgentStatus";
@@ -38,6 +39,7 @@ pub(crate) struct SubagentThreadRegistration {
     pub parent_session_id: SessionId,
     pub child_thread_id: ThreadId,
     pub child_session_id: SessionId,
+    pub agent_path: Option<String>,
     pub nickname: Option<String>,
     pub role: Option<String>,
 }
@@ -53,6 +55,7 @@ pub(crate) fn registration_for_thread(
 ) -> Option<SubagentThreadRegistration> {
     let SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
         parent_thread_id,
+        agent_path,
         agent_nickname,
         agent_role,
         ..
@@ -66,6 +69,7 @@ pub(crate) fn registration_for_thread(
         parent_session_id: session_id_from_thread_id(*parent_thread_id),
         child_thread_id,
         child_session_id: session_id_from_thread_id(child_thread_id),
+        agent_path: agent_path.as_ref().map(ToString::to_string),
         nickname: agent_nickname.clone(),
         role: agent_role.clone(),
     })
@@ -77,7 +81,11 @@ pub(crate) fn session_created_notification(
 ) -> SessionNotification {
     let meta = session_created_meta(registration, snapshot);
     let mut update = SessionInfoUpdate::new().meta(meta.clone());
-    if let Some(title) = subagent_display_name(registration.nickname.as_deref(), None) {
+    if let Some(title) = subagent_display_name(
+        registration.nickname.as_deref(),
+        registration.agent_path.as_deref(),
+        None,
+    ) {
         update = update.title(title);
     }
 
@@ -114,8 +122,9 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
             ))
         }
         EventMsg::CollabAgentSpawnEnd(event) => {
-            let display_name = subagent_display_name(event.new_agent_nickname.as_deref(), None)
-                .unwrap_or_else(|| "subagent".to_string());
+            let display_name =
+                subagent_display_name(event.new_agent_nickname.as_deref(), None, None)
+                    .unwrap_or_else(|| "subagent".to_string());
             let status = if event.new_thread_id.is_some() {
                 ToolCallStatus::Completed
             } else {
@@ -170,6 +179,7 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
         EventMsg::CollabAgentInteractionEnd(event) => {
             let display_name = subagent_display_name(
                 event.receiver_agent_nickname.as_deref(),
+                None,
                 Some(event.receiver_thread_id),
             )
             .unwrap_or_else(|| "subagent".to_string());
@@ -239,6 +249,7 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
         EventMsg::CollabResumeBegin(event) => {
             let display_name = subagent_display_name(
                 event.receiver_agent_nickname.as_deref(),
+                None,
                 Some(event.receiver_thread_id),
             )
             .unwrap_or_else(|| "subagent".to_string());
@@ -263,6 +274,7 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
         EventMsg::CollabResumeEnd(event) => {
             let display_name = subagent_display_name(
                 event.receiver_agent_nickname.as_deref(),
+                None,
                 Some(event.receiver_thread_id),
             )
             .unwrap_or_else(|| "subagent".to_string());
@@ -305,6 +317,7 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
         EventMsg::CollabCloseEnd(event) => {
             let display_name = subagent_display_name(
                 event.receiver_agent_nickname.as_deref(),
+                None,
                 Some(event.receiver_thread_id),
             )
             .unwrap_or_else(|| "subagent".to_string());
@@ -378,6 +391,9 @@ fn session_created_meta(
     }
     if let Some(nickname) = registration.nickname.as_deref() {
         meta.insert(CODEX_ACP_AGENT_NICKNAME_KEY.to_string(), json!(nickname));
+    }
+    if let Some(agent_path) = registration.agent_path.as_deref() {
+        meta.insert(CODEX_ACP_AGENT_PATH_KEY.to_string(), json!(agent_path));
     }
     if let Some(role) = registration.role.as_deref() {
         meta.insert(CODEX_ACP_AGENT_ROLE_KEY.to_string(), json!(role));
@@ -499,11 +515,17 @@ fn content(detail: Option<String>) -> Vec<ToolCallContent> {
 
 fn subagent_display_name(
     nickname: Option<&str>,
+    agent_path: Option<&str>,
     fallback_thread_id: Option<ThreadId>,
 ) -> Option<String> {
     nickname
         .filter(|value| !value.trim().is_empty())
         .map(ToString::to_string)
+        .or_else(|| {
+            agent_path
+                .and_then(|path| path.rsplit('/').find(|segment| !segment.is_empty()))
+                .map(ToString::to_string)
+        })
         .or_else(|| fallback_thread_id.map(|thread_id| format!("subagent {thread_id}")))
 }
 
@@ -538,7 +560,7 @@ fn format_agent_refs(agents: &[CollabAgentRef]) -> Option<String> {
         agents
             .iter()
             .map(|agent| {
-                subagent_display_name(agent.agent_nickname.as_deref(), Some(agent.thread_id))
+                subagent_display_name(agent.agent_nickname.as_deref(), None, Some(agent.thread_id))
                     .unwrap_or_else(|| agent.thread_id.to_string())
             })
             .collect::<Vec<_>>()
@@ -555,9 +577,12 @@ fn format_agent_statuses(statuses: &[CollabAgentStatusEntry]) -> Option<String> 
         statuses
             .iter()
             .map(|entry| {
-                let display_name =
-                    subagent_display_name(entry.agent_nickname.as_deref(), Some(entry.thread_id))
-                        .unwrap_or_else(|| entry.thread_id.to_string());
+                let display_name = subagent_display_name(
+                    entry.agent_nickname.as_deref(),
+                    None,
+                    Some(entry.thread_id),
+                )
+                .unwrap_or_else(|| entry.thread_id.to_string());
                 format!("{display_name}: {}", agent_status_label(&entry.status))
             })
             .collect::<Vec<_>>()
@@ -598,6 +623,7 @@ fn agent_status_label(status: &AgentStatus) -> String {
 mod tests {
     use super::*;
     use codex_protocol::{
+        AgentPath,
         config_types::{ApprovalsReviewer, CollaborationMode, ModeKind, Settings},
         models::PermissionProfile,
         openai_models::ReasoningEffort,
@@ -635,7 +661,10 @@ mod tests {
             session_source: SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
                 parent_thread_id,
                 depth: 1,
-                agent_path: None,
+                agent_path: Some(
+                    AgentPath::from_string("/root/research/explorer".to_string())
+                        .expect("agent path should be valid"),
+                ),
                 agent_nickname: Some("Galileo".to_string()),
                 agent_role: Some("explorer".to_string()),
             }),
@@ -668,6 +697,10 @@ mod tests {
         );
         assert_eq!(registration.nickname.as_deref(), Some("Galileo"));
         assert_eq!(registration.role.as_deref(), Some("explorer"));
+        assert_eq!(
+            registration.agent_path.as_deref(),
+            Some("/root/research/explorer")
+        );
     }
 
     #[test]
@@ -704,10 +737,46 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("Galileo")
         );
+        assert_eq!(
+            meta.get(CODEX_ACP_AGENT_PATH_KEY)
+                .and_then(|value| value.as_str()),
+            Some("/root/research/explorer")
+        );
         assert!(matches!(
             notification.update,
             SessionUpdate::SessionInfoUpdate(update) if update.title.value().map(String::as_str) == Some("Galileo")
         ));
+    }
+
+    #[test]
+    fn agent_path_is_optional_metadata_and_visible_title_fallback() {
+        assert_eq!(
+            subagent_display_name(None, Some("/root/research/explorer"), None).as_deref(),
+            Some("explorer")
+        );
+        assert_eq!(
+            subagent_display_name(Some("Galileo"), Some("/root/research/explorer"), None,)
+                .as_deref(),
+            Some("Galileo")
+        );
+
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let mut snapshot = thread_snapshot(parent_thread_id);
+        let SessionSource::SubAgent(SubAgentSource::ThreadSpawn { agent_path, .. }) =
+            &mut snapshot.session_source
+        else {
+            panic!("fixture should be a spawned subagent");
+        };
+        *agent_path = None;
+
+        let registration = registration_for_thread(child_thread_id, &snapshot)
+            .expect("thread spawn subagent should register");
+        let notification = session_created_notification(&registration, &snapshot);
+        let meta = notification
+            .meta
+            .expect("notification should carry metadata");
+        assert!(!meta.contains_key(CODEX_ACP_AGENT_PATH_KEY));
     }
 
     #[test]

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -9,7 +9,7 @@ use codex_protocol::{
     ThreadId,
     protocol::{
         AgentStatus, CollabAgentRef, CollabAgentStatusEntry, EventMsg, SessionSource,
-        SubAgentSource,
+        SubAgentActivityEvent, SubAgentActivityKind, SubAgentSource,
     },
 };
 use serde::Serialize;
@@ -96,8 +96,15 @@ pub(crate) fn session_created_notification(
     .meta(meta)
 }
 
-pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentProjection> {
+pub(crate) fn projection_for_event(
+    event: &EventMsg,
+    current_thread_id: ThreadId,
+    parent_session_id: &SessionId,
+) -> Option<SubagentProjection> {
     match event {
+        EventMsg::SubAgentActivity(event) => {
+            project_subagent_activity(event, current_thread_id, parent_session_id)
+        }
         EventMsg::CollabAgentSpawnBegin(event) => {
             let title = "Spawning subagent";
             Some(SubagentProjection::ToolCall(
@@ -347,6 +354,75 @@ pub(crate) fn projection_for_collab_event(event: &EventMsg) -> Option<SubagentPr
     }
 }
 
+fn project_subagent_activity(
+    event: &SubAgentActivityEvent,
+    current_thread_id: ThreadId,
+    parent_session_id: &SessionId,
+) -> Option<SubagentProjection> {
+    if event.agent_thread_id == current_thread_id {
+        return None;
+    }
+
+    let display_name = event.agent_path.name();
+    let (event_type, title, status) = match event.kind {
+        SubAgentActivityKind::Started => (
+            "activity_started",
+            format!("Started {display_name}"),
+            "running",
+        ),
+        SubAgentActivityKind::Interacted => (
+            "activity_interacted",
+            format!("Contacted {display_name}"),
+            "running",
+        ),
+        SubAgentActivityKind::Interrupted => (
+            "activity_interrupted",
+            format!("Interrupted {display_name}"),
+            "interrupted",
+        ),
+    };
+
+    let mut meta = Meta::new();
+    meta.insert(
+        CODEX_ACP_EVENT_TYPE_KEY.to_string(),
+        json!(CODEX_ACP_SUBAGENT_BREADCRUMB_EVENT),
+    );
+    meta.insert(
+        CODEX_ACP_SUBAGENT_EVENT_TYPE_KEY.to_string(),
+        json!(event_type),
+    );
+    meta.insert(
+        CODEX_ACP_PARENT_SESSION_ID_KEY.to_string(),
+        json!(parent_session_id.0.to_string()),
+    );
+    meta.insert(
+        CODEX_ACP_PARENT_THREAD_ID_KEY.to_string(),
+        json!(current_thread_id.to_string()),
+    );
+    meta.insert(
+        CODEX_ACP_CHILD_SESSION_ID_KEY.to_string(),
+        json!(event.agent_thread_id.to_string()),
+    );
+    meta.insert(
+        CODEX_ACP_CHILD_THREAD_ID_KEY.to_string(),
+        json!(event.agent_thread_id.to_string()),
+    );
+    meta.insert(
+        CODEX_ACP_AGENT_PATH_KEY.to_string(),
+        json!(event.agent_path),
+    );
+    meta.insert(CODEX_ACP_AGENT_STATUS_KEY.to_string(), json!(status));
+
+    Some(SubagentProjection::ToolCall(
+        ToolCall::new(subagent_activity_tool_call_id(&event.event_id), title)
+            .kind(ToolKind::Other)
+            .status(ToolCallStatus::Completed)
+            .content(content(Some(format!("Agent: {}", event.agent_path))))
+            .raw_output(raw_event(event))
+            .meta(meta),
+    ))
+}
+
 fn session_id_from_thread_id(thread_id: ThreadId) -> SessionId {
     SessionId::new(thread_id.to_string())
 }
@@ -499,6 +575,12 @@ fn waiting_end_statuses(
 
 fn subagent_tool_call_id(call_id: &str) -> String {
     format!("{CODEX_ACP_SUBAGENT_TOOL_CALL_ID_PREFIX}{call_id}")
+}
+
+/// Both 0.144 representations of a subagent activity share this protocol ID.
+/// No descriptive attribute is a valid correlation fallback when the IDs differ.
+pub(crate) fn subagent_activity_tool_call_id(protocol_id: &str) -> String {
+    subagent_tool_call_id(protocol_id)
 }
 
 fn raw_event(event: impl Serialize) -> serde_json::Value {
@@ -780,20 +862,134 @@ mod tests {
     }
 
     #[test]
+    fn subagent_activity_projects_navigable_breadcrumbs() {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let parent_session_id = SessionId::new("parent-runtime-session-id");
+
+        for (kind, event_type, status, title) in [
+            (
+                SubAgentActivityKind::Started,
+                "activity_started",
+                "running",
+                "Started explorer",
+            ),
+            (
+                SubAgentActivityKind::Interacted,
+                "activity_interacted",
+                "running",
+                "Contacted explorer",
+            ),
+            (
+                SubAgentActivityKind::Interrupted,
+                "activity_interrupted",
+                "interrupted",
+                "Interrupted explorer",
+            ),
+        ] {
+            let projection = projection_for_event(
+                &EventMsg::SubAgentActivity(SubAgentActivityEvent {
+                    event_id: format!("event-{kind:?}"),
+                    occurred_at_ms: 12,
+                    agent_thread_id: child_thread_id,
+                    agent_path: "/root/research/explorer"
+                        .try_into()
+                        .expect("agent path should be valid"),
+                    kind,
+                }),
+                parent_thread_id,
+                &parent_session_id,
+            )
+            .expect("activity should project");
+            let SubagentProjection::ToolCall(tool_call) = projection else {
+                panic!("activity should create a tool call");
+            };
+
+            assert_eq!(tool_call.title, title);
+            assert_eq!(tool_call.status, ToolCallStatus::Completed);
+            assert_eq!(
+                tool_call.tool_call_id.0.as_ref(),
+                subagent_activity_tool_call_id(&format!("event-{kind:?}"))
+            );
+            let meta = tool_call.meta.expect("activity should include metadata");
+            assert_eq!(
+                meta.get(CODEX_ACP_SUBAGENT_EVENT_TYPE_KEY)
+                    .and_then(|value| value.as_str()),
+                Some(event_type)
+            );
+            assert_eq!(
+                meta.get(CODEX_ACP_PARENT_SESSION_ID_KEY)
+                    .and_then(|value| value.as_str()),
+                Some("parent-runtime-session-id")
+            );
+            assert_eq!(
+                meta.get(CODEX_ACP_CHILD_THREAD_ID_KEY)
+                    .and_then(|value| value.as_str()),
+                Some(child_thread_id.to_string().as_str())
+            );
+            assert_eq!(
+                meta.get(CODEX_ACP_AGENT_STATUS_KEY)
+                    .and_then(|value| value.as_str()),
+                Some(status)
+            );
+        }
+    }
+
+    #[test]
+    fn subagent_activity_uses_typed_thread_identity_for_self_reference() {
+        let current_thread_id = ThreadId::new();
+        let event = EventMsg::SubAgentActivity(SubAgentActivityEvent {
+            event_id: "self".to_string(),
+            occurred_at_ms: 0,
+            agent_thread_id: current_thread_id,
+            agent_path: "/root".try_into().expect("root path should be valid"),
+            kind: SubAgentActivityKind::Started,
+        });
+        assert!(
+            projection_for_event(
+                &event,
+                current_thread_id,
+                &SessionId::new("session-id-with-a-different-serialization"),
+            )
+            .is_none()
+        );
+
+        let distinct_thread_id = ThreadId::new();
+        let EventMsg::SubAgentActivity(event) = event else {
+            unreachable!();
+        };
+        assert!(
+            projection_for_event(
+                &EventMsg::SubAgentActivity(SubAgentActivityEvent {
+                    agent_thread_id: distinct_thread_id,
+                    ..event
+                }),
+                current_thread_id,
+                &SessionId::new("parent-session"),
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
     fn collab_spawn_events_project_compact_breadcrumbs() {
         let parent_thread_id = ThreadId::new();
         let child_thread_id = ThreadId::new();
 
-        let begin = projection_for_collab_event(&EventMsg::CollabAgentSpawnBegin(
-            codex_protocol::protocol::CollabAgentSpawnBeginEvent {
-                call_id: "spawn-1".to_string(),
-                sender_thread_id: parent_thread_id,
-                prompt: "inspect the renderer".to_string(),
-                model: "gpt-5.5".to_string(),
-                reasoning_effort: ReasoningEffort::Medium,
-                started_at_ms: 0,
-            },
-        ))
+        let begin = projection_for_event(
+            &EventMsg::CollabAgentSpawnBegin(
+                codex_protocol::protocol::CollabAgentSpawnBeginEvent {
+                    call_id: "spawn-1".to_string(),
+                    sender_thread_id: parent_thread_id,
+                    prompt: "inspect the renderer".to_string(),
+                    model: "gpt-5.5".to_string(),
+                    reasoning_effort: ReasoningEffort::Medium,
+                    started_at_ms: 0,
+                },
+            ),
+            parent_thread_id,
+            &SessionId::new(parent_thread_id.to_string()),
+        )
         .expect("spawn begin should project");
         let SubagentProjection::ToolCall(tool_call) = begin else {
             panic!("expected ToolCall projection");
@@ -816,8 +1012,8 @@ mod tests {
             "spawn begin should not invent a child before Codex returns it"
         );
 
-        let end = projection_for_collab_event(&EventMsg::CollabAgentSpawnEnd(
-            codex_protocol::protocol::CollabAgentSpawnEndEvent {
+        let end = projection_for_event(
+            &EventMsg::CollabAgentSpawnEnd(codex_protocol::protocol::CollabAgentSpawnEndEvent {
                 call_id: "spawn-1".to_string(),
                 sender_thread_id: parent_thread_id,
                 new_thread_id: Some(child_thread_id),
@@ -828,8 +1024,10 @@ mod tests {
                 reasoning_effort: ReasoningEffort::Medium,
                 status: AgentStatus::Running,
                 completed_at_ms: 0,
-            },
-        ))
+            }),
+            parent_thread_id,
+            &SessionId::new(parent_thread_id.to_string()),
+        )
         .expect("spawn end should project");
         let SubagentProjection::ToolCallUpdate(update) = end else {
             panic!("expected ToolCallUpdate projection");
@@ -850,8 +1048,8 @@ mod tests {
     fn collab_waiting_end_projects_structured_agent_statuses() {
         let parent_thread_id = ThreadId::new();
         let child_thread_id = ThreadId::new();
-        let projection = projection_for_collab_event(&EventMsg::CollabWaitingEnd(
-            codex_protocol::protocol::CollabWaitingEndEvent {
+        let projection = projection_for_event(
+            &EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
                 sender_thread_id: parent_thread_id,
                 call_id: "wait-1".to_string(),
                 agent_statuses: vec![codex_protocol::protocol::CollabAgentStatusEntry {
@@ -862,8 +1060,10 @@ mod tests {
                 }],
                 statuses: HashMap::new(),
                 completed_at_ms: 0,
-            },
-        ))
+            }),
+            parent_thread_id,
+            &SessionId::new(parent_thread_id.to_string()),
+        )
         .expect("waiting end should project");
         let SubagentProjection::ToolCallUpdate(update) = projection else {
             panic!("expected ToolCallUpdate projection");

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -49,6 +49,49 @@ pub(crate) enum SubagentProjection {
     ToolCallUpdate(ToolCallUpdate),
 }
 
+#[derive(Default)]
+pub(crate) struct SubagentProjectionState {
+    wait_tool_call_ids_by_group: HashMap<String, String>,
+    wait_tool_call_ids_by_call: HashMap<String, String>,
+}
+
+impl SubagentProjectionState {
+    pub(crate) fn coalesce_wait_projection(
+        &mut self,
+        event: &EventMsg,
+        projection: &mut SubagentProjection,
+    ) {
+        let stable_tool_call_id = match event {
+            EventMsg::CollabWaitingBegin(event) => {
+                let group_key = waiting_group_key(event);
+                let stable_tool_call_id = self
+                    .wait_tool_call_ids_by_group
+                    .entry(group_key)
+                    .or_insert_with(|| subagent_tool_call_id(&event.call_id))
+                    .clone();
+                self.wait_tool_call_ids_by_call
+                    .insert(event.call_id.clone(), stable_tool_call_id.clone());
+                stable_tool_call_id
+            }
+            EventMsg::CollabWaitingEnd(event) => self
+                .wait_tool_call_ids_by_call
+                .get(&event.call_id)
+                .cloned()
+                .unwrap_or_else(|| subagent_tool_call_id(&event.call_id)),
+            _ => return,
+        };
+
+        match projection {
+            SubagentProjection::ToolCall(tool_call) => {
+                tool_call.tool_call_id = stable_tool_call_id.into();
+            }
+            SubagentProjection::ToolCallUpdate(update) => {
+                update.tool_call_id = stable_tool_call_id.into();
+            }
+        }
+    }
+}
+
 pub(crate) fn registration_for_thread(
     child_thread_id: ThreadId,
     snapshot: &ThreadConfigSnapshot,
@@ -243,8 +286,8 @@ pub(crate) fn projection_for_event(
             ToolCallUpdate::new(
                 subagent_tool_call_id(&event.call_id),
                 ToolCallUpdateFields::new()
-                    .title("Subagents finished")
-                    .status(ToolCallStatus::Completed)
+                    .title(waiting_end_title(event))
+                    .status(waiting_end_tool_status(event))
                     .content(content(
                         format_agent_statuses(&event.agent_statuses)
                             .or_else(|| format_thread_statuses(&event.statuses)),
@@ -539,6 +582,74 @@ fn waiting_end_breadcrumb_meta(event: &codex_protocol::protocol::CollabWaitingEn
         meta.insert(CODEX_ACP_AGENT_STATUSES_KEY.to_string(), json!(statuses));
     }
     meta
+}
+
+fn waiting_group_key(event: &codex_protocol::protocol::CollabWaitingBeginEvent) -> String {
+    let mut receiver_thread_ids = event
+        .receiver_thread_ids
+        .iter()
+        .chain(event.receiver_agents.iter().map(|agent| &agent.thread_id))
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    receiver_thread_ids.sort();
+    receiver_thread_ids.dedup();
+
+    if receiver_thread_ids.is_empty() {
+        format!("{}:all", event.sender_thread_id)
+    } else {
+        format!(
+            "{}:{}",
+            event.sender_thread_id,
+            receiver_thread_ids.join(",")
+        )
+    }
+}
+
+fn waiting_end_title(event: &codex_protocol::protocol::CollabWaitingEndEvent) -> &'static str {
+    let statuses = waiting_end_agent_statuses(event);
+    if statuses.is_empty() {
+        "Checked subagents"
+    } else if statuses
+        .iter()
+        .all(|status| is_terminal_agent_status(status))
+    {
+        "Subagents finished"
+    } else {
+        "Subagents still running"
+    }
+}
+
+fn waiting_end_tool_status(
+    event: &codex_protocol::protocol::CollabWaitingEndEvent,
+) -> ToolCallStatus {
+    let statuses = waiting_end_agent_statuses(event);
+    if !statuses.is_empty()
+        && statuses
+            .iter()
+            .all(|status| is_terminal_agent_status(status))
+    {
+        ToolCallStatus::Completed
+    } else {
+        ToolCallStatus::InProgress
+    }
+}
+
+fn waiting_end_agent_statuses(
+    event: &codex_protocol::protocol::CollabWaitingEndEvent,
+) -> Vec<&AgentStatus> {
+    if event.agent_statuses.is_empty() {
+        event.statuses.values().collect()
+    } else {
+        event
+            .agent_statuses
+            .iter()
+            .map(|entry| &entry.status)
+            .collect()
+    }
+}
+
+fn is_terminal_agent_status(status: &AgentStatus) -> bool {
+    !matches!(status, AgentStatus::PendingInit | AgentStatus::Running)
 }
 
 fn waiting_end_statuses(
@@ -1094,6 +1205,154 @@ mod tests {
                 .and_then(|value| value.get("completed"))
                 .is_some(),
             "status={status:?}"
+        );
+    }
+
+    #[test]
+    fn collab_waiting_end_keeps_partial_and_empty_waits_in_progress() {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let parent_session_id = SessionId::new(parent_thread_id.to_string());
+
+        for (call_id, statuses, expected_title) in [
+            (
+                "wait-running",
+                vec![
+                    AgentStatus::Completed(Some("done".to_string())),
+                    AgentStatus::Running,
+                ],
+                "Subagents still running",
+            ),
+            ("wait-empty", Vec::new(), "Checked subagents"),
+        ] {
+            let agent_statuses = statuses
+                .into_iter()
+                .enumerate()
+                .map(|(index, status)| CollabAgentStatusEntry {
+                    thread_id: if index == 0 {
+                        child_thread_id
+                    } else {
+                        ThreadId::new()
+                    },
+                    agent_nickname: None,
+                    agent_role: None,
+                    status,
+                })
+                .collect();
+            let projection = projection_for_event(
+                &EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
+                    sender_thread_id: parent_thread_id,
+                    call_id: call_id.to_string(),
+                    agent_statuses,
+                    statuses: HashMap::new(),
+                    completed_at_ms: 0,
+                }),
+                parent_thread_id,
+                &parent_session_id,
+            )
+            .expect("waiting end should project");
+            let SubagentProjection::ToolCallUpdate(update) = projection else {
+                panic!("waiting end should update a tool call");
+            };
+            assert_eq!(update.fields.title.as_deref(), Some(expected_title));
+            assert_eq!(update.fields.status, Some(ToolCallStatus::InProgress));
+        }
+    }
+
+    #[test]
+    fn repeated_waits_coalesce_by_parent_and_normalized_receivers() {
+        let parent_thread_id = ThreadId::new();
+        let other_parent_thread_id = ThreadId::new();
+        let first_child_thread_id = ThreadId::new();
+        let second_child_thread_id = ThreadId::new();
+        let parent_session_id = SessionId::new(parent_thread_id.to_string());
+        let mut state = SubagentProjectionState::default();
+
+        let mut project_begin = |sender_thread_id, call_id: &str, receiver_thread_ids| {
+            let event =
+                EventMsg::CollabWaitingBegin(codex_protocol::protocol::CollabWaitingBeginEvent {
+                    sender_thread_id,
+                    receiver_thread_ids,
+                    receiver_agents: Vec::new(),
+                    call_id: call_id.to_string(),
+                    started_at_ms: 0,
+                });
+            let mut projection = projection_for_event(&event, parent_thread_id, &parent_session_id)
+                .expect("waiting begin should project");
+            state.coalesce_wait_projection(&event, &mut projection);
+            let SubagentProjection::ToolCall(tool_call) = projection else {
+                panic!("waiting begin should create a tool call");
+            };
+            tool_call.tool_call_id.to_string()
+        };
+
+        let first = project_begin(
+            parent_thread_id,
+            "wait-1",
+            vec![first_child_thread_id, second_child_thread_id],
+        );
+        let repeated = project_begin(
+            parent_thread_id,
+            "wait-2",
+            vec![
+                second_child_thread_id,
+                first_child_thread_id,
+                first_child_thread_id,
+            ],
+        );
+        let different_group =
+            project_begin(parent_thread_id, "wait-3", vec![first_child_thread_id]);
+        let different_parent = project_begin(
+            other_parent_thread_id,
+            "wait-4",
+            vec![first_child_thread_id, second_child_thread_id],
+        );
+
+        assert_eq!(first, repeated);
+        assert_ne!(first, different_group);
+        assert_ne!(first, different_parent);
+
+        let repeated_end =
+            EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
+                sender_thread_id: parent_thread_id,
+                call_id: "wait-2".to_string(),
+                agent_statuses: vec![CollabAgentStatusEntry {
+                    thread_id: first_child_thread_id,
+                    agent_nickname: None,
+                    agent_role: None,
+                    status: AgentStatus::Completed(None),
+                }],
+                statuses: HashMap::new(),
+                completed_at_ms: 0,
+            });
+        let mut projection =
+            projection_for_event(&repeated_end, parent_thread_id, &parent_session_id)
+                .expect("waiting end should project");
+        state.coalesce_wait_projection(&repeated_end, &mut projection);
+        let SubagentProjection::ToolCallUpdate(update) = projection else {
+            panic!("waiting end should update a tool call");
+        };
+        assert_eq!(update.tool_call_id.0.as_ref(), first);
+        assert_eq!(update.fields.status, Some(ToolCallStatus::Completed));
+
+        let end_without_begin =
+            EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
+                sender_thread_id: parent_thread_id,
+                call_id: "missing-begin".to_string(),
+                agent_statuses: Vec::new(),
+                statuses: HashMap::new(),
+                completed_at_ms: 0,
+            });
+        let mut projection =
+            projection_for_event(&end_without_begin, parent_thread_id, &parent_session_id)
+                .expect("waiting end should project");
+        state.coalesce_wait_projection(&end_without_begin, &mut projection);
+        let SubagentProjection::ToolCallUpdate(update) = projection else {
+            panic!("waiting end should update a tool call");
+        };
+        assert_eq!(
+            update.tool_call_id.0.as_ref(),
+            "codex-acp:subagent:missing-begin"
         );
     }
 }

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -53,6 +53,7 @@ pub(crate) enum SubagentProjection {
 pub(crate) struct SubagentProjectionState {
     wait_tool_call_ids_by_group: HashMap<String, String>,
     wait_tool_call_ids_by_call: HashMap<String, String>,
+    wait_group_keys_by_call: HashMap<String, String>,
 }
 
 impl SubagentProjectionState {
@@ -66,18 +67,30 @@ impl SubagentProjectionState {
                 let group_key = waiting_group_key(event);
                 let stable_tool_call_id = self
                     .wait_tool_call_ids_by_group
-                    .entry(group_key)
+                    .entry(group_key.clone())
                     .or_insert_with(|| subagent_tool_call_id(&event.call_id))
                     .clone();
                 self.wait_tool_call_ids_by_call
                     .insert(event.call_id.clone(), stable_tool_call_id.clone());
+                self.wait_group_keys_by_call
+                    .insert(event.call_id.clone(), group_key);
                 stable_tool_call_id
             }
-            EventMsg::CollabWaitingEnd(event) => self
-                .wait_tool_call_ids_by_call
-                .get(&event.call_id)
-                .cloned()
-                .unwrap_or_else(|| subagent_tool_call_id(&event.call_id)),
+            EventMsg::CollabWaitingEnd(event) => {
+                let stable_tool_call_id = self
+                    .wait_tool_call_ids_by_call
+                    .remove(&event.call_id)
+                    .unwrap_or_else(|| subagent_tool_call_id(&event.call_id));
+                if let Some(group_key) = self.wait_group_keys_by_call.remove(&event.call_id)
+                    && !self
+                        .wait_group_keys_by_call
+                        .values()
+                        .any(|active_group_key| active_group_key == &group_key)
+                {
+                    self.wait_tool_call_ids_by_group.remove(&group_key);
+                }
+                stable_tool_call_id
+            }
             _ => return,
         };
 
@@ -1268,7 +1281,10 @@ mod tests {
         let parent_session_id = SessionId::new(parent_thread_id.to_string());
         let mut state = SubagentProjectionState::default();
 
-        let mut project_begin = |sender_thread_id, call_id: &str, receiver_thread_ids| {
+        let project_begin = |state: &mut SubagentProjectionState,
+                             sender_thread_id,
+                             call_id: &str,
+                             receiver_thread_ids| {
             let event =
                 EventMsg::CollabWaitingBegin(codex_protocol::protocol::CollabWaitingBeginEvent {
                     sender_thread_id,
@@ -1287,11 +1303,13 @@ mod tests {
         };
 
         let first = project_begin(
+            &mut state,
             parent_thread_id,
             "wait-1",
             vec![first_child_thread_id, second_child_thread_id],
         );
         let repeated = project_begin(
+            &mut state,
             parent_thread_id,
             "wait-2",
             vec![
@@ -1300,9 +1318,14 @@ mod tests {
                 first_child_thread_id,
             ],
         );
-        let different_group =
-            project_begin(parent_thread_id, "wait-3", vec![first_child_thread_id]);
+        let different_group = project_begin(
+            &mut state,
+            parent_thread_id,
+            "wait-3",
+            vec![first_child_thread_id],
+        );
         let different_parent = project_begin(
+            &mut state,
             other_parent_thread_id,
             "wait-4",
             vec![first_child_thread_id, second_child_thread_id],
@@ -1334,6 +1357,26 @@ mod tests {
         };
         assert_eq!(update.tool_call_id.0.as_ref(), first);
         assert_eq!(update.fields.status, Some(ToolCallStatus::Completed));
+
+        let first_end =
+            EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {
+                sender_thread_id: parent_thread_id,
+                call_id: "wait-1".to_string(),
+                agent_statuses: Vec::new(),
+                statuses: HashMap::new(),
+                completed_at_ms: 0,
+            });
+        let mut projection = projection_for_event(&first_end, parent_thread_id, &parent_session_id)
+            .expect("waiting end should project");
+        state.coalesce_wait_projection(&first_end, &mut projection);
+
+        let next_cycle = project_begin(
+            &mut state,
+            parent_thread_id,
+            "wait-next-cycle",
+            vec![first_child_thread_id, second_child_thread_id],
+        );
+        assert_ne!(next_cycle, first, "a completed wait group must be reusable");
 
         let end_without_begin =
             EventMsg::CollabWaitingEnd(codex_protocol::protocol::CollabWaitingEndEvent {

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -61,7 +61,7 @@ use codex_protocol::{
     mcp::CallToolResult,
     models::{
         ActivePermissionProfile, AdditionalPermissionProfile, PermissionProfile, ResponseItem,
-        WebSearchAction, plaintext_agent_message_content,
+        WebSearchAction,
     },
     openai_models::{ModelPreset, ReasoningEffort},
     parse_command::ParsedCommand,
@@ -942,13 +942,6 @@ fn codex_turn_lifecycle_meta(event_type: &str, turn_id: Option<&str>) -> Meta {
         meta.insert(CODEX_ACP_TURN_ID_KEY.to_string(), json!(turn_id));
     }
     meta
-}
-
-fn plaintext_inter_agent_message_payload(item: &ResponseItem) -> Option<(Option<String>, String)> {
-    let ResponseItem::AgentMessage { id, content, .. } = item else {
-        return None;
-    };
-    Some((id.clone(), plaintext_agent_message_content(content)?))
 }
 
 fn image_generation_tool_call_id(call_id: &str) -> String {
@@ -2415,15 +2408,6 @@ impl PromptState {
                     client.send_user_message(message).await;
                 }
             }
-            EventMsg::RawResponseItem(event) => {
-                if let Some((message_id, payload)) =
-                    plaintext_inter_agent_message_payload(&event.item)
-                {
-                    client
-                        .send_user_message_with_id(payload, message_id.as_deref())
-                        .await;
-                }
-            }
             EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent {
                 thread_id,
                 turn_id,
@@ -2939,6 +2923,7 @@ impl PromptState {
             | EventMsg::ThreadRolledBack(..)
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
+            | EventMsg::RawResponseItem(..)
             | EventMsg::ThreadSettingsApplied(..)
             | EventMsg::SessionConfigured(..)
             | EventMsg::RealtimeConversationStarted(..)
@@ -4303,16 +4288,10 @@ impl SessionClient {
     }
 
     async fn send_user_message(&self, text: impl Into<String>) {
-        self.send_user_message_with_id(text, None).await;
-    }
-
-    async fn send_user_message_with_id(&self, text: impl Into<String>, message_id: Option<&str>) {
-        let mut chunk = ContentChunk::new(text.into().into());
-        if let Some(message_id) = message_id {
-            chunk = chunk.message_id(message_id);
-        }
-        self.send_notification(SessionUpdate::UserMessageChunk(chunk))
-            .await;
+        self.send_notification(SessionUpdate::UserMessageChunk(ContentChunk::new(
+            text.into().into(),
+        )))
+        .await;
     }
 
     async fn send_agent_text(&self, text: impl Into<String>) {
@@ -5520,15 +5499,10 @@ impl<A: Auth> ThreadActor<A> {
     /// Only handles tool calls - messages/reasoning are handled via EventMsg.
     async fn replay_response_item(&self, item: &ResponseItem) {
         match item {
-            ResponseItem::AgentMessage { .. } => {
-                if let Some((message_id, payload)) = plaintext_inter_agent_message_payload(item) {
-                    self.client
-                        .send_user_message_with_id(payload, message_id.as_deref())
-                        .await;
-                }
-            }
-            // Skip Message and Reasoning - these are handled via EventMsg
-            ResponseItem::Message { .. } | ResponseItem::Reasoning { .. } => {}
+            // Skip messages and reasoning - these are handled internally by Codex.
+            ResponseItem::AgentMessage { .. }
+            | ResponseItem::Message { .. }
+            | ResponseItem::Reasoning { .. } => {}
             ResponseItem::FunctionCall {
                 name,
                 arguments,
@@ -8056,7 +8030,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn inter_agent_messages_stay_in_the_receiving_actor_transcript() {
+    async fn inter_agent_messages_are_not_projected_into_acp_transcripts() {
         let root_thread_id = ThreadId::new();
         let child_thread_id = ThreadId::new();
         let root_session_id = SessionId::new("root-runtime-session-id");
@@ -8097,53 +8071,12 @@ mod tests {
             )
             .await;
 
-        let root_updates = root_notifications.notifications.lock().unwrap();
-        assert!(
-            root_updates
-                .iter()
-                .all(|notification| notification.session_id == root_session_id)
-        );
-        assert!(root_updates.iter().any(|notification| matches!(
-            &notification.update,
-            SessionUpdate::UserMessageChunk(ContentChunk {
-                content: ContentBlock::Text(TextContent { text, .. }),
-                message_id: Some(message_id),
-                ..
-            }) if text == "answer for root" && message_id.0.as_ref() == "child-to-root"
-        )));
-        assert!(!root_updates.iter().any(|notification| matches!(
-            &notification.update,
-            SessionUpdate::UserMessageChunk(ContentChunk {
-                content: ContentBlock::Text(TextContent { text, .. }),
-                ..
-            }) if text == "task for child"
-        )));
-
-        let child_updates = child_notifications.notifications.lock().unwrap();
-        assert!(
-            child_updates
-                .iter()
-                .all(|notification| notification.session_id == child_session_id)
-        );
-        assert!(child_updates.iter().any(|notification| matches!(
-            &notification.update,
-            SessionUpdate::UserMessageChunk(ContentChunk {
-                content: ContentBlock::Text(TextContent { text, .. }),
-                message_id: Some(message_id),
-                ..
-            }) if text == "task for child" && message_id.0.as_ref() == "root-to-child"
-        )));
-        assert!(!child_updates.iter().any(|notification| matches!(
-            &notification.update,
-            SessionUpdate::UserMessageChunk(ContentChunk {
-                content: ContentBlock::Text(TextContent { text, .. }),
-                ..
-            }) if text == "answer for root"
-        )));
+        assert!(root_notifications.notifications.lock().unwrap().is_empty());
+        assert!(child_notifications.notifications.lock().unwrap().is_empty());
     }
 
     #[tokio::test]
-    async fn inter_agent_messages_match_between_live_and_replay() -> anyhow::Result<()> {
+    async fn inter_agent_messages_are_not_replayed_into_acp_transcripts() -> anyhow::Result<()> {
         let recipient_thread_id = ThreadId::new();
         let (mut live_state, live_client, live_notifications) =
             prompt_state_for_projection(recipient_thread_id);
@@ -8175,28 +8108,14 @@ mod tests {
         drop(message_tx);
         actor_handle.await?;
 
-        let extract_user_chunk = |notifications: &[SessionNotification]| {
-            notifications
-                .iter()
-                .find_map(|notification| match &notification.update {
-                    SessionUpdate::UserMessageChunk(ContentChunk {
-                        content: ContentBlock::Text(TextContent { text, .. }),
-                        message_id,
-                        ..
-                    }) => Some((text.clone(), message_id.clone())),
-                    _ => None,
-                })
-        };
-        let live = extract_user_chunk(&live_notifications.notifications.lock().unwrap())
-            .expect("live projection should contain a user message");
-        let replay = extract_user_chunk(&replay_notifications.notifications.lock().unwrap())
-            .expect("replay projection should contain a user message");
-        assert_eq!(live.0, "plaintext payload");
-        assert_eq!(
-            live.1.as_ref().map(|message_id| message_id.0.as_ref()),
-            Some("inter-agent-message-id")
+        assert!(live_notifications.notifications.lock().unwrap().is_empty());
+        assert!(
+            replay_notifications
+                .notifications
+                .lock()
+                .unwrap()
+                .is_empty()
         );
-        assert_eq!(live, replay);
         Ok(())
     }
 

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -61,7 +61,7 @@ use codex_protocol::{
     mcp::CallToolResult,
     models::{
         ActivePermissionProfile, AdditionalPermissionProfile, PermissionProfile, ResponseItem,
-        WebSearchAction,
+        WebSearchAction, plaintext_agent_message_content,
     },
     openai_models::{ModelPreset, ReasoningEffort},
     parse_command::ParsedCommand,
@@ -942,6 +942,13 @@ fn codex_turn_lifecycle_meta(event_type: &str, turn_id: Option<&str>) -> Meta {
         meta.insert(CODEX_ACP_TURN_ID_KEY.to_string(), json!(turn_id));
     }
     meta
+}
+
+fn plaintext_inter_agent_message_payload(item: &ResponseItem) -> Option<(Option<String>, String)> {
+    let ResponseItem::AgentMessage { id, content, .. } = item else {
+        return None;
+    };
+    Some((id.clone(), plaintext_agent_message_content(content)?))
 }
 
 fn image_generation_tool_call_id(call_id: &str) -> String {
@@ -2375,6 +2382,15 @@ impl PromptState {
                     client.send_user_message(message).await;
                 }
             }
+            EventMsg::RawResponseItem(event) => {
+                if let Some((message_id, payload)) =
+                    plaintext_inter_agent_message_payload(&event.item)
+                {
+                    client
+                        .send_user_message_with_id(payload, message_id.as_deref())
+                        .await;
+                }
+            }
             EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent {
                 thread_id,
                 turn_id,
@@ -2891,7 +2907,6 @@ impl PromptState {
             // we already have a way to diff the turn, so ignore
             | EventMsg::TurnDiff(..)
             | EventMsg::ThreadSettingsApplied(..)
-            | EventMsg::RawResponseItem(..)
             | EventMsg::SessionConfigured(..)
             | EventMsg::RealtimeConversationStarted(..)
             | EventMsg::RealtimeConversationSdp(..)
@@ -4255,10 +4270,16 @@ impl SessionClient {
     }
 
     async fn send_user_message(&self, text: impl Into<String>) {
-        self.send_notification(SessionUpdate::UserMessageChunk(ContentChunk::new(
-            text.into().into(),
-        )))
-        .await;
+        self.send_user_message_with_id(text, None).await;
+    }
+
+    async fn send_user_message_with_id(&self, text: impl Into<String>, message_id: Option<&str>) {
+        let mut chunk = ContentChunk::new(text.into().into());
+        if let Some(message_id) = message_id {
+            chunk = chunk.message_id(message_id);
+        }
+        self.send_notification(SessionUpdate::UserMessageChunk(chunk))
+            .await;
     }
 
     async fn send_agent_text(&self, text: impl Into<String>) {
@@ -5466,6 +5487,13 @@ impl<A: Auth> ThreadActor<A> {
     /// Only handles tool calls - messages/reasoning are handled via EventMsg.
     async fn replay_response_item(&self, item: &ResponseItem) {
         match item {
+            ResponseItem::AgentMessage { .. } => {
+                if let Some((message_id, payload)) = plaintext_inter_agent_message_payload(item) {
+                    self.client
+                        .send_user_message_with_id(payload, message_id.as_deref())
+                        .await;
+                }
+            }
             // Skip Message and Reasoning - these are handled via EventMsg
             ResponseItem::Message { .. } | ResponseItem::Reasoning { .. } => {}
             ResponseItem::FunctionCall {
@@ -6399,6 +6427,7 @@ mod tests {
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
     use codex_features::Feature;
     use codex_protocol::config_types::ModeKind;
+    use codex_protocol::models::AgentMessageInputContent;
     use tokio::sync::{Mutex, mpsc::UnboundedSender};
 
     use super::*;
@@ -7937,6 +7966,226 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn inter_agent_messages_stay_in_the_receiving_actor_transcript() {
+        let root_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let root_session_id = SessionId::new("root-runtime-session-id");
+        let child_session_id = SessionId::new("child-runtime-session-id");
+        let (mut root_state, root_client, root_notifications) =
+            prompt_state_for_session_projection(root_session_id.clone(), root_thread_id);
+        let (mut child_state, child_client, child_notifications) =
+            prompt_state_for_session_projection(child_session_id.clone(), child_thread_id);
+
+        child_state
+            .handle_event(
+                &child_client,
+                EventMsg::RawResponseItem(codex_protocol::protocol::RawResponseItemEvent {
+                    item: inter_agent_message(
+                        Some("root-to-child"),
+                        "not-a-thread-id",
+                        "also-not-a-thread-id",
+                        vec![AgentMessageInputContent::InputText {
+                            text: "task for child".to_string(),
+                        }],
+                    ),
+                }),
+            )
+            .await;
+        root_state
+            .handle_event(
+                &root_client,
+                EventMsg::RawResponseItem(codex_protocol::protocol::RawResponseItemEvent {
+                    item: inter_agent_message(
+                        Some("child-to-root"),
+                        "not-a-thread-id",
+                        "also-not-a-thread-id",
+                        vec![AgentMessageInputContent::InputText {
+                            text: "answer for root".to_string(),
+                        }],
+                    ),
+                }),
+            )
+            .await;
+
+        let root_updates = root_notifications.notifications.lock().unwrap();
+        assert!(
+            root_updates
+                .iter()
+                .all(|notification| notification.session_id == root_session_id)
+        );
+        assert!(root_updates.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::UserMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                message_id: Some(message_id),
+                ..
+            }) if text == "answer for root" && message_id.0.as_ref() == "child-to-root"
+        )));
+        assert!(!root_updates.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::UserMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                ..
+            }) if text == "task for child"
+        )));
+
+        let child_updates = child_notifications.notifications.lock().unwrap();
+        assert!(
+            child_updates
+                .iter()
+                .all(|notification| notification.session_id == child_session_id)
+        );
+        assert!(child_updates.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::UserMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                message_id: Some(message_id),
+                ..
+            }) if text == "task for child" && message_id.0.as_ref() == "root-to-child"
+        )));
+        assert!(!child_updates.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::UserMessageChunk(ContentChunk {
+                content: ContentBlock::Text(TextContent { text, .. }),
+                ..
+            }) if text == "answer for root"
+        )));
+    }
+
+    #[tokio::test]
+    async fn inter_agent_messages_match_between_live_and_replay() -> anyhow::Result<()> {
+        let recipient_thread_id = ThreadId::new();
+        let (mut live_state, live_client, live_notifications) =
+            prompt_state_for_projection(recipient_thread_id);
+        let item = inter_agent_message(
+            Some("inter-agent-message-id"),
+            "author-is-descriptive-only",
+            "recipient-is-descriptive-only",
+            vec![AgentMessageInputContent::InputText {
+                text: "plaintext payload".to_string(),
+            }],
+        );
+        live_state
+            .handle_event(
+                &live_client,
+                EventMsg::RawResponseItem(codex_protocol::protocol::RawResponseItemEvent {
+                    item: item.clone(),
+                }),
+            )
+            .await;
+
+        let (_session_id, replay_notifications, _thread, message_tx, actor_handle) =
+            setup(vec![]).await?;
+        let (response_tx, response_rx) = oneshot::channel();
+        message_tx.send(ThreadMessage::ReplayHistory {
+            history: vec![RolloutItem::ResponseItem(item)],
+            response_tx,
+        })?;
+        response_rx.await??;
+        drop(message_tx);
+        actor_handle.await?;
+
+        let extract_user_chunk = |notifications: &[SessionNotification]| {
+            notifications
+                .iter()
+                .find_map(|notification| match &notification.update {
+                    SessionUpdate::UserMessageChunk(ContentChunk {
+                        content: ContentBlock::Text(TextContent { text, .. }),
+                        message_id,
+                        ..
+                    }) => Some((text.clone(), message_id.clone())),
+                    _ => None,
+                })
+        };
+        let live = extract_user_chunk(&live_notifications.notifications.lock().unwrap())
+            .expect("live projection should contain a user message");
+        let replay = extract_user_chunk(&replay_notifications.notifications.lock().unwrap())
+            .expect("replay projection should contain a user message");
+        assert_eq!(live.0, "plaintext payload");
+        assert_eq!(
+            live.1.as_ref().map(|message_id| message_id.0.as_ref()),
+            Some("inter-agent-message-id")
+        );
+        assert_eq!(live, replay);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn encrypted_inter_agent_messages_are_not_projected() {
+        let (mut state, session_client, client) = prompt_state_for_projection(ThreadId::new());
+        state
+            .handle_event(
+                &session_client,
+                EventMsg::RawResponseItem(codex_protocol::protocol::RawResponseItemEvent {
+                    item: inter_agent_message(
+                        Some("encrypted"),
+                        "/root",
+                        "/root/child",
+                        vec![AgentMessageInputContent::EncryptedContent {
+                            encrypted_content: "opaque".to_string(),
+                        }],
+                    ),
+                }),
+            )
+            .await;
+        assert!(client.notifications.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn child_lifecycle_events_keep_the_child_session_id() {
+        let child_thread_id = ThreadId::new();
+        let child_session_id = SessionId::new("child-runtime-session-id");
+        let (mut state, session_client, client) =
+            prompt_state_for_session_projection(child_session_id.clone(), child_thread_id);
+
+        for event in [
+            EventMsg::TurnStarted(TurnStartedEvent {
+                model_context_window: None,
+                collaboration_mode_kind: ModeKind::default(),
+                turn_id: "turn-1".to_string(),
+                trace_id: None,
+                started_at: None,
+            }),
+            EventMsg::TurnComplete(TurnCompleteEvent {
+                last_agent_message: None,
+                turn_id: "turn-1".to_string(),
+                completed_at: None,
+                duration_ms: None,
+                time_to_first_token_ms: None,
+            }),
+            EventMsg::TurnAborted(TurnAbortedEvent {
+                turn_id: Some("turn-2".to_string()),
+                reason: codex_protocol::protocol::TurnAbortReason::Interrupted,
+                completed_at: None,
+                duration_ms: None,
+            }),
+            EventMsg::ShutdownComplete,
+        ] {
+            state.handle_event(&session_client, event).await;
+        }
+
+        let lifecycle_events = client
+            .notifications
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|notification| {
+                notification.session_id == child_session_id
+                    && matches!(
+                        &notification.update,
+                        SessionUpdate::SessionInfoUpdate(update)
+                            if update.meta.as_ref().is_some_and(|meta| {
+                                meta.get(CODEX_ACP_EVENT_TYPE_KEY)
+                                    .and_then(|value| value.as_str())
+                                    == Some(CODEX_ACP_TURN_LIFECYCLE_EVENT_TYPE)
+                            })
+                    )
+            })
+            .count();
+        assert_eq!(lifecycle_events, 4);
+    }
+
+    #[tokio::test]
     async fn unknown_submission_events_use_drain_only_projection() -> anyhow::Result<()> {
         let session_id = SessionId::new("test");
         let client = Arc::new(StubClient::new());
@@ -8656,12 +8905,13 @@ mod tests {
         assert!(!state.pending_command_output.contains_key("exec-1"));
     }
 
-    fn prompt_state_for_projection(
+    fn prompt_state_for_session_projection(
+        session_id: SessionId,
         current_thread_id: ThreadId,
     ) -> (PromptState, SessionClient, Arc<StubClient>) {
         let client = Arc::new(StubClient::new());
         let session_client = SessionClient::with_client_for_thread(
-            SessionId::new("parent-runtime-session-id"),
+            session_id,
             current_thread_id,
             client.clone(),
             Arc::default(),
@@ -8674,6 +8924,30 @@ mod tests {
             session_client,
             client,
         )
+    }
+
+    fn prompt_state_for_projection(
+        current_thread_id: ThreadId,
+    ) -> (PromptState, SessionClient, Arc<StubClient>) {
+        prompt_state_for_session_projection(
+            SessionId::new("parent-runtime-session-id"),
+            current_thread_id,
+        )
+    }
+
+    fn inter_agent_message(
+        id: Option<&str>,
+        author: &str,
+        recipient: &str,
+        content: Vec<AgentMessageInputContent>,
+    ) -> ResponseItem {
+        ResponseItem::AgentMessage {
+            id: id.map(str::to_string),
+            author: author.to_string(),
+            recipient: recipient.to_string(),
+            content,
+            internal_chat_message_metadata_passthrough: None,
+        }
     }
 
     async fn setup(

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -883,6 +883,7 @@ struct PromptState {
     active_guardian_assessments: HashSet<String>,
     active_plan_text: HashMap<String, String>,
     projected_tool_calls: HashMap<String, ProjectedToolCallState>,
+    subagent_projection_state: subagents::SubagentProjectionState,
     thread: Arc<dyn CodexThreadImpl>,
     resolution_tx: mpsc::UnboundedSender<ThreadMessage>,
     pending_permission_interactions: HashMap<String, PendingPermissionInteraction>,
@@ -1671,6 +1672,7 @@ impl PromptState {
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
             projected_tool_calls: HashMap::new(),
+            subagent_projection_state: subagents::SubagentProjectionState::default(),
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
@@ -1696,6 +1698,7 @@ impl PromptState {
             active_guardian_assessments: HashSet::new(),
             active_plan_text: HashMap::new(),
             projected_tool_calls: HashMap::new(),
+            subagent_projection_state: subagents::SubagentProjectionState::default(),
             thread,
             resolution_tx,
             pending_permission_interactions: HashMap::new(),
@@ -2260,9 +2263,11 @@ impl PromptState {
             }
         }
 
-        if let Some(projection) =
+        if let Some(mut projection) =
             subagents::projection_for_event(&event, client.thread_id, &client.session_id)
         {
+            self.subagent_projection_state
+                .coalesce_wait_projection(&event, &mut projection);
             self.send_subagent_projection(client, projection).await;
             return;
         }

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -1189,6 +1189,13 @@ fn turn_item_call_id(item: &TurnItem, projection: TurnItemProjection) -> String 
     }
 }
 
+fn is_self_referential_subagent_activity(item: &TurnItem, current_thread_id: ThreadId) -> bool {
+    matches!(
+        item,
+        TurnItem::SubAgentActivity(activity) if activity.agent_thread_id == current_thread_id
+    )
+}
+
 fn turn_item_terminal_status(item: &TurnItem) -> ToolCallStatus {
     use codex_protocol::items::{
         CollabAgentToolCallStatus, CommandExecutionStatus, DynamicToolCallStatus, McpToolCallStatus,
@@ -1938,6 +1945,9 @@ impl PromptState {
     }
 
     async fn start_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
+        if is_self_referential_subagent_activity(item, client.thread_id) {
+            return;
+        }
         let projection = turn_item_projection(item);
         if matches!(
             projection,
@@ -1982,6 +1992,9 @@ impl PromptState {
     }
 
     async fn complete_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
+        if is_self_referential_subagent_activity(item, client.thread_id) {
+            return;
+        }
         let projection = turn_item_projection(item);
         if matches!(
             projection,
@@ -7905,6 +7918,44 @@ mod tests {
             "notifications={notifications:?}"
         );
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn self_referential_turn_item_subagent_activity_is_not_projected() {
+        let current_thread_id = ThreadId::new();
+        let (mut prompt_state, session_client, client) =
+            prompt_state_for_projection(current_thread_id);
+        let item = TurnItem::SubAgentActivity(codex_protocol::items::SubAgentActivityItem {
+            id: "self-activity".to_string(),
+            kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+            agent_thread_id: current_thread_id,
+            agent_path: "/root".try_into().expect("root path should be valid"),
+        });
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::ItemStarted(ItemStartedEvent {
+                    thread_id: current_thread_id,
+                    turn_id: "turn-1".to_string(),
+                    item: item.clone(),
+                    started_at_ms: 0,
+                }),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::ItemCompleted(ItemCompletedEvent {
+                    thread_id: current_thread_id,
+                    turn_id: "turn-1".to_string(),
+                    item,
+                    completed_at_ms: 1,
+                }),
+            )
+            .await;
+
+        assert!(client.notifications.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -1948,6 +1948,16 @@ impl PromptState {
         if is_self_referential_subagent_activity(item, client.thread_id) {
             return;
         }
+        if let TurnItem::SubAgentActivity(activity) = item {
+            if let Some(projection) = subagents::projection_for_subagent_activity_item(
+                activity,
+                client.thread_id,
+                &client.session_id,
+            ) {
+                self.send_subagent_projection(client, projection).await;
+            }
+            return;
+        }
         let projection = turn_item_projection(item);
         if matches!(
             projection,
@@ -1993,6 +2003,16 @@ impl PromptState {
 
     async fn complete_turn_item(&mut self, client: &SessionClient, item: &TurnItem) {
         if is_self_referential_subagent_activity(item, client.thread_id) {
+            return;
+        }
+        if let TurnItem::SubAgentActivity(activity) = item {
+            if let Some(projection) = subagents::projection_for_subagent_activity_item(
+                activity,
+                client.thread_id,
+                &client.session_id,
+            ) {
+                self.send_subagent_projection(client, projection).await;
+            }
             return;
         }
         let projection = turn_item_projection(item);
@@ -7779,7 +7799,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn completed_only_subagent_activity_enriches_fallback_without_second_tool_call()
+    async fn completed_only_subagent_activity_is_navigable_without_specific_event()
     -> anyhow::Result<()> {
         let parent_thread_id = ThreadId::new();
         let child_thread_id = ThreadId::new();
@@ -7805,6 +7825,36 @@ mod tests {
                 }),
             )
             .await;
+        let notifications = client.notifications.lock().unwrap();
+        let tool_call_id = "codex-acp:subagent:subagent-activity-1";
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(
+                    &notification.update,
+                    SessionUpdate::ToolCall(tool_call)
+                        if tool_call.tool_call_id.0.as_ref() == tool_call_id
+                ))
+                .count(),
+            1,
+            "notifications={notifications:?}"
+        );
+        assert!(notifications.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::ToolCall(tool_call)
+                if tool_call.tool_call_id.0.as_ref() == tool_call_id
+                    && tool_call.title == "Started explorer"
+                    && tool_call.meta.as_ref().is_some_and(|meta| {
+                        meta.get("codexAcpSubagentEventType")
+                            .and_then(|value| value.as_str())
+                            == Some("activity_started")
+                            && meta.get("codexAcpChildSessionId")
+                                .and_then(|value| value.as_str())
+                                == Some(child_thread_id.to_string().as_str())
+                    })
+        )));
+        drop(notifications);
+
         prompt_state
             .handle_event(
                 &session_client,
@@ -7819,7 +7869,6 @@ mod tests {
             .await;
 
         let notifications = client.notifications.lock().unwrap();
-        let tool_call_id = "codex-acp:subagent:subagent-activity-1";
         assert_eq!(
             notifications
                 .iter()
@@ -7841,19 +7890,9 @@ mod tests {
                         if update.tool_call_id.0.as_ref() == tool_call_id
                 ))
                 .count(),
-            1,
+            0,
             "notifications={notifications:?}"
         );
-        assert!(notifications.iter().any(|notification| matches!(
-            &notification.update,
-            SessionUpdate::ToolCallUpdate(update)
-                if update.tool_call_id.0.as_ref() == tool_call_id
-                    && update.meta.as_ref().is_some_and(|meta| {
-                        meta.get("codexAcpSubagentEventType")
-                            .and_then(|value| value.as_str())
-                            == Some("activity_started")
-                    })
-        )));
         Ok(())
     }
 

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -52,6 +52,7 @@ use codex_protocol::protocol::{
 };
 use codex_protocol::review_format::format_review_findings_block;
 use codex_protocol::{
+    ThreadId,
     approvals::{ElicitationRequest, ElicitationRequestEvent},
     config_types::{ServiceTier, TrustLevel},
     dynamic_tools::{DynamicToolCallOutputContentItem, DynamicToolCallRequest},
@@ -366,6 +367,7 @@ pub struct Thread {
 impl Thread {
     pub fn new(
         session_id: SessionId,
+        thread_id: ThreadId,
         thread: Arc<dyn CodexThreadImpl>,
         auth: Arc<AuthManager>,
         models_manager: Arc<dyn ModelsManagerImpl>,
@@ -378,7 +380,7 @@ impl Thread {
 
         let actor = ThreadActor::new(
             auth,
-            SessionClient::new(session_id, cx, client_capabilities),
+            SessionClient::new(session_id, thread_id, cx, client_capabilities),
             thread.clone(),
             models_manager,
             config,
@@ -895,6 +897,7 @@ struct PromptState {
 #[derive(Default)]
 struct ProjectedToolCallState {
     emitted: bool,
+    subagent_activity: bool,
     canonical_seen: bool,
     canonical_terminal_seen: bool,
     terminal: Option<ToolCallStatus>,
@@ -1163,6 +1166,10 @@ fn turn_item_tool_kind(item: &TurnItem) -> ToolKind {
 }
 
 fn turn_item_call_id(item: &TurnItem, projection: TurnItemProjection) -> String {
+    if let TurnItem::SubAgentActivity(item) = item {
+        return subagents::subagent_activity_tool_call_id(&item.id);
+    }
+
     match projection {
         TurnItemProjection::Status => format!(
             "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}item:{}",
@@ -1934,6 +1941,7 @@ impl PromptState {
             .projected_tool_calls
             .entry(call_id.clone())
             .or_default();
+        state.subagent_activity |= matches!(item, TurnItem::SubAgentActivity(..));
         if state.emitted || state.terminal.is_some() {
             return;
         }
@@ -1978,6 +1986,7 @@ impl PromptState {
             .projected_tool_calls
             .entry(call_id.clone())
             .or_default();
+        state.subagent_activity |= matches!(item, TurnItem::SubAgentActivity(..));
         if state.canonical_terminal_seen || state.terminal.is_some() {
             return;
         }
@@ -2149,6 +2158,27 @@ impl PromptState {
         client.send_tool_call_update(update).await;
     }
 
+    async fn send_subagent_projection(
+        &mut self,
+        client: &SessionClient,
+        projection: SubagentProjection,
+    ) {
+        match projection {
+            SubagentProjection::ToolCall(tool_call) => {
+                self.send_canonical_tool_call(client, tool_call).await;
+            }
+            SubagentProjection::ToolCallUpdate(update) => {
+                self.send_canonical_tool_update(
+                    client,
+                    update,
+                    "Subagent activity",
+                    ToolKind::Other,
+                )
+                .await;
+            }
+        }
+    }
+
     async fn send_image_generation_started(
         &self,
         client: &SessionClient,
@@ -2215,8 +2245,25 @@ impl PromptState {
     async fn handle_event(&mut self, client: &SessionClient, event: EventMsg) {
         self.event_count += 1;
 
-        if let Some(projection) = subagents::projection_for_collab_event(&event) {
-            send_subagent_projection(client, projection).await;
+        if let EventMsg::SubAgentActivity(activity) = &event {
+            let tool_call_id = subagents::subagent_activity_tool_call_id(&activity.event_id);
+            if !self.projected_tool_calls.contains_key(&tool_call_id)
+                && self
+                    .projected_tool_calls
+                    .values()
+                    .any(|state| state.subagent_activity)
+            {
+                warn!(
+                    event_id = %activity.event_id,
+                    "No matching protocol ID links this subagent activity to an earlier fallback; preserving separate activities"
+                );
+            }
+        }
+
+        if let Some(projection) =
+            subagents::projection_for_event(&event, client.thread_id, &client.session_id)
+        {
+            self.send_subagent_projection(client, projection).await;
             return;
         }
 
@@ -4128,6 +4175,7 @@ fn parse_command_tool_call(parsed_cmd: Vec<ParsedCommand>, cwd: &Path) -> ParseC
 #[derive(Clone)]
 struct SessionClient {
     session_id: SessionId,
+    thread_id: ThreadId,
     client: Arc<dyn ClientSender>,
     client_capabilities: Arc<Mutex<ClientCapabilities>>,
 }
@@ -4135,11 +4183,13 @@ struct SessionClient {
 impl SessionClient {
     fn new(
         session_id: SessionId,
+        thread_id: ThreadId,
         cx: ConnectionTo<Client>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
     ) -> Self {
         Self {
             session_id,
+            thread_id,
             client: Arc::new(AcpConnection(cx)),
             client_capabilities,
         }
@@ -4151,8 +4201,19 @@ impl SessionClient {
         client: Arc<dyn ClientSender>,
         client_capabilities: Arc<Mutex<ClientCapabilities>>,
     ) -> Self {
+        Self::with_client_for_thread(session_id, ThreadId::new(), client, client_capabilities)
+    }
+
+    #[cfg(test)]
+    fn with_client_for_thread(
+        session_id: SessionId,
+        thread_id: ThreadId,
+        client: Arc<dyn ClientSender>,
+        client_capabilities: Arc<Mutex<ClientCapabilities>>,
+    ) -> Self {
         Self {
             session_id,
+            thread_id,
             client,
             client_capabilities,
         }
@@ -5609,13 +5670,6 @@ impl<A: Auth> ThreadActor<A> {
                 self.closed_event_projections.remove(&expired);
             }
         }
-    }
-}
-
-async fn send_subagent_projection(client: &SessionClient, projection: SubagentProjection) {
-    match projection {
-        SubagentProjection::ToolCall(tool_call) => client.send_tool_call(tool_call).await,
-        SubagentProjection::ToolCallUpdate(update) => client.send_tool_call_update(update).await,
     }
 }
 
@@ -7678,6 +7732,206 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completed_only_subagent_activity_enriches_fallback_without_second_tool_call()
+    -> anyhow::Result<()> {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let (mut prompt_state, session_client, client) =
+            prompt_state_for_projection(parent_thread_id);
+        let agent_path: codex_protocol::AgentPath = "/root/research/explorer"
+            .try_into()
+            .expect("valid agent path");
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::ItemCompleted(ItemCompletedEvent {
+                    thread_id: parent_thread_id,
+                    turn_id: "turn-1".to_string(),
+                    item: TurnItem::SubAgentActivity(codex_protocol::items::SubAgentActivityItem {
+                        id: "subagent-activity-1".to_string(),
+                        kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                        agent_thread_id: child_thread_id,
+                        agent_path: agent_path.clone(),
+                    }),
+                    completed_at_ms: 1,
+                }),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::SubAgentActivity(codex_protocol::protocol::SubAgentActivityEvent {
+                    event_id: "subagent-activity-1".to_string(),
+                    occurred_at_ms: 1,
+                    agent_thread_id: child_thread_id,
+                    agent_path,
+                    kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                }),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let tool_call_id = "codex-acp:subagent:subagent-activity-1";
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(
+                    &notification.update,
+                    SessionUpdate::ToolCall(tool_call)
+                        if tool_call.tool_call_id.0.as_ref() == tool_call_id
+                ))
+                .count(),
+            1,
+            "notifications={notifications:?}"
+        );
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(
+                    &notification.update,
+                    SessionUpdate::ToolCallUpdate(update)
+                        if update.tool_call_id.0.as_ref() == tool_call_id
+                ))
+                .count(),
+            1,
+            "notifications={notifications:?}"
+        );
+        assert!(notifications.iter().any(|notification| matches!(
+            &notification.update,
+            SessionUpdate::ToolCallUpdate(update)
+                if update.tool_call_id.0.as_ref() == tool_call_id
+                    && update.meta.as_ref().is_some_and(|meta| {
+                        meta.get("codexAcpSubagentEventType")
+                            .and_then(|value| value.as_str())
+                            == Some("activity_started")
+                    })
+        )));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn specific_subagent_activity_prevents_a_later_turn_item_duplicate() -> anyhow::Result<()>
+    {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let (mut prompt_state, session_client, client) =
+            prompt_state_for_projection(parent_thread_id);
+        let agent_path: codex_protocol::AgentPath = "/root/research/explorer"
+            .try_into()
+            .expect("valid agent path");
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::SubAgentActivity(codex_protocol::protocol::SubAgentActivityEvent {
+                    event_id: "subagent-activity-1".to_string(),
+                    occurred_at_ms: 1,
+                    agent_thread_id: child_thread_id,
+                    agent_path: agent_path.clone(),
+                    kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                }),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::ItemCompleted(ItemCompletedEvent {
+                    thread_id: parent_thread_id,
+                    turn_id: "turn-1".to_string(),
+                    item: TurnItem::SubAgentActivity(codex_protocol::items::SubAgentActivityItem {
+                        id: "subagent-activity-1".to_string(),
+                        kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                        agent_thread_id: child_thread_id,
+                        agent_path,
+                    }),
+                    completed_at_ms: 1,
+                }),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(notification.update, SessionUpdate::ToolCall(_)))
+                .count(),
+            1,
+            "notifications={notifications:?}"
+        );
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(
+                    notification.update,
+                    SessionUpdate::ToolCallUpdate(_)
+                ))
+                .count(),
+            0,
+            "notifications={notifications:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn distinct_subagent_activity_ids_remain_separate_tool_calls() -> anyhow::Result<()> {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let (mut prompt_state, session_client, client) =
+            prompt_state_for_projection(parent_thread_id);
+        let agent_path: codex_protocol::AgentPath = "/root/research/explorer"
+            .try_into()
+            .expect("valid agent path");
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::ItemCompleted(ItemCompletedEvent {
+                    thread_id: parent_thread_id,
+                    turn_id: "turn-1".to_string(),
+                    item: TurnItem::SubAgentActivity(codex_protocol::items::SubAgentActivityItem {
+                        id: "fallback-id".to_string(),
+                        kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                        agent_thread_id: child_thread_id,
+                        agent_path: agent_path.clone(),
+                    }),
+                    completed_at_ms: 1,
+                }),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::SubAgentActivity(codex_protocol::protocol::SubAgentActivityEvent {
+                    event_id: "specific-id".to_string(),
+                    occurred_at_ms: 1,
+                    agent_thread_id: child_thread_id,
+                    agent_path,
+                    kind: codex_protocol::protocol::SubAgentActivityKind::Started,
+                }),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let ids = notifications
+            .iter()
+            .filter_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(tool_call) => Some(tool_call.tool_call_id.0.as_ref()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            vec![
+                "codex-acp:subagent:fallback-id",
+                "codex-acp:subagent:specific-id"
+            ],
+            "notifications={notifications:?}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn unknown_submission_events_use_drain_only_projection() -> anyhow::Result<()> {
         let session_id = SessionId::new("test");
         let client = Arc::new(StubClient::new());
@@ -8395,6 +8649,26 @@ mod tests {
             )
             .await;
         assert!(!state.pending_command_output.contains_key("exec-1"));
+    }
+
+    fn prompt_state_for_projection(
+        current_thread_id: ThreadId,
+    ) -> (PromptState, SessionClient, Arc<StubClient>) {
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client_for_thread(
+            SessionId::new("parent-runtime-session-id"),
+            current_thread_id,
+            client.clone(),
+            Arc::default(),
+        );
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        (
+            PromptState::new("projection".to_string(), thread, resolution_tx, response_tx),
+            session_client,
+            client,
+        )
     }
 
     async fn setup(


### PR DESCRIPTION
## Summary

- Adds the ACP contract for parent/child subagent activity and navigable child transcript breadcrumbs.
- Preserves child lifecycle state across parent waits and resets completed wait groups correctly.
- Hides inter-agent protocol messages from parent transcripts so child final answers do not render as plain chat content.
- Uses child persisted or custom titles for visible breadcrumb labels.
- Known limitation: the v2 subagent protocol does not currently expose the coordination messages exchanged between subagents for rendering in NeverWrite. Models still using the v1 subagent flow can show those messages.
   - V1  sub agents: 5.6 Luna end below. 
   - v2 sub agents: 5.6 Terra and Sol. 
- In v2 subagents can launch their own subagents. 

## Validation

- `cargo test --locked --manifest-path vendor/codex-acp/Cargo.toml`
- `git diff --check`
- `npm run electron:sidecar:stage -- --skip-build`
- Verified that the staged ACP binary matches the ARM release binary hash.
- Manual app smoke test: child breadcrumbs open their transcripts and parent conversations no longer show protocol payloads.