### PR TITLE
feat(chat): streamline chat activity and change review experience

### DIFF
--- a/apps/desktop/src/features/ai/activityDisplayMode.ts
+++ b/apps/desktop/src/features/ai/activityDisplayMode.ts
@@ -1,0 +1,13 @@
+export const ACTIVITY_DISPLAY_MODES = [
+    "expanded",
+    "collapsed",
+    "hidden",
+] as const;
+
+export type ActivityDisplayMode = (typeof ACTIVITY_DISPLAY_MODES)[number];
+
+export function normalizeActivityDisplayMode(
+    value: unknown,
+): ActivityDisplayMode {
+    return value === "expanded" || value === "hidden" ? value : "collapsed";
+}

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -130,6 +130,33 @@ describe("AIChatMessageItem errors", () => {
     });
 });
 
+describe("AIChatMessageItem reasoning", () => {
+    it("renders reasoning with the same compact activity language", () => {
+        renderMessage({
+            content: "Checking source reliability",
+            id: "thinking:1",
+            kind: "thinking",
+            role: "assistant",
+            timestamp: Date.now(),
+            title: "Thinking",
+        });
+
+        expect(screen.getByText("Reasoning")).toBeInTheDocument();
+        expect(
+            document.querySelector("[data-reasoning-activity]"),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByText("Checking source reliability"),
+        ).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Reasoning" }));
+
+        expect(
+            screen.getByText("Checking source reliability"),
+        ).toBeInTheDocument();
+    });
+});
+
 describe("AIChatMessageItem user input", () => {
     it("submits all selected options for multi-select questions", () => {
         const onUserInputResponse = vi.fn();

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -671,6 +671,66 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.getByText(/new line/)).toBeInTheDocument();
     });
 
+    it("opens the diff's own file when a tool reports multiple changes", () => {
+        const firstPath = "/vault/notes/first.md";
+        const secondPath = "/vault/notes/second.md";
+        setVaultNotes([
+            {
+                id: "first-note",
+                path: firstPath,
+                title: "first",
+                modified_at: 1,
+                created_at: 1,
+            },
+            {
+                id: "second-note",
+                path: secondPath,
+                title: "second",
+                modified_at: 1,
+                created_at: 1,
+            },
+        ]);
+
+        renderMessage({
+            id: "tool:multi-file",
+            role: "assistant",
+            kind: "tool",
+            title: "Apply updates",
+            content: "Updated two notes",
+            timestamp: Date.now(),
+            diffs: [
+                {
+                    path: firstPath,
+                    kind: "update",
+                    old_text: "first old",
+                    new_text: "first new",
+                },
+                {
+                    path: secondPath,
+                    kind: "update",
+                    old_text: "second old",
+                    new_text: "second new",
+                },
+            ],
+            meta: {
+                tool: "edit",
+                status: "completed",
+                target: firstPath,
+            },
+        });
+
+        expect(
+            within(getChangeReviewRail(firstPath)).getByRole("button", {
+                name: `Open ${firstPath}`,
+            }),
+        ).toBeInTheDocument();
+        expect(
+            within(getChangeReviewRail(secondPath)).getByRole("button", {
+                name: `Open ${secondPath}`,
+            }),
+        ).toBeInTheDocument();
+    });
+
     it("disables line wrapping inside edit file diffs when editor line wrapping is disabled", () => {
         useSettingsStore.setState({ lineWrapping: false });
         setVaultNotes([

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -83,6 +83,10 @@ function getChangeReviewRail(path: string) {
 
 function expectChangeReviewRail(path: string, action = "Edited") {
     const rail = getChangeReviewRail(path);
+    expect(
+        rail.querySelector("[data-change-review-operation-icon]"),
+    ).not.toBeNull();
+    expect(rail.querySelector("[data-change-review-file-icon]")).toBeNull();
     expect(within(rail).getByText(action)).toBeInTheDocument();
     expect(
         within(rail).getByText(path.split("/").at(-1) ?? path),

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -135,6 +135,41 @@ describe("AIChatMessageItem errors", () => {
     });
 });
 
+describe("AIChatMessageItem assistant references", () => {
+    it("uses the icon-led link appearance for assistant file references", () => {
+        setVaultEntries([
+            {
+                id: "src/main.ts",
+                path: "/vault/src/main.ts",
+                relative_path: "src/main.ts",
+                title: "main.ts",
+                file_name: "main.ts",
+                extension: "ts",
+                kind: "file",
+                modified_at: 0,
+                created_at: 0,
+                size: 32,
+                mime_type: "text/typescript",
+            },
+        ]);
+
+        renderMessage({
+            content: "Read [main.ts](src/main.ts).",
+            id: "assistant:file-reference",
+            kind: "text",
+            role: "assistant",
+            timestamp: Date.now(),
+        });
+
+        const reference = screen.getByRole("button", { name: "main.ts" });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+    });
+});
+
 describe("AIChatMessageItem reasoning", () => {
     it("renders reasoning with the same compact activity language", () => {
         renderMessage({

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -777,6 +777,33 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.queryByText("Edit 1 file")).not.toBeInTheDocument();
     });
 
+    it("keeps review snapshots on the existing rich diff card", () => {
+        renderMessage({
+            id: "tool:review-snapshot",
+            role: "assistant",
+            kind: "tool",
+            title: "Edit watcher",
+            content: "Updated watcher.rs",
+            timestamp: Date.now(),
+            reviewDiffs: [
+                {
+                    path: "/vault/src/watcher.rs",
+                    kind: "update",
+                    old_text: "old line",
+                    new_text: "new line",
+                },
+            ],
+            meta: {
+                tool: "edit",
+                status: "completed",
+                target: "/vault/src/watcher.rs",
+            },
+        });
+
+        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument();
+    });
+
     it("shows Writing for active edit cards without a target path", () => {
         renderMessage({
             id: "tool:writing",

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { invoke, openPath, revealItemInDir } from "@neverwrite/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
@@ -68,6 +68,35 @@ function createDiffMessage(
             target: diff.path,
         },
     };
+}
+
+function getChangeReviewRail(path: string) {
+    const rail = document.querySelector<HTMLElement>(
+        `[data-change-review-path="${path}"]`,
+    );
+    if (!rail) {
+        throw new Error(`Expected a change review rail for ${path}.`);
+    }
+    return rail;
+}
+
+function expectChangeReviewRail(path: string, action = "Edited") {
+    const rail = getChangeReviewRail(path);
+    expect(within(rail).getByText(action)).toBeInTheDocument();
+    expect(
+        within(rail).getByText(path.split("/").at(-1) ?? path),
+    ).toBeInTheDocument();
+    return rail;
+}
+
+function expandChangeReviewRail(path: string) {
+    const rail = getChangeReviewRail(path);
+    fireEvent.click(
+        within(rail).getByRole("button", {
+            name: "Expand inline diff review",
+        }),
+    );
+    return rail;
 }
 
 beforeEach(() => {
@@ -499,15 +528,15 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        expect(screen.getByText("Edited watcher.md")).toBeInTheDocument();
+        const rail = expectChangeReviewRail("/vault/notes/watcher.md");
         expect(
-            screen.getByRole("button", { name: "Open" }),
+            within(rail).getByRole("button", {
+                name: "Open /vault/notes/watcher.md",
+            }),
         ).toBeInTheDocument();
         expect(screen.queryByText("Reject")).not.toBeInTheDocument();
 
-        fireEvent.click(
-            screen.getByRole("button", { name: /Edited watcher\.md/i }),
-        );
+        expandChangeReviewRail("/vault/notes/watcher.md");
 
         expect(screen.getByText(/old line/)).toBeInTheDocument();
         expect(screen.getByText(/new line/)).toBeInTheDocument();
@@ -548,7 +577,7 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        fireEvent.click(screen.getByRole("button", { name: /watcher.md/i }));
+        expandChangeReviewRail("/vault/notes/watcher.md");
 
         const diffPreview = screen.getByTestId(
             "diff-content:/vault/notes/watcher.md",
@@ -595,7 +624,7 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        fireEvent.click(screen.getByRole("button", { name: /watcher.rs/i }));
+        expandChangeReviewRail("/vault/src/watcher.rs");
 
         expect(screen.getAllByText("13").length).toBeGreaterThanOrEqual(1);
         expect(screen.queryByText("+ old line")).not.toBeInTheDocument();
@@ -629,9 +658,11 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
+        const rail = expectChangeReviewRail("/vault/src/watcher.rs");
         expect(
-            screen.getByRole("button", { name: "Open" }),
+            within(rail).getByRole("button", {
+                name: "Open /vault/src/watcher.rs",
+            }),
         ).toBeInTheDocument();
     });
 
@@ -665,7 +696,7 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
         expect(screen.queryByText("Earlier change")).not.toBeInTheDocument();
         expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
-        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
+        expectChangeReviewRail("/vault/src/watcher.rs");
     });
 
     it("keeps non-visible work cycles on the rich diff card without a recency badge", () => {
@@ -700,7 +731,7 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
         expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
         expect(screen.queryByText("Recent change")).not.toBeInTheDocument();
-        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
+        expectChangeReviewRail("/vault/src/watcher.rs");
     });
 
     it("keeps historical permission diffs inspectable without rendering decision actions", () => {
@@ -800,8 +831,12 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        expect(screen.getByText("Edited watcher.rs")).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Open" })).toBeInTheDocument();
+        const rail = expectChangeReviewRail("/vault/src/watcher.rs");
+        expect(
+            within(rail).getByRole("button", {
+                name: "Open /vault/src/watcher.rs",
+            }),
+        ).toBeInTheDocument();
     });
 
     it("shows Writing for active edit cards without a target path", () => {
@@ -898,12 +933,10 @@ describe("AIChatMessageItem tool diffs", () => {
             }),
         );
 
-        expect(screen.getByText("Edited final.md")).toBeInTheDocument();
-        expect(screen.getByText("moved from draft.md")).toBeInTheDocument();
+        const rail = expectChangeReviewRail("/vault/archive/final.md");
+        expect(within(rail).getByText("Moved from draft.md")).toBeInTheDocument();
 
-        fireEvent.click(
-            screen.getByRole("button", { name: /Edited final\.md/i }),
-        );
+        expandChangeReviewRail("/vault/archive/final.md");
 
         expect(
             screen.queryByTestId("diff-content:/vault/archive/final.md"),
@@ -921,11 +954,10 @@ describe("AIChatMessageItem tool diffs", () => {
             }),
         );
 
-        expect(screen.getByText("partial")).toBeInTheDocument();
+        const rail = expectChangeReviewRail("/vault/archive/deleted.md");
+        expect(within(rail).getByText("Partial")).toBeInTheDocument();
 
-        fireEvent.click(
-            screen.getByRole("button", { name: /Edited deleted\.md/i }),
-        );
+        expandChangeReviewRail("/vault/archive/deleted.md");
 
         expect(
             screen.getByText("(partial preview — delete snapshot unavailable)"),
@@ -966,9 +998,7 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.getByText("+~1")).toBeInTheDocument();
         expect(screen.getByText("-~1")).toBeInTheDocument();
 
-        fireEvent.click(
-            screen.getByRole("button", { name: /Edited giant\.md/i }),
-        );
+        expandChangeReviewRail("/vault/giant.md");
 
         expect(screen.getByText("shared 1199")).toBeInTheDocument();
         expect(screen.getByText(/large file preview/i)).toBeInTheDocument();
@@ -985,7 +1015,7 @@ describe("AIChatMessageItem tool diffs", () => {
             }),
         );
 
-        fireEvent.click(screen.getByRole("button", { name: /watcher.rs/i }));
+        expandChangeReviewRail("/vault/src/watcher.rs");
 
         const diffContent = screen.getByTestId(
             "diff-content:/vault/src/watcher.rs",
@@ -1044,7 +1074,7 @@ describe("AIChatMessageItem tool diffs", () => {
             },
         });
 
-        fireEvent.click(screen.getByRole("button", { name: /exact.md/i }));
+        expandChangeReviewRail("/vault/exact.md");
 
         expect(screen.queryByText("alpha")).not.toBeInTheDocument();
         expect(screen.queryByText("101")).not.toBeInTheDocument();
@@ -1126,8 +1156,8 @@ describe("AIChatMessageItem tool diffs", () => {
         fireEvent.click(
             screen.getAllByRole("button", { name: "Increase diff zoom" })[0],
         );
-        fireEvent.click(screen.getByRole("button", { name: /first.rs/i }));
-        fireEvent.click(screen.getByRole("button", { name: /second.rs/i }));
+        expandChangeReviewRail("/vault/src/first.rs");
+        expandChangeReviewRail("/vault/src/second.rs");
 
         expect(
             screen.getByTestId("diff-content:/vault/src/first.rs"),
@@ -1149,7 +1179,7 @@ describe("AIChatMessageItem tool diffs", () => {
             sessionId: "session-diff-state",
         });
 
-        fireEvent.click(screen.getByRole("button", { name: /persisted\.rs/i }));
+        expandChangeReviewRail("/vault/src/persisted.rs");
         expect(
             screen.getByTestId("diff-content:/vault/src/persisted.rs"),
         ).toBeInTheDocument();

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -1252,7 +1252,7 @@ describe("AIChatMessageItem tool diffs", () => {
         ).toHaveLength(1);
         expect(screen.queryByText("Previous:")).toBeNull();
         expect(screen.getByText("Updated:")).toBeInTheDocument();
-        expect(screen.getByText("1")).toBeInTheDocument();
+        expect(screen.queryByText("1")).toBeNull();
 
         fireEvent.click(
             screen.getByRole("button", { name: "Show source diff" }),

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -5,6 +5,7 @@ import { useEditorStore } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import {
+    getClipboardMock,
     renderComponent,
     setEditorTabs,
     setVaultEntries,
@@ -334,6 +335,65 @@ describe("AIChatMessageItem generated images", () => {
 });
 
 describe("AIChatMessageItem user image attachments", () => {
+    it("uses Comando's responsive user bubble width", () => {
+        const view = renderMessage({
+            id: "user:compact-bubble",
+            role: "user",
+            kind: "text",
+            content: "Keep this compact",
+            timestamp: Date.now(),
+        });
+
+        expect(
+            view.container.querySelector("[data-user-message]"),
+        ).toHaveClass("w-full");
+        expect(
+            view.container.querySelector("[data-user-message-bubble]"),
+        ).toHaveClass("ml-auto", "w-[70%]", "max-w-full");
+        expect(
+            view.container.querySelector("[data-user-message-bubble]"),
+        ).toHaveAttribute(
+            "style",
+            expect.stringContaining(
+                "background-color: color-mix(in srgb, var(--accent) 5%, var(--bg-tertiary))",
+            ),
+        );
+        expect(
+            view.container.querySelector("[data-user-message-bubble]"),
+        ).toHaveAttribute(
+            "style",
+            expect.stringContaining(
+                "border: 1px solid color-mix(in srgb, var(--accent) 16%, var(--border))",
+            ),
+        );
+    });
+
+    it("shows sent time and copies the user message", async () => {
+        const timestamp = Date.parse("2026-07-11T15:42:00Z");
+        const view = renderMessage({
+            id: "user:copy",
+            role: "user",
+            kind: "text",
+            content: "Copy this prompt",
+            timestamp,
+        });
+
+        expect(
+            view.container.querySelector("[data-user-message-metadata] time"),
+        ).toHaveAttribute("dateTime", new Date(timestamp).toISOString());
+
+        fireEvent.click(screen.getByRole("button", { name: "Copy message" }));
+
+        await waitFor(() => {
+            expect(getClipboardMock().writeText).toHaveBeenCalledWith(
+                "Copy this prompt",
+            );
+        });
+        expect(
+            screen.getByRole("button", { name: "Message copied" }),
+        ).toBeInTheDocument();
+    });
+
     it("renders image attachments below user text", () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
         const filePath = "/vault/assets/chat/screenshot.png";

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -663,6 +663,9 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.queryByText("Reject")).not.toBeInTheDocument();
 
         expandChangeReviewRail("/vault/notes/watcher.md");
+        fireEvent.click(
+            screen.getByRole("button", { name: "Show source diff" }),
+        );
 
         expect(screen.getByText(/old line/)).toBeInTheDocument();
         expect(screen.getByText(/new line/)).toBeInTheDocument();
@@ -704,6 +707,9 @@ describe("AIChatMessageItem tool diffs", () => {
         });
 
         expandChangeReviewRail("/vault/notes/watcher.md");
+        fireEvent.click(
+            screen.getByRole("button", { name: "Show source diff" }),
+        );
 
         const diffPreview = screen.getByTestId(
             "diff-content:/vault/notes/watcher.md",
@@ -1125,6 +1131,9 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.getByText("-~1")).toBeInTheDocument();
 
         expandChangeReviewRail("/vault/giant.md");
+        fireEvent.click(
+            screen.getByRole("button", { name: "Show source diff" }),
+        );
 
         expect(screen.getByText("shared 1199")).toBeInTheDocument();
         expect(screen.getByText(/large file preview/i)).toBeInTheDocument();
@@ -1201,12 +1210,95 @@ describe("AIChatMessageItem tool diffs", () => {
         });
 
         expandChangeReviewRail("/vault/exact.md");
+        fireEvent.click(
+            screen.getByRole("button", { name: "Show source diff" }),
+        );
 
         expect(screen.queryByText("alpha")).not.toBeInTheDocument();
         expect(screen.queryByText("101")).not.toBeInTheDocument();
         expect(screen.getAllByText("102")).toHaveLength(2);
         expect(screen.getByText("before")).toBeInTheDocument();
         expect(screen.getByText("after")).toBeInTheDocument();
+    });
+
+    it("opens Markdown changes as a decorated preview and can return to the source diff", () => {
+        renderMessage({
+            id: "tool:markdown-preview",
+            role: "assistant",
+            kind: "tool",
+            title: "Edit note",
+            content: "Updated briefing.md",
+            timestamp: Date.now(),
+            diffs: [
+                {
+                    path: "/vault/briefing.md",
+                    kind: "update",
+                    old_text: "> **Previous:** short note",
+                    new_text: "> **Updated:** longer note",
+                },
+            ],
+            meta: {
+                tool: "edit",
+                status: "completed",
+                target: "/vault/briefing.md",
+            },
+        });
+
+        expandChangeReviewRail("/vault/briefing.md");
+
+        expect(screen.getByTestId("markdown-diff-preview")).toBeInTheDocument();
+        expect(
+            document.querySelectorAll('[data-markdown-preview-block="true"]'),
+        ).toHaveLength(1);
+        expect(screen.queryByText("Previous:")).toBeNull();
+        expect(screen.getByText("Updated:")).toBeInTheDocument();
+        expect(screen.getByText("1")).toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: "Show source diff" }),
+        );
+
+        expect(screen.queryByTestId("markdown-diff-preview")).toBeNull();
+        expect(
+            screen.getByTestId("diff-content:/vault/briefing.md"),
+        ).toBeInTheDocument();
+    });
+
+    it("renders a changed Markdown table in preview mode", () => {
+        renderMessage({
+            id: "tool:markdown-table-preview",
+            role: "assistant",
+            kind: "tool",
+            title: "Edit table",
+            content: "Updated status.md",
+            timestamp: Date.now(),
+            diffs: [
+                {
+                    path: "/vault/status.md",
+                    kind: "update",
+                    old_text: [
+                        "| Status | Owner |",
+                        "| --- | --- |",
+                        "| Draft | Ana |",
+                    ].join("\n"),
+                    new_text: [
+                        "| Status | Owner |",
+                        "| --- | --- |",
+                        "| Ready | Ana |",
+                    ].join("\n"),
+                },
+            ],
+            meta: {
+                tool: "edit",
+                status: "completed",
+                target: "/vault/status.md",
+            },
+        });
+
+        expandChangeReviewRail("/vault/status.md");
+
+        expect(screen.getByRole("table")).toBeInTheDocument();
+        expect(screen.getByRole("cell", { name: "Ready" })).toBeInTheDocument();
     });
 
     it("disables zoom controls at the configured min and max", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -878,16 +878,6 @@ export function PlanMessage({
     );
 }
 
-function formatElapsedMs(ms: number) {
-    const totalSeconds = Math.max(0, Math.floor(ms / 1000));
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    const seconds = totalSeconds % 60;
-    if (hours > 0) return `${hours}h ${String(minutes).padStart(2, "0")}m`;
-    if (minutes > 0) return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
-    return `${seconds}s`;
-}
-
 function messageMetaString(message: AIChatMessage, key: string): string | null {
     const value = message.meta?.[key];
     return typeof value === "string" && value.trim() ? value : null;
@@ -1190,54 +1180,6 @@ function StatusMessage({ message }: { message: AIChatMessage }) {
     const title = message.title ?? message.content;
     const detail =
         message.content && message.content !== title ? message.content : null;
-
-    if (statusKind === "turn_started") {
-        const elapsedMs =
-            typeof message.meta?.elapsed_ms === "number"
-                ? message.meta.elapsed_ms
-                : null;
-        return (
-            <div className="min-w-0 max-w-full py-2">
-                <div className="flex min-w-0 max-w-full items-center gap-3">
-                    <div
-                        className="h-px flex-1"
-                        style={{
-                            backgroundColor: "var(--border)",
-                            opacity: 0.5,
-                        }}
-                    />
-                    <span
-                        className="shrink-0 uppercase tracking-[0.14em]"
-                        style={{
-                            color: "var(--text-secondary)",
-                            fontSize: "0.68em",
-                            opacity: 0.7,
-                        }}
-                    >
-                        {title}
-                    </span>
-                    {elapsedMs != null ? (
-                        <span
-                            style={{
-                                color: "var(--text-secondary)",
-                                fontSize: "0.66em",
-                                opacity: 0.55,
-                            }}
-                        >
-                            {formatElapsedMs(elapsedMs)}
-                        </span>
-                    ) : null}
-                    <div
-                        className="h-px flex-1"
-                        style={{
-                            backgroundColor: "var(--border)",
-                            opacity: 0.5,
-                        }}
-                    />
-                </div>
-            </div>
-        );
-    }
 
     if (emphasis === "error" || statusKind === "stream_error") {
         return (

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -57,6 +57,7 @@ import {
     ToolIcon,
     type ToolTargetContextMenuPayload,
 } from "./ToolActivityItem";
+import { isActivityTimelineEntry } from "./activityTimelinePresentation";
 import {
     useChatRowUiEntry,
     useStoredRowExpanded,
@@ -3204,6 +3205,9 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
     }
 
     if (message.kind === "status") {
+        if (isActivityTimelineEntry(message)) {
+            return <ToolActivityItem message={message} sessionId={sessionId} />;
+        }
         return <StatusMessage message={message} />;
     }
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -425,32 +425,78 @@ function UserTextMessage({
 }) {
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<UserMentionContextMenuPayload> | null>(null);
+    const [copied, setCopied] = useState(false);
+    const formattedTime = formatUserMessageTime(message.timestamp);
+    const canCopy = message.content.trim().length > 0;
+
+    const copyMessage = () => {
+        if (!canCopy) return;
+
+        void navigator.clipboard.writeText(message.content).then(() => {
+            setCopied(true);
+            window.setTimeout(() => setCopied(false), 1500);
+        });
+    };
 
     return (
         <div
-            className="min-w-0 max-w-full whitespace-pre-wrap rounded-lg px-3 py-2"
-            style={{
-                color: "var(--text-primary)",
-                backgroundColor: "var(--bg-tertiary)",
-                border: "1px solid var(--border)",
-                overflowWrap: "anywhere",
-                wordBreak: "break-word",
-            }}
+            className="min-w-0 w-full max-w-full"
+            data-user-message="true"
         >
-            {renderUserContent(
-                message.content,
-                pillMetrics,
-                (event, payload) => {
-                    event.preventDefault();
-                    event.stopPropagation();
-                    setContextMenu({
-                        x: event.clientX,
-                        y: event.clientY,
-                        payload,
-                    });
-                },
-            )}
-            <UserMessageAttachments attachments={message.attachments} />
+            <div
+                className="ml-auto min-w-0 w-[70%] max-w-full whitespace-pre-wrap rounded-lg px-3 py-2"
+                data-user-message-bubble="true"
+                style={{
+                    color: "var(--text-primary)",
+                    backgroundColor:
+                        "color-mix(in srgb, var(--accent) 5%, var(--bg-tertiary))",
+                    border: "1px solid color-mix(in srgb, var(--accent) 16%, var(--border))",
+                    overflowWrap: "anywhere",
+                    wordBreak: "break-word",
+                }}
+            >
+                {renderUserContent(
+                    message.content,
+                    pillMetrics,
+                    (event, payload) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        setContextMenu({
+                            x: event.clientX,
+                            y: event.clientY,
+                            payload,
+                        });
+                    },
+                )}
+                <UserMessageAttachments attachments={message.attachments} />
+            </div>
+            <div
+                className="mt-1 flex min-h-5 items-center justify-end gap-1.5 px-0.5 text-text-secondary"
+                data-user-message-metadata="true"
+                style={{
+                    fontFamily: "var(--font-mono), ui-monospace, monospace",
+                    fontSize: "10px",
+                    opacity: 0.72,
+                }}
+            >
+                {formattedTime ? (
+                    <time dateTime={new Date(message.timestamp).toISOString()}>
+                        {formattedTime}
+                    </time>
+                ) : null}
+                {canCopy ? (
+                    <button
+                        aria-label={copied ? "Message copied" : "Copy message"}
+                        className="flex h-5 w-5 items-center justify-center rounded text-text-secondary transition-colors hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--accent)]"
+                        onClick={copyMessage}
+                        style={copied ? { color: "var(--diff-add)" } : undefined}
+                        title={copied ? "Copied" : "Copy message"}
+                        type="button"
+                    >
+                        {copied ? <CopySuccessIcon /> : <CopyMessageIcon />}
+                    </button>
+                ) : null}
+            </div>
             {contextMenu ? (
                 <ContextMenu
                     menu={contextMenu}
@@ -500,6 +546,54 @@ function UserTextMessage({
                 />
             ) : null}
         </div>
+    );
+}
+
+function formatUserMessageTime(timestamp: number) {
+    if (!Number.isFinite(timestamp)) {
+        return null;
+    }
+
+    return new Intl.DateTimeFormat(undefined, {
+        hour: "numeric",
+        minute: "2-digit",
+    }).format(timestamp);
+}
+
+function CopyMessageIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+            width="12"
+        >
+            <rect height="13" rx="2" width="13" x="8" y="8" />
+            <path d="M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3" />
+        </svg>
+    );
+}
+
+function CopySuccessIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="12"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.7"
+            viewBox="0 0 24 24"
+            width="12"
+        >
+            <path d="m5 12 4 4L19 6" />
+        </svg>
     );
 }
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -884,6 +884,7 @@ export function PlanMessage({
                             content={detail}
                             pillMetrics={pillMetrics}
                             chatFontSize={chatFontSize}
+                            fileReferenceAppearance="link"
                         />
                     </div>
                 </div>
@@ -2484,6 +2485,7 @@ function PermissionMessage({
                                 content={expanded ? details : preview}
                                 pillMetrics={pillMetrics}
                                 chatFontSize={chatFontSize}
+                                fileReferenceAppearance="link"
                             />
                             {isLong && (
                                 <button
@@ -3309,6 +3311,7 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
                 content={message.content}
                 pillMetrics={pillMetrics}
                 chatFontSize={chatFontSize}
+                fileReferenceAppearance="link"
             />
         </div>
     );

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -563,21 +563,25 @@ function ThinkingMessage({
     const content = stripMarkdownBold(message.content).trim();
 
     return (
-        <div className="min-w-0 max-w-full">
+        <div
+            className="group min-w-0 max-w-full rounded-md px-2 py-1 transition-colors hover:bg-bg-elevated"
+            data-reasoning-activity="true"
+            style={{ color: "var(--text-secondary)", fontSize: "0.83em" }}
+        >
             <button
                 type="button"
                 onClick={() => {
                     if (content || message.inProgress) setExpanded((v) => !v);
                 }}
-                className="flex items-center gap-2 py-0.5"
+                className="flex min-h-7 w-full items-center gap-2 text-left"
                 style={{
                     color: "var(--text-secondary)",
                     backgroundColor: "transparent",
                     border: "none",
                     cursor:
                         !content && !message.inProgress ? "default" : "pointer",
-                    opacity: 0.7,
-                    fontSize: "0.85em",
+                    opacity: 0.8,
+                    padding: 0,
                 }}
             >
                 <svg
@@ -596,20 +600,34 @@ function ThinkingMessage({
                 >
                     <path d="M4.5 2.5L8 6L4.5 9.5" />
                 </svg>
-                <span>Thinking{message.inProgress ? "..." : ""}</span>
+                <span className="min-w-0 flex-1 truncate font-medium">
+                    Reasoning{message.inProgress ? "..." : ""}
+                </span>
+                {message.inProgress ? (
+                    <span
+                        aria-label="Reasoning in progress"
+                        className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+                        style={{ backgroundColor: "var(--accent)" }}
+                    />
+                ) : null}
             </button>
             {expanded && (content || message.inProgress) && (
-                <div
-                    className="mt-1 whitespace-pre-wrap pl-5 italic"
+                <pre
+                    className="mt-1 max-h-40 overflow-y-auto rounded px-2 py-1.5"
                     style={{
+                        backgroundColor: "var(--bg-tertiary)",
+                        border: "1px solid var(--border)",
                         color: "var(--text-secondary)",
-                        opacity: 0.7,
+                        fontSize: "0.96em",
+                        lineHeight: 1.4,
+                        margin: 0,
                         overflowWrap: "anywhere",
+                        whiteSpace: "pre-wrap",
                         wordBreak: "break-word",
                     }}
                 >
                     {content}
-                </div>
+                </pre>
             )}
         </div>
     );

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -15,7 +15,6 @@ import {
 import type {
     AIChatAttachment,
     AIChatMessage,
-    AIChatSession,
     AIFileDiff,
     AIPermissionOption,
     AIUrlElicitationAction,
@@ -27,11 +26,6 @@ import type { ChatPillMetrics } from "./chatPillMetrics";
 import type { ChatPillVariant } from "./chatPillPalette";
 import { useChatStore } from "../store/chatStore";
 import { selectVisibleTrackedFiles } from "../store/editedFilesBufferModel";
-import {
-    resolveChatRowUiSessionId,
-    useChatRowUiStore,
-    type ChatRowUiState,
-} from "../store/chatRowUiStore";
 import {
     computeDiffStats,
     computeFileDiffStats,
@@ -47,7 +41,6 @@ import {
     canOpenAiEditedFileByAbsolutePath,
     openAiEditedFileByAbsolutePath,
 } from "../chatFileNavigation";
-import { openChatSessionInWorkspace } from "../chatPaneMovement";
 import { useEditorStore } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
@@ -57,15 +50,21 @@ import {
     buildVaultPreviewUrlFromAbsolutePath,
 } from "../../../app/utils/filePreviewUrl";
 import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import {
+    OpenSessionActionButton,
+    ToolActivityItem,
+    ToolIcon,
+    type ToolTargetContextMenuPayload,
+} from "./ToolActivityItem";
+import {
+    useChatRowUiEntry,
+    useStoredRowExpanded,
+} from "./chatRowUiPresentation";
 
 interface UserMentionContextMenuPayload {
     label: string;
     kind: "note" | "file";
     path?: string;
-}
-
-interface ToolTargetContextMenuPayload {
-    target: string;
 }
 
 function isImageFileAttachment(attachment: AIChatAttachment) {
@@ -527,172 +526,13 @@ function stripMarkdownBold(text: string) {
     return text.replace(/\*\*(.+?)\*\*/g, "$1");
 }
 
-function getOpenSessionActionLabel(
-    message: AIChatMessage,
-    resolvedSessionTitle: string | null,
-) {
-    const explicitLabel = message.toolAction?.label?.trim();
-    if (explicitLabel) return explicitLabel;
-
-    if (resolvedSessionTitle) return `Open ${resolvedSessionTitle}`;
-
-    const name = (message.title ?? "")
-        .replace(/^(spawned|started|opened)\s+/i, "")
-        .trim();
-    return name.length > 0 && name.length <= 28 ? `Open ${name}` : "Open";
-}
-
-function sessionMatchesOpenSessionRef(session: AIChatSession, ref: string) {
-    return (
-        session.sessionId === ref ||
-        session.historySessionId === ref ||
-        session.runtimeSessionId === ref
-    );
-}
-
-function resolveOpenSessionActionId(
-    sessionsById: Record<string, AIChatSession>,
-    sessionOrder: string[],
-    ref: string | null,
-) {
-    if (!ref) return null;
-    const candidates = Object.values(sessionsById).filter((session) =>
-        sessionMatchesOpenSessionRef(session, ref),
-    );
-    if (candidates.length === 0) return null;
-
-    const sessionOrderRank = new Map(
-        sessionOrder.map((sessionId, index) => [sessionId, index]),
-    );
-    candidates.sort((left, right) => {
-        const leftLive = left.runtimeState === "live" && !left.isPersistedSession;
-        const rightLive =
-            right.runtimeState === "live" && !right.isPersistedSession;
-        if (leftLive !== rightLive) return leftLive ? -1 : 1;
-
-        const leftExact = left.sessionId === ref;
-        const rightExact = right.sessionId === ref;
-        if (leftExact !== rightExact) return leftExact ? -1 : 1;
-
-        const leftRank = sessionOrderRank.get(left.sessionId) ?? Number.MAX_SAFE_INTEGER;
-        const rightRank =
-            sessionOrderRank.get(right.sessionId) ?? Number.MAX_SAFE_INTEGER;
-        return leftRank - rightRank;
-    });
-
-    return candidates[0].sessionId;
-}
-
-function OpenSessionActionButton({ message }: { message: AIChatMessage }) {
-    const openSessionAction =
-        message.toolAction?.kind === "open_session" ? message.toolAction : null;
-    const openSessionId = openSessionAction?.session_id ?? null;
-    const resolvedOpenSessionId = useChatStore((state) =>
-        resolveOpenSessionActionId(
-            state.sessionsById,
-            state.sessionOrder,
-            openSessionId,
-        ),
-    );
-    const resolvedOpenSessionTitle = useChatStore((state) => {
-        if (!resolvedOpenSessionId) return null;
-        const session = state.sessionsById[resolvedOpenSessionId];
-        return (
-            session?.customTitle?.trim() ||
-            session?.persistedTitle?.trim() ||
-            null
-        );
-    });
-    const canOpenSession = resolvedOpenSessionId !== null;
-
-    if (!openSessionAction) {
-        return null;
-    }
-
-    const label = getOpenSessionActionLabel(message, resolvedOpenSessionTitle);
-
-    return (
-        <button
-            type="button"
-            disabled={!canOpenSession}
-            className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium"
-            style={{
-                background: "transparent",
-                border: "1px solid color-mix(in srgb, var(--border) 82%, transparent)",
-                color: canOpenSession
-                    ? "var(--text-secondary)"
-                    : "color-mix(in srgb, var(--text-secondary) 62%, transparent)",
-                cursor: canOpenSession ? "pointer" : "default",
-            }}
-            title={canOpenSession ? label : "Session is not available yet"}
-            onClick={(event) => {
-                event.stopPropagation();
-                if (!resolvedOpenSessionId) return;
-                void openChatSessionInWorkspace(resolvedOpenSessionId);
-            }}
-        >
-            {label}
-        </button>
-    );
-}
-
-function useChatRowUiEntry(
-    sessionId: string | null | undefined,
-    messageId: string,
-) {
-    const resolvedSessionId = resolveChatRowUiSessionId(sessionId);
-    const rowState = useChatRowUiStore(
-        (state) => state.rowsBySessionId[resolvedSessionId]?.[messageId],
-    );
-    const patchRow = useChatRowUiStore((state) => state.patchRow);
-
-    const updateRow = useCallback(
-        (
-            patch:
-                | Partial<ChatRowUiState>
-                | ((current: ChatRowUiState) => Partial<ChatRowUiState>),
-        ) => {
-            patchRow(resolvedSessionId, messageId, patch);
-        },
-        [messageId, patchRow, resolvedSessionId],
-    );
-
-    return {
-        rowState,
-        updateRow,
-    };
-}
-
-function useStoredRowExpanded(
-    sessionId: string | null | undefined,
-    messageId: string,
-    fallback: boolean,
-) {
-    const { rowState, updateRow } = useChatRowUiEntry(sessionId, messageId);
-    const expanded = rowState?.expanded ?? fallback;
-
-    const setExpanded = useCallback(
-        (value: boolean | ((current: boolean) => boolean)) => {
-            updateRow((current) => ({
-                expanded:
-                    typeof value === "function"
-                        ? value(current.expanded ?? fallback)
-                        : value,
-            }));
-        },
-        [fallback, updateRow],
-    );
-
-    return [expanded, setExpanded] as const;
-}
-
 type DiffPresentationMode = "active" | "historical" | "none";
 
 function getDiffPresentationMode(
     message: AIChatMessage,
     visibleWorkCycleId?: string | null,
 ) {
-    if (!message.diffs?.length) {
+    if (!message.diffs?.length && !message.reviewDiffs?.length) {
         return "none";
     }
 
@@ -774,327 +614,6 @@ function ThinkingMessage({
     );
 }
 
-/** Catppuccin file-type icon for tool messages with a resolvable file target;
- *  falls back to the verb-based ToolIcon when no path is available. */
-function ToolFileIcon({
-    target,
-    toolKind,
-    size = 13,
-    opacity = 0.86,
-}: {
-    target: string | null;
-    toolKind?: string;
-    size?: number;
-    opacity?: number;
-}) {
-    if (target) {
-        return (
-            <FileTypeIcon
-                fileName={target}
-                size={size}
-                opacity={opacity}
-            />
-        );
-    }
-    return <ToolIcon kind={toolKind} />;
-}
-
-function ToolIcon({ kind }: { kind?: string }) {
-    const k = String(kind ?? "");
-    if (k === "read" || k === "search") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <circle cx="5.5" cy="5.5" r="3" />
-                <path d="M7.5 7.5L10 10" />
-            </svg>
-        );
-    }
-    if (k === "edit") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <path d="M7 2l3 3-7 7H0V9z" />
-            </svg>
-        );
-    }
-    if (k === "execute") {
-        return (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 12 12"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <path d="M2 3l4 3-4 3z" />
-                <path d="M7 9h3" />
-            </svg>
-        );
-    }
-    // default gear
-    return (
-        <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-        >
-            <circle cx="6" cy="6" r="1.5" />
-            <path d="M6 1v1.5M6 9.5V11M1 6h1.5M9.5 6H11M2.5 2.5l1 1M8.5 8.5l1 1M9.5 2.5l-1 1M3.5 8.5l-1 1" />
-        </svg>
-    );
-}
-
-/** Compact card for file-mutating tools (edit, delete, move). */
-function FileToolMessage({
-    message,
-    sessionId,
-}: {
-    message: AIChatMessage;
-    sessionId?: string | null;
-}) {
-    const [expanded, setExpanded] = useStoredRowExpanded(
-        sessionId,
-        message.id,
-        false,
-    );
-    const [contextMenu, setContextMenu] =
-        useState<ContextMenuState<ToolTargetContextMenuPayload> | null>(null);
-    const toolKind = String(message.meta?.tool ?? "edit");
-    const target = message.meta?.target ? String(message.meta.target) : null;
-    const canOpenTarget = target
-        ? canOpenAiEditedFileByAbsolutePath(target)
-        : false;
-    const shortTarget = target?.split("/").pop() ?? null;
-    const status = String(message.meta?.status ?? "");
-    const isCompleted = status === "completed";
-    const isInProgress = status === "in_progress";
-
-    const isRead = toolKind === "read" || toolKind === "search";
-    const accent = toolKind === "delete" ? "#ef4444" : "#6b7280"; // neutral gray for read/edit/move
-
-    const actionLabel = isRead
-        ? "Read"
-        : toolKind === "delete"
-          ? "Deleted"
-          : toolKind === "move"
-            ? "Moved"
-            : "Updated";
-    const displayLabel =
-        shortTarget ??
-        (toolKind === "edit" && isInProgress ? "Writing" : message.title) ??
-        actionLabel;
-
-    // Detail: show summary/content if it provides extra info beyond filename
-    const detail =
-        message.content &&
-        message.content !== displayLabel &&
-        message.content !== (message.title ?? toolKind)
-            ? message.content
-            : null;
-
-    return (
-        <div
-            className="min-w-0 max-w-full overflow-hidden rounded-lg"
-            style={{
-                border: `1px solid color-mix(in srgb, ${accent} 25%, var(--border))`,
-                backgroundColor: `color-mix(in srgb, ${accent} 4%, var(--bg-secondary))`,
-                opacity: isCompleted ? 0.65 : 1,
-                transition: "opacity 0.2s ease",
-            }}
-        >
-            {/* Header */}
-            <div
-                className="flex items-center gap-2 px-3 py-1.5"
-                style={{
-                    cursor: detail ? "pointer" : "default",
-                    borderBottom:
-                        detail && expanded
-                            ? `1px solid color-mix(in srgb, ${accent} 15%, var(--border))`
-                            : "none",
-                }}
-                onClick={detail ? () => setExpanded((v) => !v) : undefined}
-            >
-                {/* Icon */}
-                <span className="shrink-0">
-                    <ToolFileIcon
-                        target={target}
-                        toolKind={toolKind}
-                        size={13}
-                    />
-                </span>
-
-                {/* Filename + action */}
-                <span
-                    className="min-w-0 flex-1 truncate"
-                    title={target ?? undefined}
-                    style={{
-                        color: target ? "var(--accent)" : "var(--text-primary)",
-                        fontSize: "0.83em",
-                        fontWeight: 500,
-                        cursor: canOpenTarget ? "pointer" : "default",
-                        textDecoration: "none",
-                    }}
-                    onClick={
-                        canOpenTarget && target
-                            ? (e) => {
-                                  e.stopPropagation();
-                                  void openAiEditedFileByAbsolutePath(target);
-                              }
-                            : undefined
-                    }
-                    onContextMenu={
-                        canOpenTarget && target
-                            ? (event) => {
-                                  event.preventDefault();
-                                  event.stopPropagation();
-                                  setContextMenu({
-                                      x: event.clientX,
-                                      y: event.clientY,
-                                      payload: { target },
-                                  });
-                              }
-                            : undefined
-                    }
-                    onMouseEnter={
-                        canOpenTarget
-                            ? (e) => {
-                                  (
-                                      e.currentTarget as HTMLElement
-                                  ).style.textDecoration = "underline";
-                              }
-                            : undefined
-                    }
-                    onMouseLeave={
-                        canOpenTarget
-                            ? (e) => {
-                                  (
-                                      e.currentTarget as HTMLElement
-                                  ).style.textDecoration = "none";
-                              }
-                            : undefined
-                    }
-                >
-                    {displayLabel}
-                </span>
-
-                {/* Status */}
-                {isInProgress ? (
-                    <span
-                        className="inline-block h-1.5 w-1.5 animate-pulse rounded-full shrink-0"
-                        style={{ backgroundColor: accent }}
-                    />
-                ) : isCompleted ? (
-                    <span
-                        style={{
-                            color: accent,
-                            fontSize: "0.75em",
-                            opacity: 0.8,
-                        }}
-                    >
-                        {actionLabel}
-                    </span>
-                ) : null}
-
-                {/* Expand chevron */}
-                {detail && (
-                    <svg
-                        width="10"
-                        height="10"
-                        viewBox="0 0 10 10"
-                        fill="none"
-                        stroke={accent}
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="shrink-0"
-                        style={{
-                            transform: expanded
-                                ? "rotate(180deg)"
-                                : "rotate(0)",
-                            transition: "transform 0.15s ease",
-                            opacity: 0.6,
-                        }}
-                    >
-                        <path d="M2.5 4L5 6.5L7.5 4" />
-                    </svg>
-                )}
-            </div>
-
-            {/* Expandable detail */}
-            {expanded && detail && (
-                <div className="px-3 py-1.5">
-                    <pre
-                        className="max-h-32 overflow-y-auto rounded px-2 py-1.5"
-                        style={{
-                            backgroundColor: `color-mix(in srgb, ${accent} 4%, var(--bg-tertiary))`,
-                            border: `1px solid color-mix(in srgb, ${accent} 10%, var(--border))`,
-                            color: "var(--text-secondary)",
-                            fontSize: "0.78em",
-                            lineHeight: 1.4,
-                            overflowWrap: "anywhere",
-                            whiteSpace: "pre-wrap",
-                            wordBreak: "break-word",
-                            margin: 0,
-                        }}
-                    >
-                        {detail}
-                    </pre>
-                </div>
-            )}
-            {contextMenu ? (
-                <ContextMenu
-                    menu={contextMenu}
-                    onClose={() => setContextMenu(null)}
-                    entries={[
-                        {
-                            label: "Open",
-                            action: () => {
-                                void openAiEditedFileByAbsolutePath(
-                                    contextMenu.payload.target,
-                                );
-                            },
-                        },
-                        {
-                            label: "Open in New Tab",
-                            action: () => {
-                                void openAiEditedFileByAbsolutePath(
-                                    contextMenu.payload.target,
-                                    { newTab: true },
-                                );
-                            },
-                        },
-                    ]}
-                />
-            ) : null}
-        </div>
-    );
-}
-
 function ToolMessage({
     message,
     sessionId,
@@ -1104,19 +623,10 @@ function ToolMessage({
     sessionId?: string | null;
     diffPresentationMode?: DiffPresentationMode;
 }) {
-    const [expanded, setExpanded] = useStoredRowExpanded(
-        sessionId,
-        message.id,
-        false,
-    );
-    const toolKind = String(message.meta?.tool ?? "");
-    const target = message.meta?.target ? String(message.meta.target) : null;
-    const shortTarget = target?.split("/").pop() ?? null;
-    const title = message.title ?? toolKind;
-    const label = shortTarget ?? title;
-    const status = String(message.meta?.status ?? "");
-    const isCompleted = status === "completed";
-    if (diffPresentationMode !== "none" && message.diffs?.length) {
+    if (
+        diffPresentationMode !== "none" &&
+        (message.diffs?.length || message.reviewDiffs?.length)
+    ) {
         return (
             <ChangeReviewPanel
                 message={message}
@@ -1126,88 +636,7 @@ function ToolMessage({
         );
     }
 
-    // File-mutating tools get card treatment
-    if (toolKind === "edit" || toolKind === "delete" || toolKind === "move") {
-        return <FileToolMessage message={message} sessionId={sessionId} />;
-    }
-
-    // Read/search tools with a file target get card treatment
-    if ((toolKind === "read" || toolKind === "search") && target) {
-        return <FileToolMessage message={message} sessionId={sessionId} />;
-    }
-
-    // Show detail content if it differs from the label (e.g. long shell commands)
-    const detail =
-        message.content &&
-        message.content !== label &&
-        message.content !== title
-            ? message.content
-            : null;
-
-    return (
-        <div
-            className="min-w-0 max-w-full py-0.5"
-            style={{
-                color: "var(--text-secondary)",
-                opacity: isCompleted ? 0.45 : 0.7,
-                fontSize: "0.85em",
-            }}
-        >
-            <div
-                className="flex min-w-0 items-center gap-2"
-                style={{ cursor: detail ? "pointer" : "default" }}
-                onClick={detail ? () => setExpanded((v) => !v) : undefined}
-            >
-                <ToolFileIcon target={target} toolKind={toolKind} size={12} />
-                <span className="min-w-0 flex-1 truncate">{label}</span>
-                {!isCompleted && status === "in_progress" ? (
-                    <span
-                        className="inline-block h-1.5 w-1.5 animate-pulse rounded-full"
-                        style={{ backgroundColor: "var(--accent)" }}
-                    />
-                ) : null}
-                {detail && (
-                    <svg
-                        width="10"
-                        height="10"
-                        viewBox="0 0 10 10"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="1.5"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        style={{
-                            flexShrink: 0,
-                            transform: expanded
-                                ? "rotate(180deg)"
-                                : "rotate(0)",
-                            transition: "transform 0.15s ease",
-                        }}
-                    >
-                        <path d="M2.5 4L5 6.5L7.5 4" />
-                    </svg>
-                )}
-                <OpenSessionActionButton message={message} />
-            </div>
-            {expanded && detail && (
-                <pre
-                    className="mt-1 max-h-40 overflow-y-auto rounded px-2 py-1.5"
-                    style={{
-                        backgroundColor: "var(--bg-tertiary)",
-                        border: "1px solid var(--border)",
-                        fontSize: "0.82em",
-                        lineHeight: 1.4,
-                        overflowWrap: "anywhere",
-                        whiteSpace: "pre-wrap",
-                        wordBreak: "break-word",
-                        margin: 0,
-                    }}
-                >
-                    {detail}
-                </pre>
-            )}
-        </div>
-    );
+    return <ToolActivityItem message={message} sessionId={sessionId} />;
 }
 
 export function PlanMessage({
@@ -3788,7 +3217,7 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
     onDismissMessage,
 }: AIChatMessageItemProps) {
     const diffPresentationMode = readOnly
-        ? message.diffs?.length
+        ? message.diffs?.length || message.reviewDiffs?.length
             ? "historical"
             : "none"
         : getDiffPresentationMode(message, visibleWorkCycleId);

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -2,7 +2,6 @@ import {
     memo,
     useCallback,
     useMemo,
-    useRef,
     useState,
     type MouseEvent,
     type ReactElement,
@@ -50,6 +49,8 @@ import {
     buildVaultPreviewUrlFromAbsolutePath,
 } from "../../../app/utils/filePreviewUrl";
 import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import { ChangeReviewToolRail } from "./ChangeReviewToolRail";
+import { ResizableDiffContainer } from "./ResizableDiffContainer";
 import {
     OpenSessionActionButton,
     ToolActivityItem,
@@ -1360,93 +1361,6 @@ function StatusMessage({ message }: { message: AIChatMessage }) {
     );
 }
 
-const DIFF_DEFAULT_HEIGHT = 200;
-const DIFF_MIN_HEIGHT = 80;
-
-function ResizableDiffContainer({
-    accent,
-    children,
-}: {
-    accent: string;
-    children: ReactElement;
-}) {
-    const [height, setHeight] = useState(DIFF_DEFAULT_HEIGHT);
-    const dragging = useRef(false);
-    const startY = useRef(0);
-    const startH = useRef(0);
-
-    const onPointerDown = useCallback(
-        (e: React.PointerEvent) => {
-            e.preventDefault();
-            dragging.current = true;
-            startY.current = e.clientY;
-            startH.current = height;
-            (e.target as HTMLElement).setPointerCapture(e.pointerId);
-        },
-        [height],
-    );
-
-    const onPointerMove = useCallback((e: React.PointerEvent) => {
-        if (!dragging.current) return;
-        const delta = e.clientY - startY.current;
-        setHeight(Math.max(DIFF_MIN_HEIGHT, startH.current + delta));
-    }, []);
-
-    const onPointerUp = useCallback(() => {
-        dragging.current = false;
-    }, []);
-
-    return (
-        <div
-            style={{
-                borderBottom: `1px solid color-mix(in srgb, ${accent} 8%, var(--border))`,
-            }}
-        >
-            <div
-                style={{
-                    maxHeight: height,
-                    overflowY: "auto",
-                }}
-            >
-                {children}
-            </div>
-            {/* Resize handle */}
-            <div
-                onPointerDown={onPointerDown}
-                onPointerMove={onPointerMove}
-                onPointerUp={onPointerUp}
-                style={{
-                    height: 6,
-                    cursor: "ns-resize",
-                    display: "flex",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    backgroundColor: "transparent",
-                    transition: "background-color 0.15s ease",
-                }}
-                onMouseEnter={(e) => {
-                    (e.currentTarget as HTMLElement).style.backgroundColor =
-                        "color-mix(in srgb, var(--text-secondary) 10%, transparent)";
-                }}
-                onMouseLeave={(e) => {
-                    (e.currentTarget as HTMLElement).style.backgroundColor =
-                        "transparent";
-                }}
-            >
-                <div
-                    style={{
-                        width: 32,
-                        height: 2,
-                        borderRadius: 1,
-                        backgroundColor: "var(--text-secondary)",
-                        opacity: 0.3,
-                    }}
-                />
-            </div>
-        </div>
-    );
-}
-
 function ChangeReviewFileRow({
     diff,
     accent,
@@ -1879,6 +1793,18 @@ function ChangeReviewPanel({
     const singleDiffExpanded = rowState?.singleDiffExpanded ?? false;
     const [openFileContextMenu, setOpenFileContextMenu] =
         useState<ContextMenuState<ToolTargetContextMenuPayload> | null>(null);
+    if (isToolMessage) {
+        return (
+            <ChangeReviewToolRail
+                diffs={diffs}
+                diffZoom={editDiffZoom}
+                lineWrapping={lineWrapping}
+                message={message}
+                onDiffZoomChange={setEditDiffZoom}
+                sessionId={sessionId}
+            />
+        );
+    }
     return (
         <div
             className="min-w-0 max-w-full overflow-hidden rounded-lg"

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -618,6 +618,11 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(screen.queryByTestId("recent-diff-badge")).toBeNull();
         expect(screen.queryByTestId("historical-diff-summary")).toBeNull();
         expect(screen.queryByText("Earlier change")).not.toBeInTheDocument();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /show full activity/i }),
+        );
+
         expect(screen.getByText("Edited oldest.ts")).toBeInTheDocument();
         expect(screen.getByText("Edited older.ts")).toBeInTheDocument();
         expect(screen.getByText("Edited recent.ts")).toBeInTheDocument();
@@ -746,5 +751,186 @@ describe("AIChatMessageList streaming run indicator", () => {
                 configurable: true,
             });
         }
+    });
+
+    it("groups consecutive tools into a collapsed activity rail", () => {
+        const messages: AIChatMessage[] = [
+            {
+                id: "user:prompt",
+                role: "user",
+                kind: "text",
+                content: "Inspect the project",
+                timestamp: 1,
+            },
+            {
+                id: "tool:read",
+                role: "assistant",
+                kind: "tool",
+                content: "Read package.json",
+                title: "Read package.json",
+                timestamp: 2,
+                meta: {
+                    status: "completed",
+                    target: "/vault/package.json",
+                    tool: "read",
+                },
+            },
+            {
+                id: "tool:search",
+                role: "assistant",
+                kind: "tool",
+                content: "Search for review",
+                title: "Search for review",
+                timestamp: 3,
+                meta: {
+                    status: "completed",
+                    tool: "grep",
+                },
+            },
+            {
+                id: "assistant:answer",
+                role: "assistant",
+                kind: "text",
+                content: "The review flow is ready.",
+                timestamp: 4,
+            },
+        ];
+
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-activity-rail"
+                messages={messages}
+                status="idle"
+            />,
+        );
+
+        expect(
+            view.container.querySelectorAll('[data-chat-row="true"]'),
+        ).toHaveLength(3);
+        expect(
+            view.container.querySelector('[data-activity-rail="true"]'),
+        ).toHaveAttribute("data-activity-count", "2");
+        expect(
+            view.container.querySelectorAll("[data-tool-activity-id]"),
+        ).toHaveLength(0);
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /show full activity/i }),
+        );
+
+        expect(
+            view.container.querySelectorAll("[data-tool-activity-id]"),
+        ).toHaveLength(2);
+        expect(
+            view.container.querySelector('[data-chat-message-id="tool:read"]'),
+        ).not.toBeNull();
+        expect(
+            view.container.querySelector('[data-chat-message-id="tool:search"]'),
+        ).not.toBeNull();
+    });
+
+    it("opens a collapsed rail when the outline targets one of its tools", async () => {
+        const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+        const scrollIntoView = vi.fn();
+        Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+            value: scrollIntoView,
+            configurable: true,
+        });
+        const messages: AIChatMessage[] = [
+            createMessages()[0]!,
+            {
+                id: "tool:outline",
+                role: "assistant",
+                kind: "tool",
+                content: "Read context",
+                title: "Read context",
+                timestamp: 2,
+                meta: {
+                    status: "completed",
+                    target: "/vault/context.md",
+                    tool: "read",
+                },
+            },
+        ];
+
+        try {
+            const view = renderComponent(
+                <AIChatMessageList
+                    sessionId="session-activity-outline"
+                    messages={messages}
+                    status="idle"
+                    scrollToMessageId="tool:outline"
+                />,
+            );
+
+            await waitFor(() => {
+                expect(scrollIntoView).toHaveBeenCalledWith({
+                    block: "center",
+                    behavior: "smooth",
+                });
+            });
+
+            expect(
+                view.container.querySelector(
+                    '[data-chat-message-id="tool:outline"]',
+                ),
+            ).toHaveAttribute("data-chat-outline-active", "true");
+
+            view.rerender(
+                <AIChatMessageList
+                    sessionId="session-activity-outline"
+                    messages={messages}
+                    status="idle"
+                />,
+            );
+
+            expect(
+                view.container.querySelector('[data-tool-activity-id="tool:outline"]'),
+            ).not.toBeNull();
+        } finally {
+            Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
+                value: originalScrollIntoView,
+                configurable: true,
+            });
+        }
+    });
+
+    it("expands rails while find searches tool activity", async () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-activity-find"
+                messages={[
+                    {
+                        id: "tool:find",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Read hidden context",
+                        title: "Read hidden context",
+                        timestamp: 1,
+                        meta: {
+                            status: "completed",
+                            target: "/vault/context.md",
+                            tool: "read",
+                        },
+                    },
+                ]}
+                status="idle"
+                findOpen
+            />,
+        );
+
+        expect(
+            view.container.querySelectorAll("[data-tool-activity-id]"),
+        ).toHaveLength(0);
+
+        fireEvent.change(screen.getByRole("textbox", { name: "Find in chat" }), {
+            target: { value: "hidden context" },
+        });
+
+        await waitFor(() => {
+            expect(
+                view.container.querySelector('[data-tool-activity-id="tool:find"]'),
+            ).not.toBeNull();
+        });
     });
 });

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -219,7 +219,7 @@ describe("AIChatMessageList streaming run indicator", () => {
         ).not.toBeInTheDocument();
     });
 
-    it("shows elapsed time on the turn_started divider when elapsed_ms is stamped", () => {
+    it("does not render turn-start markers after a run completes", () => {
         const messages: AIChatMessage[] = [
             {
                 id: "status:turn-1",
@@ -248,8 +248,9 @@ describe("AIChatMessageList streaming run indicator", () => {
             <AIChatMessageList messages={messages} status="idle" />,
         );
 
-        // The elapsed time appears inline in the turn divider
-        expect(screen.getByText("45s")).toBeInTheDocument();
+        expect(screen.queryByText("New turn")).not.toBeInTheDocument();
+        expect(screen.queryByText("45s")).not.toBeInTheDocument();
+        expect(screen.getByText("Done")).toBeInTheDocument();
     });
 
     it("falls back to the latest user message when the turn-start event is missing", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -623,10 +623,18 @@ describe("AIChatMessageList streaming run indicator", () => {
             screen.getByRole("button", { name: /show full activity/i }),
         );
 
-        expect(screen.getByText("Edited oldest.ts")).toBeInTheDocument();
-        expect(screen.getByText("Edited older.ts")).toBeInTheDocument();
-        expect(screen.getByText("Edited recent.ts")).toBeInTheDocument();
-        expect(screen.getByText("Edited current.ts")).toBeInTheDocument();
+        expect(
+            document.querySelector('[data-change-review-path="/vault/src/oldest.ts"]'),
+        ).toBeInTheDocument();
+        expect(
+            document.querySelector('[data-change-review-path="/vault/src/older.ts"]'),
+        ).toBeInTheDocument();
+        expect(
+            document.querySelector('[data-change-review-path="/vault/src/recent.ts"]'),
+        ).toBeInTheDocument();
+        expect(
+            document.querySelector('[data-change-review-path="/vault/src/current.ts"]'),
+        ).toBeInTheDocument();
     });
 
     it("lets the user dismiss the pinned plan banner and keeps the plan in the timeline", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -5,6 +5,7 @@ import type { AIChatMessage } from "../types";
 import { AIChatMessageList } from "./AIChatMessageList";
 import { resetChatMessageListViewState } from "./chatMessageListViewState";
 import { resetChatRowUiStore } from "../store/chatRowUiStore";
+import { useChatStore } from "../store/chatStore";
 import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 
 function createMessages(): AIChatMessage[] {
@@ -107,6 +108,7 @@ describe("AIChatMessageList streaming run indicator", () => {
         vi.useRealTimers();
         resetChatMessageListViewState();
         resetChatRowUiStore();
+        useChatStore.setState({ toolActivityDisplayMode: "collapsed" });
     });
 
     it("keeps reasoning, web, edit, and MCP activity in one chronological rail", () => {
@@ -916,6 +918,87 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(
             view.container.querySelector('[data-chat-message-id="tool:search"]'),
         ).not.toBeNull();
+    });
+
+    it("hides routine activity while preserving changes, failures, and subagents", () => {
+        useChatStore.setState({ toolActivityDisplayMode: "hidden" });
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-hidden-activity"
+                status="idle"
+                messages={[
+                    {
+                        id: "tool:read",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Read notes",
+                        timestamp: 1,
+                        meta: { status: "completed", tool: "read" },
+                    },
+                    {
+                        id: "tool:search",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Search notes",
+                        timestamp: 2,
+                        meta: { status: "completed", tool: "search" },
+                    },
+                    {
+                        id: "tool:edit",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Edited notes",
+                        timestamp: 3,
+                        meta: { status: "completed", tool: "edit" },
+                    },
+                    {
+                        id: "status:subagent",
+                        role: "system",
+                        kind: "status",
+                        content: "Subagent completed",
+                        timestamp: 4,
+                        title: "Analyst completed",
+                        meta: {
+                            status: "completed",
+                            status_event: "subagent_lifecycle",
+                        },
+                    },
+                    {
+                        id: "tool:failed",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Command failed",
+                        timestamp: 5,
+                        meta: { status: "failed", tool: "command" },
+                    },
+                    {
+                        id: "tool:subagent",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Spawned analyst",
+                        timestamp: 6,
+                        meta: { status: "completed", tool: "other" },
+                        toolAction: {
+                            kind: "open_session",
+                            session_id: "child-session",
+                        },
+                    },
+                ]}
+            />,
+        );
+
+        expect(
+            Array.from(
+                view.container.querySelectorAll<HTMLElement>(
+                    "[data-tool-activity-id]",
+                ),
+            ).map((entry) => entry.dataset.toolActivityId),
+        ).toEqual([
+            "tool:edit",
+            "status:subagent",
+            "tool:failed",
+            "tool:subagent",
+        ]);
     });
 
     it("opens a collapsed rail when the outline targets one of its tools", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -1001,6 +1001,42 @@ describe("AIChatMessageList streaming run indicator", () => {
         ]);
     });
 
+    it("does not mark a completed change as active when hidden routine work follows it", () => {
+        useChatStore.setState({ toolActivityDisplayMode: "hidden" });
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-hidden-active-tail"
+                status="streaming"
+                messages={[
+                    {
+                        id: "tool:edit",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Edited notes",
+                        timestamp: 1,
+                        meta: { status: "completed", tool: "edit" },
+                    },
+                    {
+                        id: "tool:read",
+                        role: "assistant",
+                        kind: "tool",
+                        content: "Reading context",
+                        timestamp: 2,
+                        meta: {
+                            status: "in_progress",
+                            tool: "read",
+                        },
+                    },
+                ]}
+            />,
+        );
+
+        expect(
+            view.container.querySelector('[data-activity-rail="true"]'),
+        ).toHaveAttribute("aria-busy", "false");
+        expect(screen.queryByText(/working/i)).not.toBeInTheDocument();
+    });
+
     it("opens a collapsed rail when the outline targets one of its tools", async () => {
         const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
         const scrollIntoView = vi.fn();

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -1037,7 +1037,8 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(screen.queryByText(/working/i)).not.toBeInTheDocument();
     });
 
-    it("opens a collapsed rail when the outline targets one of its tools", async () => {
+    it("opens a hidden routine rail when the outline targets one of its tools", async () => {
+        useChatStore.setState({ toolActivityDisplayMode: "hidden" });
         const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
         const scrollIntoView = vi.fn();
         Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
@@ -1094,7 +1095,7 @@ describe("AIChatMessageList streaming run indicator", () => {
 
             expect(
                 view.container.querySelector('[data-tool-activity-id="tool:outline"]'),
-            ).not.toBeNull();
+            ).toBeNull();
         } finally {
             Object.defineProperty(HTMLElement.prototype, "scrollIntoView", {
                 value: originalScrollIntoView,
@@ -1104,6 +1105,7 @@ describe("AIChatMessageList streaming run indicator", () => {
     });
 
     it("expands rails while find searches tool activity", async () => {
+        useChatStore.setState({ toolActivityDisplayMode: "hidden" });
         const view = renderComponent(
             <AIChatMessageList
                 sessionId="session-activity-find"

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -109,6 +109,86 @@ describe("AIChatMessageList streaming run indicator", () => {
         resetChatRowUiStore();
     });
 
+    it("keeps reasoning, web, edit, and MCP activity in one chronological rail", () => {
+        renderComponent(
+            <AIChatMessageList
+                messages={[
+                    {
+                        content: "Checking sources",
+                        id: "thinking:1",
+                        kind: "thinking",
+                        role: "assistant",
+                        timestamp: 1,
+                        title: "Thinking",
+                    },
+                    {
+                        content: "Search: site:aljazeera.com",
+                        id: "tool:web",
+                        kind: "tool",
+                        meta: {
+                            status: "completed",
+                            target: "site:aljazeera.com",
+                            tool: "web_search",
+                        },
+                        role: "assistant",
+                        timestamp: 2,
+                        title: "Web search",
+                    },
+                    {
+                        content: "Comparing results",
+                        id: "thinking:2",
+                        kind: "thinking",
+                        role: "assistant",
+                        timestamp: 3,
+                        title: "Thinking",
+                    },
+                    {
+                        content: "Updated daily.md",
+                        id: "tool:edit",
+                        kind: "tool",
+                        meta: {
+                            status: "completed",
+                            target: "/vault/daily.md",
+                            tool: "edit",
+                        },
+                        role: "assistant",
+                        timestamp: 4,
+                        title: "Edit daily note",
+                    },
+                    {
+                        content: "Fetched market data",
+                        id: "tool:mcp",
+                        kind: "tool",
+                        meta: {
+                            status: "completed",
+                            tool: "mcp_market_data",
+                        },
+                        role: "assistant",
+                        timestamp: 5,
+                        title: "Query market MCP",
+                    },
+                ]}
+                status="idle"
+            />,
+        );
+
+        expect(document.querySelectorAll("[data-activity-rail]")).toHaveLength(1);
+        expect(document.querySelector("[data-activity-count]")).toHaveAttribute(
+            "data-activity-count",
+            "3",
+        );
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /show full activity/i }),
+        );
+
+        expect(
+            Array.from(
+                document.querySelectorAll<HTMLElement>("[data-chat-message-id]"),
+            ).map((entry) => entry.dataset.chatMessageId),
+        ).toEqual(["thinking:1", "tool:web", "thinking:2", "tool:edit", "tool:mcp"]);
+    });
+
     it("renders the elapsed timer during streaming and hides it when the run ends", () => {
         vi.useFakeTimers();
         vi.setSystemTime(new Date("2026-03-12T15:00:00Z"));

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -37,6 +37,7 @@ import {
     useChatRowUiStore,
 } from "../store/chatRowUiStore";
 import { useChatStore } from "../store/chatStore";
+import type { ActivityDisplayMode } from "../activityDisplayMode";
 import { isTurnStartedStatusMessage } from "../transcriptModel";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 import { ChatFindBar } from "./find/ChatFindBar";
@@ -284,6 +285,7 @@ function renderTimelineRow(
         highlightedMessageId?: string | null;
         forceExpandedMessageId?: string | null;
         forceExpandedForSearch?: boolean;
+        activityDisplayMode: ActivityDisplayMode;
     },
 ) {
     if (row.kind === "run-indicator") {
@@ -299,6 +301,7 @@ function renderTimelineRow(
     if (row.kind === "activity-segment") {
         return (
             <ToolActivitySegment
+                activityDisplayMode={options.activityDisplayMode}
                 forceExpandedMessageId={options.forceExpandedMessageId}
                 forceExpandedForSearch={options.forceExpandedForSearch}
                 highlightedMessageId={options.highlightedMessageId}
@@ -422,6 +425,9 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     );
     const rowUiSessionId = resolveChatRowUiSessionId(sessionId);
     const dismissMessage = useChatStore((state) => state.dismissMessage);
+    const activityDisplayMode = useChatStore(
+        (state) => state.toolActivityDisplayMode,
+    );
     const handleDismissMessage = useCallback(
         (messageId: string) => {
             if (!sessionId) return;
@@ -523,7 +529,10 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                     message.id === visiblePinnedPlanId
                 ),
         );
-        const presentationRows = buildActivityTimelineRows(timelineMessages);
+        const presentationRows = buildActivityTimelineRows(
+            timelineMessages,
+            activityDisplayMode,
+        );
         const trailingPresentationRow = presentationRows.at(-1);
 
         for (const presentationRow of presentationRows) {
@@ -560,6 +569,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         return rows;
     }, [
+        activityDisplayMode,
         messages,
         runIndicatorAnchor,
         sessionId,
@@ -581,8 +591,10 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             forceExpandedMessageId: scrollToMessageId,
             forceExpandedForSearch: findOpen && findQuery.trim().length > 0,
             highlightedMessageId: outlineHighlightedMessageId,
+            activityDisplayMode,
         }),
         [
+            activityDisplayMode,
             chatFontSize,
             findOpen,
             scrollToMessageId,

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -37,6 +37,7 @@ import {
     useChatRowUiStore,
 } from "../store/chatRowUiStore";
 import { useChatStore } from "../store/chatStore";
+import { isTurnStartedStatusMessage } from "../transcriptModel";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 import { ChatFindBar } from "./find/ChatFindBar";
 import { useChatFind } from "./find/useChatFind";
@@ -514,15 +515,14 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     const visiblePinnedPlanId = visiblePinnedPlan?.id ?? null;
     const timelineRows = useMemo(() => {
         const rows: TimelineRow[] = [];
-        const timelineMessages = visiblePinnedPlanId
-            ? messages.filter(
-                  (message) =>
-                      !(
-                          message.kind === "plan" &&
-                          message.id === visiblePinnedPlanId
-                      ),
-              )
-            : messages;
+        const timelineMessages = messages.filter(
+            (message) =>
+                !isTurnStartedStatusMessage(message) &&
+                !(
+                    message.kind === "plan" &&
+                    message.id === visiblePinnedPlanId
+                ),
+        );
         const presentationRows = buildActivityTimelineRows(timelineMessages);
         const trailingPresentationRow = presentationRows.at(-1);
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -534,6 +534,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             activityDisplayMode,
         );
         const trailingPresentationRow = presentationRows.at(-1);
+        const lastTimelineMessageId = timelineMessages.at(-1)?.id;
 
         for (const presentationRow of presentationRows) {
             if (presentationRow.kind === "message") {
@@ -548,7 +549,9 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             rows.push({
                 isCurrentTurnTail:
                     status === "streaming" &&
-                    trailingPresentationRow?.id === presentationRow.id,
+                    trailingPresentationRow?.id === presentationRow.id &&
+                    presentationRow.entries.at(-1)?.message.id ===
+                        lastTimelineMessageId,
                 key: getActivityTimelineRowKey(sessionId, presentationRow.id),
                 kind: "activity-segment",
                 segment: presentationRow,

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -519,6 +519,13 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     const dismissPinnedPlan = useChatRowUiStore((state) => state.patchRow);
     const visiblePinnedPlan = pinnedPlanDismissed ? null : pinnedPlan;
     const visiblePinnedPlanId = visiblePinnedPlan?.id ?? null;
+    const shouldRevealHiddenActivity =
+        scrollToMessageId !== null ||
+        (findOpen && findQuery.trim().length > 0);
+    const timelineActivityDisplayMode =
+        activityDisplayMode === "hidden" && shouldRevealHiddenActivity
+            ? "collapsed"
+            : activityDisplayMode;
     const timelineRows = useMemo(() => {
         const rows: TimelineRow[] = [];
         const timelineMessages = messages.filter(
@@ -531,7 +538,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         );
         const presentationRows = buildActivityTimelineRows(
             timelineMessages,
-            activityDisplayMode,
+            timelineActivityDisplayMode,
         );
         const trailingPresentationRow = presentationRows.at(-1);
         const lastTimelineMessageId = timelineMessages.at(-1)?.id;
@@ -572,11 +579,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         return rows;
     }, [
-        activityDisplayMode,
         messages,
         runIndicatorAnchor,
         sessionId,
         status,
+        timelineActivityDisplayMode,
         visiblePinnedPlanId,
     ]);
     const rowRenderOptions = useMemo(

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -9,6 +9,7 @@ import {
     useState,
 } from "react";
 import { AIChatMessageItem, PlanMessage } from "./AIChatMessageItem";
+import { ToolActivitySegment } from "./ToolActivitySegment";
 import {
     ContextMenu,
     type ContextMenuState,
@@ -39,6 +40,11 @@ import { useChatStore } from "../store/chatStore";
 import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
 import { ChatFindBar } from "./find/ChatFindBar";
 import { useChatFind } from "./find/useChatFind";
+import {
+    buildActivityTimelineRows,
+    getActivityTimelineRowKey,
+    type ActivityTimelineSegmentRow,
+} from "./activityTimelinePresentation";
 
 interface AIChatMessageListProps {
     sessionId?: string | null;
@@ -73,6 +79,12 @@ type TimelineRow =
           key: string;
           kind: "message";
           message: AIChatMessage;
+      }
+    | {
+          isCurrentTurnTail: boolean;
+          key: string;
+          kind: "activity-segment";
+          segment: ActivityTimelineSegmentRow;
       }
     | {
           key: string;
@@ -268,6 +280,9 @@ function renderTimelineRow(
             action: AIUrlElicitationAction,
         ) => void;
         onDismissMessage?: (messageId: string) => void;
+        highlightedMessageId?: string | null;
+        forceExpandedMessageId?: string | null;
+        forceExpandedForSearch?: boolean;
     },
 ) {
     if (row.kind === "run-indicator") {
@@ -280,11 +295,52 @@ function renderTimelineRow(
         );
     }
 
+    if (row.kind === "activity-segment") {
+        return (
+            <ToolActivitySegment
+                forceExpandedMessageId={options.forceExpandedMessageId}
+                forceExpandedForSearch={options.forceExpandedForSearch}
+                highlightedMessageId={options.highlightedMessageId}
+                isCurrentTurnTail={row.isCurrentTurnTail}
+                renderEntry={(message) =>
+                    renderTimelineMessage(message, options)
+                }
+                segment={row.segment}
+                sessionId={options.sessionId}
+            />
+        );
+    }
+
+    return renderTimelineMessage(row.message, options);
+}
+
+function renderTimelineMessage(
+    message: AIChatMessage,
+    options: {
+        sessionId?: string | null;
+        readOnly?: boolean;
+        pillMetrics: ReturnType<typeof getChatPillMetrics>;
+        chatFontSize: number;
+        visibleWorkCycleId?: string | null;
+        onPermissionResponse?: (requestId: string, optionId?: string) => void;
+        onUserInputResponse?: (
+            requestId: string,
+            answers: Record<string, string[]>,
+            action?: AIUserInputAction,
+        ) => void;
+        onUrlElicitationOpen?: (requestId: string) => void;
+        onUrlElicitationResponse?: (
+            requestId: string,
+            action: AIUrlElicitationAction,
+        ) => void;
+        onDismissMessage?: (messageId: string) => void;
+    },
+) {
     return (
         <AIChatMessageItem
             sessionId={options.sessionId}
             readOnly={options.readOnly}
-            message={row.message}
+            message={message}
             pillMetrics={options.pillMetrics}
             chatFontSize={options.chatFontSize}
             visibleWorkCycleId={options.visibleWorkCycleId}
@@ -455,21 +511,38 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     );
     const dismissPinnedPlan = useChatRowUiStore((state) => state.patchRow);
     const visiblePinnedPlan = pinnedPlanDismissed ? null : pinnedPlan;
+    const visiblePinnedPlanId = visiblePinnedPlan?.id ?? null;
     const timelineRows = useMemo(() => {
         const rows: TimelineRow[] = [];
+        const timelineMessages = visiblePinnedPlanId
+            ? messages.filter(
+                  (message) =>
+                      !(
+                          message.kind === "plan" &&
+                          message.id === visiblePinnedPlanId
+                      ),
+              )
+            : messages;
+        const presentationRows = buildActivityTimelineRows(timelineMessages);
+        const trailingPresentationRow = presentationRows.at(-1);
 
-        for (const message of messages) {
-            if (
-                message.kind === "plan" &&
-                message.id === visiblePinnedPlan?.id
-            ) {
+        for (const presentationRow of presentationRows) {
+            if (presentationRow.kind === "message") {
+                rows.push({
+                    key: scopeTimelineRowKey(sessionId, presentationRow.id),
+                    kind: "message",
+                    message: presentationRow.message,
+                });
                 continue;
             }
 
             rows.push({
-                key: scopeTimelineRowKey(sessionId, message.id),
-                kind: "message",
-                message,
+                isCurrentTurnTail:
+                    status === "streaming" &&
+                    trailingPresentationRow?.id === presentationRow.id,
+                key: getActivityTimelineRowKey(sessionId, presentationRow.id),
+                kind: "activity-segment",
+                segment: presentationRow,
             });
         }
 
@@ -491,7 +564,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         runIndicatorAnchor,
         sessionId,
         status,
-        visiblePinnedPlan?.id,
+        visiblePinnedPlanId,
     ]);
     const rowRenderOptions = useMemo(
         () => ({
@@ -505,10 +578,17 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             onUrlElicitationOpen,
             onUrlElicitationResponse,
             onDismissMessage: handleDismissMessage,
+            forceExpandedMessageId: scrollToMessageId,
+            forceExpandedForSearch: findOpen && findQuery.trim().length > 0,
+            highlightedMessageId: outlineHighlightedMessageId,
         }),
         [
             chatFontSize,
+            findOpen,
+            scrollToMessageId,
+            findQuery,
             handleDismissMessage,
+            outlineHighlightedMessageId,
             onPermissionResponse,
             onUserInputResponse,
             onUrlElicitationOpen,

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -4,7 +4,6 @@ import {
     ContextMenu,
     type ContextMenuState,
 } from "../../../components/context-menu/ContextMenu";
-import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 import {
     computeFileDiffStats,
     formatDiffStat,
@@ -18,6 +17,7 @@ import {
     openAiEditedFileByAbsolutePath,
 } from "../chatFileNavigation";
 import { useChatRowUiEntry } from "./chatRowUiPresentation";
+import { ToolIcon } from "./ToolActivityItem";
 import type { AIChatMessage, AIFileDiff } from "../types";
 
 interface ChangeReviewToolRailProps {
@@ -147,6 +147,13 @@ function ChangeReviewToolRailRow({
         : false;
     const isFailed = status === "failed" || status === "error";
     const isInProgress = status === "in_progress" || status === "pending";
+    const operationIconKind =
+        toolKind === "edit" ||
+        toolKind === "update" ||
+        toolKind === "write" ||
+        toolKind === "create"
+            ? "edit"
+            : toolKind;
 
     return (
         <div
@@ -163,13 +170,13 @@ function ChangeReviewToolRailRow({
                 <span
                     aria-hidden="true"
                     className="shrink-0"
-                    style={{ color: accent, display: "inline-flex" }}
+                    data-change-review-operation-icon="true"
+                    style={{
+                        color: isFailed ? accent : "var(--text-secondary)",
+                        display: "inline-flex",
+                    }}
                 >
-                    {isFailed ? (
-                        <WarningIcon />
-                    ) : (
-                        <FileTypeIcon fileName={diff.path} opacity={0.85} size={14} />
-                    )}
+                    {isFailed ? <WarningIcon /> : <ToolIcon kind={operationIconKind} />}
                 </span>
                 <span className="shrink-0 opacity-70">{actionLabel}</span>
                 {canOpen && openPath ? (

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -1,0 +1,361 @@
+import { useState } from "react";
+
+import {
+    ContextMenu,
+    type ContextMenuState,
+} from "../../../components/context-menu/ContextMenu";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import {
+    computeFileDiffStats,
+    formatDiffStat,
+    getFileNameFromPath,
+} from "../diff/reviewDiff";
+import { DiffZoomControls } from "./DiffZoomControls";
+import { EditedFileDiffPreview } from "./editedFilesPresentation";
+import { ResizableDiffContainer } from "./ResizableDiffContainer";
+import {
+    canOpenAiEditedFileByAbsolutePath,
+    openAiEditedFileByAbsolutePath,
+} from "../chatFileNavigation";
+import { useChatRowUiEntry } from "./chatRowUiPresentation";
+import type { AIChatMessage, AIFileDiff } from "../types";
+
+interface ChangeReviewToolRailProps {
+    readonly diffs: readonly AIFileDiff[];
+    readonly diffZoom: number;
+    readonly lineWrapping: boolean;
+    readonly message: AIChatMessage;
+    readonly onDiffZoomChange: (zoom: number) => void;
+    readonly sessionId?: string | null;
+}
+
+interface OpenFileContextMenuPayload {
+    readonly target: string;
+}
+
+function Chevron({ expanded }: { readonly expanded: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="10"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="2"
+            style={{
+                transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+                transition: "transform 140ms ease",
+            }}
+            viewBox="0 0 24 24"
+            width="10"
+        >
+            <polyline points="8 6 14 12 8 18" />
+        </svg>
+    );
+}
+
+function WarningIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="14"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.5"
+            viewBox="0 0 24 24"
+            width="14"
+        >
+            <path d="M12 3 2 21h20L12 3Z" />
+            <path d="M12 9v4" />
+            <circle cx="12" cy="17" fill="currentColor" r="0.75" />
+        </svg>
+    );
+}
+
+function getToolActionLabel(toolKind: string) {
+    switch (toolKind.toLowerCase()) {
+        case "create":
+        case "write":
+            return "Created";
+        case "delete":
+        case "remove":
+            return "Deleted";
+        case "move":
+        case "rename":
+            return "Moved";
+        default:
+            return "Edited";
+    }
+}
+
+function getDiffBadge(diff: AIFileDiff) {
+    if (diff.reversible === false) return "Partial";
+    if (diff.kind === "add") return "New file";
+    if (diff.kind === "delete") return "Deleted";
+    if (diff.kind === "move") {
+        const previous = diff.previous_path
+            ? getFileNameFromPath(diff.previous_path)
+            : null;
+        return previous ? `Moved from ${previous}` : "Moved";
+    }
+    return null;
+}
+
+function getAccent(toolKind: string, status: string) {
+    if (status === "failed" || status === "error") return "#f87171";
+    if (toolKind === "delete" || toolKind === "remove") {
+        return "var(--diff-remove)";
+    }
+    return "var(--accent)";
+}
+
+function ChangeReviewToolRailRow({
+    diff,
+    diffZoom,
+    expanded,
+    lineWrapping,
+    message,
+    onDiffZoomChange,
+    onToggle,
+}: {
+    readonly diff: AIFileDiff;
+    readonly diffZoom: number;
+    readonly expanded: boolean;
+    readonly lineWrapping: boolean;
+    readonly message: AIChatMessage;
+    readonly onDiffZoomChange: (zoom: number) => void;
+    readonly onToggle: () => void;
+}) {
+    const [contextMenu, setContextMenu] =
+        useState<ContextMenuState<OpenFileContextMenuPayload> | null>(null);
+    const toolKind = String(message.meta?.tool ?? "").toLowerCase();
+    const status = String(message.meta?.status ?? "").toLowerCase();
+    const fileName = getFileNameFromPath(diff.path);
+    const actionLabel = getToolActionLabel(toolKind);
+    const accent = getAccent(toolKind, status);
+    const stats = computeFileDiffStats(diff);
+    const badge = getDiffBadge(diff);
+    const openPath =
+        diff.kind === "delete"
+            ? null
+            : (message.meta?.target ? String(message.meta.target) : diff.path);
+    const canOpen = openPath
+        ? canOpenAiEditedFileByAbsolutePath(openPath)
+        : false;
+    const isFailed = status === "failed" || status === "error";
+    const isInProgress = status === "in_progress" || status === "pending";
+
+    return (
+        <div
+            className="min-w-0 max-w-full select-none"
+            data-change-review-path={diff.path}
+            data-change-review-surface="rail-row"
+            style={{
+                color: "var(--text-secondary)",
+                fontFamily: "var(--font-mono), ui-monospace, monospace",
+                fontSize: "0.82em",
+            }}
+        >
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-2">
+                <span
+                    aria-hidden="true"
+                    className="shrink-0"
+                    style={{ color: accent, display: "inline-flex" }}
+                >
+                    {isFailed ? (
+                        <WarningIcon />
+                    ) : (
+                        <FileTypeIcon fileName={diff.path} opacity={0.85} size={14} />
+                    )}
+                </span>
+                <span className="shrink-0 opacity-70">{actionLabel}</span>
+                {canOpen && openPath ? (
+                    <button
+                        aria-label={`Open ${openPath}`}
+                        className="min-w-0 truncate text-left text-text-primary underline decoration-text-secondary/40 underline-offset-2 hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--accent)]"
+                        onClick={() => void openAiEditedFileByAbsolutePath(openPath)}
+                        onContextMenu={(event) => {
+                            event.preventDefault();
+                            setContextMenu({
+                                x: event.clientX,
+                                y: event.clientY,
+                                payload: { target: openPath },
+                            });
+                        }}
+                        title={openPath}
+                        type="button"
+                    >
+                        {fileName}
+                    </button>
+                ) : (
+                    <span
+                        className="min-w-0 truncate text-text-primary"
+                        title={diff.path}
+                    >
+                        {fileName}
+                    </span>
+                )}
+                <span className="min-w-0 flex-1" />
+                {badge ? (
+                    <span
+                        className="shrink-0 text-[10px] font-medium"
+                        style={{
+                            color:
+                                diff.reversible === false
+                                    ? "#b45309"
+                                    : diff.kind === "delete"
+                                      ? "var(--diff-remove)"
+                                      : diff.kind === "add"
+                                        ? "var(--diff-add)"
+                                        : "var(--text-secondary)",
+                        }}
+                    >
+                        {badge}
+                    </span>
+                ) : null}
+                {stats.additions > 0 ? (
+                    <span
+                        className="shrink-0 font-bold"
+                        style={{ color: "var(--diff-add)", fontSize: "0.9em" }}
+                    >
+                        +{formatDiffStat(stats.additions, stats.approximate)}
+                    </span>
+                ) : null}
+                {stats.deletions > 0 ? (
+                    <span
+                        className="shrink-0 font-bold"
+                        style={{ color: "var(--diff-remove)", fontSize: "0.9em" }}
+                    >
+                        -{formatDiffStat(stats.deletions, stats.approximate)}
+                    </span>
+                ) : null}
+                <DiffZoomControls
+                    accent={accent}
+                    onZoomChange={onDiffZoomChange}
+                    zoom={diffZoom}
+                />
+                {isInProgress ? (
+                    <span
+                        aria-label="Running"
+                        className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+                        style={{ backgroundColor: "var(--accent)" }}
+                    />
+                ) : null}
+                {isFailed ? (
+                    <span
+                        className="shrink-0 text-[10px] font-semibold uppercase"
+                        style={{ color: "#f87171" }}
+                    >
+                        Failed
+                    </span>
+                ) : null}
+                <button
+                    aria-label={`${expanded ? "Collapse" : "Expand"} inline diff review`}
+                    className="flex h-5 w-5 shrink-0 items-center justify-center rounded text-text-secondary hover:bg-bg-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--accent)]"
+                    onClick={onToggle}
+                    type="button"
+                >
+                    <Chevron expanded={expanded} />
+                </button>
+            </div>
+
+            {expanded ? (
+                <div className="ml-5 mt-1 overflow-hidden border-l border-border pl-2">
+                    <ResizableDiffContainer accent={accent}>
+                        <EditedFileDiffPreview
+                            compactContextLines={0}
+                            compactLineNumbers
+                            diff={diff}
+                            diffZoom={diffZoom}
+                            expanded={expanded}
+                            lineWrapping={lineWrapping}
+                            showWhenEmpty={false}
+                            testId={`diff-content:${diff.path}`}
+                        />
+                    </ResizableDiffContainer>
+                </div>
+            ) : null}
+            {contextMenu ? (
+                <ContextMenu
+                    entries={[
+                        {
+                            label: "Open",
+                            action: () => {
+                                void openAiEditedFileByAbsolutePath(
+                                    contextMenu.payload.target,
+                                );
+                            },
+                        },
+                        {
+                            label: "Open in New Tab",
+                            action: () => {
+                                void openAiEditedFileByAbsolutePath(
+                                    contextMenu.payload.target,
+                                    { newTab: true },
+                                );
+                            },
+                        },
+                    ]}
+                    menu={contextMenu}
+                    onClose={() => setContextMenu(null)}
+                />
+            ) : null}
+        </div>
+    );
+}
+
+export function ChangeReviewToolRail({
+    diffs,
+    diffZoom,
+    lineWrapping,
+    message,
+    onDiffZoomChange,
+    sessionId,
+}: ChangeReviewToolRailProps) {
+    const { rowState, updateRow } = useChatRowUiEntry(sessionId, message.id);
+    const isSingleFile = diffs.length === 1;
+
+    return (
+        <div className="space-y-1" data-change-review-tool-rail="true">
+            {diffs.map((diff) => {
+                const expanded = isSingleFile
+                    ? (rowState?.singleDiffExpanded ?? false)
+                    : (rowState?.diffExpandedByPath?.[diff.path] ?? false);
+
+                return (
+                    <ChangeReviewToolRailRow
+                        diff={diff}
+                        diffZoom={diffZoom}
+                        expanded={expanded}
+                        key={diff.path}
+                        lineWrapping={lineWrapping}
+                        message={message}
+                        onDiffZoomChange={onDiffZoomChange}
+                        onToggle={() =>
+                            updateRow((current) =>
+                                isSingleFile
+                                    ? {
+                                          singleDiffExpanded: !(
+                                              current.singleDiffExpanded ?? false
+                                          ),
+                                      }
+                                    : {
+                                          diffExpandedByPath: {
+                                              ...(current.diffExpandedByPath ?? {}),
+                                              [diff.path]: !current
+                                                  .diffExpandedByPath?.[
+                                                  diff.path
+                                              ],
+                                          },
+                                      },
+                            )
+                        }
+                    />
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -240,10 +240,9 @@ function ChangeReviewToolRailRow({
     const accent = getAccent(toolKind, status);
     const stats = computeFileDiffStats(diff);
     const badge = getDiffBadge(diff);
-    const openPath =
-        diff.kind === "delete"
-            ? null
-            : (message.meta?.target ? String(message.meta.target) : diff.path);
+    // A tool target can describe the operation (or just one file in a batch).
+    // Each rail row must open the file represented by its own diff.
+    const openPath = diff.kind === "delete" ? null : diff.path;
     const canOpen = openPath
         ? canOpenAiEditedFileByAbsolutePath(openPath)
         : false;

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -160,19 +160,29 @@ function ChangeReviewToolRailRow({
             }}
         >
             <div className="flex min-h-7 w-full min-w-0 items-center gap-2 px-2">
-                <span
-                    aria-hidden="true"
-                    className="flex w-3.5 shrink-0 items-center justify-center"
-                    data-change-review-operation-icon="true"
-                    style={{
-                        color: isFailed ? accent : "var(--text-secondary)",
-                    }}
-                >
-                    {isFailed ? (
-                        <WarningIcon />
-                    ) : (
-                        <FileTypeIcon fileName={fileName} size={13} opacity={0.86} />
-                    )}
+                <span className="flex shrink-0 items-center gap-1.5">
+                    <span
+                        aria-hidden="true"
+                        className="flex w-3.5 shrink-0 items-center justify-center"
+                        data-change-review-operation-icon="true"
+                        style={{
+                            color: isFailed ? accent : "var(--text-secondary)",
+                        }}
+                    >
+                        {isFailed ? (
+                            <WarningIcon />
+                        ) : (
+                            <FileTypeIcon
+                                fileName={fileName}
+                                size={13}
+                                opacity={0.86}
+                            />
+                        )}
+                    </span>
+                    <span
+                        aria-hidden="true"
+                        className="flex w-3.5 shrink-0 items-center justify-center"
+                    />
                 </span>
                 <span className="shrink-0 opacity-70">{actionLabel}</span>
                 {canOpen && openPath ? (

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -38,7 +38,6 @@ interface OpenFileContextMenuPayload {
 
 type MarkdownPreviewBlock = {
     content: string;
-    lineNumbers: number[];
 };
 
 const DIFF_PREVIEW_PILL_METRICS: ChatPillMetrics = {
@@ -76,12 +75,6 @@ function getMarkdownPreviewBlocks(diff: AIFileDiff): MarkdownPreviewBlock[] {
         if (displayLines.length > 0) {
             blocks.push({
                 content: displayLines.map((line) => line.text).join("\n"),
-                lineNumbers: displayLines.map(
-                    (line) =>
-                        (hasAdditions
-                            ? line.newLineNumber
-                            : line.oldLineNumber) ?? 0,
-                ),
             });
         }
 
@@ -118,31 +111,9 @@ function MarkdownChangePreview({
             {blocks.map((block, index) => {
                 return (
                     <section
-                        key={`${block.lineNumbers[0] ?? "block"}:${index}`}
+                        key={`${block.content.length}:${index}`}
                         data-markdown-preview-block="true"
-                        style={{
-                            display: "grid",
-                            gridTemplateColumns: "44px minmax(0, 1fr)",
-                        }}
                     >
-                        <div
-                            style={{
-                                padding: "0 6px 0 4px",
-                                borderRight:
-                                    "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
-                                color: "var(--text-secondary)",
-                                fontSize: "0.85em",
-                                opacity: 0.55,
-                                textAlign: "right",
-                                userSelect: "none",
-                            }}
-                        >
-                            {block.lineNumbers.map((lineNumber, lineIndex) => (
-                                <div key={`${lineNumber}:${lineIndex}`}>
-                                    {lineNumber || ""}
-                                </div>
-                            ))}
-                        </div>
                         <MarkdownContent
                             blockQuoteAppearance="plain"
                             className="min-w-0 px-2"

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -1,10 +1,11 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import {
     ContextMenu,
     type ContextMenuState,
 } from "../../../components/context-menu/ContextMenu";
 import {
+    computeDiffLines,
     computeFileDiffStats,
     formatDiffStat,
     getFileNameFromPath,
@@ -19,6 +20,8 @@ import {
 } from "../chatFileNavigation";
 import { useChatRowUiEntry } from "./chatRowUiPresentation";
 import type { AIChatMessage, AIFileDiff } from "../types";
+import { MarkdownContent } from "./MarkdownContent";
+import type { ChatPillMetrics } from "./chatPillMetrics";
 
 interface ChangeReviewToolRailProps {
     readonly diffs: readonly AIFileDiff[];
@@ -31,6 +34,127 @@ interface ChangeReviewToolRailProps {
 
 interface OpenFileContextMenuPayload {
     readonly target: string;
+}
+
+type MarkdownPreviewBlock = {
+    content: string;
+    lineNumbers: number[];
+};
+
+const DIFF_PREVIEW_PILL_METRICS: ChatPillMetrics = {
+    fontSize: 12,
+    lineHeight: 1.3,
+    paddingX: 6,
+    paddingY: 1,
+    radius: 6,
+    gapX: 2,
+    maxWidth: 180,
+    offsetY: 0,
+};
+
+function isMarkdownPath(path: string) {
+    return /\.(?:md|mdx|markdown)$/i.test(path);
+}
+
+function getMarkdownPreviewBlocks(diff: AIFileDiff): MarkdownPreviewBlock[] {
+    const blocks: MarkdownPreviewBlock[] = [];
+    let pendingLines: ReturnType<typeof computeDiffLines> = [];
+
+    const flushPendingLines = () => {
+        if (pendingLines.length === 0) return;
+
+        // Prefer the new side of a modified hunk. Rendering a whole Markdown
+        // block lets tables, lists, and other multi-line structures retain
+        // their syntax instead of treating each changed line in isolation.
+        const hasAdditions = pendingLines.some((line) => line.type === "add");
+        const displayLines = pendingLines.filter(
+            (line) =>
+                line.type === "context" ||
+                line.type === (hasAdditions ? "add" : "remove"),
+        );
+
+        if (displayLines.length > 0) {
+            blocks.push({
+                content: displayLines.map((line) => line.text).join("\n"),
+                lineNumbers: displayLines.map(
+                    (line) =>
+                        (hasAdditions
+                            ? line.newLineNumber
+                            : line.oldLineNumber) ?? 0,
+                ),
+            });
+        }
+
+        pendingLines = [];
+    };
+
+    for (const line of computeDiffLines(diff)) {
+        if (line.type === "separator") {
+            flushPendingLines();
+            continue;
+        }
+        pendingLines.push(line);
+    }
+
+    flushPendingLines();
+    return blocks;
+}
+
+function MarkdownChangePreview({
+    blocks,
+}: {
+    blocks: readonly MarkdownPreviewBlock[];
+}) {
+    return (
+        <div
+            data-testid="markdown-diff-preview"
+            className="flex flex-col py-1"
+            style={{
+                color: "var(--text-primary)",
+                fontSize: "1.06em",
+                lineHeight: 1.55,
+            }}
+        >
+            {blocks.map((block, index) => {
+                return (
+                    <section
+                        key={`${block.lineNumbers[0] ?? "block"}:${index}`}
+                        data-markdown-preview-block="true"
+                        style={{
+                            display: "grid",
+                            gridTemplateColumns: "44px minmax(0, 1fr)",
+                        }}
+                    >
+                        <div
+                            style={{
+                                padding: "0 6px 0 4px",
+                                borderRight:
+                                    "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
+                                color: "var(--text-secondary)",
+                                fontSize: "0.85em",
+                                opacity: 0.55,
+                                textAlign: "right",
+                                userSelect: "none",
+                            }}
+                        >
+                            {block.lineNumbers.map((lineNumber, lineIndex) => (
+                                <div key={`${lineNumber}:${lineIndex}`}>
+                                    {lineNumber || ""}
+                                </div>
+                            ))}
+                        </div>
+                        <MarkdownContent
+                            blockQuoteAppearance="plain"
+                            className="min-w-0 px-2"
+                            content={block.content}
+                            fileReferenceAppearance="link"
+                            pillMetrics={DIFF_PREVIEW_PILL_METRICS}
+                        />
+                    </section>
+                );
+            })}
+        </div>
+    );
 }
 
 function Chevron({ expanded }: { readonly expanded: boolean }) {
@@ -131,6 +255,13 @@ function ChangeReviewToolRailRow({
 }) {
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<OpenFileContextMenuPayload> | null>(null);
+    const markdownPreviewBlocks = useMemo(
+        () => (isMarkdownPath(diff.path) ? getMarkdownPreviewBlocks(diff) : []),
+        [diff],
+    );
+    const [showMarkdownPreview, setShowMarkdownPreview] = useState(
+        () => markdownPreviewBlocks.length > 0,
+    );
     const toolKind = String(message.meta?.tool ?? "").toLowerCase();
     const status = String(message.meta?.status ?? "").toLowerCase();
     const fileName = getFileNameFromPath(diff.path);
@@ -250,6 +381,33 @@ function ChangeReviewToolRailRow({
                     onZoomChange={onDiffZoomChange}
                     zoom={diffZoom}
                 />
+                {markdownPreviewBlocks.length > 0 ? (
+                    <button
+                        type="button"
+                        aria-label={
+                            showMarkdownPreview
+                                ? "Show source diff"
+                                : "Show markdown preview"
+                        }
+                        title={
+                            showMarkdownPreview
+                                ? "Show source diff"
+                                : "Show markdown preview"
+                        }
+                        onClick={() =>
+                            setShowMarkdownPreview((current) => !current)
+                        }
+                        className="p-0 text-[10px] font-medium hover:text-text-primary focus-visible:outline-none focus-visible:underline"
+                        style={{
+                            border: "none",
+                            color: "var(--text-secondary)",
+                            backgroundColor: "transparent",
+                            cursor: "pointer",
+                        }}
+                    >
+                        {showMarkdownPreview ? "View" : "Preview"}
+                    </button>
+                ) : null}
                 {isInProgress ? (
                     <span
                         aria-label="Running"
@@ -276,18 +434,22 @@ function ChangeReviewToolRailRow({
             </div>
 
             {expanded ? (
-                <div className="ml-5 mt-1 overflow-hidden border-l border-border pl-2">
+                <div className="ml-5 mt-1 overflow-hidden pl-2">
                     <ResizableDiffContainer accent={accent}>
-                        <EditedFileDiffPreview
-                            compactContextLines={0}
-                            compactLineNumbers
-                            diff={diff}
-                            diffZoom={diffZoom}
-                            expanded={expanded}
-                            lineWrapping={lineWrapping}
-                            showWhenEmpty={false}
-                            testId={`diff-content:${diff.path}`}
-                        />
+                        {showMarkdownPreview && markdownPreviewBlocks.length > 0 ? (
+                            <MarkdownChangePreview blocks={markdownPreviewBlocks} />
+                        ) : (
+                            <EditedFileDiffPreview
+                                compactContextLines={0}
+                                compactLineNumbers
+                                diff={diff}
+                                diffZoom={diffZoom}
+                                expanded={expanded}
+                                lineWrapping={lineWrapping}
+                                showWhenEmpty={false}
+                                testId={`diff-content:${diff.path}`}
+                            />
+                        )}
                     </ResizableDiffContainer>
                 </div>
             ) : null}

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -159,8 +159,8 @@ function ChangeReviewToolRailRow({
                 fontSize: "0.82em",
             }}
         >
-            <div className="flex min-h-7 w-full min-w-0 items-center gap-2 px-2">
-                <span className="flex shrink-0 items-center gap-1.5">
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-1 px-2">
+                <span className="flex shrink-0 items-center gap-1">
                     <span
                         aria-hidden="true"
                         className="flex w-3.5 shrink-0 items-center justify-center"

--- a/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
+++ b/apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx
@@ -9,6 +9,7 @@ import {
     formatDiffStat,
     getFileNameFromPath,
 } from "../diff/reviewDiff";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 import { DiffZoomControls } from "./DiffZoomControls";
 import { EditedFileDiffPreview } from "./editedFilesPresentation";
 import { ResizableDiffContainer } from "./ResizableDiffContainer";
@@ -17,7 +18,6 @@ import {
     openAiEditedFileByAbsolutePath,
 } from "../chatFileNavigation";
 import { useChatRowUiEntry } from "./chatRowUiPresentation";
-import { ToolIcon } from "./ToolActivityItem";
 import type { AIChatMessage, AIFileDiff } from "../types";
 
 interface ChangeReviewToolRailProps {
@@ -147,13 +147,6 @@ function ChangeReviewToolRailRow({
         : false;
     const isFailed = status === "failed" || status === "error";
     const isInProgress = status === "in_progress" || status === "pending";
-    const operationIconKind =
-        toolKind === "edit" ||
-        toolKind === "update" ||
-        toolKind === "write" ||
-        toolKind === "create"
-            ? "edit"
-            : toolKind;
 
     return (
         <div
@@ -166,17 +159,20 @@ function ChangeReviewToolRailRow({
                 fontSize: "0.82em",
             }}
         >
-            <div className="flex min-h-7 w-full min-w-0 items-center gap-2">
+            <div className="flex min-h-7 w-full min-w-0 items-center gap-2 px-2">
                 <span
                     aria-hidden="true"
-                    className="shrink-0"
+                    className="flex w-3.5 shrink-0 items-center justify-center"
                     data-change-review-operation-icon="true"
                     style={{
                         color: isFailed ? accent : "var(--text-secondary)",
-                        display: "inline-flex",
                     }}
                 >
-                    {isFailed ? <WarningIcon /> : <ToolIcon kind={operationIconKind} />}
+                    {isFailed ? (
+                        <WarningIcon />
+                    ) : (
+                        <FileTypeIcon fileName={fileName} size={13} opacity={0.86} />
+                    )}
                 </span>
                 <span className="shrink-0 opacity-70">{actionLabel}</span>
                 {canOpen && openPath ? (

--- a/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
+++ b/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
@@ -1,37 +1,42 @@
-import type { CSSProperties, MouseEventHandler } from "react";
+import type { CSSProperties, MouseEventHandler, ReactNode } from "react";
 import { type ChatPillMetrics } from "./chatPillMetrics";
 import { CHAT_PILL_VARIANTS, type ChatPillVariant } from "./chatPillPalette";
 
 interface ChatInlinePillProps {
+    appearance?: "link" | "pill";
     label: string;
     metrics: ChatPillMetrics;
     title?: string;
     interactive?: boolean;
+    leadingVisual?: ReactNode;
     variant?: ChatPillVariant;
     onClick?: () => void;
     onContextMenu?: MouseEventHandler<HTMLElement>;
 }
 
 export function ChatInlinePill({
+    appearance = "pill",
     label,
     metrics,
     title,
     interactive = false,
+    leadingVisual,
     variant = "accent",
     onClick,
     onContextMenu,
 }: ChatInlinePillProps) {
     const palette = CHAT_PILL_VARIANTS[variant];
     const clickable = interactive || typeof onClick === "function";
+    const isLink = appearance === "link";
     const style: CSSProperties = {
         display: "inline-flex",
         alignItems: "center",
         margin: `0 ${metrics.gapX}px`,
-        padding: `${metrics.paddingY}px ${metrics.paddingX}px`,
+        padding: isLink ? 0 : `${metrics.paddingY}px ${metrics.paddingX}px`,
         maxInlineSize: "100%",
-        borderRadius: metrics.radius,
-        background: palette.background,
-        color: palette.color,
+        borderRadius: isLink ? 2 : metrics.radius,
+        background: isLink ? "transparent" : palette.background,
+        color: isLink ? "var(--accent)" : palette.color,
         fontSize: metrics.fontSize,
         lineHeight: metrics.lineHeight,
         border: "none",
@@ -39,23 +44,44 @@ export function ChatInlinePill({
         fontFamily: "inherit",
         verticalAlign: "baseline",
         overflowWrap: "anywhere",
-        transform: `translateY(${metrics.offsetY}px)`,
+        transform: `translateY(${isLink ? 2 : metrics.offsetY}px)`,
+        filter: "brightness(1)",
         opacity: clickable ? 0.85 : 1,
-        transition: clickable ? "opacity 80ms ease" : undefined,
+        transition: clickable
+            ? "opacity 80ms ease, filter 80ms ease"
+            : undefined,
     };
 
     const content = (
         <span
             style={{
-                display: "block",
+                alignItems: "center",
+                display: "inline-flex",
+                gap: leadingVisual ? 4 : 0,
                 minWidth: 0,
                 maxWidth: "100%",
-                overflowWrap: "anywhere",
-                whiteSpace: "normal",
-                wordBreak: "break-word",
             }}
         >
-            {label}
+            {leadingVisual ? (
+                <span
+                    aria-hidden="true"
+                    style={{ display: "inline-flex", flexShrink: 0 }}
+                >
+                    {leadingVisual}
+                </span>
+            ) : null}
+            <span
+                style={{
+                    display: "block",
+                    minWidth: 0,
+                    maxWidth: "100%",
+                    overflowWrap: "anywhere",
+                    whiteSpace: "normal",
+                    wordBreak: "break-word",
+                }}
+            >
+                {label}
+            </span>
         </span>
     );
 
@@ -69,9 +95,11 @@ export function ChatInlinePill({
                 title={title ?? label}
                 onMouseEnter={(e) => {
                     e.currentTarget.style.opacity = "1";
+                    e.currentTarget.style.filter = "brightness(1.08)";
                 }}
                 onMouseLeave={(e) => {
                     e.currentTarget.style.opacity = "0.85";
+                    e.currentTarget.style.filter = "brightness(1)";
                 }}
             >
                 {content}

--- a/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.test.tsx
+++ b/apps/desktop/src/features/ai/components/HistoryTranscriptViewer.test.tsx
@@ -121,4 +121,56 @@ describe("HistoryTranscriptViewer", () => {
             marginInline: "auto",
         });
     });
+
+    it("renders persisted tool activity through the read-only activity rail", () => {
+        const session = createEmptyPersistedSession("history-activity-rail", {
+            messages: [
+                {
+                    id: "history-tool-1",
+                    role: "assistant",
+                    kind: "tool",
+                    content: "Read project notes",
+                    title: "Read project notes",
+                    timestamp: 10,
+                    meta: {
+                        status: "completed",
+                        target: "/vault/notes/project.md",
+                        tool: "read",
+                    },
+                },
+                {
+                    id: "history-tool-2",
+                    role: "assistant",
+                    kind: "tool",
+                    content: "Search project notes",
+                    title: "Search project notes",
+                    timestamp: 11,
+                    meta: {
+                        status: "completed",
+                        tool: "search",
+                    },
+                },
+            ],
+        });
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [],
+            ensureSessionTranscriptLoaded: vi.fn().mockResolvedValue(true),
+            sessionsById: {
+                [session.sessionId]: session,
+            },
+        }));
+
+        const view = renderComponent(
+            <HistoryTranscriptViewer historySessionId={session.sessionId} />,
+        );
+
+        expect(
+            view.container.querySelector('[data-activity-rail="true"]'),
+        ).toHaveAttribute("data-activity-count", "2");
+        expect(
+            view.container.querySelectorAll("[data-tool-activity-id]"),
+        ).toHaveLength(0);
+    });
 });

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -34,7 +34,7 @@ describe("MarkdownContent", () => {
         );
 
         const pill = screen.getByRole("button", { name: longLabel });
-        const label = pill.querySelector("span");
+        const label = pill.querySelector("span > span");
 
         expect(pill).toBeInTheDocument();
         expect(label).toHaveTextContent(longLabel);
@@ -69,6 +69,83 @@ describe("MarkdownContent", () => {
         expect(
             screen.queryByRole("link", { name: "README" }),
         ).not.toBeInTheDocument();
+    });
+
+    it("renders chat file references as icon-led links", () => {
+        setVaultEntries([
+            {
+                id: "src/main.ts",
+                path: "/vault/src/main.ts",
+                relative_path: "src/main.ts",
+                title: "main.ts",
+                file_name: "main.ts",
+                extension: "ts",
+                kind: "file",
+                modified_at: 0,
+                created_at: 0,
+                size: 32,
+                mime_type: "text/typescript",
+            },
+        ]);
+
+        renderComponent(
+            <MarkdownContent
+                content="Read [main.ts](src/main.ts)."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        const reference = screen.getByRole("button", { name: "main.ts" });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+    });
+
+    it("renders indexed folders as non-interactive icon links in every supported syntax", () => {
+        setVaultEntries([
+            {
+                id: "docs",
+                path: "/vault/docs",
+                relative_path: "docs",
+                title: "docs",
+                file_name: "docs",
+                extension: "",
+                kind: "folder",
+                modified_at: 0,
+                created_at: 0,
+                size: 0,
+                mime_type: null,
+            },
+        ]);
+
+        const { container } = renderComponent(
+            <MarkdownContent
+                content="Inline `/vault/docs`, [docs](docs), and /vault/docs"
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        const folders = container.querySelectorAll<HTMLElement>(
+            '[title="docs"], [title="/vault/docs"]',
+        );
+        expect(folders).toHaveLength(3);
+        expect(container.querySelectorAll('button[title="docs"]')).toHaveLength(
+            0,
+        );
+        expect(
+            container.querySelectorAll('button[title="/vault/docs"]'),
+        ).toHaveLength(0);
+        for (const folder of folders) {
+            expect(folder).toHaveStyle({
+                background: "transparent",
+                padding: "0px",
+            });
+            expect(folder.querySelector("svg")).not.toBeNull();
+        }
     });
 
     it("renders raw http and https URLs as external links", () => {
@@ -125,6 +202,7 @@ describe("MarkdownContent", () => {
         renderComponent(
             <MarkdownContent
                 content="Coincide con [apps/web-clipper/package.json](apps/web-clipper/package.json)."
+                fileReferenceAppearance="link"
                 pillMetrics={pillMetrics}
             />,
         );
@@ -428,18 +506,19 @@ describe("MarkdownContent", () => {
         expect(preview.querySelector("ol")).toHaveTextContent(
             "First itemSecond item",
         );
-        expect(screen.getByRole("button", { name: "Preview" })).toHaveAttribute(
-            "aria-pressed",
-            "true",
-        );
+        const toggle = screen.getByRole("button", {
+            name: "Toggle markdown display mode",
+        });
+        expect(toggle).toHaveAttribute("title", "Show source");
 
-        fireEvent.click(screen.getByRole("button", { name: "Source" }));
+        fireEvent.click(toggle);
 
         expect(screen.queryByTestId("chat-markdown-preview")).toBeNull();
-        expect(screen.getByRole("button", { name: "Source" })).toHaveAttribute(
-            "aria-pressed",
-            "true",
-        );
+        expect(
+            screen.getByRole("button", {
+                name: "Toggle markdown display mode",
+            }),
+        ).toHaveAttribute("title", "Show preview");
         expect(screen.getByText((_text, node) => node?.tagName === "CODE")).toHaveTextContent(
             /# Rendered heading.*1\. First item.*2\. Second item/s,
         );

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -372,7 +372,9 @@ describe("MarkdownContent", () => {
             />,
         );
 
-        expect(screen.getByText("C++")).toHaveClass("chat-code-header");
+        expect(screen.getByText("C++").parentElement).toHaveClass(
+            "chat-code-header",
+        );
 
         await waitFor(() => {
             expect(
@@ -393,12 +395,54 @@ describe("MarkdownContent", () => {
             />,
         );
 
-        expect(screen.getByText("Bash")).toHaveClass("chat-code-header");
+        expect(screen.getByText("Bash").parentElement).toHaveClass(
+            "chat-code-header",
+        );
         expect(screen.getByRole("button", { name: "Copy code block" })).toHaveClass(
             "chat-code-copy-button",
         );
         expect(container.querySelector(".chat-code-frame")).not.toBeNull();
         expect(container.querySelector(".chat-code-block")).not.toBeNull();
+    });
+
+    it("previews markdown fences and lets the user inspect their source", () => {
+        renderComponent(
+            <MarkdownContent
+                content={[
+                    "```markdown",
+                    "# Rendered heading",
+                    "",
+                    "1. First item",
+                    "2. Second item",
+                    "```",
+                ].join("\n")}
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        const preview = screen.getByTestId("chat-markdown-preview");
+        expect(preview).toHaveTextContent("Rendered heading");
+        expect(preview.querySelector(".nw-md-heading")).toHaveTextContent(
+            "Rendered heading",
+        );
+        expect(preview.querySelector("ol")).toHaveTextContent(
+            "First itemSecond item",
+        );
+        expect(screen.getByRole("button", { name: "Preview" })).toHaveAttribute(
+            "aria-pressed",
+            "true",
+        );
+
+        fireEvent.click(screen.getByRole("button", { name: "Source" }));
+
+        expect(screen.queryByTestId("chat-markdown-preview")).toBeNull();
+        expect(screen.getByRole("button", { name: "Source" })).toHaveAttribute(
+            "aria-pressed",
+            "true",
+        );
+        expect(screen.getByText((_text, node) => node?.tagName === "CODE")).toHaveTextContent(
+            /# Rendered heading.*1\. First item.*2\. Second item/s,
+        );
     });
 
     it("renders markdown tables as semantic table markup", () => {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -372,7 +372,7 @@ describe("MarkdownContent", () => {
             />,
         );
 
-        expect(screen.getByText("c++")).toBeInTheDocument();
+        expect(screen.getByText("C++")).toHaveClass("chat-code-header");
 
         await waitFor(() => {
             expect(
@@ -383,6 +383,22 @@ describe("MarkdownContent", () => {
         expect(screen.getByText("return")).toHaveClass(
             "cm-static-token-keyword",
         );
+    });
+
+    it("uses the compact Comando frame for chat code fences", () => {
+        const { container } = renderComponent(
+            <MarkdownContent
+                content={["```bash", "git status", "```"].join("\n")}
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(screen.getByText("Bash")).toHaveClass("chat-code-header");
+        expect(screen.getByRole("button", { name: "Copy code block" })).toHaveClass(
+            "chat-code-copy-button",
+        );
+        expect(container.querySelector(".chat-code-frame")).not.toBeNull();
+        expect(container.querySelector(".chat-code-block")).not.toBeNull();
     });
 
     it("renders markdown tables as semantic table markup", () => {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -474,14 +474,7 @@ function renderInlineMarkdown(
                 );
             } else {
                 parts.push(
-                    <code
-                        key={key}
-                        className="rounded px-1.5 py-0.5 text-[0.85em]"
-                        style={{
-                            backgroundColor: "var(--bg-tertiary)",
-                            color: "var(--accent)",
-                        }}
-                    >
+                    <code key={key} className="chat-inline-code">
                         {codeText}
                     </code>,
                 );

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -1274,21 +1274,26 @@ function formatCodeLanguageLabel(language?: string) {
 function CodeBlock({
     content,
     info,
+    pillMetrics,
     chatFontSize = 14,
 }: {
     content: string;
     info?: string;
+    pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
 }) {
     const [copied, setCopied] = useState(false);
+    const [showMarkdownSource, setShowMarkdownSource] = useState(false);
     const languageSupport = useMarkdownCodeLanguageSupport(info);
     const languageToken = extractFenceLanguageToken(info ?? "");
+    const normalizedLanguage = languageToken?.toLowerCase();
     const languageLabel = formatCodeLanguageLabel(
         languageToken ?? info?.trim(),
     );
+    const isMarkdownFence =
+        normalizedLanguage === "markdown" || normalizedLanguage === "md";
     const isUnifiedDiff =
-        languageToken?.toLowerCase() === "diff" ||
-        languageToken?.toLowerCase() === "patch";
+        normalizedLanguage === "diff" || normalizedLanguage === "patch";
     const diffLines = useMemo(
         () => (isUnifiedDiff ? computeUnifiedDiffLines(content) : []),
         [content, isUnifiedDiff],
@@ -1344,10 +1349,42 @@ function CodeBlock({
                         fontSize: languageLabelFontSize,
                     }}
                 >
-                    {languageLabel}
+                    <span>{languageLabel}</span>
+                    {isMarkdownFence ? (
+                        <span
+                            aria-label="Markdown display mode"
+                            className="chat-code-mode-toggle"
+                            role="group"
+                        >
+                            <button
+                                aria-pressed={!showMarkdownSource}
+                                className="chat-code-mode-button"
+                                onClick={() => setShowMarkdownSource(false)}
+                                type="button"
+                            >
+                                Preview
+                            </button>
+                            <button
+                                aria-pressed={showMarkdownSource}
+                                className="chat-code-mode-button"
+                                onClick={() => setShowMarkdownSource(true)}
+                                type="button"
+                            >
+                                Source
+                            </button>
+                        </span>
+                    ) : null}
                 </div>
             ) : null}
-            {diffLines.length > 0 ? (
+            {isMarkdownFence && !showMarkdownSource ? (
+                <div
+                    className="chat-markdown-preview"
+                    data-testid="chat-markdown-preview"
+                    style={{ fontSize: chatFontSize }}
+                >
+                    <TextBlock content={content} pillMetrics={pillMetrics} />
+                </div>
+            ) : diffLines.length > 0 ? (
                 <div
                     className="max-w-full overflow-auto leading-relaxed"
                     style={{
@@ -1415,6 +1452,7 @@ export const MarkdownContent = memo(function MarkdownContent({
                         key={i}
                         content={block.content}
                         info={block.info}
+                        pillMetrics={pillMetrics}
                         chatFontSize={chatFontSize}
                     />
                 ) : (

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -49,6 +49,7 @@ interface MarkdownContentProps {
     className?: string;
     pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
+    blockQuoteAppearance?: "accent" | "plain";
     /**
      * Visual treatment for inline vault references. Chat surfaces pass "link"
      * for the accent-colored, icon-led appearance; other surfaces keep "pill".
@@ -866,10 +867,12 @@ function TextBlock({
     content,
     pillMetrics,
     fileReferenceAppearance = "pill",
+    blockQuoteAppearance = "accent",
 }: {
     content: string;
     pillMetrics: ChatPillMetrics;
     fileReferenceAppearance?: FileReferenceAppearance;
+    blockQuoteAppearance?: "accent" | "plain";
 }) {
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<MarkdownPillContextMenuPayload> | null>(null);
@@ -1198,9 +1201,12 @@ function TextBlock({
             elements.push(
                 <blockquote
                     key={elements.length}
-                    className="my-1 border-l-2 pl-3 italic"
+                    className={
+                        blockQuoteAppearance === "accent"
+                            ? "my-1 border-l-2 pl-3 italic"
+                            : "my-1 italic"
+                    }
                     style={{
-                        borderColor: "var(--accent)",
                         color: "var(--text-secondary)",
                         overflowWrap: "anywhere",
                         wordBreak: "break-word",
@@ -1563,6 +1569,7 @@ export const MarkdownContent = memo(function MarkdownContent({
     className,
     pillMetrics,
     chatFontSize = 14,
+    blockQuoteAppearance = "accent",
     fileReferenceAppearance = "pill",
 }: MarkdownContentProps) {
     const blocks = useMemo(() => parseBlocks(content), [content]);
@@ -1592,6 +1599,7 @@ export const MarkdownContent = memo(function MarkdownContent({
                         key={i}
                         content={block.content}
                         pillMetrics={pillMetrics}
+                        blockQuoteAppearance={blockQuoteAppearance}
                         fileReferenceAppearance={fileReferenceAppearance}
                     />
                 ),

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -1312,36 +1312,54 @@ function CodeBlock({
         <div
             className={`chat-code-frame group relative my-1 min-w-0 max-w-full overflow-hidden${languageLabel ? "" : " chat-code-frame--unlabeled"}`}
         >
-            <button
-                type="button"
-                onClick={handleCopy}
-                aria-label="Copy code block"
-                title={copied ? "Copied" : "Copy"}
-                className="chat-code-copy-button absolute z-10 flex items-center justify-center"
-                style={{
-                    color: copied ? "var(--accent)" : "var(--text-secondary)",
-                }}
-            >
-                <svg
-                    width="11"
-                    height="11"
-                    viewBox="0 0 14 14"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
+            <div className="chat-code-actions absolute z-10 flex items-center">
+                {isMarkdownFence ? (
+                    <button
+                        type="button"
+                        aria-label="Toggle markdown display mode"
+                        title={showMarkdownSource ? "Show preview" : "Show source"}
+                        onClick={() =>
+                            setShowMarkdownSource((value) => !value)
+                        }
+                        className="chat-code-mode-button"
+                        style={{ fontSize: languageLabelFontSize }}
+                    >
+                        {showMarkdownSource ? "Preview" : "Source"}
+                    </button>
+                ) : null}
+                <button
+                    type="button"
+                    onClick={handleCopy}
+                    aria-label="Copy code block"
+                    title={copied ? "Copied" : "Copy"}
+                    className="chat-code-copy-button flex items-center justify-center"
+                    style={{
+                        color: copied
+                            ? "var(--accent)"
+                            : "var(--text-secondary)",
+                    }}
                 >
-                    {copied ? (
-                        <path d="M3 7l2.2 2.2L11 3.8" />
-                    ) : (
-                        <>
-                            <rect x="5" y="3" width="6" height="8" rx="1.2" />
-                            <path d="M3.5 9.5H3A1 1 0 012 8.5v-5A1.5 1.5 0 013.5 2H8" />
-                        </>
-                    )}
-                </svg>
-            </button>
+                    <svg
+                        width="11"
+                        height="11"
+                        viewBox="0 0 14 14"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        {copied ? (
+                            <path d="M3 7l2.2 2.2L11 3.8" />
+                        ) : (
+                            <>
+                                <rect x="5" y="3" width="6" height="8" rx="1.2" />
+                                <path d="M3.5 9.5H3A1 1 0 012 8.5v-5A1.5 1.5 0 013.5 2H8" />
+                            </>
+                        )}
+                    </svg>
+                </button>
+            </div>
             {languageLabel ? (
                 <div
                     className="chat-code-header"
@@ -1350,30 +1368,6 @@ function CodeBlock({
                     }}
                 >
                     <span>{languageLabel}</span>
-                    {isMarkdownFence ? (
-                        <span
-                            aria-label="Markdown display mode"
-                            className="chat-code-mode-toggle"
-                            role="group"
-                        >
-                            <button
-                                aria-pressed={!showMarkdownSource}
-                                className="chat-code-mode-button"
-                                onClick={() => setShowMarkdownSource(false)}
-                                type="button"
-                            >
-                                Preview
-                            </button>
-                            <button
-                                aria-pressed={showMarkdownSource}
-                                className="chat-code-mode-button"
-                                onClick={() => setShowMarkdownSource(true)}
-                                type="button"
-                            >
-                                Source
-                            </button>
-                        </span>
-                    ) : null}
                 </div>
             ) : null}
             {isMarkdownFence && !showMarkdownSource ? (

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -1208,6 +1208,69 @@ function TextBlock({
     );
 }
 
+const codeLanguageLabels: Record<string, string> = {
+    bash: "Bash",
+    c: "C",
+    "c++": "C++",
+    cpp: "C++",
+    cs: "C#",
+    csharp: "C#",
+    css: "CSS",
+    diff: "Diff",
+    docker: "Dockerfile",
+    dockerfile: "Dockerfile",
+    gql: "GraphQL",
+    graphql: "GraphQL",
+    html: "HTML",
+    java: "Java",
+    javascript: "JavaScript",
+    js: "JavaScript",
+    json: "JSON",
+    jsonc: "JSONC",
+    jsx: "JSX",
+    make: "Makefile",
+    makefile: "Makefile",
+    markdown: "Markdown",
+    md: "Markdown",
+    mdx: "MDX",
+    php: "PHP",
+    powershell: "PowerShell",
+    ps1: "PowerShell",
+    pwsh: "PowerShell",
+    py: "Python",
+    python: "Python",
+    rb: "Ruby",
+    rs: "Rust",
+    ruby: "Ruby",
+    rust: "Rust",
+    scss: "SCSS",
+    sh: "Shell",
+    shell: "Shell",
+    sql: "SQL",
+    text: "Text",
+    ts: "TypeScript",
+    tsx: "TSX",
+    typescript: "TypeScript",
+    xml: "XML",
+    yaml: "YAML",
+    yml: "YAML",
+    zsh: "Zsh",
+};
+
+function formatCodeLanguageLabel(language?: string) {
+    const normalizedLanguage = language?.trim().toLowerCase();
+    if (!normalizedLanguage) return undefined;
+
+    return (
+        codeLanguageLabels[normalizedLanguage] ??
+        normalizedLanguage
+            .split(/[-_]+/)
+            .filter(Boolean)
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(" ")
+    );
+}
+
 function CodeBlock({
     content,
     info,
@@ -1220,10 +1283,9 @@ function CodeBlock({
     const [copied, setCopied] = useState(false);
     const languageSupport = useMarkdownCodeLanguageSupport(info);
     const languageToken = extractFenceLanguageToken(info ?? "");
-    const languageLabel =
-        languageToken?.toLowerCase() === "md"
-            ? "Markdown"
-            : (languageToken ?? info?.trim());
+    const languageLabel = formatCodeLanguageLabel(
+        languageToken ?? info?.trim(),
+    );
     const isUnifiedDiff =
         languageToken?.toLowerCase() === "diff" ||
         languageToken?.toLowerCase() === "patch";
@@ -1243,28 +1305,16 @@ function CodeBlock({
 
     return (
         <div
-            className="group relative my-2 min-w-0 max-w-full overflow-hidden rounded-lg"
-            style={{
-                backgroundColor: "var(--bg-tertiary)",
-                border: "1px solid var(--border)",
-            }}
+            className={`chat-code-frame group relative my-1 min-w-0 max-w-full overflow-hidden${languageLabel ? "" : " chat-code-frame--unlabeled"}`}
         >
             <button
                 type="button"
                 onClick={handleCopy}
                 aria-label="Copy code block"
                 title={copied ? "Copied" : "Copy"}
-                className="absolute right-2 z-10 flex items-center justify-center rounded-md"
+                className="chat-code-copy-button absolute z-10 flex items-center justify-center"
                 style={{
-                    top: languageLabel ? 5 : 8,
-                    width: 22,
-                    height: 22,
-                    border: "1px solid var(--border)",
-                    backgroundColor:
-                        "color-mix(in srgb, var(--bg-elevated) 92%, transparent)",
                     color: copied ? "var(--accent)" : "var(--text-secondary)",
-                    opacity: 0.9,
-                    cursor: "pointer",
                 }}
             >
                 <svg
@@ -1289,11 +1339,9 @@ function CodeBlock({
             </button>
             {languageLabel ? (
                 <div
-                    className="px-3 py-2 pr-10 uppercase tracking-wider"
+                    className="chat-code-header"
                     style={{
                         fontSize: languageLabelFontSize,
-                        color: "var(--text-secondary)",
-                        borderBottom: "1px solid var(--border)",
                     }}
                 >
                     {languageLabel}
@@ -1314,7 +1362,7 @@ function CodeBlock({
                 </div>
             ) : (
                 <pre
-                    className="max-w-full overflow-y-auto p-3 leading-relaxed"
+                    className="chat-code-block max-w-full overflow-y-auto leading-relaxed"
                     style={{
                         fontSize: codeFontSize,
                         margin: 0,

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -3,6 +3,7 @@ import {
     useMemo,
     useState,
     type MouseEvent,
+    type MouseEventHandler,
     type ReactElement,
     type ReactNode,
 } from "react";
@@ -17,6 +18,9 @@ import {
 } from "../../../app/utils/vaultEntries";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { resolveVaultAbsolutePath } from "../../../app/utils/vaultPaths";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import { FolderTypeIcon } from "../../../components/icons/FolderTypeIcon";
+import type { ChatPillVariant } from "./chatPillPalette";
 import {
     DIFF_PANEL_MAX_HEIGHT,
     computeUnifiedDiffLines,
@@ -45,6 +49,11 @@ interface MarkdownContentProps {
     className?: string;
     pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
+    /**
+     * Visual treatment for inline vault references. Chat surfaces pass "link"
+     * for the accent-colored, icon-led appearance; other surfaces keep "pill".
+     */
+    fileReferenceAppearance?: FileReferenceAppearance;
 }
 
 function safeDecodeUriComponent(value: string) {
@@ -188,6 +197,97 @@ function parseRelativeTextFileReference(value: string) {
         path: resolvedPath,
         fileName: resolvedPath.split("/").pop() ?? resolvedPath,
     };
+}
+
+/**
+ * Resolves a vault folder reference. Unlike file references, folders are only
+ * recognized when the vault index actually knows the path as a directory, so
+ * extension-less prose never masquerades as a folder link.
+ */
+function parseVaultFolderReference(
+    value: string,
+    options?: { allowRelative?: boolean },
+) {
+    const trimmed = value.trim();
+    const resolvedPath = resolveVaultLocalPath(trimmed, options);
+    if (!resolvedPath) return null;
+    if (
+        parseVaultReference(resolvedPath) ||
+        parseExcalidrawReference(trimmed) ||
+        parsePdfReference(trimmed)
+    ) {
+        return null;
+    }
+    const entry = useVaultStore
+        .getState()
+        .entries.find((candidate) => candidate.path === resolvedPath);
+    if (!entry || entry.kind !== "folder") return null;
+
+    return {
+        path: resolvedPath,
+        folderName: resolvedPath.split("/").pop() ?? resolvedPath,
+    };
+}
+
+type FileReferenceAppearance = "link" | "pill";
+
+function referenceIconSize(metrics: ChatPillMetrics) {
+    return Math.max(11, Math.min(14, metrics.fontSize));
+}
+
+/**
+ * Single owner for inline vault references (notes, files, PDFs, drawings and
+ * folders). Every parser branch funnels through here so the link appearance and
+ * leading icon stay consistent; folders stay non-interactive per Comando.
+ */
+function renderReferencePill(params: {
+    key: number;
+    label: string;
+    title: string;
+    variant: ChatPillVariant;
+    metrics: ChatPillMetrics;
+    appearance: FileReferenceAppearance;
+    iconPath: string;
+    isFolder?: boolean;
+    onClick?: () => void;
+    onContextMenu?: MouseEventHandler<HTMLElement>;
+}): ReactElement {
+    const leadingVisual =
+        params.appearance === "link" ? (
+            params.isFolder ? (
+                <FolderTypeIcon
+                    folderName={params.iconPath}
+                    opacity={1}
+                    open={false}
+                    size={referenceIconSize(params.metrics)}
+                />
+            ) : (
+                <FileTypeIcon
+                    fileName={params.iconPath}
+                    opacity={1}
+                    size={referenceIconSize(params.metrics)}
+                />
+            )
+        ) : undefined;
+
+    return (
+        <ChatInlinePill
+            appearance={params.appearance}
+            interactive={params.onClick != null}
+            key={params.key}
+            label={params.label}
+            leadingVisual={leadingVisual}
+            metrics={params.metrics}
+            onClick={params.onClick}
+            onContextMenu={params.onContextMenu}
+            title={params.title}
+            variant={params.variant}
+        />
+    );
+}
+
+function noteIconPath(reference: string) {
+    return /\.md$/i.test(reference) ? reference : `${reference}.md`;
 }
 
 interface Block {
@@ -363,6 +463,7 @@ function renderInlineMarkdown(
     onMapContextMenu?: InlineContextMenuHandler,
     onPdfContextMenu?: InlineContextMenuHandler,
     onFileContextMenu?: InlineContextMenuHandler,
+    appearance: FileReferenceAppearance = "pill",
 ): Array<string | ReactElement> {
     const parts: Array<string | ReactElement> = [];
     // Process: wikilinks, inline code, bold, italic, links, raw URLs, and absolute vault file paths.
@@ -386,17 +487,19 @@ function renderInlineMarkdown(
             const [target, alias] = inner.split("|");
             const label = alias ?? target;
             parts.push(
-                <ChatInlinePill
-                    key={key}
-                    label={label.trim()}
-                    metrics={pillMetrics}
-                    interactive
-                    onClick={() => void openChatNoteByReference(target.trim())}
-                    onContextMenu={(event) =>
-                        onNoteContextMenu(event, target.trim())
-                    }
-                    title={target.trim()}
-                />,
+                renderReferencePill({
+                    key,
+                    label: label.trim(),
+                    title: target.trim(),
+                    variant: "accent",
+                    metrics: pillMetrics,
+                    appearance,
+                    iconPath: noteIconPath(target.trim()),
+                    onClick: () =>
+                        void openChatNoteByReference(target.trim()),
+                    onContextMenu: (event) =>
+                        onNoteContextMenu(event, target.trim()),
+                }),
             );
         } else if (match[2]) {
             // inline code — render vault files as pills
@@ -409,6 +512,10 @@ function renderInlineMarkdown(
                 !parsedReference && !pdfRef
                     ? parseTextFileReference(codeText)
                     : null;
+            const folderRef =
+                !parsedReference && !pdfRef && !textFileRef
+                    ? parseVaultFolderReference(codeText)
+                    : null;
             if (parsedReference) {
                 const fileName =
                     parsedReference.path
@@ -417,60 +524,68 @@ function renderInlineMarkdown(
                         ?.replace(/\.md$/i, "") ??
                     parsedReference.path.replace(/\.md$/i, "");
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="accent"
-                        onClick={() =>
-                            void openChatNoteByReference(parsedReference.path)
-                        }
-                        onContextMenu={(event) =>
-                            onNoteContextMenu(event, parsedReference.path)
-                        }
-                        title={codeText}
-                    />,
+                    renderReferencePill({
+                        key,
+                        label: fileName,
+                        title: codeText,
+                        variant: "accent",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: parsedReference.path,
+                        onClick: () =>
+                            void openChatNoteByReference(parsedReference.path),
+                        onContextMenu: (event) =>
+                            onNoteContextMenu(event, parsedReference.path),
+                    }),
                 );
             } else if (pdfRef) {
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={pdfRef.fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="file"
-                        onClick={() => void openChatPdfByReference(pdfRef.path)}
-                        onContextMenu={
-                            onPdfContextMenu
-                                ? (event) =>
-                                      onPdfContextMenu(event, pdfRef.path)
-                                : undefined
-                        }
-                        title={codeText}
-                    />,
+                    renderReferencePill({
+                        key,
+                        label: pdfRef.fileName,
+                        title: codeText,
+                        variant: "file",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: pdfRef.path,
+                        onClick: () => void openChatPdfByReference(pdfRef.path),
+                        onContextMenu: onPdfContextMenu
+                            ? (event) => onPdfContextMenu(event, pdfRef.path)
+                            : undefined,
+                    }),
                 );
             } else if (textFileRef) {
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={textFileRef.fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="file"
-                        onClick={() =>
+                    renderReferencePill({
+                        key,
+                        label: textFileRef.fileName,
+                        title: codeText,
+                        variant: "file",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: textFileRef.path,
+                        onClick: () =>
                             void openAiEditedFileByAbsolutePath(
                                 textFileRef.path,
-                            )
-                        }
-                        onContextMenu={
-                            onFileContextMenu
-                                ? (event) =>
-                                      onFileContextMenu(event, textFileRef.path)
-                                : undefined
-                        }
-                        title={codeText}
-                    />,
+                            ),
+                        onContextMenu: onFileContextMenu
+                            ? (event) =>
+                                  onFileContextMenu(event, textFileRef.path)
+                            : undefined,
+                    }),
+                );
+            } else if (folderRef) {
+                parts.push(
+                    renderReferencePill({
+                        key,
+                        label: folderRef.folderName,
+                        title: codeText,
+                        variant: "folder",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: folderRef.path,
+                        isFolder: true,
+                    }),
                 );
             } else {
                 parts.push(
@@ -517,76 +632,83 @@ function renderInlineMarkdown(
                 const textFileRef =
                     parseRelativeTextFileReference(decoded) ??
                     parseRelativeTextFileReference(linkMatch[1]);
+                const folderRef =
+                    !excalidrawRef && !pdfLinkRef && !textFileRef
+                        ? (parseVaultFolderReference(decoded, {
+                              allowRelative: true,
+                          }) ??
+                          parseVaultFolderReference(linkMatch[1], {
+                              allowRelative: true,
+                          }))
+                        : null;
                 if (excalidrawRef) {
                     parts.push(
-                        <ChatInlinePill
-                            key={key}
-                            label={excalidrawRef.fileName}
-                            metrics={pillMetrics}
-                            interactive
-                            variant="file"
-                            onClick={() =>
-                                void openChatMapByReference(excalidrawRef.path)
-                            }
-                            onContextMenu={
-                                onMapContextMenu
-                                    ? (event) =>
-                                          onMapContextMenu(
-                                              event,
-                                              excalidrawRef.path,
-                                          )
-                                    : undefined
-                            }
-                            title={decoded}
-                        />,
+                        renderReferencePill({
+                            key,
+                            label: excalidrawRef.fileName,
+                            title: decoded,
+                            variant: "file",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: excalidrawRef.path,
+                            onClick: () =>
+                                void openChatMapByReference(excalidrawRef.path),
+                            onContextMenu: onMapContextMenu
+                                ? (event) =>
+                                      onMapContextMenu(event, excalidrawRef.path)
+                                : undefined,
+                        }),
                     );
                 } else if (pdfLinkRef) {
                     parts.push(
-                        <ChatInlinePill
-                            key={key}
-                            label={pdfLinkRef.fileName}
-                            metrics={pillMetrics}
-                            interactive
-                            variant="file"
-                            onClick={() =>
-                                void openChatPdfByReference(pdfLinkRef.path)
-                            }
-                            onContextMenu={
-                                onPdfContextMenu
-                                    ? (event) =>
-                                          onPdfContextMenu(
-                                              event,
-                                              pdfLinkRef.path,
-                                          )
-                                    : undefined
-                            }
-                            title={decoded}
-                        />,
+                        renderReferencePill({
+                            key,
+                            label: pdfLinkRef.fileName,
+                            title: decoded,
+                            variant: "file",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: pdfLinkRef.path,
+                            onClick: () =>
+                                void openChatPdfByReference(pdfLinkRef.path),
+                            onContextMenu: onPdfContextMenu
+                                ? (event) =>
+                                      onPdfContextMenu(event, pdfLinkRef.path)
+                                : undefined,
+                        }),
                     );
                 } else if (textFileRef) {
                     parts.push(
-                        <ChatInlinePill
-                            key={key}
-                            label={textFileRef.fileName}
-                            metrics={pillMetrics}
-                            interactive
-                            variant="file"
-                            onClick={() =>
+                        renderReferencePill({
+                            key,
+                            label: textFileRef.fileName,
+                            title: decoded,
+                            variant: "file",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: textFileRef.path,
+                            onClick: () =>
                                 void openAiEditedFileByAbsolutePath(
                                     textFileRef.path,
-                                )
-                            }
-                            onContextMenu={
-                                onFileContextMenu
-                                    ? (event) =>
-                                          onFileContextMenu(
-                                              event,
-                                              textFileRef.path,
-                                          )
-                                    : undefined
-                            }
-                            title={decoded}
-                        />,
+                                ),
+                            onContextMenu: onFileContextMenu
+                                ? (event) =>
+                                      onFileContextMenu(event, textFileRef.path)
+                                : undefined,
+                        }),
+                    );
+                } else if (folderRef) {
+                    parts.push(
+                        renderReferencePill({
+                            key,
+                            label: folderRef.folderName,
+                            title: decoded,
+                            variant: "folder",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: folderRef.path,
+                            isFolder: true,
+                        }),
                     );
                 } else if (parsedReference) {
                     const fileName =
@@ -595,22 +717,21 @@ function renderInlineMarkdown(
                             .pop()
                             ?.replace(/\.md$/, "") ?? linkMatch[1];
                     parts.push(
-                        <ChatInlinePill
-                            key={key}
-                            label={fileName}
-                            metrics={pillMetrics}
-                            interactive
-                            variant="accent"
-                            onClick={() =>
+                        renderReferencePill({
+                            key,
+                            label: fileName,
+                            title: decoded,
+                            variant: "accent",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: parsedReference.path,
+                            onClick: () =>
                                 void openChatNoteByReference(
                                     parsedReference.path,
-                                )
-                            }
-                            onContextMenu={(event) =>
-                                onNoteContextMenu(event, parsedReference.path)
-                            }
-                            title={decoded}
-                        />,
+                                ),
+                            onContextMenu: (event) =>
+                                onNoteContextMenu(event, parsedReference.path),
+                        }),
                     );
                 } else {
                     parts.push(renderExternalLink(key, url, linkMatch[1]));
@@ -628,70 +749,77 @@ function renderInlineMarkdown(
             const excalidrawRef = parseExcalidrawReference(filePath);
             const pdfPathRef = parsePdfReference(filePath);
             const textFileRef = parseTextFileReference(filePath);
+            const folderRef =
+                !excalidrawRef && !pdfPathRef && !textFileRef
+                    ? parseVaultFolderReference(filePath)
+                    : null;
             if (excalidrawRef) {
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={excalidrawRef.fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="file"
-                        onClick={() =>
-                            void openChatMapByReference(excalidrawRef.path)
-                        }
-                        onContextMenu={
-                            onMapContextMenu
-                                ? (event) =>
-                                      onMapContextMenu(
-                                          event,
-                                          excalidrawRef.path,
-                                      )
-                                : undefined
-                        }
-                        title={filePath}
-                    />,
+                    renderReferencePill({
+                        key,
+                        label: excalidrawRef.fileName,
+                        title: filePath,
+                        variant: "file",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: excalidrawRef.path,
+                        onClick: () =>
+                            void openChatMapByReference(excalidrawRef.path),
+                        onContextMenu: onMapContextMenu
+                            ? (event) =>
+                                  onMapContextMenu(event, excalidrawRef.path)
+                            : undefined,
+                    }),
                 );
             } else if (pdfPathRef) {
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={pdfPathRef.fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="file"
-                        onClick={() =>
-                            void openChatPdfByReference(pdfPathRef.path)
-                        }
-                        onContextMenu={
-                            onPdfContextMenu
-                                ? (event) =>
-                                      onPdfContextMenu(event, pdfPathRef.path)
-                                : undefined
-                        }
-                        title={filePath}
-                    />,
+                    renderReferencePill({
+                        key,
+                        label: pdfPathRef.fileName,
+                        title: filePath,
+                        variant: "file",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: pdfPathRef.path,
+                        onClick: () =>
+                            void openChatPdfByReference(pdfPathRef.path),
+                        onContextMenu: onPdfContextMenu
+                            ? (event) => onPdfContextMenu(event, pdfPathRef.path)
+                            : undefined,
+                    }),
                 );
             } else if (textFileRef) {
                 parts.push(
-                    <ChatInlinePill
-                        key={key}
-                        label={textFileRef.fileName}
-                        metrics={pillMetrics}
-                        interactive
-                        variant="file"
-                        onClick={() =>
+                    renderReferencePill({
+                        key,
+                        label: textFileRef.fileName,
+                        title: filePath,
+                        variant: "file",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: textFileRef.path,
+                        onClick: () =>
                             void openAiEditedFileByAbsolutePath(
                                 textFileRef.path,
-                            )
-                        }
-                        onContextMenu={
-                            onFileContextMenu
-                                ? (event) =>
-                                      onFileContextMenu(event, textFileRef.path)
-                                : undefined
-                        }
-                        title={filePath}
-                    />,
+                            ),
+                        onContextMenu: onFileContextMenu
+                            ? (event) =>
+                                  onFileContextMenu(event, textFileRef.path)
+                            : undefined,
+                    }),
+                );
+            } else if (folderRef) {
+                parts.push(
+                    renderReferencePill({
+                        key,
+                        label: folderRef.folderName,
+                        title: filePath,
+                        variant: "folder",
+                        metrics: pillMetrics,
+                        appearance,
+                        iconPath: folderRef.path,
+                        isFolder: true,
+                    }),
                 );
             } else {
                 const parsedReference = parseVaultReference(filePath);
@@ -702,20 +830,21 @@ function renderInlineMarkdown(
                             .pop()
                             ?.replace(/\.md$/, "") ?? filePath;
                     parts.push(
-                        <ChatInlinePill
-                            key={key}
-                            label={fileName}
-                            metrics={pillMetrics}
-                            interactive
-                            variant="accent"
-                            onClick={() =>
-                                void openChatNoteByReference(parsedReference.path)
-                            }
-                            onContextMenu={(event) =>
-                                onNoteContextMenu(event, parsedReference.path)
-                            }
-                            title={filePath}
-                        />,
+                        renderReferencePill({
+                            key,
+                            label: fileName,
+                            title: filePath,
+                            variant: "accent",
+                            metrics: pillMetrics,
+                            appearance,
+                            iconPath: parsedReference.path,
+                            onClick: () =>
+                                void openChatNoteByReference(
+                                    parsedReference.path,
+                                ),
+                            onContextMenu: (event) =>
+                                onNoteContextMenu(event, parsedReference.path),
+                        }),
                     );
                 } else {
                     parts.push(full);
@@ -736,9 +865,11 @@ function renderInlineMarkdown(
 function TextBlock({
     content,
     pillMetrics,
+    fileReferenceAppearance = "pill",
 }: {
     content: string;
     pillMetrics: ChatPillMetrics;
+    fileReferenceAppearance?: FileReferenceAppearance;
 }) {
     const [contextMenu, setContextMenu] =
         useState<ContextMenuState<MarkdownPillContextMenuPayload> | null>(null);
@@ -831,6 +962,7 @@ function TextBlock({
                             handleMapContextMenu,
                             handlePdfContextMenu,
                             handleFileContextMenu,
+                            fileReferenceAppearance,
                         )}
                     </li>
                 ))}
@@ -884,6 +1016,7 @@ function TextBlock({
                                             handleMapContextMenu,
                                             handlePdfContextMenu,
                                             handleFileContextMenu,
+                                            fileReferenceAppearance,
                                         )}
                                     </th>
                                 ))}
@@ -915,6 +1048,7 @@ function TextBlock({
                                                 handleMapContextMenu,
                                                 handlePdfContextMenu,
                                                 handleFileContextMenu,
+                                                fileReferenceAppearance,
                                             )}
                                         </td>
                                     ))}
@@ -1012,6 +1146,7 @@ function TextBlock({
                         handleMapContextMenu,
                         handlePdfContextMenu,
                         handleFileContextMenu,
+                        fileReferenceAppearance,
                     )}
                 </div>,
             );
@@ -1078,6 +1213,7 @@ function TextBlock({
                         handleMapContextMenu,
                         handlePdfContextMenu,
                         handleFileContextMenu,
+                        fileReferenceAppearance,
                     )}
                 </blockquote>,
             );
@@ -1109,6 +1245,7 @@ function TextBlock({
                     handleMapContextMenu,
                     handlePdfContextMenu,
                     handleFileContextMenu,
+                    fileReferenceAppearance,
                 )}
             </div>,
         );
@@ -1269,11 +1406,13 @@ function CodeBlock({
     info,
     pillMetrics,
     chatFontSize = 14,
+    fileReferenceAppearance = "pill",
 }: {
     content: string;
     info?: string;
     pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
+    fileReferenceAppearance?: FileReferenceAppearance;
 }) {
     const [copied, setCopied] = useState(false);
     const [showMarkdownSource, setShowMarkdownSource] = useState(false);
@@ -1369,7 +1508,11 @@ function CodeBlock({
                     data-testid="chat-markdown-preview"
                     style={{ fontSize: chatFontSize }}
                 >
-                    <TextBlock content={content} pillMetrics={pillMetrics} />
+                    <TextBlock
+                        content={content}
+                        pillMetrics={pillMetrics}
+                        fileReferenceAppearance={fileReferenceAppearance}
+                    />
                 </div>
             ) : diffLines.length > 0 ? (
                 <div
@@ -1420,6 +1563,7 @@ export const MarkdownContent = memo(function MarkdownContent({
     className,
     pillMetrics,
     chatFontSize = 14,
+    fileReferenceAppearance = "pill",
 }: MarkdownContentProps) {
     const blocks = useMemo(() => parseBlocks(content), [content]);
 
@@ -1441,12 +1585,14 @@ export const MarkdownContent = memo(function MarkdownContent({
                         info={block.info}
                         pillMetrics={pillMetrics}
                         chatFontSize={chatFontSize}
+                        fileReferenceAppearance={fileReferenceAppearance}
                     />
                 ) : (
                     <TextBlock
                         key={i}
                         content={block.content}
                         pillMetrics={pillMetrics}
+                        fileReferenceAppearance={fileReferenceAppearance}
                     />
                 ),
             )}

--- a/apps/desktop/src/features/ai/components/ResizableDiffContainer.tsx
+++ b/apps/desktop/src/features/ai/components/ResizableDiffContainer.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useRef, useState, type ReactElement } from "react";
+
+const DIFF_DEFAULT_HEIGHT = 200;
+const DIFF_MIN_HEIGHT = 80;
+
+export function ResizableDiffContainer({
+    accent,
+    children,
+}: {
+    readonly accent: string;
+    readonly children: ReactElement;
+}) {
+    const [height, setHeight] = useState(DIFF_DEFAULT_HEIGHT);
+    const dragging = useRef(false);
+    const startY = useRef(0);
+    const startH = useRef(0);
+
+    const onPointerDown = useCallback(
+        (event: React.PointerEvent) => {
+            event.preventDefault();
+            dragging.current = true;
+            startY.current = event.clientY;
+            startH.current = height;
+            (event.target as HTMLElement).setPointerCapture(event.pointerId);
+        },
+        [height],
+    );
+
+    const onPointerMove = useCallback((event: React.PointerEvent) => {
+        if (!dragging.current) return;
+        const delta = event.clientY - startY.current;
+        setHeight(Math.max(DIFF_MIN_HEIGHT, startH.current + delta));
+    }, []);
+
+    const onPointerUp = useCallback(() => {
+        dragging.current = false;
+    }, []);
+
+    return (
+        <div
+            style={{
+                borderBottom: `1px solid color-mix(in srgb, ${accent} 8%, var(--border))`,
+            }}
+        >
+            <div style={{ maxHeight: height, overflowY: "auto" }}>{children}</div>
+            <div
+                aria-label="Resize diff preview"
+                onMouseEnter={(event) => {
+                    event.currentTarget.style.backgroundColor =
+                        "color-mix(in srgb, var(--text-secondary) 10%, transparent)";
+                }}
+                onMouseLeave={(event) => {
+                    event.currentTarget.style.backgroundColor = "transparent";
+                }}
+                onPointerDown={onPointerDown}
+                onPointerMove={onPointerMove}
+                onPointerUp={onPointerUp}
+                role="separator"
+                style={{
+                    alignItems: "center",
+                    backgroundColor: "transparent",
+                    cursor: "ns-resize",
+                    display: "flex",
+                    height: 6,
+                    justifyContent: "center",
+                    transition: "background-color 0.15s ease",
+                }}
+            >
+                <div
+                    aria-hidden="true"
+                    style={{
+                        backgroundColor: "var(--text-secondary)",
+                        borderRadius: 1,
+                        height: 2,
+                        opacity: 0.3,
+                        width: 32,
+                    }}
+                />
+            </div>
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { renderComponent } from "../../../test/test-utils";
+import { resetChatStore } from "../store/chatStore";
+import { resetChatRowUiStore } from "../store/chatRowUiStore";
+import type { AIChatMessage } from "../types";
+import { ToolActivityItem } from "./ToolActivityItem";
+
+function createTool(
+    id: string,
+    overrides: Partial<AIChatMessage> = {},
+): AIChatMessage {
+    return {
+        content: id,
+        id,
+        kind: "tool",
+        meta: {
+            status: "completed",
+            tool: "read",
+        },
+        role: "assistant",
+        timestamp: Date.now(),
+        title: "Read file",
+        ...overrides,
+    };
+}
+
+afterEach(() => {
+    resetChatStore();
+    resetChatRowUiStore();
+});
+
+describe("ToolActivityItem", () => {
+    it("renders read and search targets as compact routine rows", () => {
+        const view = renderComponent(
+            <div>
+                <ToolActivityItem
+                    message={createTool("tool:read", {
+                        meta: {
+                            status: "completed",
+                            target: "/vault/src/reader.ts",
+                            tool: "read",
+                        },
+                    })}
+                    sessionId="session-1"
+                />
+                <ToolActivityItem
+                    message={createTool("tool:search", {
+                        meta: {
+                            status: "completed",
+                            target: "/vault/src/search.ts",
+                            tool: "search",
+                        },
+                        title: "Search source",
+                    })}
+                    sessionId="session-1"
+                />
+            </div>,
+        );
+
+        expect(screen.getByText("reader.ts")).toBeInTheDocument();
+        expect(screen.getByText("search.ts")).toBeInTheDocument();
+        expect(screen.getByText("Read")).toBeInTheDocument();
+        expect(screen.getByText("Searched")).toBeInTheDocument();
+        expect(
+            view.container.querySelectorAll('[data-tool-activity-row="routine"]'),
+        ).toHaveLength(2);
+    });
+
+    it("discloses command detail without changing the row identity", () => {
+        const view = renderComponent(
+            <ToolActivityItem
+                message={createTool("tool:command", {
+                    content: "pnpm --dir apps/desktop test",
+                    meta: {
+                        status: "completed",
+                        tool: "command",
+                    },
+                    title: "Run desktop tests",
+                })}
+                sessionId="session-1"
+            />,
+        );
+
+        const row = view.container.querySelector('[data-tool-activity-row]');
+        expect(row).toHaveAttribute("role", "button");
+        expect(screen.queryByText("pnpm --dir apps/desktop test")).toBeNull();
+
+        fireEvent.click(row!);
+
+        expect(
+            screen.getByText("pnpm --dir apps/desktop test"),
+        ).toBeInTheDocument();
+        expect(row).toHaveAttribute("aria-expanded", "true");
+    });
+
+    it("keeps edits without diffs and failed tools visibly distinct", () => {
+        const view = renderComponent(
+            <div>
+                <ToolActivityItem
+                    message={createTool("tool:edit", {
+                        meta: {
+                            status: "completed",
+                            target: "/vault/src/write.ts",
+                            tool: "edit",
+                        },
+                        title: "Edit write",
+                    })}
+                    sessionId="session-1"
+                />
+                <ToolActivityItem
+                    message={createTool("tool:failed", {
+                        content: "Command exited with status 1",
+                        meta: {
+                            status: "failed",
+                            tool: "command",
+                        },
+                        title: "Run validation",
+                    })}
+                    sessionId="session-1"
+                />
+            </div>,
+        );
+
+        expect(screen.getByText("write.ts")).toBeInTheDocument();
+        expect(screen.getByText("Updated")).toBeInTheDocument();
+        expect(screen.getByText("Failed")).toBeInTheDocument();
+        expect(
+            view.container.querySelector('[data-tool-activity-row="attention"]'),
+        ).toHaveAttribute("data-tool-activity-status", "failed");
+    });
+
+    it("preserves the open-session breadcrumb for subagent activity", () => {
+        renderComponent(
+            <ToolActivityItem
+                message={createTool("tool:subagent", {
+                    content: "Spawned Worker",
+                    meta: {
+                        status: "completed",
+                        tool: "other",
+                    },
+                    title: "Spawned Worker",
+                    toolAction: {
+                        kind: "open_session",
+                        session_id: "missing-child",
+                    },
+                })}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(screen.getByRole("button", { name: "Open Worker" })).toBeDisabled();
+    });
+});

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
@@ -115,6 +115,22 @@ describe("ToolActivityItem", () => {
         ).toBeInTheDocument();
     });
 
+    it("recognizes MCP activity when ACP reports it as an other tool", () => {
+        const view = renderComponent(
+            <ToolActivityItem
+                message={createTool("tool:mcp-other", {
+                    meta: { status: "completed", tool: "other" },
+                    title: "Tool: codex_apps/binance_get_futures_usds_mark_price",
+                })}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(
+            view.container.querySelector('[data-tool-activity-source="mcp"]'),
+        ).toBeInTheDocument();
+    });
+
     it("discloses command detail without changing the row identity", () => {
         const view = renderComponent(
             <ToolActivityItem

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
@@ -64,8 +64,55 @@ describe("ToolActivityItem", () => {
         expect(screen.getByText("Read")).toBeInTheDocument();
         expect(screen.getByText("Searched")).toBeInTheDocument();
         expect(
+            view.container.querySelectorAll(
+                '[data-tool-activity-operation-icon="true"]',
+            ),
+        ).toHaveLength(2);
+        expect(
+            view.container.querySelectorAll(
+                '[data-tool-activity-file-icon="true"]',
+            ),
+        ).toHaveLength(2);
+        expect(
             view.container.querySelectorAll('[data-tool-activity-row="routine"]'),
         ).toHaveLength(2);
+    });
+
+    it("gives web and MCP tools their own semantic activity treatment", () => {
+        const view = renderComponent(
+            <div>
+                <ToolActivityItem
+                    message={createTool("tool:web", {
+                        meta: {
+                            status: "completed",
+                            target: "https://example.com/search?q=markets",
+                            tool: "web_search",
+                        },
+                        title: "Web search",
+                    })}
+                    sessionId="session-1"
+                />
+                <ToolActivityItem
+                    message={createTool("tool:mcp", {
+                        meta: {
+                            status: "completed",
+                            tool: "mcp_browser_query",
+                        },
+                        title: "Query browser MCP",
+                    })}
+                    sessionId="session-1"
+                />
+            </div>,
+        );
+
+        expect(screen.getByText("Searched")).toBeInTheDocument();
+        expect(screen.getByText("Query browser MCP")).toBeInTheDocument();
+        expect(
+            view.container.querySelector('[data-tool-activity-source="web"]'),
+        ).toBeInTheDocument();
+        expect(
+            view.container.querySelector('[data-tool-activity-source="mcp"]'),
+        ).toBeInTheDocument();
     });
 
     it("discloses command detail without changing the row identity", () => {

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -1,0 +1,469 @@
+import { useCallback, useState, type KeyboardEvent } from "react";
+
+import {
+    ContextMenu,
+    type ContextMenuState,
+} from "../../../components/context-menu/ContextMenu";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import { openChatSessionInWorkspace } from "../chatPaneMovement";
+import {
+    canOpenAiEditedFileByAbsolutePath,
+    openAiEditedFileByAbsolutePath,
+} from "../chatFileNavigation";
+import { useChatStore } from "../store/chatStore";
+import type { AIChatMessage, AIChatSession } from "../types";
+import { useStoredRowExpanded } from "./chatRowUiPresentation";
+
+export interface ToolTargetContextMenuPayload {
+    target: string;
+}
+
+function getOpenSessionActionLabel(
+    message: AIChatMessage,
+    resolvedSessionTitle: string | null,
+) {
+    const explicitLabel = message.toolAction?.label?.trim();
+    if (explicitLabel) return explicitLabel;
+
+    if (resolvedSessionTitle) return `Open ${resolvedSessionTitle}`;
+
+    const name = (message.title ?? "")
+        .replace(/^(spawned|started|opened)\s+/i, "")
+        .trim();
+    return name.length > 0 && name.length <= 28 ? `Open ${name}` : "Open";
+}
+
+function sessionMatchesOpenSessionRef(session: AIChatSession, ref: string) {
+    return (
+        session.sessionId === ref ||
+        session.historySessionId === ref ||
+        session.runtimeSessionId === ref
+    );
+}
+
+function resolveOpenSessionActionId(
+    sessionsById: Record<string, AIChatSession>,
+    sessionOrder: string[],
+    ref: string | null,
+) {
+    if (!ref) return null;
+    const candidates = Object.values(sessionsById).filter((session) =>
+        sessionMatchesOpenSessionRef(session, ref),
+    );
+    if (candidates.length === 0) return null;
+
+    const sessionOrderRank = new Map(
+        sessionOrder.map((sessionId, index) => [sessionId, index]),
+    );
+    candidates.sort((left, right) => {
+        const leftLive = left.runtimeState === "live" && !left.isPersistedSession;
+        const rightLive =
+            right.runtimeState === "live" && !right.isPersistedSession;
+        if (leftLive !== rightLive) return leftLive ? -1 : 1;
+
+        const leftExact = left.sessionId === ref;
+        const rightExact = right.sessionId === ref;
+        if (leftExact !== rightExact) return leftExact ? -1 : 1;
+
+        const leftRank = sessionOrderRank.get(left.sessionId) ?? Number.MAX_SAFE_INTEGER;
+        const rightRank =
+            sessionOrderRank.get(right.sessionId) ?? Number.MAX_SAFE_INTEGER;
+        return leftRank - rightRank;
+    });
+
+    return candidates[0].sessionId;
+}
+
+export function OpenSessionActionButton({
+    message,
+}: {
+    message: AIChatMessage;
+}) {
+    const openSessionAction =
+        message.toolAction?.kind === "open_session" ? message.toolAction : null;
+    const openSessionId = openSessionAction?.session_id ?? null;
+    const resolvedOpenSessionId = useChatStore((state) =>
+        resolveOpenSessionActionId(
+            state.sessionsById,
+            state.sessionOrder,
+            openSessionId,
+        ),
+    );
+    const resolvedOpenSessionTitle = useChatStore((state) => {
+        if (!resolvedOpenSessionId) return null;
+        const session = state.sessionsById[resolvedOpenSessionId];
+        return (
+            session?.customTitle?.trim() ||
+            session?.persistedTitle?.trim() ||
+            null
+        );
+    });
+    const canOpenSession = resolvedOpenSessionId !== null;
+
+    if (!openSessionAction) {
+        return null;
+    }
+
+    const label = getOpenSessionActionLabel(message, resolvedOpenSessionTitle);
+
+    return (
+        <button
+            type="button"
+            disabled={!canOpenSession}
+            className="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-medium"
+            style={{
+                background: "transparent",
+                border: "1px solid color-mix(in srgb, var(--border) 82%, transparent)",
+                color: canOpenSession
+                    ? "var(--text-secondary)"
+                    : "color-mix(in srgb, var(--text-secondary) 62%, transparent)",
+                cursor: canOpenSession ? "pointer" : "default",
+            }}
+            title={canOpenSession ? label : "Session is not available yet"}
+            onClick={(event) => {
+                event.stopPropagation();
+                if (!resolvedOpenSessionId) return;
+                void openChatSessionInWorkspace(resolvedOpenSessionId);
+            }}
+        >
+            {label}
+        </button>
+    );
+}
+
+export function ToolIcon({ kind }: { kind?: string }) {
+    const normalizedKind = String(kind ?? "");
+    if (normalizedKind === "read" || normalizedKind === "search") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <circle cx="5.5" cy="5.5" r="3" />
+                <path d="M7.5 7.5L10 10" />
+            </svg>
+        );
+    }
+    if (normalizedKind === "edit") {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <path d="M7 2l3 3-7 7H0V9z" />
+            </svg>
+        );
+    }
+    if (
+        normalizedKind === "execute" ||
+        normalizedKind === "command" ||
+        normalizedKind === "bash" ||
+        normalizedKind === "shell" ||
+        normalizedKind === "terminal"
+    ) {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <path d="M2 3l4 3-4 3z" />
+                <path d="M7 9h3" />
+            </svg>
+        );
+    }
+
+    return (
+        <svg
+            width="12"
+            height="12"
+            viewBox="0 0 12 12"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+        >
+            <circle cx="6" cy="6" r="1.5" />
+            <path d="M6 1v1.5M6 9.5V11M1 6h1.5M9.5 6H11M2.5 2.5l1 1M8.5 8.5l1 1M9.5 2.5l-1 1M3.5 8.5l-1 1" />
+        </svg>
+    );
+}
+
+function ToolFileIcon({
+    target,
+    toolKind,
+}: {
+    target: string | null;
+    toolKind: string;
+}) {
+    if (target) {
+        return <FileTypeIcon fileName={target} size={13} opacity={0.86} />;
+    }
+    return <ToolIcon kind={toolKind} />;
+}
+
+function getActionLabel(toolKind: string) {
+    if (toolKind === "read") return "Read";
+    if (toolKind === "search") return "Searched";
+    if (toolKind === "delete") return "Deleted";
+    if (toolKind === "move") return "Moved";
+    if (toolKind === "edit") return "Updated";
+    if (toolKind === "execute" || toolKind === "command") return "Ran";
+    return "Completed";
+}
+
+function Chevron({ expanded }: { expanded: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            width="10"
+            height="10"
+            viewBox="0 0 10 10"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="shrink-0"
+            style={{
+                transform: expanded ? "rotate(180deg)" : "rotate(0)",
+                transition: "transform 0.15s ease",
+            }}
+        >
+            <path d="M2.5 4L5 6.5L7.5 4" />
+        </svg>
+    );
+}
+
+interface ToolActivityItemProps {
+    readonly message: AIChatMessage;
+    readonly sessionId?: string | null;
+}
+
+/**
+ * The compact row used inside an expanded activity rail. Diff-backed tools
+ * deliberately stay outside this component so ChangeReviewPanel remains the
+ * only owner of review state and accept/reject controls.
+ */
+export function ToolActivityItem({
+    message,
+    sessionId,
+}: ToolActivityItemProps) {
+    const [expanded, setExpanded] = useStoredRowExpanded(
+        sessionId,
+        message.id,
+        false,
+    );
+    const [contextMenu, setContextMenu] =
+        useState<ContextMenuState<ToolTargetContextMenuPayload> | null>(null);
+    const toolKind = String(message.meta?.tool ?? "").toLowerCase();
+    const target = message.meta?.target ? String(message.meta.target) : null;
+    const shortTarget = target?.split(/[\\/]/).filter(Boolean).at(-1) ?? null;
+    const status = String(message.meta?.status ?? "").toLowerCase();
+    const isFailed = status === "cancelled" || status === "error" || status === "failed";
+    const isInProgress =
+        message.inProgress === true ||
+        status === "in_progress" ||
+        status === "pending";
+    const isCompleted = status === "completed";
+    const actionLabel = getActionLabel(toolKind);
+    const label =
+        shortTarget ??
+        (toolKind === "edit" && isInProgress ? "Writing" : message.title?.trim()) ??
+        actionLabel;
+    const detail =
+        message.content.trim() &&
+        message.content !== label &&
+        message.content !== message.title
+            ? message.content
+            : null;
+    const canOpenTarget = target
+        ? canOpenAiEditedFileByAbsolutePath(target)
+        : false;
+    const isAttention = isFailed || message.toolAction != null;
+    const stateLabel = isFailed
+        ? status === "cancelled"
+            ? "Cancelled"
+            : "Failed"
+        : isInProgress
+          ? "Running"
+          : isCompleted
+            ? actionLabel
+            : null;
+
+    const toggleDetail = useCallback(() => {
+        if (detail) setExpanded((value) => !value);
+    }, [detail, setExpanded]);
+    const onKeyDown = useCallback(
+        (event: KeyboardEvent<HTMLDivElement>) => {
+            if (!detail || event.target !== event.currentTarget) return;
+            if (event.key === "Enter" || event.key === " ") {
+                event.preventDefault();
+                toggleDetail();
+            }
+        },
+        [detail, toggleDetail],
+    );
+
+    return (
+        <div
+            aria-expanded={detail ? expanded : undefined}
+            className="group min-w-0 rounded-md px-2 py-1 transition-colors hover:bg-bg-elevated"
+            data-tool-activity-row={isAttention ? "attention" : "routine"}
+            data-tool-activity-status={status || undefined}
+            onClick={toggleDetail}
+            onKeyDown={onKeyDown}
+            role={detail ? "button" : undefined}
+            style={{
+                backgroundColor: isFailed
+                    ? "color-mix(in srgb, #dc2626 7%, transparent)"
+                    : undefined,
+                color: "var(--text-secondary)",
+                cursor: detail ? "pointer" : "default",
+                fontSize: "0.83em",
+            }}
+            tabIndex={detail ? 0 : undefined}
+        >
+            <div className="flex min-w-0 items-center gap-2">
+                <span
+                    className="flex shrink-0 items-center"
+                    style={{ color: isFailed ? "#f87171" : undefined }}
+                >
+                    <ToolFileIcon target={target} toolKind={toolKind} />
+                </span>
+                <span
+                    className="min-w-0 flex-1 truncate font-medium"
+                    title={target ?? undefined}
+                    style={{
+                        color: target ? "var(--accent)" : "var(--text-primary)",
+                        cursor: canOpenTarget ? "pointer" : undefined,
+                        textDecoration: "none",
+                    }}
+                    onClick={
+                        canOpenTarget && target
+                            ? (event) => {
+                                  event.stopPropagation();
+                                  void openAiEditedFileByAbsolutePath(target);
+                              }
+                            : undefined
+                    }
+                    onContextMenu={
+                        canOpenTarget && target
+                            ? (event) => {
+                                  event.preventDefault();
+                                  event.stopPropagation();
+                                  setContextMenu({
+                                      x: event.clientX,
+                                      y: event.clientY,
+                                      payload: { target },
+                                  });
+                              }
+                            : undefined
+                    }
+                    onMouseEnter={
+                        canOpenTarget
+                            ? (event) => {
+                                  event.currentTarget.style.textDecoration =
+                                      "underline";
+                              }
+                            : undefined
+                    }
+                    onMouseLeave={
+                        canOpenTarget
+                            ? (event) => {
+                                  event.currentTarget.style.textDecoration =
+                                      "none";
+                              }
+                            : undefined
+                    }
+                >
+                    {label}
+                </span>
+                {isInProgress ? (
+                    <span
+                        aria-label="Running"
+                        className="inline-block h-1.5 w-1.5 shrink-0 animate-pulse rounded-full"
+                        style={{ backgroundColor: "var(--accent)" }}
+                    />
+                ) : null}
+                {stateLabel && !isInProgress ? (
+                    <span
+                        className="shrink-0 text-[10px]"
+                        style={{
+                            color: isFailed
+                                ? "#f87171"
+                                : "var(--text-secondary)",
+                            opacity: isFailed ? 1 : 0.7,
+                        }}
+                    >
+                        {stateLabel}
+                    </span>
+                ) : null}
+                {detail ? <Chevron expanded={expanded} /> : null}
+                <OpenSessionActionButton message={message} />
+            </div>
+            {expanded && detail ? (
+                <pre
+                    className="mt-1 max-h-40 overflow-y-auto rounded px-2 py-1.5"
+                    data-tool-activity-detail="true"
+                    style={{
+                        backgroundColor: "var(--bg-tertiary)",
+                        border: "1px solid var(--border)",
+                        color: "var(--text-secondary)",
+                        fontSize: "0.96em",
+                        lineHeight: 1.4,
+                        margin: 0,
+                        overflowWrap: "anywhere",
+                        whiteSpace: "pre-wrap",
+                        wordBreak: "break-word",
+                    }}
+                >
+                    {detail}
+                </pre>
+            ) : null}
+            {contextMenu ? (
+                <ContextMenu
+                    menu={contextMenu}
+                    onClose={() => setContextMenu(null)}
+                    entries={[
+                        {
+                            label: "Open",
+                            action: () => {
+                                void openAiEditedFileByAbsolutePath(
+                                    contextMenu.payload.target,
+                                );
+                            },
+                        },
+                        {
+                            label: "Open in New Tab",
+                            action: () => {
+                                void openAiEditedFileByAbsolutePath(
+                                    contextMenu.payload.target,
+                                    { newTab: true },
+                                );
+                            },
+                        },
+                    ]}
+                />
+            ) : null}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -251,6 +251,15 @@ function getActionLabel(toolKind: string) {
     return "Completed";
 }
 
+function isMcpActivity(message: AIChatMessage, toolKind: string) {
+    if (toolKind === "mcp" || toolKind.startsWith("mcp_")) {
+        return true;
+    }
+
+    const descriptor = `${message.title ?? ""}\n${message.content}`.toLowerCase();
+    return descriptor.includes("mcp") || descriptor.includes("codex_apps/");
+}
+
 function Chevron({ expanded }: { expanded: boolean }) {
     return (
         <svg
@@ -320,10 +329,14 @@ export function ToolActivityItem({
         ? canOpenAiEditedFileByAbsolutePath(target)
         : false;
     const isAttention = isFailed || message.toolAction != null;
-    const activitySource = toolKind === "mcp" || toolKind.startsWith("mcp_")
+    const isMcp = isMcpActivity(message, toolKind);
+    const displayKind = isMcp && !toolKind.startsWith("mcp") ? "mcp" : toolKind;
+    const activitySource = isMcp
         ? "mcp"
         : SEARCH_TOOL_KINDS.has(toolKind)
           ? "web"
+          : message.kind === "status"
+            ? "status"
           : "tool";
     const stateLabel = isFailed
         ? status === "cancelled"
@@ -375,7 +388,7 @@ export function ToolActivityItem({
                     data-tool-activity-operation-icon="true"
                     style={{ color: isFailed ? "#f87171" : undefined }}
                 >
-                    <ToolIcon kind={toolKind} />
+                    <ToolIcon kind={displayKind} />
                 </span>
                 {target ? (
                     <span

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -18,6 +18,16 @@ export interface ToolTargetContextMenuPayload {
     target: string;
 }
 
+const SEARCH_TOOL_KINDS = new Set([
+    "browse",
+    "fetch",
+    "find",
+    "grep",
+    "search",
+    "web_fetch",
+    "web_search",
+]);
+
 function getOpenSessionActionLabel(
     message: AIChatMessage,
     resolvedSessionTitle: string | null,
@@ -133,7 +143,7 @@ export function OpenSessionActionButton({
 
 export function ToolIcon({ kind }: { kind?: string }) {
     const normalizedKind = String(kind ?? "");
-    if (normalizedKind === "read" || normalizedKind === "search") {
+    if (normalizedKind === "read" || SEARCH_TOOL_KINDS.has(normalizedKind)) {
         return (
             <svg
                 width="12"
@@ -190,6 +200,26 @@ export function ToolIcon({ kind }: { kind?: string }) {
         );
     }
 
+    if (normalizedKind === "mcp" || normalizedKind.startsWith("mcp_")) {
+        return (
+            <svg
+                width="12"
+                height="12"
+                viewBox="0 0 12 12"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            >
+                <circle cx="3" cy="3" r="1.25" />
+                <circle cx="9" cy="3" r="1.25" />
+                <circle cx="6" cy="9" r="1.25" />
+                <path d="M4.1 3h3.8M3.7 4.1l1.6 3.1M8.3 4.1L6.7 7.2" />
+            </svg>
+        );
+    }
+
     return (
         <svg
             width="12"
@@ -207,22 +237,13 @@ export function ToolIcon({ kind }: { kind?: string }) {
     );
 }
 
-function ToolFileIcon({
-    target,
-    toolKind,
-}: {
-    target: string | null;
-    toolKind: string;
-}) {
-    if (target) {
-        return <FileTypeIcon fileName={target} size={13} opacity={0.86} />;
-    }
-    return <ToolIcon kind={toolKind} />;
-}
-
 function getActionLabel(toolKind: string) {
     if (toolKind === "read") return "Read";
-    if (toolKind === "search") return "Searched";
+    if (SEARCH_TOOL_KINDS.has(toolKind)) {
+        return toolKind === "fetch" || toolKind === "web_fetch"
+            ? "Fetched"
+            : "Searched";
+    }
     if (toolKind === "delete") return "Deleted";
     if (toolKind === "move") return "Moved";
     if (toolKind === "edit") return "Updated";
@@ -299,6 +320,11 @@ export function ToolActivityItem({
         ? canOpenAiEditedFileByAbsolutePath(target)
         : false;
     const isAttention = isFailed || message.toolAction != null;
+    const activitySource = toolKind === "mcp" || toolKind.startsWith("mcp_")
+        ? "mcp"
+        : SEARCH_TOOL_KINDS.has(toolKind)
+          ? "web"
+          : "tool";
     const stateLabel = isFailed
         ? status === "cancelled"
             ? "Cancelled"
@@ -328,6 +354,7 @@ export function ToolActivityItem({
             aria-expanded={detail ? expanded : undefined}
             className="group min-w-0 rounded-md px-2 py-1 transition-colors hover:bg-bg-elevated"
             data-tool-activity-row={isAttention ? "attention" : "routine"}
+            data-tool-activity-source={activitySource}
             data-tool-activity-status={status || undefined}
             onClick={toggleDetail}
             onKeyDown={onKeyDown}
@@ -345,10 +372,20 @@ export function ToolActivityItem({
             <div className="flex min-w-0 items-center gap-2">
                 <span
                     className="flex shrink-0 items-center"
+                    data-tool-activity-operation-icon="true"
                     style={{ color: isFailed ? "#f87171" : undefined }}
                 >
-                    <ToolFileIcon target={target} toolKind={toolKind} />
+                    <ToolIcon kind={toolKind} />
                 </span>
+                {target ? (
+                    <span
+                        aria-hidden="true"
+                        className="flex shrink-0 items-center"
+                        data-tool-activity-file-icon="true"
+                    >
+                        <FileTypeIcon fileName={target} size={13} opacity={0.86} />
+                    </span>
+                ) : null}
                 <span
                     className="min-w-0 flex-1 truncate font-medium"
                     title={target ?? undefined}

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -383,22 +383,28 @@ export function ToolActivityItem({
             tabIndex={detail ? 0 : undefined}
         >
             <div className="flex min-w-0 items-center gap-2">
-                <span
-                    className="flex shrink-0 items-center"
-                    data-tool-activity-operation-icon="true"
-                    style={{ color: isFailed ? "#f87171" : undefined }}
-                >
-                    <ToolIcon kind={displayKind} />
-                </span>
-                {target ? (
+                <span className="flex shrink-0 items-center gap-1.5">
+                    <span
+                        className="flex w-3.5 shrink-0 items-center justify-center"
+                        data-tool-activity-operation-icon="true"
+                        style={{ color: isFailed ? "#f87171" : undefined }}
+                    >
+                        <ToolIcon kind={displayKind} />
+                    </span>
                     <span
                         aria-hidden="true"
-                        className="flex shrink-0 items-center"
+                        className="flex w-3.5 shrink-0 items-center justify-center"
                         data-tool-activity-file-icon="true"
                     >
-                        <FileTypeIcon fileName={target} size={13} opacity={0.86} />
+                        {target ? (
+                            <FileTypeIcon
+                                fileName={target}
+                                size={13}
+                                opacity={0.86}
+                            />
+                        ) : null}
                     </span>
-                ) : null}
+                </span>
                 <span
                     className="min-w-0 flex-1 truncate font-medium"
                     title={target ?? undefined}

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -344,7 +344,7 @@ export function ToolActivityItem({
             : "Failed"
         : isInProgress
           ? "Running"
-          : isCompleted
+          : isCompleted && !target
             ? actionLabel
             : null;
 
@@ -389,70 +389,63 @@ export function ToolActivityItem({
                         data-tool-activity-operation-icon="true"
                         style={{ color: isFailed ? "#f87171" : undefined }}
                     >
-                        <ToolIcon kind={displayKind} />
-                    </span>
-                    <span
-                        aria-hidden="true"
-                        className="flex w-3.5 shrink-0 items-center justify-center"
-                        data-tool-activity-file-icon="true"
-                    >
                         {target ? (
                             <FileTypeIcon
                                 fileName={target}
                                 size={13}
                                 opacity={0.86}
                             />
-                        ) : null}
+                        ) : (
+                            <ToolIcon kind={displayKind} />
+                        )}
                     </span>
+                    <span
+                        aria-hidden="true"
+                        className="flex w-3.5 shrink-0 items-center justify-center"
+                        data-tool-activity-file-icon="true"
+                    />
                 </span>
-                <span
-                    className="min-w-0 flex-1 truncate font-medium"
-                    title={target ?? undefined}
-                    style={{
-                        color: target ? "var(--accent)" : "var(--text-primary)",
-                        cursor: canOpenTarget ? "pointer" : undefined,
-                        textDecoration: "none",
-                    }}
-                    onClick={
-                        canOpenTarget && target
-                            ? (event) => {
-                                  event.stopPropagation();
-                                  void openAiEditedFileByAbsolutePath(target);
-                              }
-                            : undefined
-                    }
-                    onContextMenu={
-                        canOpenTarget && target
-                            ? (event) => {
-                                  event.preventDefault();
-                                  event.stopPropagation();
-                                  setContextMenu({
-                                      x: event.clientX,
-                                      y: event.clientY,
-                                      payload: { target },
-                                  });
-                              }
-                            : undefined
-                    }
-                    onMouseEnter={
-                        canOpenTarget
-                            ? (event) => {
-                                  event.currentTarget.style.textDecoration =
-                                      "underline";
-                              }
-                            : undefined
-                    }
-                    onMouseLeave={
-                        canOpenTarget
-                            ? (event) => {
-                                  event.currentTarget.style.textDecoration =
-                                      "none";
-                              }
-                            : undefined
-                    }
-                >
-                    {label}
-                </span>
+                {target ? (
+                    <>
+                        <span className="shrink-0 opacity-70">{actionLabel}</span>
+                        {canOpenTarget ? (
+                            <button
+                                className="min-w-0 flex-1 truncate text-left text-text-primary underline decoration-text-secondary/40 underline-offset-2 hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:shadow-[0_0_0_1px_var(--accent)]"
+                                onClick={(event) => {
+                                    event.stopPropagation();
+                                    void openAiEditedFileByAbsolutePath(target);
+                                }}
+                                onContextMenu={(event) => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    setContextMenu({
+                                        x: event.clientX,
+                                        y: event.clientY,
+                                        payload: { target },
+                                    });
+                                }}
+                                title={target}
+                                type="button"
+                            >
+                                {shortTarget}
+                            </button>
+                        ) : (
+                            <span
+                                className="min-w-0 flex-1 truncate text-text-primary"
+                                title={target}
+                            >
+                                {shortTarget}
+                            </span>
+                        )}
+                    </>
+                ) : (
+                    <span
+                        className="min-w-0 flex-1 truncate font-medium"
+                        style={{ color: "var(--text-primary)" }}
+                    >
+                        {label}
+                    </span>
+                )}
                 {isInProgress ? (
                     <span
                         aria-label="Running"

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.tsx
@@ -382,8 +382,8 @@ export function ToolActivityItem({
             }}
             tabIndex={detail ? 0 : undefined}
         >
-            <div className="flex min-w-0 items-center gap-2">
-                <span className="flex shrink-0 items-center gap-1.5">
+            <div className="flex min-w-0 items-center gap-1">
+                <span className="flex shrink-0 items-center gap-1">
                     <span
                         className="flex w-3.5 shrink-0 items-center justify-center"
                         data-tool-activity-operation-icon="true"

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -85,6 +85,67 @@ describe("ToolActivitySegment", () => {
         );
     });
 
+    it("renders reasoning, web, edit, and MCP entries in their original order", () => {
+        const reasoning: AIChatMessage = {
+            content: "Checking sources",
+            id: "thinking-1",
+            kind: "thinking",
+            role: "assistant",
+            timestamp: 1,
+            title: "Thinking",
+        };
+        const webSearch = createTool("tool:web", {
+            meta: {
+                status: "completed",
+                tool: "web_search",
+            },
+            timestamp: 2,
+            title: "Web search",
+        });
+        const edit = createTool("tool:edit", {
+            meta: {
+                status: "completed",
+                target: "src/note.ts",
+                tool: "edit",
+            },
+            timestamp: 3,
+            title: "Edit note",
+        });
+        const mcp = createTool("tool:mcp", {
+            meta: {
+                status: "completed",
+                tool: "mcp_browser_query",
+            },
+            timestamp: 4,
+            title: "Query browser MCP",
+        });
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div>{message.id}</div>
+        ));
+        const segment = createSegment([reasoning, webSearch, edit, mcp]);
+
+        renderComponent(
+            <ToolActivitySegment
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        renderEntry.mockClear();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /show full activity/i }),
+        );
+
+        expect(renderEntry.mock.calls.map(([message]) => message.id)).toEqual([
+            "thinking-1",
+            "tool:web",
+            "tool:edit",
+            "tool:mcp",
+        ]);
+    });
+
     it("uses current wording only for the active turn tail", () => {
         const segment = createSegment([createTool("tool-1")]);
 
@@ -150,7 +211,7 @@ describe("ToolActivitySegment", () => {
         ).toHaveAttribute("data-activity-count", "50");
     });
 
-    it("keeps changes, failures, and subagent breadcrumbs visible while routine work is collapsed", () => {
+    it("keeps failures and subagent breadcrumbs visible while changes stay collapsed", () => {
         const renderEntry = vi.fn((message: AIChatMessage) => (
             <div data-child-activity={message.id}>{message.title}</div>
         ));
@@ -185,12 +246,15 @@ describe("ToolActivitySegment", () => {
             />,
         );
 
-        expect(renderEntry).toHaveBeenCalledTimes(3);
+        expect(renderEntry).toHaveBeenCalledTimes(2);
         expect(
             document.querySelector('[data-tool-activity-id="tool:read"]'),
         ).toBeNull();
         expect(
+            document.querySelector('[data-tool-activity-id="tool:edit"]'),
+        ).toBeNull();
+        expect(
             document.querySelectorAll('[data-tool-activity-visibility="always"]'),
-        ).toHaveLength(3);
+        ).toHaveLength(2);
     });
 });

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -1,0 +1,152 @@
+import { act, fireEvent, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { renderComponent } from "../../../test/test-utils";
+import { resetChatRowUiStore } from "../store/chatRowUiStore";
+import type { AIChatMessage } from "../types";
+import {
+    buildActivityTimelineRows,
+    type ActivityTimelineSegmentRow,
+} from "./activityTimelinePresentation";
+import { ToolActivitySegment } from "./ToolActivitySegment";
+
+function createTool(
+    id: string,
+    overrides: Partial<AIChatMessage> = {},
+): AIChatMessage {
+    return {
+        content: id,
+        id,
+        kind: "tool",
+        meta: {
+            status: "completed",
+            target: `src/${id}.ts`,
+            tool: "read",
+        },
+        role: "assistant",
+        timestamp: Number(id.match(/\d+/)?.[0] ?? "0"),
+        title: `Read ${id}`,
+        ...overrides,
+    };
+}
+
+function createSegment(messages: AIChatMessage[]): ActivityTimelineSegmentRow {
+    const segment = buildActivityTimelineRows(messages).find(
+        (row): row is ActivityTimelineSegmentRow =>
+            row.kind === "activity-segment",
+    );
+    if (!segment) {
+        throw new Error("Expected an activity segment.");
+    }
+    return segment;
+}
+
+afterEach(() => {
+    resetChatRowUiStore();
+});
+
+describe("ToolActivitySegment", () => {
+    it("keeps entries unmounted until the user expands the rail", () => {
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div data-child-activity={message.id}>{message.title}</div>
+        ));
+        const segment = createSegment([
+            createTool("tool-1"),
+            createTool("tool-2"),
+        ]);
+
+        renderComponent(
+            <ToolActivitySegment
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(renderEntry).not.toHaveBeenCalled();
+        expect(screen.getByRole("button", { name: /show full activity/i })).toHaveAttribute(
+            "aria-expanded",
+            "false",
+        );
+
+        act(() => {
+            fireEvent.click(
+                screen.getByRole("button", { name: /show full activity/i }),
+            );
+        });
+
+        expect(renderEntry).toHaveBeenCalledTimes(2);
+        expect(
+            document.querySelectorAll("[data-tool-activity-id]"),
+        ).toHaveLength(2);
+        expect(screen.getByRole("button", { name: /hide full activity/i })).toHaveAttribute(
+            "aria-expanded",
+            "true",
+        );
+    });
+
+    it("uses current wording only for the active turn tail", () => {
+        const segment = createSegment([createTool("tool-1")]);
+
+        const view = renderComponent(
+            <ToolActivitySegment
+                isCurrentTurnTail
+                renderEntry={(message) => <div>{message.title}</div>}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(screen.getByText(/working/i)).toBeInTheDocument();
+        expect(screen.getByText(/current:/i)).toBeInTheDocument();
+        expect(
+            view.container.querySelector("[data-tool-activity-segment]"),
+        ).toHaveAttribute("aria-busy", "true");
+    });
+
+    it("expands when navigation targets one of its hidden tool messages", () => {
+        const segment = createSegment([createTool("tool-1")]);
+
+        renderComponent(
+            <ToolActivitySegment
+                forceExpandedMessageId="tool-1"
+                highlightedMessageId="tool-1"
+                renderEntry={(message) => <div>{message.title}</div>}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(
+            document.querySelector('[data-chat-message-id="tool-1"]'),
+        ).toHaveAttribute("data-chat-outline-active", "true");
+        expect(screen.getByRole("button", { name: /hide full activity/i })).toHaveAttribute(
+            "aria-expanded",
+            "true",
+        );
+    });
+
+    it("keeps a large collapsed rail cheap to render", () => {
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div>{message.title}</div>
+        ));
+        const segment = createSegment(
+            Array.from({ length: 50 }, (_, index) =>
+                createTool(`tool-${index}`),
+            ),
+        );
+
+        renderComponent(
+            <ToolActivitySegment
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(renderEntry).not.toHaveBeenCalled();
+        expect(
+            document.querySelector("[data-activity-count]"),
+        ).toHaveAttribute("data-activity-count", "50");
+    });
+});

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -257,4 +257,49 @@ describe("ToolActivitySegment", () => {
             document.querySelectorAll('[data-tool-activity-visibility="always"]'),
         ).toHaveLength(2);
     });
+
+    it("keeps routine MCP status and provider tools collapsed", () => {
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div data-child-activity={message.id}>{message.title}</div>
+        ));
+        const segment = createSegment([
+            {
+                content: "binance_get_futures_usds_mark_price",
+                id: "status:mcp",
+                kind: "status",
+                meta: {
+                    emphasis: "neutral",
+                    status: "in_progress",
+                    status_event: "item_activity",
+                },
+                role: "system",
+                timestamp: 1,
+                title: "Calling MCP tool",
+            },
+            createTool("tool:mcp", {
+                meta: { status: "completed", tool: "other" },
+                timestamp: 2,
+                title: "Tool: codex_apps/binance_get_futures_usds_mark_price",
+            }),
+        ]);
+
+        renderComponent(
+            <ToolActivitySegment
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(renderEntry).not.toHaveBeenCalled();
+
+        fireEvent.click(
+            screen.getByRole("button", { name: /show full activity/i }),
+        );
+
+        expect(renderEntry.mock.calls.map(([message]) => message.id)).toEqual([
+            "status:mcp",
+            "tool:mcp",
+        ]);
+    });
 });

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -163,6 +163,27 @@ describe("ToolActivitySegment", () => {
         expect(
             view.container.querySelector("[data-tool-activity-segment]"),
         ).toHaveAttribute("aria-busy", "true");
+        expect(
+            view.container.querySelector(
+                "[data-activity-rail-working-indicator]",
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("only shows the terminal indicator while a rail is active", () => {
+        const view = renderComponent(
+            <ToolActivitySegment
+                renderEntry={(message) => <div>{message.title}</div>}
+                segment={createSegment([createTool("tool-1")])}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(
+            view.container.querySelector(
+                "[data-activity-rail-working-indicator]",
+            ),
+        ).toBeNull();
     });
 
     it("expands when navigation targets one of its hidden tool messages", () => {

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -149,4 +149,48 @@ describe("ToolActivitySegment", () => {
             document.querySelector("[data-activity-count]"),
         ).toHaveAttribute("data-activity-count", "50");
     });
+
+    it("keeps changes, failures, and subagent breadcrumbs visible while routine work is collapsed", () => {
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div data-child-activity={message.id}>{message.title}</div>
+        ));
+        const segment = createSegment([
+            createTool("tool:read"),
+            createTool("tool:edit", {
+                meta: {
+                    status: "completed",
+                    target: "src/edited.ts",
+                    tool: "edit",
+                },
+            }),
+            createTool("tool:failed", {
+                meta: {
+                    status: "failed",
+                    tool: "command",
+                },
+            }),
+            createTool("tool:subagent", {
+                toolAction: {
+                    kind: "open_session",
+                    session_id: "child-session",
+                },
+            }),
+        ]);
+
+        renderComponent(
+            <ToolActivitySegment
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-1"
+            />,
+        );
+
+        expect(renderEntry).toHaveBeenCalledTimes(3);
+        expect(
+            document.querySelector('[data-tool-activity-id="tool:read"]'),
+        ).toBeNull();
+        expect(
+            document.querySelectorAll('[data-tool-activity-visibility="always"]'),
+        ).toHaveLength(3);
+    });
 });

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.test.tsx
@@ -170,6 +170,49 @@ describe("ToolActivitySegment", () => {
         ).toBeInTheDocument();
     });
 
+    it("uses the display preference as the immediate rail state", () => {
+        const renderEntry = vi.fn((message: AIChatMessage) => (
+            <div>{message.title}</div>
+        ));
+        const segment = createSegment([createTool("tool-1")]);
+        const view = renderComponent(
+            <ToolActivitySegment
+                activityDisplayMode="collapsed"
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-display-mode"
+            />,
+        );
+
+        expect(renderEntry).not.toHaveBeenCalled();
+
+        view.rerender(
+            <ToolActivitySegment
+                activityDisplayMode="expanded"
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-display-mode"
+            />,
+        );
+
+        expect(renderEntry).toHaveBeenCalledWith(
+            expect.objectContaining({ id: "tool-1" }),
+        );
+
+        view.rerender(
+            <ToolActivitySegment
+                activityDisplayMode="collapsed"
+                renderEntry={renderEntry}
+                segment={segment}
+                sessionId="session-display-mode"
+            />,
+        );
+
+        expect(
+            view.container.querySelector('[data-tool-activity-id="tool-1"]'),
+        ).toBeNull();
+    });
+
     it("only shows the terminal indicator while a rail is active", () => {
         const view = renderComponent(
             <ToolActivitySegment

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -51,34 +51,16 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
     );
 }
 
-function WorkingActivityIndicator() {
+function ActivityIndicator({ active }: { readonly active: boolean }) {
     return (
         <span
             aria-hidden="true"
-            className="activity-rail-working-indicator"
-            data-activity-rail-working-indicator="true"
-        >
-            <span className="activity-rail-working-cubes">
-                {[0, 1, 2, 3].map((cube) => (
-                    <span
-                        className="activity-rail-working-cube"
-                        key={cube}
-                    />
-                ))}
-            </span>
-        </span>
-    );
-}
-
-function WorkedActivityIndicator() {
-    return (
-        <span
-            aria-hidden="true"
-            className="activity-rail-worked-indicator"
-            data-activity-rail-worked-indicator="true"
+            className="activity-rail-indicator"
+            data-activity-rail-worked-indicator={active ? undefined : "true"}
+            data-activity-rail-working-indicator={active ? "true" : undefined}
         >
             <svg
-                className="activity-rail-worked-cube"
+                className="activity-rail-chevron"
                 fill="none"
                 height="12"
                 stroke="currentColor"
@@ -184,11 +166,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 type="button"
             >
                 <span className="flex min-w-0 flex-1 items-start gap-1.5">
-                    {isCurrentTurnTail ? (
-                        <WorkingActivityIndicator />
-                    ) : (
-                        <WorkedActivityIndicator />
-                    )}
+                    <ActivityIndicator active={isCurrentTurnTail} />
                     <span className="min-w-0 flex-1">
                         <span
                             className="block truncate text-[11px] font-semibold leading-4"

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -92,7 +92,11 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     const hasChanges = segment.summary.changeCount > 0;
     const visibleEntries = expanded
         ? segment.entries
-        : segment.entries.filter((entry) => entry.policy !== "groupable");
+        : segment.entries.filter(
+              (entry) =>
+                  entry.policy === "standalone-attention" ||
+                  entry.policy === "standalone-unknown",
+          );
     const activityState = isCurrentTurnTail ? "In progress" : "Completed";
     const accessibleChangeSummary = hasChanges
         ? ` ${segment.summary.changeStats.additions} additions, ${segment.summary.changeStats.deletions} deletions. Changed.`

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import { formatDiffStat } from "../diff/reviewDiff";
+import type { ActivityDisplayMode } from "../activityDisplayMode";
 import type { AIChatMessage } from "../types";
 import {
     resolveChatRowUiSessionId,
@@ -19,6 +20,7 @@ import {
 } from "./activityTimelinePresentation";
 
 interface ToolActivitySegmentProps {
+    readonly activityDisplayMode?: ActivityDisplayMode;
     readonly forceExpandedMessageId?: string | null;
     readonly forceExpandedForSearch?: boolean;
     readonly highlightedMessageId?: string | null;
@@ -88,6 +90,7 @@ function getChatOutlineStyle(isActive: boolean): CSSProperties | undefined {
 }
 
 export const ToolActivitySegment = memo(function ToolActivitySegment({
+    activityDisplayMode = "collapsed",
     forceExpandedMessageId = null,
     forceExpandedForSearch = false,
     highlightedMessageId = null,
@@ -107,7 +110,10 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
         (entry) => entry.message.id === forceExpandedMessageId,
     );
     const expanded =
-        forceExpanded || forceExpandedForSearch || storedExpanded === true;
+        forceExpanded ||
+        forceExpandedForSearch ||
+        activityDisplayMode === "hidden" ||
+        (storedExpanded ?? activityDisplayMode === "expanded");
     const contentId = `${segment.id}:activity`;
     const headline = getActivityTimelineSegmentHeadline(
         segment.summary,

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -90,6 +90,9 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     );
     const latestLabel = getActivityTimelineLatestLabel(segment);
     const hasChanges = segment.summary.changeCount > 0;
+    const visibleEntries = expanded
+        ? segment.entries
+        : segment.entries.filter((entry) => entry.policy !== "groupable");
     const activityState = isCurrentTurnTail ? "In progress" : "Completed";
     const accessibleChangeSummary = hasChanges
         ? ` ${segment.summary.changeStats.additions} additions, ${segment.summary.changeStats.deletions} deletions. Changed.`
@@ -181,9 +184,11 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 </span>
             </button>
 
-            {expanded ? (
+            {visibleEntries.length > 0 ? (
                 <div
-                    aria-label="Full tool activity"
+                    aria-label={
+                        expanded ? "Full tool activity" : "Important tool activity"
+                    }
                     className="pt-1"
                     id={contentId}
                     role="region"
@@ -192,7 +197,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                         className="activity-tree flex min-w-0 flex-col gap-1.5"
                         role="list"
                     >
-                        {segment.entries.map((entry) => {
+                        {visibleEntries.map((entry) => {
                             const isHighlighted =
                                 entry.message.id === highlightedMessageId;
                             return (

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -1,0 +1,230 @@
+import {
+    memo,
+    useCallback,
+    useLayoutEffect,
+    type CSSProperties,
+    type ReactNode,
+} from "react";
+
+import { formatDiffStat } from "../diff/reviewDiff";
+import type { AIChatMessage } from "../types";
+import {
+    resolveChatRowUiSessionId,
+    useChatRowUiStore,
+} from "../store/chatRowUiStore";
+import {
+    getActivityTimelineLatestLabel,
+    getActivityTimelineSegmentHeadline,
+    type ActivityTimelineSegmentRow,
+} from "./activityTimelinePresentation";
+
+interface ToolActivitySegmentProps {
+    readonly forceExpandedMessageId?: string | null;
+    readonly forceExpandedForSearch?: boolean;
+    readonly highlightedMessageId?: string | null;
+    /** True only while this segment is the trailing activity of an active turn. */
+    readonly isCurrentTurnTail?: boolean;
+    readonly renderEntry: (message: AIChatMessage) => ReactNode;
+    readonly segment: ActivityTimelineSegmentRow;
+    readonly sessionId?: string | null;
+}
+
+function Chevron({ expanded }: { readonly expanded: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="11"
+            stroke="currentColor"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth="1.8"
+            style={{
+                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                transition: "transform 150ms ease",
+            }}
+            viewBox="0 0 16 16"
+            width="11"
+        >
+            <path d="m4 6 4 4 4-4" />
+        </svg>
+    );
+}
+
+function getChatOutlineStyle(isActive: boolean): CSSProperties | undefined {
+    return isActive
+        ? {
+              background: "color-mix(in srgb, var(--accent) 8%, transparent)",
+              borderRadius: 8,
+              outline: "1px solid color-mix(in srgb, var(--accent) 20%, transparent)",
+              transition: "background 160ms ease, outline-color 160ms ease",
+          }
+        : undefined;
+}
+
+export const ToolActivitySegment = memo(function ToolActivitySegment({
+    forceExpandedMessageId = null,
+    forceExpandedForSearch = false,
+    highlightedMessageId = null,
+    isCurrentTurnTail = false,
+    renderEntry,
+    segment,
+    sessionId = null,
+}: ToolActivitySegmentProps) {
+    const rowUiSessionId = resolveChatRowUiSessionId(sessionId);
+    const storedExpanded = useChatRowUiStore(
+        (state) =>
+            state.rowsBySessionId[rowUiSessionId]?.[segment.id]
+                ?.activitySegmentExpanded,
+    );
+    const patchRow = useChatRowUiStore((state) => state.patchRow);
+    const forceExpanded = segment.entries.some(
+        (entry) => entry.message.id === forceExpandedMessageId,
+    );
+    const expanded =
+        forceExpanded || forceExpandedForSearch || storedExpanded === true;
+    const contentId = `${segment.id}:activity`;
+    const headline = getActivityTimelineSegmentHeadline(
+        segment.summary,
+        isCurrentTurnTail,
+    );
+    const latestLabel = getActivityTimelineLatestLabel(segment);
+    const hasChanges = segment.summary.changeCount > 0;
+    const activityState = isCurrentTurnTail ? "In progress" : "Completed";
+    const accessibleChangeSummary = hasChanges
+        ? ` ${segment.summary.changeStats.additions} additions, ${segment.summary.changeStats.deletions} deletions. Changed.`
+        : "";
+    const accessibleLabel = `${expanded ? "Hide" : "Show"} full activity: ${headline}.${accessibleChangeSummary} ${activityState}.`;
+
+    const setExpanded = useCallback(
+        (value: boolean | ((current: boolean) => boolean)) => {
+            patchRow(rowUiSessionId, segment.id, (current) => ({
+                activitySegmentExpanded:
+                    typeof value === "function"
+                        ? value(current.activitySegmentExpanded === true)
+                        : value,
+            }));
+        },
+        [patchRow, rowUiSessionId, segment.id],
+    );
+
+    useLayoutEffect(() => {
+        if (forceExpanded && storedExpanded !== true) {
+            setExpanded(true);
+        }
+    }, [forceExpanded, setExpanded, storedExpanded]);
+
+    return (
+        <div
+            aria-busy={isCurrentTurnTail}
+            className="activity-rail min-w-0"
+            data-activity-count={segment.summary.actionCount}
+            data-activity-rail="true"
+            data-tool-activity-segment={segment.id}
+        >
+            <button
+                aria-controls={contentId}
+                aria-expanded={expanded}
+                aria-label={accessibleLabel}
+                className="flex min-h-10 w-full items-center gap-2 rounded-md px-1 py-1 text-left transition-colors hover:bg-bg-elevated focus-visible:bg-bg-elevated focus-visible:outline-none focus-visible:shadow-[inset_0_0_0_1px_var(--accent)]"
+                onClick={() => setExpanded((current) => !current)}
+                style={{
+                    background: "none",
+                    border: "none",
+                    color: "var(--text-primary)",
+                }}
+                type="button"
+            >
+                <span className="min-w-0 flex-1">
+                    <span
+                        className="block truncate text-[11px] font-medium leading-4"
+                        title={headline}
+                    >
+                        {headline}
+                    </span>
+                    <span
+                        className="block truncate text-[10px] leading-3.5 text-text-secondary"
+                        data-activity-rail-current="true"
+                        title={latestLabel}
+                    >
+                        {isCurrentTurnTail ? "Current" : "Latest"}: {latestLabel}
+                    </span>
+                </span>
+                {hasChanges ? (
+                    <span
+                        className="flex shrink-0 items-center gap-1.5 text-[10px] font-medium"
+                        data-activity-change-summary="true"
+                    >
+                        {segment.summary.changeStats.additions > 0 ? (
+                            <span style={{ color: "var(--diff-add)" }}>
+                                +
+                                {formatDiffStat(
+                                    segment.summary.changeStats.additions,
+                                    segment.summary.changeStats.approximate,
+                                )}
+                            </span>
+                        ) : null}
+                        {segment.summary.changeStats.deletions > 0 ? (
+                            <span style={{ color: "var(--diff-remove)" }}>
+                                -
+                                {formatDiffStat(
+                                    segment.summary.changeStats.deletions,
+                                    segment.summary.changeStats.approximate,
+                                )}
+                            </span>
+                        ) : null}
+                        <span className="text-text-secondary">Changed</span>
+                    </span>
+                ) : null}
+                <span className="shrink-0 text-text-secondary">
+                    <Chevron expanded={expanded} />
+                </span>
+            </button>
+
+            {expanded ? (
+                <div
+                    aria-label="Full tool activity"
+                    className="pt-1"
+                    id={contentId}
+                    role="region"
+                >
+                    <div
+                        className="activity-tree flex min-w-0 flex-col gap-1.5"
+                        role="list"
+                    >
+                        {segment.entries.map((entry) => {
+                            const isHighlighted =
+                                entry.message.id === highlightedMessageId;
+                            return (
+                                <div
+                                    className="activity-tree-branch min-w-0 pl-10"
+                                    data-activity-rail-decoration="branch"
+                                    data-activity-rail-indent="child"
+                                    data-chat-message-id={entry.message.id}
+                                    data-chat-outline-active={
+                                        isHighlighted ? "true" : undefined
+                                    }
+                                    data-tool-activity-id={entry.message.id}
+                                    data-tool-activity-visibility={
+                                        entry.policy === "groupable"
+                                            ? "expanded-only"
+                                            : "always"
+                                    }
+                                    key={entry.message.id}
+                                    role="listitem"
+                                    style={getChatOutlineStyle(isHighlighted)}
+                                >
+                                    <div className="min-w-0 py-0.5">
+                                        {renderEntry(entry.message)}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+});
+
+ToolActivitySegment.displayName = "ToolActivitySegment";

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -51,6 +51,19 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
     );
 }
 
+function WorkingTerminalIndicator() {
+    return (
+        <span
+            aria-hidden="true"
+            className="activity-rail-working-indicator"
+            data-activity-rail-working-indicator="true"
+        >
+            <span>{">"}</span>
+            <span className="activity-rail-working-cursor">_</span>
+        </span>
+    );
+}
+
 function getChatOutlineStyle(isActive: boolean): CSSProperties | undefined {
     return isActive
         ? {
@@ -140,19 +153,22 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 }}
                 type="button"
             >
-                <span className="min-w-0 flex-1">
-                    <span
-                        className="block truncate text-[11px] font-medium leading-4"
-                        title={headline}
-                    >
-                        {headline}
-                    </span>
-                    <span
-                        className="block truncate text-[10px] leading-3.5 text-text-secondary"
-                        data-activity-rail-current="true"
-                        title={latestLabel}
-                    >
-                        {isCurrentTurnTail ? "Current" : "Latest"}: {latestLabel}
+                <span className="flex min-w-0 flex-1 items-start gap-1.5">
+                    {isCurrentTurnTail ? <WorkingTerminalIndicator /> : null}
+                    <span className="min-w-0 flex-1">
+                        <span
+                            className="block truncate text-[11px] font-medium leading-4"
+                            title={headline}
+                        >
+                            {headline}
+                        </span>
+                        <span
+                            className="block truncate text-[10px] leading-3.5 text-text-secondary"
+                            data-activity-rail-current="true"
+                            title={latestLabel}
+                        >
+                            {isCurrentTurnTail ? "Current" : "Latest"}: {latestLabel}
+                        </span>
                     </span>
                 </span>
                 {hasChanges ? (

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -191,7 +191,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                     )}
                     <span className="min-w-0 flex-1">
                         <span
-                            className="block truncate text-[11px] font-medium leading-4"
+                            className="block truncate text-[11px] font-semibold leading-4"
                             title={headline}
                         >
                             {headline}

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -93,9 +93,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
     const visibleEntries = expanded
         ? segment.entries
         : segment.entries.filter(
-              (entry) =>
-                  entry.policy === "standalone-attention" ||
-                  entry.policy === "standalone-unknown",
+              (entry) => entry.policy === "standalone-attention",
           );
     const activityState = isCurrentTurnTail ? "In progress" : "Completed";
     const accessibleChangeSummary = hasChanges
@@ -217,7 +215,9 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                                     data-tool-activity-visibility={
                                         entry.policy === "groupable"
                                             ? "expanded-only"
-                                            : "always"
+                                            : entry.policy === "standalone-attention"
+                                              ? "always"
+                                              : "expanded-only"
                                     }
                                     key={entry.message.id}
                                     role="listitem"

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -70,6 +70,30 @@ function WorkingActivityIndicator() {
     );
 }
 
+function WorkedActivityIndicator() {
+    return (
+        <span
+            aria-hidden="true"
+            className="activity-rail-worked-indicator"
+            data-activity-rail-worked-indicator="true"
+        >
+            <svg
+                className="activity-rail-worked-cube"
+                fill="none"
+                height="12"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.8"
+                viewBox="0 0 16 16"
+                width="12"
+            >
+                <path d="m6 4 4 4-4 4" />
+            </svg>
+        </span>
+    );
+}
+
 function getChatOutlineStyle(isActive: boolean): CSSProperties | undefined {
     return isActive
         ? {
@@ -160,7 +184,11 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 type="button"
             >
                 <span className="flex min-w-0 flex-1 items-start gap-1.5">
-                    {isCurrentTurnTail ? <WorkingActivityIndicator /> : null}
+                    {isCurrentTurnTail ? (
+                        <WorkingActivityIndicator />
+                    ) : (
+                        <WorkedActivityIndicator />
+                    )}
                     <span className="min-w-0 flex-1">
                         <span
                             className="block truncate text-[11px] font-medium leading-4"

--- a/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivitySegment.tsx
@@ -51,15 +51,21 @@ function Chevron({ expanded }: { readonly expanded: boolean }) {
     );
 }
 
-function WorkingTerminalIndicator() {
+function WorkingActivityIndicator() {
     return (
         <span
             aria-hidden="true"
             className="activity-rail-working-indicator"
             data-activity-rail-working-indicator="true"
         >
-            <span>{">"}</span>
-            <span className="activity-rail-working-cursor">_</span>
+            <span className="activity-rail-working-cubes">
+                {[0, 1, 2, 3].map((cube) => (
+                    <span
+                        className="activity-rail-working-cube"
+                        key={cube}
+                    />
+                ))}
+            </span>
         </span>
     );
 }
@@ -154,7 +160,7 @@ export const ToolActivitySegment = memo(function ToolActivitySegment({
                 type="button"
             >
                 <span className="flex min-w-0 flex-1 items-start gap-1.5">
-                    {isCurrentTurnTail ? <WorkingTerminalIndicator /> : null}
+                    {isCurrentTurnTail ? <WorkingActivityIndicator /> : null}
                     <span className="min-w-0 flex-1">
                         <span
                             className="block truncate text-[11px] font-medium leading-4"

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
@@ -97,8 +97,68 @@ describe("buildActivityTimelineRows", () => {
         ]);
     });
 
+    it("keeps reasoning and tools in one chronological rail", () => {
+        const reasoning = createMessage("thinking-1", {
+            content: "Inspecting sources",
+            kind: "thinking",
+            title: "Thinking",
+        });
+        const webSearch = createTool("tool:web-search", {
+            meta: { status: "completed", tool: "web_search" },
+            title: "Web search",
+        });
+        const edit = createTool("tool:edit", {
+            diffs: [
+                {
+                    kind: "update",
+                    new_text: "after",
+                    old_text: "before",
+                    path: "/vault/note.md",
+                },
+            ],
+            meta: { status: "completed", tool: "edit" },
+            title: "Edit note",
+        });
+        const mcp = createTool("tool:mcp", {
+            meta: { status: "completed", tool: "mcp_browser_query" },
+            title: "Query browser MCP",
+        });
+
+        const rows = buildActivityTimelineRows([
+            reasoning,
+            webSearch,
+            createMessage("thinking-2", {
+                kind: "thinking",
+                title: "Thinking",
+            }),
+            edit,
+            mcp,
+        ]);
+
+        const segment = getOnlySegment(rows);
+        expect(rows).toHaveLength(1);
+        expect(segment.entries.map((entry) => entry.message)).toEqual([
+            reasoning,
+            webSearch,
+            expect.objectContaining({ id: "thinking-2" }),
+            edit,
+            mcp,
+        ]);
+        expect(segment.entries.map((entry) => entry.policy)).toEqual([
+            "groupable",
+            "groupable",
+            "groupable",
+            "standalone-change",
+            "standalone-unknown",
+        ]);
+        expect(segment.summary).toMatchObject({
+            actionCount: 3,
+            latestMessageId: "tool:mcp",
+            reasoningCount: 2,
+        });
+    });
+
     it.each([
-        "thinking",
         "status",
         "permission",
         "error",

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
@@ -1,0 +1,298 @@
+import { describe, expect, it } from "vitest";
+
+import type { AIChatMessage, AIFileDiff } from "../types";
+import {
+    buildActivityTimelineRows,
+    deriveActivityTimelineChangeStats,
+    getActivityTimelineRowKey,
+    getActivityTimelineSegmentHeadline,
+    getActivityTimelineToolPolicy,
+    type ActivityTimelineSegmentRow,
+    type ActivityTimelineToolEntry,
+} from "./activityTimelinePresentation";
+
+function createMessage(
+    id: string,
+    overrides: Partial<AIChatMessage> = {},
+): AIChatMessage {
+    return {
+        content: id,
+        id,
+        kind: "text",
+        role: "assistant",
+        timestamp: Number(id.match(/\d+/)?.[0] ?? "0"),
+        ...overrides,
+    };
+}
+
+function createTool(
+    id: string,
+    overrides: Partial<AIChatMessage> = {},
+): AIChatMessage {
+    return createMessage(id, {
+        kind: "tool",
+        meta: {
+            status: "completed",
+            tool: "read",
+        },
+        title: `Read ${id}`,
+        ...overrides,
+    });
+}
+
+function getOnlySegment(rows: ReturnType<typeof buildActivityTimelineRows>) {
+    const segment = rows.find(
+        (row): row is ActivityTimelineSegmentRow =>
+            row.kind === "activity-segment",
+    );
+    if (!segment) {
+        throw new Error("Expected an activity segment.");
+    }
+    return segment;
+}
+
+function createEntry(diff: AIFileDiff): ActivityTimelineToolEntry {
+    return {
+        message: createTool(`tool-${diff.path}`, {
+            diffs: [diff],
+            meta: {
+                status: "completed",
+                tool: "edit",
+            },
+        }),
+        policy: "standalone-change",
+    };
+}
+
+describe("buildActivityTimelineRows", () => {
+    it("inserts one activity segment between surrounding text messages", () => {
+        const before = createMessage("assistant-before");
+        const firstTool = createTool("tool-1");
+        const secondTool = createTool("tool-2", {
+            meta: { status: "completed", tool: "grep" },
+        });
+        const after = createMessage("assistant-after");
+
+        const rows = buildActivityTimelineRows([
+            before,
+            firstTool,
+            secondTool,
+            after,
+        ]);
+
+        expect(rows.map((row) => row.kind)).toEqual([
+            "message",
+            "activity-segment",
+            "message",
+        ]);
+        const segment = getOnlySegment(rows);
+        expect(segment.id).toBe("activity-segment:tool-1");
+        expect(segment.entries.map((entry) => entry.message)).toEqual([
+            firstTool,
+            secondTool,
+        ]);
+        expect(segment.entries.map((entry) => entry.policy)).toEqual([
+            "groupable",
+            "groupable",
+        ]);
+    });
+
+    it.each([
+        "thinking",
+        "status",
+        "permission",
+        "error",
+    ] as const)("uses %s messages as a segment boundary", (kind) => {
+        const boundary = createMessage(`boundary-${kind}`, {
+            kind,
+            role: kind === "error" ? "system" : "assistant",
+        });
+        const rows = buildActivityTimelineRows([
+            createTool("tool-1"),
+            boundary,
+            createTool("tool-2"),
+        ]);
+
+        expect(rows.map((row) => row.kind)).toEqual([
+            "activity-segment",
+            "message",
+            "activity-segment",
+        ]);
+    });
+
+    it("keeps a diff-bearing tool in the segment with its original message", () => {
+        const tool = createTool("tool-edit", {
+            diffs: [
+                {
+                    kind: "update",
+                    new_text: "after",
+                    old_text: "before",
+                    path: "/vault/note.md",
+                },
+            ],
+            meta: { status: "completed", tool: "edit" },
+        });
+
+        const segment = getOnlySegment(buildActivityTimelineRows([tool]));
+
+        expect(segment.entries[0]?.message).toBe(tool);
+        expect(segment.entries[0]?.policy).toBe("standalone-change");
+        expect(segment.summary.changeStats).toEqual({
+            additions: 1,
+            approximate: false,
+            deletions: 1,
+        });
+    });
+
+    it("keeps mutating, failed, subagent, and unknown tools visible", () => {
+        const messages = [
+            createTool("tool-edit", {
+                meta: { status: "in_progress", tool: "edit" },
+            }),
+            createTool("tool-failed", {
+                meta: { status: "failed", tool: "shell" },
+            }),
+            createTool("tool-subagent", {
+                meta: { status: "completed", tool: "other" },
+                toolAction: {
+                    kind: "open_session",
+                    session_id: "child-session",
+                },
+            }),
+            createTool("tool-unknown", {
+                meta: { status: "completed", tool: "future_provider_tool" },
+            }),
+        ];
+
+        const segment = getOnlySegment(buildActivityTimelineRows(messages));
+
+        expect(segment.entries.map((entry) => entry.policy)).toEqual([
+            "standalone-change",
+            "standalone-attention",
+            "standalone-attention",
+            "standalone-unknown",
+        ]);
+        expect(segment.summary.isInProgress).toBe(true);
+        expect(segment.summary.failureCount).toBe(1);
+    });
+
+    it("keeps segment identity stable when its trailing tool is updated", () => {
+        const initialRows = buildActivityTimelineRows([
+            createTool("tool-1"),
+            createTool("tool-2", {
+                meta: { status: "in_progress", tool: "shell" },
+            }),
+        ]);
+        const completedRows = buildActivityTimelineRows([
+            createTool("tool-1"),
+            createTool("tool-2", {
+                content: "Command completed",
+                meta: { status: "completed", tool: "shell" },
+            }),
+        ]);
+
+        const initialSegment = getOnlySegment(initialRows);
+        const completedSegment = getOnlySegment(completedRows);
+
+        expect(completedSegment.id).toBe(initialSegment.id);
+        expect(completedSegment.id).toBe("activity-segment:tool-1");
+        expect(getActivityTimelineRowKey("session-a", initialSegment.id)).not.toBe(
+            getActivityTimelineRowKey("session-b", completedSegment.id),
+        );
+    });
+
+    it("does not mutate the transcript input", () => {
+        const messages = [
+            createMessage("assistant-before"),
+            createTool("tool-1", {
+                diffs: [
+                    {
+                        kind: "update",
+                        new_text: "after",
+                        old_text: "before",
+                        path: "/vault/note.md",
+                    },
+                ],
+            }),
+        ];
+        const snapshot = structuredClone(messages);
+
+        buildActivityTimelineRows(messages);
+
+        expect(messages).toEqual(snapshot);
+    });
+});
+
+describe("activity timeline summaries", () => {
+    it("uses an exploration headline for read and search activity", () => {
+        const segment = getOnlySegment(
+            buildActivityTimelineRows([
+                createTool("tool-read", {
+                    meta: {
+                        status: "completed",
+                        target: "/vault/notes/context.md",
+                        tool: "read",
+                    },
+                }),
+                createTool("tool-search", {
+                    meta: { status: "completed", tool: "search" },
+                }),
+            ]),
+        );
+
+        expect(getActivityTimelineSegmentHeadline(segment.summary)).toBe(
+            "Explored 1 file · 1 search",
+        );
+    });
+
+    it("calculates the net diff for compatible repeated file snapshots", () => {
+        const stats = deriveActivityTimelineChangeStats([
+            createEntry({
+                kind: "update",
+                new_text: "base\nfirst",
+                old_text: "base",
+                path: "/vault/note.md",
+            }),
+            createEntry({
+                kind: "update",
+                new_text: "base\nfirst\nsecond",
+                old_text: "base",
+                path: "/vault/note.md",
+            }),
+        ]);
+
+        expect(stats).toEqual({
+            additions: 2,
+            approximate: false,
+            deletions: 0,
+        });
+    });
+
+    it("marks incomplete snapshots approximate instead of merging them", () => {
+        const stats = deriveActivityTimelineChangeStats([
+            createEntry({
+                kind: "update",
+                new_text: "after",
+                path: "/vault/note.md",
+            }),
+        ]);
+
+        expect(stats).toEqual({
+            additions: 1,
+            approximate: true,
+            deletions: 0,
+        });
+    });
+});
+
+describe("getActivityTimelineToolPolicy", () => {
+    it("treats successful commands as routine activity", () => {
+        expect(
+            getActivityTimelineToolPolicy(
+                createTool("tool-command", {
+                    meta: { status: "completed", tool: "shell" },
+                }),
+            ),
+        ).toBe("groupable");
+    });
+});

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
@@ -149,7 +149,7 @@ describe("buildActivityTimelineRows", () => {
             "groupable",
             "groupable",
             "standalone-change",
-            "standalone-unknown",
+            "groupable",
         ]);
         expect(segment.summary).toMatchObject({
             actionCount: 3,
@@ -204,7 +204,7 @@ describe("buildActivityTimelineRows", () => {
         });
     });
 
-    it("keeps mutating, failed, subagent, and unknown tools visible", () => {
+    it("keeps changes, failures, and subagent actions visible while routine tools collapse", () => {
         const messages = [
             createTool("tool-edit", {
                 meta: { status: "in_progress", tool: "edit" },
@@ -230,11 +230,104 @@ describe("buildActivityTimelineRows", () => {
             "standalone-change",
             "standalone-attention",
             "standalone-attention",
-            "standalone-unknown",
+            "groupable",
         ]);
         expect(segment.summary.isInProgress).toBe(true);
         expect(segment.summary.failureCount).toBe(1);
     });
+
+    it("joins routine status updates with surrounding activity", () => {
+        const callingMcp = createMessage("status:mcp", {
+            content: "binance_get_futures_usds_mark_price",
+            kind: "status",
+            meta: {
+                emphasis: "neutral",
+                status: "in_progress",
+                status_event: "item_activity",
+            },
+            role: "system",
+            title: "Calling MCP tool",
+        });
+        const mcpResult = createTool("tool:mcp-result", {
+            meta: { status: "completed", tool: "other" },
+            title: "Tool: codex_apps/binance_get_futures_usds_mark_price",
+        });
+        const subagentProgress = createMessage("status:subagent", {
+            kind: "status",
+            meta: {
+                emphasis: "neutral",
+                status: "completed",
+                status_event: "subagent_lifecycle",
+            },
+            role: "system",
+            title: "Mendel completed research",
+        });
+
+        const segment = getOnlySegment(
+            buildActivityTimelineRows([callingMcp, mcpResult, subagentProgress]),
+        );
+
+        expect(segment.entries.map((entry) => entry.message.id)).toEqual([
+            "status:mcp",
+            "tool:mcp-result",
+            "status:subagent",
+        ]);
+        expect(segment.entries.map((entry) => entry.policy)).toEqual([
+            "groupable",
+            "groupable",
+            "groupable",
+        ]);
+        expect(segment.summary.actionCount).toBe(1);
+    });
+
+    it("uses a complete headline for a status-only rail", () => {
+        const segment = getOnlySegment(
+            buildActivityTimelineRows([
+                createMessage("status:plan", {
+                    kind: "status",
+                    meta: {
+                        emphasis: "neutral",
+                        status: "completed",
+                        status_event: "item_activity",
+                    },
+                    role: "system",
+                    title: "Updating plan",
+                }),
+            ]),
+        );
+
+        expect(segment.summary.statusCount).toBe(1);
+        expect(getActivityTimelineSegmentHeadline(segment.summary)).toBe(
+            "Worked",
+        );
+    });
+
+    it.each(["turn_started", "session_recovery", "model_reroute", "review_mode"])(
+        "keeps %s status as a timeline boundary",
+        (statusEvent) => {
+            const boundary = createMessage(`status:${statusEvent}`, {
+                kind: "status",
+                meta: {
+                    emphasis: "neutral",
+                    status: "completed",
+                    status_event: statusEvent,
+                },
+                role: "system",
+            });
+
+            const rows = buildActivityTimelineRows([
+                createTool("tool-before"),
+                boundary,
+                createTool("tool-after"),
+            ]);
+
+            expect(rows.map((row) => row.kind)).toEqual([
+                "activity-segment",
+                "message",
+                "activity-segment",
+            ]);
+        },
+    );
 
     it("keeps segment identity stable when its trailing tool is updated", () => {
         const initialRows = buildActivityTimelineRows([

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.test.ts
@@ -236,7 +236,7 @@ describe("buildActivityTimelineRows", () => {
         expect(segment.summary.failureCount).toBe(1);
     });
 
-    it("joins routine status updates with surrounding activity", () => {
+    it("keeps subagent lifecycle updates visible within surrounding activity", () => {
         const callingMcp = createMessage("status:mcp", {
             content: "binance_get_futures_usds_mark_price",
             kind: "status",
@@ -275,7 +275,7 @@ describe("buildActivityTimelineRows", () => {
         expect(segment.entries.map((entry) => entry.policy)).toEqual([
             "groupable",
             "groupable",
-            "groupable",
+            "standalone-attention",
         ]);
         expect(segment.summary.actionCount).toBe(1);
     });

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
@@ -1,0 +1,483 @@
+import { computeDiffStats, type DiffStats } from "../diff/reviewDiff";
+import type { AIChatMessage, AIFileDiff } from "../types";
+
+const COMMAND_TOOL_KINDS = new Set([
+    "bash",
+    "command",
+    "execute",
+    "shell",
+    "terminal",
+]);
+
+const GROUPABLE_TOOL_KINDS = new Set([
+    "fetch",
+    "find",
+    "glob",
+    "grep",
+    "list",
+    "read",
+    "read_file",
+    "search",
+]);
+
+const MUTATING_FILE_TOOL_KINDS = new Set([
+    "apply_patch",
+    "create",
+    "delete",
+    "edit",
+    "move",
+    "remove",
+    "rename",
+    "update",
+    "write",
+]);
+
+const FILE_TOOL_KINDS = new Set([
+    ...GROUPABLE_TOOL_KINDS,
+    ...MUTATING_FILE_TOOL_KINDS,
+]);
+
+const SEARCH_TOOL_KINDS = new Set(["find", "glob", "grep", "search"]);
+const DETACHED_ACTIVITY_TIMELINE_SCOPE = "__detached_activity_timeline__";
+
+export type ActivityTimelineToolPolicy =
+    | "groupable"
+    | "standalone-change"
+    | "standalone-attention"
+    | "standalone-unknown";
+
+export interface ActivityTimelineToolEntry {
+    readonly message: AIChatMessage;
+    readonly policy: ActivityTimelineToolPolicy;
+}
+
+export interface ActivityTimelineChangeStats {
+    readonly additions: number;
+    readonly approximate: boolean;
+    readonly deletions: number;
+}
+
+export interface ActivityTimelineSegmentSummary {
+    readonly actionCount: number;
+    readonly changeCount: number;
+    readonly changeStats: ActivityTimelineChangeStats;
+    readonly changedFileCount: number;
+    readonly commandCount: number;
+    readonly failureCount: number;
+    readonly fileCount: number;
+    readonly isInProgress: boolean;
+    readonly latestMessageId: string;
+    readonly latestTitle: string;
+    readonly searchCount: number;
+    readonly startedAt: number;
+    readonly updatedAt: number;
+}
+
+export interface ActivityTimelineMessageRow {
+    readonly id: string;
+    readonly kind: "message";
+    readonly message: AIChatMessage;
+}
+
+export interface ActivityTimelineSegmentRow {
+    readonly entries: readonly ActivityTimelineToolEntry[];
+    readonly id: string;
+    readonly kind: "activity-segment";
+    readonly summary: ActivityTimelineSegmentSummary;
+}
+
+export type ActivityTimelineRow =
+    | ActivityTimelineMessageRow
+    | ActivityTimelineSegmentRow;
+
+interface SegmentFileState {
+    readonly finalPath: string;
+    readonly initialPath: string;
+    readonly initialText: string | null;
+    readonly isText: boolean;
+    readonly reversible: boolean;
+    readonly finalText: string | null;
+}
+
+function getMessageMetaString(message: AIChatMessage, key: string): string | null {
+    const value = message.meta?.[key];
+    return typeof value === "string" && value.trim() ? value : null;
+}
+
+function getToolKind(message: AIChatMessage): string {
+    return getMessageMetaString(message, "tool")?.toLowerCase() ?? "";
+}
+
+function getToolTarget(message: AIChatMessage): string | null {
+    return getMessageMetaString(message, "target");
+}
+
+function getToolStatus(message: AIChatMessage): string {
+    return getMessageMetaString(message, "status")?.toLowerCase() ?? "";
+}
+
+function getToolDiffs(message: AIChatMessage): readonly AIFileDiff[] {
+    return message.reviewDiffs ?? message.diffs ?? [];
+}
+
+function isFailedTool(message: AIChatMessage): boolean {
+    const status = getToolStatus(message);
+    return status === "cancelled" || status === "error" || status === "failed";
+}
+
+function isInProgressTool(message: AIChatMessage): boolean {
+    const status = getToolStatus(message);
+    return (
+        message.inProgress === true ||
+        status === "in_progress" ||
+        status === "pending"
+    );
+}
+
+function isMutatingFileTool(message: AIChatMessage): boolean {
+    return MUTATING_FILE_TOOL_KINDS.has(getToolKind(message));
+}
+
+function hasChangeData(message: AIChatMessage): boolean {
+    return getToolDiffs(message).length > 0 || isMutatingFileTool(message);
+}
+
+function getEntryTitle(message: AIChatMessage): string {
+    return message.title?.trim() || message.content.trim() || "Tool activity";
+}
+
+function addPath(paths: Set<string>, path: string | null | undefined) {
+    const normalized = path?.trim();
+    if (normalized) {
+        paths.add(normalized);
+    }
+}
+
+function hasCompleteSnapshot(diff: AIFileDiff): boolean {
+    if (diff.is_text === false) {
+        return false;
+    }
+
+    if (diff.kind === "add") {
+        return diff.new_text !== undefined;
+    }
+
+    if (diff.kind === "delete") {
+        return diff.old_text !== undefined;
+    }
+
+    return diff.old_text !== undefined && diff.new_text !== undefined;
+}
+
+function createSegmentFileState(diff: AIFileDiff): SegmentFileState {
+    const initialPath = diff.previous_path ?? diff.path;
+    const initialText = diff.kind === "add" ? null : (diff.old_text ?? null);
+    const finalText = diff.kind === "delete" ? null : (diff.new_text ?? null);
+
+    return {
+        finalPath: diff.path,
+        finalText,
+        initialPath,
+        initialText,
+        isText: diff.is_text !== false,
+        reversible: diff.reversible !== false,
+    };
+}
+
+function toNetDiff(state: SegmentFileState): AIFileDiff | null {
+    const samePath = state.initialPath === state.finalPath;
+    if (samePath && state.initialText === state.finalText) {
+        return null;
+    }
+
+    const kind: AIFileDiff["kind"] =
+        state.initialText === null
+            ? "add"
+            : state.finalText === null
+              ? "delete"
+              : samePath
+                ? "update"
+                : "move";
+
+    return {
+        is_text: state.isText,
+        kind,
+        new_text: state.finalText,
+        old_text: state.initialText,
+        path: state.finalPath,
+        previous_path: samePath ? null : state.initialPath,
+        reversible: state.reversible,
+    };
+}
+
+function sumDiffStats(diffs: readonly AIFileDiff[]): DiffStats {
+    return computeDiffStats([...diffs]);
+}
+
+function combineDiffStats(
+    netDiffs: readonly AIFileDiff[],
+    fallbackDiffs: readonly AIFileDiff[],
+): ActivityTimelineChangeStats {
+    const net = sumDiffStats(netDiffs);
+    const fallback = sumDiffStats(fallbackDiffs);
+
+    return {
+        additions: net.additions + fallback.additions,
+        approximate:
+            net.approximate === true ||
+            fallback.approximate === true ||
+            fallbackDiffs.length > 0,
+        deletions: net.deletions + fallback.deletions,
+    };
+}
+
+/**
+ * A segment can merge only unambiguous snapshots. Incomplete or ambiguous
+ * diffs stay as approximate totals instead of inventing a combined history.
+ */
+export function deriveActivityTimelineChangeStats(
+    entries: readonly ActivityTimelineToolEntry[],
+): ActivityTimelineChangeStats {
+    const states: SegmentFileState[] = [];
+    const fallbackDiffs: AIFileDiff[] = [];
+
+    for (const entry of entries) {
+        for (const diff of getToolDiffs(entry.message)) {
+            if (!hasCompleteSnapshot(diff)) {
+                fallbackDiffs.push(diff);
+                continue;
+            }
+
+            const previousPath = diff.previous_path ?? diff.path;
+            const matches = states.filter(
+                (state) => state.finalPath === previousPath,
+            );
+
+            if (matches.length > 1) {
+                fallbackDiffs.push(diff);
+                continue;
+            }
+
+            const existing = matches[0];
+            if (!existing) {
+                states.push(createSegmentFileState(diff));
+                continue;
+            }
+
+            const next = createSegmentFileState(diff);
+            const replacementIndex = states.indexOf(existing);
+            states[replacementIndex] = {
+                ...existing,
+                finalPath: next.finalPath,
+                finalText: next.finalText,
+                isText: existing.isText && next.isText,
+                reversible: existing.reversible && next.reversible,
+            };
+        }
+    }
+
+    const netDiffs = states
+        .map(toNetDiff)
+        .filter((diff): diff is AIFileDiff => diff !== null);
+    return combineDiffStats(netDiffs, fallbackDiffs);
+}
+
+export function getActivityTimelineToolPolicy(
+    message: AIChatMessage,
+): ActivityTimelineToolPolicy {
+    if (hasChangeData(message)) {
+        // Changes keep their own review surface instead of becoming a routine row.
+        return "standalone-change";
+    }
+
+    if (isFailedTool(message) || message.toolAction != null) {
+        return "standalone-attention";
+    }
+
+    const kind = getToolKind(message);
+    if (
+        COMMAND_TOOL_KINDS.has(kind) ||
+        GROUPABLE_TOOL_KINDS.has(kind)
+    ) {
+        return "groupable";
+    }
+
+    return "standalone-unknown";
+}
+
+export function buildActivityTimelineSegmentSummary(
+    entries: readonly ActivityTimelineToolEntry[],
+): ActivityTimelineSegmentSummary {
+    const latestEntry = entries.at(-1);
+    const firstEntry = entries[0];
+    if (!firstEntry || !latestEntry) {
+        throw new Error("An activity segment requires at least one tool entry.");
+    }
+
+    const changedFiles = new Set<string>();
+    const fileTargets = new Set<string>();
+    let changeCount = 0;
+    let commandCount = 0;
+    let failureCount = 0;
+    let searchCount = 0;
+    let isInProgress = false;
+    let updatedAt = firstEntry.message.timestamp;
+
+    for (const entry of entries) {
+        const { message, policy } = entry;
+        const kind = getToolKind(message);
+        const target = getToolTarget(message);
+        const diffs = getToolDiffs(message);
+
+        if (COMMAND_TOOL_KINDS.has(kind)) {
+            commandCount += 1;
+        }
+        if (SEARCH_TOOL_KINDS.has(kind)) {
+            searchCount += 1;
+        }
+        if (FILE_TOOL_KINDS.has(kind)) {
+            addPath(fileTargets, target);
+        }
+        if (policy === "standalone-change") {
+            changeCount += 1;
+            addPath(changedFiles, target);
+        }
+        if (isFailedTool(message)) {
+            failureCount += 1;
+        }
+        if (isInProgressTool(message)) {
+            isInProgress = true;
+        }
+        if (message.timestamp > updatedAt) {
+            updatedAt = message.timestamp;
+        }
+
+        for (const diff of diffs) {
+            addPath(fileTargets, diff.path);
+            addPath(fileTargets, diff.previous_path);
+            if (policy === "standalone-change") {
+                addPath(changedFiles, diff.path);
+            }
+        }
+    }
+
+    return {
+        actionCount: entries.length,
+        changeCount,
+        changeStats: deriveActivityTimelineChangeStats(entries),
+        changedFileCount: changedFiles.size,
+        commandCount,
+        failureCount,
+        fileCount: fileTargets.size,
+        isInProgress,
+        latestMessageId: latestEntry.message.id,
+        latestTitle: getEntryTitle(latestEntry.message),
+        searchCount,
+        startedAt: firstEntry.message.timestamp,
+        updatedAt,
+    };
+}
+
+export function getActivityTimelineSegmentHeadline(
+    summary: ActivityTimelineSegmentSummary,
+    isCurrentTurnTail = false,
+): string {
+    const details = [
+        pluralize(summary.actionCount, "action"),
+        summary.changedFileCount > 0
+            ? pluralize(
+                  summary.changedFileCount,
+                  "file changed",
+                  "files changed",
+              )
+            : null,
+        summary.failureCount > 0
+            ? pluralize(summary.failureCount, "failure")
+            : null,
+    ].filter((detail): detail is string => detail !== null);
+
+    if (isCurrentTurnTail) {
+        return `Working · ${details.join(" · ")}`;
+    }
+
+    if (
+        summary.changeCount === 0 &&
+        summary.commandCount === 0 &&
+        summary.failureCount === 0 &&
+        (summary.fileCount > 0 || summary.searchCount > 0)
+    ) {
+        const explorationDetails = [
+            summary.fileCount > 0
+                ? pluralize(summary.fileCount, "file")
+                : null,
+            summary.searchCount > 0
+                ? pluralize(summary.searchCount, "search", "searches")
+                : null,
+        ].filter((detail): detail is string => detail !== null);
+        return `Explored ${explorationDetails.join(" · ")}`;
+    }
+
+    return `Worked · ${details.join(" · ")}`;
+}
+
+export function getActivityTimelineLatestLabel(
+    segment: ActivityTimelineSegmentRow,
+): string {
+    const latestMessage = segment.entries.at(-1)?.message;
+    return latestMessage
+        ? (getToolTarget(latestMessage) ?? getEntryTitle(latestMessage))
+        : segment.summary.latestTitle;
+}
+
+export function getActivityTimelineRowKey(
+    sessionId: string | null | undefined,
+    rowId: string,
+): string {
+    return `${sessionId ?? DETACHED_ACTIVITY_TIMELINE_SCOPE}:${rowId}`;
+}
+
+export function buildActivityTimelineRows(
+    messages: readonly AIChatMessage[],
+): ActivityTimelineRow[] {
+    const rows: ActivityTimelineRow[] = [];
+    let segmentEntries: ActivityTimelineToolEntry[] = [];
+
+    const flushSegment = () => {
+        const firstEntry = segmentEntries[0];
+        if (!firstEntry) {
+            return;
+        }
+
+        rows.push({
+            entries: segmentEntries,
+            id: `activity-segment:${firstEntry.message.id}`,
+            kind: "activity-segment",
+            summary: buildActivityTimelineSegmentSummary(segmentEntries),
+        });
+        segmentEntries = [];
+    };
+
+    for (const message of messages) {
+        if (message.kind === "tool") {
+            segmentEntries.push({
+                message,
+                policy: getActivityTimelineToolPolicy(message),
+            });
+            continue;
+        }
+
+        flushSegment();
+        rows.push({
+            id: message.id,
+            kind: "message",
+            message,
+        });
+    }
+
+    flushSegment();
+    return rows;
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`) {
+    return `${count} ${count === 1 ? singular : plural}`;
+}

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
@@ -46,10 +46,9 @@ const DETACHED_ACTIVITY_TIMELINE_SCOPE = "__detached_activity_timeline__";
 export type ActivityTimelineToolPolicy =
     | "groupable"
     | "standalone-change"
-    | "standalone-attention"
-    | "standalone-unknown";
+    | "standalone-attention";
 
-/** A rail entry may be a reasoning event or a runtime tool activity. */
+/** A rail entry may be reasoning, routine status, or a runtime tool activity. */
 export interface ActivityTimelineToolEntry {
     readonly message: AIChatMessage;
     readonly policy: ActivityTimelineToolPolicy;
@@ -74,6 +73,7 @@ export interface ActivityTimelineSegmentSummary {
     readonly latestTitle: string;
     readonly reasoningCount: number;
     readonly searchCount: number;
+    readonly statusCount: number;
     readonly startedAt: number;
     readonly updatedAt: number;
 }
@@ -130,6 +130,23 @@ function isFailedTool(message: AIChatMessage): boolean {
     return status === "cancelled" || status === "error" || status === "failed";
 }
 
+function getStatusEventKind(message: AIChatMessage): string {
+    return getMessageMetaString(message, "status_event")?.toLowerCase() ?? "";
+}
+
+function isRoutineStatusActivity(message: AIChatMessage): boolean {
+    if (message.kind !== "status") {
+        return false;
+    }
+
+    // These events describe work already represented by the conversation's
+    // activity stream. State changes and recovery notices remain boundaries.
+    return (
+        getStatusEventKind(message) === "item_activity" ||
+        getStatusEventKind(message) === "subagent_lifecycle"
+    );
+}
+
 function isInProgressTool(message: AIChatMessage): boolean {
     const status = getToolStatus(message);
     return (
@@ -155,8 +172,12 @@ function getEntryTitle(message: AIChatMessage): string {
     );
 }
 
-function isTimelineActivity(message: AIChatMessage) {
-    return message.kind === "thinking" || message.kind === "tool";
+export function isActivityTimelineEntry(message: AIChatMessage) {
+    return (
+        message.kind === "thinking" ||
+        message.kind === "tool" ||
+        isRoutineStatusActivity(message)
+    );
 }
 
 function getLatestToolEntry(
@@ -307,24 +328,24 @@ export function getActivityTimelineToolPolicy(
     if (message.kind === "thinking") {
         return "groupable";
     }
-    if (hasChangeData(message)) {
-        // Changes keep their own review surface instead of becoming a routine row.
-        return "standalone-change";
-    }
 
     if (isFailedTool(message) || message.toolAction != null) {
         return "standalone-attention";
     }
 
-    const kind = getToolKind(message);
-    if (
-        COMMAND_TOOL_KINDS.has(kind) ||
-        GROUPABLE_TOOL_KINDS.has(kind)
-    ) {
+    if (isRoutineStatusActivity(message)) {
         return "groupable";
     }
 
-    return "standalone-unknown";
+    if (hasChangeData(message)) {
+        // Changes keep their own review surface instead of becoming a routine row.
+        return "standalone-change";
+    }
+
+    // ACP providers use ToolKind::Other for MCP and extension tools. A
+    // successful unknown tool is still routine work; only failures and
+    // user-facing actions need to remain visible in a collapsed rail.
+    return "groupable";
 }
 
 export function buildActivityTimelineSegmentSummary(
@@ -344,6 +365,7 @@ export function buildActivityTimelineSegmentSummary(
     let failureCount = 0;
     let reasoningCount = 0;
     let searchCount = 0;
+    let statusCount = 0;
     let isInProgress = false;
     let updatedAt = firstEntry.message.timestamp;
 
@@ -351,6 +373,9 @@ export function buildActivityTimelineSegmentSummary(
         const { message, policy } = entry;
         if (message.kind === "thinking") {
             reasoningCount += 1;
+        }
+        if (message.kind === "status") {
+            statusCount += 1;
         }
         const kind = getToolKind(message);
         const target = getToolTarget(message);
@@ -402,6 +427,7 @@ export function buildActivityTimelineSegmentSummary(
         latestTitle: getEntryTitle((latestToolEntry ?? latestEntry).message),
         reasoningCount,
         searchCount,
+        statusCount,
         startedAt: firstEntry.message.timestamp,
         updatedAt,
     };
@@ -411,6 +437,10 @@ export function getActivityTimelineSegmentHeadline(
     summary: ActivityTimelineSegmentSummary,
     isCurrentTurnTail = false,
 ): string {
+    if (summary.actionCount === 0 && summary.reasoningCount === 0) {
+        return isCurrentTurnTail ? "Working" : "Worked";
+    }
+
     const details = [
         pluralize(summary.actionCount, "action"),
         summary.changedFileCount > 0
@@ -494,7 +524,7 @@ export function buildActivityTimelineRows(
     };
 
     for (const message of messages) {
-        if (isTimelineActivity(message)) {
+        if (isActivityTimelineEntry(message)) {
             segmentEntries.push({
                 message,
                 policy: getActivityTimelineToolPolicy(message),

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
@@ -1,4 +1,5 @@
 import { computeDiffStats, type DiffStats } from "../diff/reviewDiff";
+import type { ActivityDisplayMode } from "../activityDisplayMode";
 import type { AIChatMessage, AIFileDiff } from "../types";
 
 const COMMAND_TOOL_KINDS = new Set([
@@ -143,6 +144,13 @@ function isRoutineStatusActivity(message: AIChatMessage): boolean {
     // activity stream. State changes and recovery notices remain boundaries.
     return (
         getStatusEventKind(message) === "item_activity" ||
+        getStatusEventKind(message) === "subagent_lifecycle"
+    );
+}
+
+function isSubagentLifecycleActivity(message: AIChatMessage): boolean {
+    return (
+        message.kind === "status" &&
         getStatusEventKind(message) === "subagent_lifecycle"
     );
 }
@@ -333,6 +341,10 @@ export function getActivityTimelineToolPolicy(
         return "standalone-attention";
     }
 
+    if (isSubagentLifecycleActivity(message)) {
+        return "standalone-attention";
+    }
+
     if (isRoutineStatusActivity(message)) {
         return "groupable";
     }
@@ -504,6 +516,7 @@ export function getActivityTimelineRowKey(
 
 export function buildActivityTimelineRows(
     messages: readonly AIChatMessage[],
+    displayMode: ActivityDisplayMode = "collapsed",
 ): ActivityTimelineRow[] {
     const rows: ActivityTimelineRow[] = [];
     let segmentEntries: ActivityTimelineToolEntry[] = [];
@@ -525,10 +538,16 @@ export function buildActivityTimelineRows(
 
     for (const message of messages) {
         if (isActivityTimelineEntry(message)) {
-            segmentEntries.push({
+            const entry = {
                 message,
                 policy: getActivityTimelineToolPolicy(message),
-            });
+            };
+
+            if (displayMode === "hidden" && entry.policy === "groupable") {
+                continue;
+            }
+
+            segmentEntries.push(entry);
             continue;
         }
 

--- a/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
+++ b/apps/desktop/src/features/ai/components/activityTimelinePresentation.ts
@@ -10,6 +10,7 @@ const COMMAND_TOOL_KINDS = new Set([
 ]);
 
 const GROUPABLE_TOOL_KINDS = new Set([
+    "browse",
     "fetch",
     "find",
     "glob",
@@ -18,6 +19,8 @@ const GROUPABLE_TOOL_KINDS = new Set([
     "read",
     "read_file",
     "search",
+    "web_fetch",
+    "web_search",
 ]);
 
 const MUTATING_FILE_TOOL_KINDS = new Set([
@@ -46,6 +49,7 @@ export type ActivityTimelineToolPolicy =
     | "standalone-attention"
     | "standalone-unknown";
 
+/** A rail entry may be a reasoning event or a runtime tool activity. */
 export interface ActivityTimelineToolEntry {
     readonly message: AIChatMessage;
     readonly policy: ActivityTimelineToolPolicy;
@@ -68,6 +72,7 @@ export interface ActivityTimelineSegmentSummary {
     readonly isInProgress: boolean;
     readonly latestMessageId: string;
     readonly latestTitle: string;
+    readonly reasoningCount: number;
     readonly searchCount: number;
     readonly startedAt: number;
     readonly updatedAt: number;
@@ -143,7 +148,21 @@ function hasChangeData(message: AIChatMessage): boolean {
 }
 
 function getEntryTitle(message: AIChatMessage): string {
-    return message.title?.trim() || message.content.trim() || "Tool activity";
+    return (
+        message.title?.trim() ||
+        message.content.trim() ||
+        (message.kind === "thinking" ? "Thinking" : "Tool activity")
+    );
+}
+
+function isTimelineActivity(message: AIChatMessage) {
+    return message.kind === "thinking" || message.kind === "tool";
+}
+
+function getLatestToolEntry(
+    entries: readonly ActivityTimelineToolEntry[],
+) {
+    return entries.findLast((entry) => entry.message.kind === "tool") ?? null;
 }
 
 function addPath(paths: Set<string>, path: string | null | undefined) {
@@ -285,6 +304,9 @@ export function deriveActivityTimelineChangeStats(
 export function getActivityTimelineToolPolicy(
     message: AIChatMessage,
 ): ActivityTimelineToolPolicy {
+    if (message.kind === "thinking") {
+        return "groupable";
+    }
     if (hasChangeData(message)) {
         // Changes keep their own review surface instead of becoming a routine row.
         return "standalone-change";
@@ -309,6 +331,7 @@ export function buildActivityTimelineSegmentSummary(
     entries: readonly ActivityTimelineToolEntry[],
 ): ActivityTimelineSegmentSummary {
     const latestEntry = entries.at(-1);
+    const latestToolEntry = getLatestToolEntry(entries);
     const firstEntry = entries[0];
     if (!firstEntry || !latestEntry) {
         throw new Error("An activity segment requires at least one tool entry.");
@@ -319,12 +342,16 @@ export function buildActivityTimelineSegmentSummary(
     let changeCount = 0;
     let commandCount = 0;
     let failureCount = 0;
+    let reasoningCount = 0;
     let searchCount = 0;
     let isInProgress = false;
     let updatedAt = firstEntry.message.timestamp;
 
     for (const entry of entries) {
         const { message, policy } = entry;
+        if (message.kind === "thinking") {
+            reasoningCount += 1;
+        }
         const kind = getToolKind(message);
         const target = getToolTarget(message);
         const diffs = getToolDiffs(message);
@@ -362,7 +389,8 @@ export function buildActivityTimelineSegmentSummary(
     }
 
     return {
-        actionCount: entries.length,
+        actionCount: entries.filter((entry) => entry.message.kind === "tool")
+            .length,
         changeCount,
         changeStats: deriveActivityTimelineChangeStats(entries),
         changedFileCount: changedFiles.size,
@@ -370,8 +398,9 @@ export function buildActivityTimelineSegmentSummary(
         failureCount,
         fileCount: fileTargets.size,
         isInProgress,
-        latestMessageId: latestEntry.message.id,
-        latestTitle: getEntryTitle(latestEntry.message),
+        latestMessageId: (latestToolEntry ?? latestEntry).message.id,
+        latestTitle: getEntryTitle((latestToolEntry ?? latestEntry).message),
+        reasoningCount,
         searchCount,
         startedAt: firstEntry.message.timestamp,
         updatedAt,
@@ -397,7 +426,14 @@ export function getActivityTimelineSegmentHeadline(
     ].filter((detail): detail is string => detail !== null);
 
     if (isCurrentTurnTail) {
+        if (summary.actionCount === 0 && summary.reasoningCount > 0) {
+            return "Thinking";
+        }
         return `Working · ${details.join(" · ")}`;
+    }
+
+    if (summary.actionCount === 0 && summary.reasoningCount > 0) {
+        return "Reasoned";
     }
 
     if (
@@ -423,7 +459,7 @@ export function getActivityTimelineSegmentHeadline(
 export function getActivityTimelineLatestLabel(
     segment: ActivityTimelineSegmentRow,
 ): string {
-    const latestMessage = segment.entries.at(-1)?.message;
+    const latestMessage = getLatestToolEntry(segment.entries)?.message;
     return latestMessage
         ? (getToolTarget(latestMessage) ?? getEntryTitle(latestMessage))
         : segment.summary.latestTitle;
@@ -458,7 +494,7 @@ export function buildActivityTimelineRows(
     };
 
     for (const message of messages) {
-        if (message.kind === "tool") {
+        if (isTimelineActivity(message)) {
             segmentEntries.push({
                 message,
                 policy: getActivityTimelineToolPolicy(message),

--- a/apps/desktop/src/features/ai/components/chatContentLayout.ts
+++ b/apps/desktop/src/features/ai/components/chatContentLayout.ts
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 
-export const AI_CHAT_CONTENT_MAX_WIDTH_PX = 740;
+export const AI_CHAT_CONTENT_MAX_WIDTH_PX = 600;
 
 export const AI_CHAT_CONTENT_COLUMN_STYLE = {
     width: "100%",

--- a/apps/desktop/src/features/ai/components/chatRowUiPresentation.ts
+++ b/apps/desktop/src/features/ai/components/chatRowUiPresentation.ts
@@ -1,0 +1,57 @@
+import { useCallback } from "react";
+
+import {
+    resolveChatRowUiSessionId,
+    useChatRowUiStore,
+    type ChatRowUiState,
+} from "../store/chatRowUiStore";
+
+export function useChatRowUiEntry(
+    sessionId: string | null | undefined,
+    messageId: string,
+) {
+    const resolvedSessionId = resolveChatRowUiSessionId(sessionId);
+    const rowState = useChatRowUiStore(
+        (state) => state.rowsBySessionId[resolvedSessionId]?.[messageId],
+    );
+    const patchRow = useChatRowUiStore((state) => state.patchRow);
+
+    const updateRow = useCallback(
+        (
+            patch:
+                | Partial<ChatRowUiState>
+                | ((current: ChatRowUiState) => Partial<ChatRowUiState>),
+        ) => {
+            patchRow(resolvedSessionId, messageId, patch);
+        },
+        [messageId, patchRow, resolvedSessionId],
+    );
+
+    return {
+        rowState,
+        updateRow,
+    };
+}
+
+export function useStoredRowExpanded(
+    sessionId: string | null | undefined,
+    messageId: string,
+    fallback: boolean,
+) {
+    const { rowState, updateRow } = useChatRowUiEntry(sessionId, messageId);
+    const expanded = rowState?.expanded ?? fallback;
+
+    const setExpanded = useCallback(
+        (value: boolean | ((current: boolean) => boolean)) => {
+            updateRow((current) => ({
+                expanded:
+                    typeof value === "function"
+                        ? value(current.expanded ?? fallback)
+                        : value,
+            }));
+        },
+        [fallback, updateRow],
+    );
+
+    return [expanded, setExpanded] as const;
+}

--- a/apps/desktop/src/features/ai/components/editedFilesPresentation.test.tsx
+++ b/apps/desktop/src/features/ai/components/editedFilesPresentation.test.tsx
@@ -82,8 +82,29 @@ describe("DiffLineView", () => {
         expect(row).toHaveAttribute("data-line-wrapping", "true");
         expect(row).toHaveStyle({
             whiteSpace: "pre-wrap",
-            wordBreak: "break-all",
+            wordBreak: "normal",
         });
+    });
+
+    it("keeps changed text readable without a polarity gutter", () => {
+        render(
+            <DiffLineView
+                line={{
+                    type: "remove",
+                    prefix: "- ",
+                    text: "previous Markdown paragraph",
+                    oldLineNumber: 5,
+                }}
+            />,
+        );
+
+        const row = screen
+            .getByText("previous Markdown paragraph")
+            .closest("[data-diff-line]");
+        expect(row).not.toBeNull();
+        expect(row).toHaveStyle({ color: "var(--text-primary)" });
+        expect(screen.getByText("5")).toBeInTheDocument();
+        expect(screen.queryByText("−")).toBeNull();
     });
 
     it("renders syntax highlighting when a language support is provided", () => {

--- a/apps/desktop/src/features/ai/components/editedFilesPresentation.tsx
+++ b/apps/desktop/src/features/ai/components/editedFilesPresentation.tsx
@@ -431,11 +431,15 @@ function getDiffLineGridTemplateColumns({
 function getDiffLineTextStyles(lineWrapping: boolean) {
     return {
         whiteSpace: lineWrapping ? ("pre-wrap" as const) : ("pre" as const),
-        wordBreak: lineWrapping ? ("break-all" as const) : ("normal" as const),
+        wordBreak: "normal" as const,
         overflowWrap: lineWrapping
             ? ("anywhere" as const)
             : ("normal" as const),
     };
+}
+
+function getDiffLineTextColor(line: DiffLine) {
+    return line.type === "context" ? "var(--text-secondary)" : "var(--text-primary)";
 }
 
 function compactExactDiffContext(
@@ -539,6 +543,8 @@ export function DiffLineView({
         if (compactLineNumbers) {
             return (
                 <div
+                    data-diff-line="true"
+                    data-line-wrapping={String(lineWrapping)}
                     style={{
                         display: "grid",
                         gridTemplateColumns: getDiffLineGridTemplateColumns({
@@ -554,18 +560,7 @@ export function DiffLineView({
                                 : line.type === "remove"
                                   ? "color-mix(in srgb, var(--diff-remove) 5%, transparent)"
                                   : "transparent",
-                        color:
-                            line.type === "add"
-                                ? "var(--diff-add)"
-                                : line.type === "remove"
-                                  ? "var(--diff-remove)"
-                                  : "var(--text-secondary)",
-                        borderLeft:
-                            line.type === "add"
-                                ? "2px solid color-mix(in srgb, var(--diff-add) 45%, transparent)"
-                                : line.type === "remove"
-                                  ? "2px solid color-mix(in srgb, var(--diff-remove) 45%, transparent)"
-                                  : "2px solid transparent",
+                        color: getDiffLineTextColor(line),
                     }}
                 >
                     <div
@@ -606,18 +601,7 @@ export function DiffLineView({
                             : line.type === "remove"
                               ? "color-mix(in srgb, var(--diff-remove) 5%, transparent)"
                               : "transparent",
-                    color:
-                        line.type === "add"
-                            ? "var(--diff-add)"
-                            : line.type === "remove"
-                              ? "var(--diff-remove)"
-                              : "var(--text-secondary)",
-                    borderLeft:
-                        line.type === "add"
-                            ? "2px solid color-mix(in srgb, var(--diff-add) 45%, transparent)"
-                            : line.type === "remove"
-                              ? "2px solid color-mix(in srgb, var(--diff-remove) 45%, transparent)"
-                              : "2px solid transparent",
+                    color: getDiffLineTextColor(line),
                 }}
             >
                 <div
@@ -693,18 +677,7 @@ export function DiffLineView({
                         : line.type === "remove"
                           ? "color-mix(in srgb, var(--diff-remove) 5%, transparent)"
                           : "transparent",
-                color:
-                    line.type === "add"
-                        ? "var(--diff-add)"
-                        : line.type === "remove"
-                          ? "var(--diff-remove)"
-                          : "var(--text-secondary)",
-                borderLeft:
-                    line.type === "add"
-                        ? "2px solid color-mix(in srgb, var(--diff-add) 45%, transparent)"
-                        : line.type === "remove"
-                          ? "2px solid color-mix(in srgb, var(--diff-remove) 45%, transparent)"
-                          : "2px solid transparent",
+                color: getDiffLineTextColor(line),
             }}
         >
             <div

--- a/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
+++ b/apps/desktop/src/features/ai/components/find/ChatFindBar.tsx
@@ -114,7 +114,7 @@ export function ChatFindBar({
                         else onNext();
                     }
                 }}
-                placeholder="Find in visible chat…"
+                placeholder="Find in chat…"
                 aria-label="Find in chat"
                 spellCheck={false}
                 className="h-[22px] min-w-0 rounded px-2 outline-none"

--- a/apps/desktop/src/features/ai/store/chatRowUiStore.ts
+++ b/apps/desktop/src/features/ai/store/chatRowUiStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 export interface ChatRowUiState {
+    activitySegmentExpanded?: boolean;
     expanded?: boolean;
     singleDiffExpanded?: boolean;
     diffExpandedByPath?: Record<string, boolean>;

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -561,6 +561,47 @@ describe("chatStore", () => {
         expect(useChatStore.getState().editDiffZoom).toBe(0.72);
     });
 
+    it("uses collapsed tool activity display by default", () => {
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe(
+            "collapsed",
+        );
+    });
+
+    it("restores a valid persisted tool activity display preference", () => {
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({ toolActivityDisplayMode: "expanded" }),
+        );
+
+        resetChatStore();
+
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe(
+            "expanded",
+        );
+    });
+
+    it("normalizes an invalid persisted tool activity display preference", () => {
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({ toolActivityDisplayMode: "always-open" }),
+        );
+
+        resetChatStore();
+
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe(
+            "collapsed",
+        );
+    });
+
+    it("persists tool activity display updates globally", () => {
+        useChatStore.getState().setToolActivityDisplayMode("hidden");
+
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe("hidden");
+        expect(
+            JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}"),
+        ).toMatchObject({ toolActivityDisplayMode: "hidden" });
+    });
+
     it("restores persisted edit diff zoom from AI preferences", () => {
         localStorage.setItem(
             AI_PREFS_KEY,
@@ -848,6 +889,28 @@ describe("chatStore", () => {
         vi.advanceTimersByTime(80);
 
         expect(useChatStore.getState().editDiffZoom).toBe(0.9);
+        vi.useRealTimers();
+    });
+
+    it("synchronizes tool activity display changes from another window", () => {
+        vi.useFakeTimers();
+
+        localStorage.setItem(
+            AI_PREFS_KEY,
+            JSON.stringify({ toolActivityDisplayMode: "expanded" }),
+        );
+        window.dispatchEvent(
+            new StorageEvent("storage", {
+                key: AI_PREFS_KEY,
+                newValue: localStorage.getItem(AI_PREFS_KEY),
+            }),
+        );
+
+        vi.advanceTimersByTime(80);
+
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe(
+            "expanded",
+        );
         vi.useRealTimers();
     });
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -169,6 +169,10 @@ import {
     buildClaudeTerminalSetupStatus,
 } from "../utils/claudeTerminalRuntime";
 import { checkClaudeCodeInstalled } from "../../terminal/claudeCodeTerminal";
+import {
+    normalizeActivityDisplayMode,
+    type ActivityDisplayMode,
+} from "../activityDisplayMode";
 
 const AI_PREFS_KEY = "neverwrite.ai.preferences";
 const AI_RUNTIME_CACHE_KEY = "neverwrite.ai.runtime-catalog";
@@ -225,6 +229,7 @@ interface AiPreferences {
     editDiffZoom?: number;
     historyRetentionDays?: number;
     screenshotRetentionSeconds?: number;
+    toolActivityDisplayMode?: ActivityDisplayMode;
     defaultRuntimeId?: string;
 }
 
@@ -238,6 +243,7 @@ interface NormalizedAiPreferences {
     editDiffZoom: number;
     historyRetentionDays: number;
     screenshotRetentionSeconds: number;
+    toolActivityDisplayMode: ActivityDisplayMode;
 }
 
 const DEFAULT_AI_PREFERENCES: NormalizedAiPreferences = {
@@ -250,6 +256,7 @@ const DEFAULT_AI_PREFERENCES: NormalizedAiPreferences = {
     editDiffZoom: 0.72,
     historyRetentionDays: 0,
     screenshotRetentionSeconds: DEFAULT_SCREENSHOT_RETENTION_SECONDS,
+    toolActivityDisplayMode: "collapsed",
 };
 
 interface AIRuntimeCatalogSnapshot {
@@ -310,6 +317,7 @@ function aiPrefsEqual(
         | "editDiffZoom"
         | "historyRetentionDays"
         | "screenshotRetentionSeconds"
+        | "toolActivityDisplayMode"
     >,
     right: NormalizedAiPreferences,
 ) {
@@ -322,7 +330,8 @@ function aiPrefsEqual(
         left.chatFontFamily === right.chatFontFamily &&
         left.editDiffZoom === right.editDiffZoom &&
         left.historyRetentionDays === right.historyRetentionDays &&
-        left.screenshotRetentionSeconds === right.screenshotRetentionSeconds
+        left.screenshotRetentionSeconds === right.screenshotRetentionSeconds &&
+        left.toolActivityDisplayMode === right.toolActivityDisplayMode
     );
 }
 
@@ -409,6 +418,9 @@ function getNormalizedAiPreferences(): NormalizedAiPreferences {
         editDiffZoom: prefs.editDiffZoom ?? 0.72,
         historyRetentionDays: prefs.historyRetentionDays ?? 0,
         screenshotRetentionSeconds,
+        toolActivityDisplayMode: normalizeActivityDisplayMode(
+            prefs.toolActivityDisplayMode,
+        ),
     };
 }
 
@@ -1587,6 +1599,7 @@ interface ChatStore {
     setEditDiffZoom: (size: number) => void;
     setHistoryRetentionDays: (days: number) => Promise<void>;
     setScreenshotRetentionSeconds: (seconds: number) => void;
+    setToolActivityDisplayMode: (mode: ActivityDisplayMode) => void;
     openNotePicker: () => void;
     closeNotePicker: () => void;
     forkSession: (sessionId: string) => Promise<void>;
@@ -7545,6 +7558,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         historyRetentionDays: DEFAULT_AI_PREFERENCES.historyRetentionDays,
         screenshotRetentionSeconds:
             DEFAULT_AI_PREFERENCES.screenshotRetentionSeconds,
+        toolActivityDisplayMode: DEFAULT_AI_PREFERENCES.toolActivityDisplayMode,
         composerPartsBySessionId: {},
         queuedMessagesBySessionId: {},
         queuedMessageEditBySessionId: {},
@@ -12881,6 +12895,12 @@ export const useChatStore = create<ChatStore>((set, get) => {
             saveAiPreferences({ screenshotRetentionSeconds: next });
         },
 
+        setToolActivityDisplayMode: (mode) => {
+            const next = normalizeActivityDisplayMode(mode);
+            set({ toolActivityDisplayMode: next });
+            saveAiPreferences({ toolActivityDisplayMode: next });
+        },
+
         openNotePicker: () => set({ notePickerOpen: true }),
 
         closeNotePicker: () => set({ notePickerOpen: false }),
@@ -12976,6 +12996,7 @@ export function hydrateChatStorePreferences() {
         editDiffZoom: prefs.editDiffZoom,
         historyRetentionDays: prefs.historyRetentionDays,
         screenshotRetentionSeconds: prefs.screenshotRetentionSeconds,
+        toolActivityDisplayMode: prefs.toolActivityDisplayMode,
     });
 }
 
@@ -13009,6 +13030,8 @@ export function initializeChatStoreRuntime() {
                               historyRetentionDays: prefs.historyRetentionDays,
                               screenshotRetentionSeconds:
                                   prefs.screenshotRetentionSeconds,
+                              toolActivityDisplayMode:
+                                  prefs.toolActivityDisplayMode,
                           },
                 );
             }, 80);
@@ -13093,6 +13116,7 @@ export function resetChatStore() {
         editDiffZoom: prefs.editDiffZoom,
         historyRetentionDays: prefs.historyRetentionDays,
         screenshotRetentionSeconds: prefs.screenshotRetentionSeconds,
+        toolActivityDisplayMode: prefs.toolActivityDisplayMode,
         composerPartsBySessionId: {},
         queuedMessagesBySessionId: {},
         queuedMessageEditBySessionId: {},

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1386,6 +1386,7 @@ interface ChatStore {
     editDiffZoom: number;
     historyRetentionDays: number;
     screenshotRetentionSeconds: number;
+    toolActivityDisplayMode: ActivityDisplayMode;
     composerPartsBySessionId: Record<string, AIComposerPart[]>;
     queuedMessagesBySessionId: Record<string, QueuedChatMessage[]>;
     queuedMessageEditBySessionId: Record<string, QueuedMessageEditState>;

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -602,6 +602,35 @@ describe("SettingsPanel", () => {
         expect(toggle).toHaveAttribute("aria-checked", "false");
     });
 
+    it("renders, persists, and searches the global tool activity display setting", () => {
+        useChatStore.setState({ toolActivityDisplayMode: "collapsed" });
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "AI" }));
+
+        const label = screen.getByText("Tool activity display");
+        const row = label.parentElement?.parentElement;
+        expect(row).not.toBeNull();
+
+        fireEvent.click(
+            within(row as HTMLElement).getByRole("button", {
+                name: "Collapsed",
+            }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Expanded" }));
+
+        expect(useChatStore.getState().toolActivityDisplayMode).toBe(
+            "expanded",
+        );
+
+        fireEvent.change(
+            screen.getByRole("textbox", { name: "Search settings" }),
+            { target: { value: "hide routine activity" } },
+        );
+
+        expect(screen.getByText("Tool activity display")).toBeInTheDocument();
+    });
+
     it("groups the font family selector and persists new bundled font options", () => {
         renderComponent(<SettingsPanel onClose={() => {}} />);
 

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -22,6 +22,7 @@ import {
     type RecentVault,
 } from "../../app/store/vaultStore";
 import { useChatStore } from "../ai/store/chatStore";
+import type { ActivityDisplayMode } from "../ai/activityDisplayMode";
 import { useSpellcheckStore } from "../spellcheck/store";
 import { getShortcutSettingsEntries } from "../../app/shortcuts/registry";
 import {
@@ -3903,6 +3904,12 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
     const setContextUsageBarEnabled = useChatStore(
         (s) => s.setContextUsageBarEnabled,
     );
+    const toolActivityDisplayMode = useChatStore(
+        (s) => s.toolActivityDisplayMode,
+    );
+    const setToolActivityDisplayMode = useChatStore(
+        (s) => s.setToolActivityDisplayMode,
+    );
     const screenshotRetentionSeconds = useChatStore(
         (s) => s.screenshotRetentionSeconds,
     );
@@ -3943,6 +3950,13 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
     const showChat = sectionHasSettingsSearchMatches(searchQuery, "Chat", [
         ["Chat font family", "Font used for messages in the chat.", ...fontKeywords],
         ["Chat font size", "Font size of messages in the chat, in pixels."],
+        [
+            "Tool activity display",
+            "Choose how tool activity appears between assistant messages.",
+            "Expanded",
+            "Collapsed",
+            "Hide routine activity",
+        ],
         [
             "Chat history retention",
             "How long saved chat histories stay on disk before they are automatically deleted.",
@@ -4037,6 +4051,31 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                         min={12}
                         max={28}
                         onChange={setChatFontSize}
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Chat"
+                label="Tool activity display"
+                description="Choose how tool activity appears between assistant messages."
+                keywords={["Expanded", "Collapsed", "Hide routine activity"]}
+                control={
+                    <SelectField
+                        value={toolActivityDisplayMode}
+                        options={[
+                            { value: "expanded", label: "Expanded" },
+                            { value: "collapsed", label: "Collapsed" },
+                            {
+                                value: "hidden",
+                                label: "Hide routine activity",
+                            },
+                        ]}
+                        onChange={(value) =>
+                            setToolActivityDisplayMode(
+                                value as ActivityDisplayMode,
+                            )
+                        }
                     />
                 }
             />
@@ -4602,6 +4641,10 @@ const STATIC_CATEGORY_SEARCH_VALUES: Record<Category, readonly SearchValue[]> = 
         "Chat",
         "Chat font family",
         "Chat font size",
+        "Tool activity display",
+        "Expanded",
+        "Collapsed",
+        "Hide routine activity",
         "Chat history retention",
         "Composer",
         "Require command enter control enter to send",

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -934,6 +934,66 @@ body.dragging-tab * {
     filter: brightness(0.95);
 }
 
+/* Activity rails own their container query so dense chat panes can hide their
+   secondary label without coupling that decision to the application width. */
+.activity-rail {
+    container-type: inline-size;
+}
+
+.activity-tree-branch {
+    --activity-tree-color: color-mix(
+        in srgb,
+        var(--text-secondary) 34%,
+        transparent
+    );
+    position: relative;
+}
+
+.activity-tree-branch::before,
+.activity-tree-branch::after {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+}
+
+.activity-tree-branch::before {
+    background: repeating-linear-gradient(
+        to bottom,
+        var(--activity-tree-color) 0 2px,
+        transparent 2px 5px
+    );
+    bottom: -0.375rem;
+    left: 1rem;
+    top: -0.375rem;
+    width: 1px;
+}
+
+.activity-tree-branch::after {
+    background: repeating-linear-gradient(
+        to right,
+        var(--activity-tree-color) 0 2px,
+        transparent 2px 5px
+    );
+    height: 1px;
+    left: 1rem;
+    top: 1rem;
+    width: 0.875rem;
+}
+
+.activity-tree-branch:first-child::before {
+    top: -1.5rem;
+}
+
+.activity-tree-branch:last-child::before {
+    bottom: calc(100% - 1rem);
+}
+
+@container (max-width: 360px) {
+    [data-activity-rail-current="true"] {
+        display: none;
+    }
+}
+
 /* ── Settings panel primitives ─────────────────────────────────
    Toggle switches, segmented controls, select dropdowns, +/- steppers
    and theme tiles all share the same tactile press feel as the rest of

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -616,6 +616,57 @@ html[data-desktop-platform="windows"].dark {
         color-mix(in srgb, var(--code-markup) 72%, transparent);
 }
 
+/* Chat fences share Comando's compact, single-surface code frame. */
+.chat-code-frame {
+    border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
+    border-radius: 6px;
+    background: color-mix(in srgb, var(--bg-tertiary) 68%, transparent);
+}
+
+.chat-code-header {
+    display: flex;
+    min-height: 2.45em;
+    align-items: center;
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-weight: 600;
+    padding: 0.18em 2.75em 0 1em;
+}
+
+.chat-code-copy-button {
+    top: 0.55em;
+    right: 0.55em;
+    width: 20px;
+    height: 20px;
+    border: 0;
+    background: transparent;
+    cursor: pointer;
+    opacity: 0.72;
+    padding: 0;
+    transition:
+        color 100ms ease,
+        opacity 100ms ease;
+}
+
+.chat-code-copy-button:hover {
+    color: var(--text-primary) !important;
+    opacity: 1;
+}
+
+.chat-code-copy-button:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
+    outline-offset: 2px;
+}
+
+.chat-code-block {
+    padding: 0.3em 1em 0.85em;
+}
+
+.chat-code-frame--unlabeled .chat-code-block {
+    padding-top: 0.85em;
+    padding-right: 2.75em;
+}
+
 body.resizing-sidebar,
 body.resizing-sidebar * {
     cursor: col-resize !important;

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -646,6 +646,28 @@ body.dragging-tab * {
     }
 }
 
+.activity-rail-working-indicator {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: baseline;
+    gap: 1px;
+    color: var(--accent);
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 16px;
+}
+
+.activity-rail-working-cursor {
+    animation: devtools-terminal-cursor 850ms steps(1, end) infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .activity-rail-working-cursor {
+        animation: none;
+    }
+}
+
 .terminal-surface {
     height: 100%;
     min-height: 0;

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1016,6 +1016,18 @@ body.dragging-tab * {
     }
 }
 
+/* Keep user prompts compact in wide panes, then recover the full row width
+   when the chat column itself becomes too narrow for a fixed percentage. */
+[data-user-message="true"] {
+    container-type: inline-size;
+}
+
+@container (max-width: 420px) {
+    [data-user-message-bubble="true"] {
+        width: 100%;
+    }
+}
+
 /* ── Settings panel primitives ─────────────────────────────────
    Toggle switches, segmented controls, select dropdowns, +/- steppers
    and theme tiles all share the same tactile press feel as the rest of

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -686,75 +686,7 @@ body.dragging-tab * {
     cursor: grabbing !important;
 }
 
-@keyframes activity-rail-cube-orbit {
-    to {
-        transform: rotate(1turn);
-    }
-}
-
-@keyframes activity-rail-cube-pulse {
-    0%,
-    100% {
-        opacity: 0.28;
-        transform: scale(0.72);
-    }
-    50% {
-        opacity: 1;
-        transform: scale(1);
-    }
-}
-
-.activity-rail-working-indicator {
-    display: inline-grid;
-    flex: 0 0 auto;
-    place-items: center;
-    width: 16px;
-    height: 16px;
-}
-
-.activity-rail-working-cubes {
-    position: relative;
-    display: block;
-    width: 12px;
-    height: 12px;
-    animation: activity-rail-cube-orbit 1.15s linear infinite;
-}
-
-.activity-rail-working-cube {
-    position: absolute;
-    width: 4px;
-    height: 4px;
-    border-radius: 1px;
-    background: var(--accent);
-    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
-    animation: activity-rail-cube-pulse 880ms ease-in-out infinite;
-}
-
-.activity-rail-working-cube:nth-child(1) {
-    top: 0;
-    left: 4px;
-    animation-delay: 0ms;
-}
-
-.activity-rail-working-cube:nth-child(2) {
-    top: 4px;
-    right: 0;
-    animation-delay: 110ms;
-}
-
-.activity-rail-working-cube:nth-child(3) {
-    bottom: 0;
-    left: 4px;
-    animation-delay: 220ms;
-}
-
-.activity-rail-working-cube:nth-child(4) {
-    top: 4px;
-    left: 0;
-    animation-delay: 330ms;
-}
-
-.activity-rail-worked-indicator {
+.activity-rail-indicator {
     display: inline-grid;
     flex: 0 0 auto;
     place-items: center;
@@ -763,15 +695,8 @@ body.dragging-tab * {
     color: var(--text-primary);
 }
 
-.activity-rail-worked-cube {
+.activity-rail-chevron {
     display: block;
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .activity-rail-working-cubes,
-    .activity-rail-working-cube {
-        animation: none;
-    }
 }
 
 .terminal-surface {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -635,35 +635,77 @@ body.dragging-tab * {
     cursor: grabbing !important;
 }
 
-@keyframes devtools-terminal-cursor {
-    0%,
-    49% {
-        opacity: 1;
+@keyframes activity-rail-cube-orbit {
+    to {
+        transform: rotate(1turn);
     }
-    50%,
+}
+
+@keyframes activity-rail-cube-pulse {
+    0%,
     100% {
-        opacity: 0;
+        opacity: 0.28;
+        transform: scale(0.72);
+    }
+    50% {
+        opacity: 1;
+        transform: scale(1);
     }
 }
 
 .activity-rail-working-indicator {
-    display: inline-flex;
+    display: inline-grid;
     flex: 0 0 auto;
-    align-items: baseline;
-    gap: 1px;
-    color: var(--accent);
-    font-family: var(--font-mono);
-    font-size: 11px;
-    font-weight: 600;
-    line-height: 16px;
+    place-items: center;
+    width: 16px;
+    height: 16px;
 }
 
-.activity-rail-working-cursor {
-    animation: devtools-terminal-cursor 850ms steps(1, end) infinite;
+.activity-rail-working-cubes {
+    position: relative;
+    display: block;
+    width: 12px;
+    height: 12px;
+    animation: activity-rail-cube-orbit 1.15s linear infinite;
+}
+
+.activity-rail-working-cube {
+    position: absolute;
+    width: 4px;
+    height: 4px;
+    border-radius: 1px;
+    background: var(--accent);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent);
+    animation: activity-rail-cube-pulse 880ms ease-in-out infinite;
+}
+
+.activity-rail-working-cube:nth-child(1) {
+    top: 0;
+    left: 4px;
+    animation-delay: 0ms;
+}
+
+.activity-rail-working-cube:nth-child(2) {
+    top: 4px;
+    right: 0;
+    animation-delay: 110ms;
+}
+
+.activity-rail-working-cube:nth-child(3) {
+    bottom: 0;
+    left: 4px;
+    animation-delay: 220ms;
+}
+
+.activity-rail-working-cube:nth-child(4) {
+    top: 4px;
+    left: 0;
+    animation-delay: 330ms;
 }
 
 @media (prefers-reduced-motion: reduce) {
-    .activity-rail-working-cursor {
+    .activity-rail-working-cubes,
+    .activity-rail-working-cube {
         animation: none;
     }
 }

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -634,41 +634,39 @@ html[data-desktop-platform="windows"].dark {
     padding: 0.18em 2.75em 0 1em;
 }
 
-.chat-code-mode-toggle {
-    display: inline-flex;
-    align-items: center;
-    gap: 2px;
-    margin-left: auto;
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--bg-primary) 34%, transparent);
-    padding: 2px;
+.chat-code-actions {
+    top: 0.55em;
+    right: 0.55em;
+    gap: 0.55em;
 }
 
 .chat-code-mode-button {
     border: 0;
-    border-radius: 3px;
     background: transparent;
     color: var(--text-secondary);
     cursor: pointer;
-    font: inherit;
+    font-family: var(--font-mono);
     font-weight: 500;
     line-height: 1.4;
-    padding: 1px 6px;
+    padding: 0;
+    opacity: 0.72;
+    transition:
+        color 120ms ease,
+        opacity 120ms ease;
 }
 
-.chat-code-mode-button[aria-pressed="true"] {
-    background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+.chat-code-mode-button:hover {
     color: var(--text-primary);
+    opacity: 1;
 }
 
 .chat-code-mode-button:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
-    outline-offset: 1px;
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 
 .chat-code-copy-button {
-    top: 0.55em;
-    right: 0.55em;
     width: 20px;
     height: 20px;
     border: 0;

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -616,6 +616,20 @@ html[data-desktop-platform="windows"].dark {
         color-mix(in srgb, var(--code-markup) 72%, transparent);
 }
 
+.chat-inline-code {
+    padding: 1px 4px;
+    border-radius: 3px;
+    background: color-mix(in srgb, var(--bg-tertiary) 82%, transparent);
+    box-decoration-break: clone;
+    -webkit-box-decoration-break: clone;
+    box-shadow: inset 0 0 0 1px
+        color-mix(in srgb, var(--border) 42%, transparent);
+    color: color-mix(in srgb, var(--text-primary) 78%, var(--text-secondary));
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.82em;
+    overflow-wrap: anywhere;
+}
+
 /* Chat fences share Comando's compact, single-surface code frame. */
 .chat-code-frame {
     border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -703,6 +703,19 @@ body.dragging-tab * {
     animation-delay: 330ms;
 }
 
+.activity-rail-worked-indicator {
+    display: inline-grid;
+    flex: 0 0 auto;
+    place-items: center;
+    width: 16px;
+    height: 16px;
+    color: var(--text-primary);
+}
+
+.activity-rail-worked-cube {
+    display: block;
+}
+
 @media (prefers-reduced-motion: reduce) {
     .activity-rail-working-cubes,
     .activity-rail-working-cube {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -627,10 +627,43 @@ html[data-desktop-platform="windows"].dark {
     display: flex;
     min-height: 2.45em;
     align-items: center;
+    gap: 0.75em;
     color: var(--text-secondary);
     font-family: var(--font-mono);
     font-weight: 600;
     padding: 0.18em 2.75em 0 1em;
+}
+
+.chat-code-mode-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    margin-left: auto;
+    border-radius: 4px;
+    background: color-mix(in srgb, var(--bg-primary) 34%, transparent);
+    padding: 2px;
+}
+
+.chat-code-mode-button {
+    border: 0;
+    border-radius: 3px;
+    background: transparent;
+    color: var(--text-secondary);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 500;
+    line-height: 1.4;
+    padding: 1px 6px;
+}
+
+.chat-code-mode-button[aria-pressed="true"] {
+    background: color-mix(in srgb, var(--bg-elevated) 88%, transparent);
+    color: var(--text-primary);
+}
+
+.chat-code-mode-button:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
+    outline-offset: 1px;
 }
 
 .chat-code-copy-button {
@@ -659,6 +692,11 @@ html[data-desktop-platform="windows"].dark {
 }
 
 .chat-code-block {
+    padding: 0.3em 1em 0.85em;
+}
+
+.chat-markdown-preview {
+    min-width: 0;
     padding: 0.3em 1em 0.85em;
 }
 

--- a/docs/ai-change-control.md
+++ b/docs/ai-change-control.md
@@ -105,14 +105,16 @@ Inline or partial review:
 
 ## Review Surfaces
 
-There are two review surfaces:
+There are three review surfaces:
 
 - Full Review tab: [`AIReviewView.tsx`](../apps/desktop/src/features/ai/components/AIReviewView.tsx) opens from the editor and shows pending changes with global actions, expansion state, zoom, persisted scroll/anchor state, and per-file diff cards.
 - Compact Edits surface: [`EditedFilesBufferPanel.tsx`](../apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx) appears in the chat sidebar and offers compact keep/reject/review/undo actions.
+- Chat activity rows: [`ChangeReviewToolRail.tsx`](../apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx) renders change-review progress and diff previews in the conversation timeline. It is a navigation and inspection surface; keep/reject state and actions still derive from the same canonical ActionLog projection.
 
-Both surfaces render shared rows through
+The Review tab and Edits surface render shared rows through
 [`EditedFilesReviewList.tsx`](../apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx)
-and derive file items from the same tracked-file projection. Keep user-facing UI
+and derive file items from the same tracked-file projection. Chat activity rows
+also derive their change-review state from that projection. Keep user-facing UI
 copy in English.
 
 Review projection groups spans into hunks and chunks:

--- a/docs/review-hardening-checklist.md
+++ b/docs/review-hardening-checklist.md
@@ -140,6 +140,21 @@ back to the agent.
 - [ ] Click undo from the compact panel and confirm the rejected tracked files
       and disk content are restored when safe.
 
+## Chat Activity And Change Review
+
+- [ ] Set Tool activity display to `expanded`, `collapsed`, and `hidden` in
+      Settings, then confirm each mode produces the expected conversation
+      timeline presentation.
+- [ ] With activity hidden, navigate directly to a tool or change-review
+      message and confirm its activity segment is temporarily revealed.
+- [ ] With activity hidden, search for a tool or change-review message and
+      confirm matching activity is revealed while the search result is active.
+- [ ] Confirm hidden activity does not leave a change-review row styled as the
+      active tail of a streaming turn.
+- [ ] Open a Markdown change preview in an activity card and confirm the
+      rendered preview, source fallback, gutter, and file reference links are
+      readable and navigate to the expected target.
+
 ## File Lifecycle Cases
 
 - [ ] Modified file: reject restores original content; accept keeps agent

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -87,6 +87,7 @@ the same Settings stores.
 | AI / Context | `autoContextEnabled` | Per-vault, global fallback | `false` | `neverwrite.ai.auto-context:<vault-path>` | Legacy `neverwrite.ai.preferences.autoContextEnabled` is still read as fallback. |
 | AI / Chat | `chatFontFamily` | Global | `system` | `neverwrite.ai.preferences` | Validated with editor font-family normalization. |
 | AI / Chat | `chatFontSize` | Global | `14` | `neverwrite.ai.preferences` | Chat transcript font size. |
+| AI / Chat | `toolActivityDisplayMode` | Global | `collapsed` | `neverwrite.ai.preferences` | Controls whether tool activity is expanded, collapsed, or hidden. Hidden activity is temporarily revealed for search results and explicit message navigation. |
 | AI / Chat | `historyRetentionDays` | Global preference, applied to current vault histories | `0` | `neverwrite.ai.preferences` | `0` means forever; pruning operates on the currently open vault's `.neverwrite/sessions/`. |
 | AI / Composer | `requireCmdEnterToSend` | Global | `false` | `neverwrite.ai.preferences` | Changes Enter behavior in the AI composer. |
 | AI / Composer | `contextUsageBarEnabled` | Global | `true` | `neverwrite.ai.preferences` | Shows or hides composer context usage. |


### PR DESCRIPTION
## Summary

- Rework chat tool activity into a chronological timeline with compact, expanded, and completed states.
- Present change reviews as activity rows with improved edited-file presentation and resizable diff content.
- Add a persisted Tool Activity display preference in Settings.
- Improve Markdown rendering in chat, including code fences, inline code, file references, and Markdown change previews.
- Tighten chat content width for a more focused reading experience.

## Details

- Add dedicated activity timeline presentation, segments, and activity item components.
- Keep hidden activity from incorrectly marking a change-review row as active, and reveal it temporarily when navigating to a matching message or search result.
- Preserve the existing change-review behavior while integrating it into the activity timeline.
- Add Markdown preview support for changes shown in activity cards, with a simplified preview gutter.
- Render file references as icon links and align read/edit activity rows consistently.
- Refresh chat visual hierarchy: active/completed indicators, spacing, message bubbles, and code styling.
- Type the persisted tool activity display preference in the chat store.

## Testing

- `npm --prefix apps/desktop test -- src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/components/AIChatMessageList.test.tsx`
  - 2 test files passed; 76 tests passed.
- Expanded coverage for activity timeline construction and rendering, activity items and segments, hidden activity navigation, Markdown, settings, transcript, edited files, and the chat store.