### PR TITLE
Unify vault reference styling across AI chat

### DIFF
--- a/apps/desktop/src/components/icons/CatppuccinIcon.tsx
+++ b/apps/desktop/src/components/icons/CatppuccinIcon.tsx
@@ -1,15 +1,9 @@
 import {
-    FALLBACK_CATPPUCCIN_ICON,
-    getCatppuccinIcon,
     getCatppuccinViewBox,
     getThemedCatppuccinIconBody,
-    resolveAvailableCatppuccinIcon,
     type CatppuccinIconName,
 } from "./catppuccin-icons";
-
-function scaleIconSize(value: number): string {
-    return `calc(${value}px * var(--file-tree-scale, 1))`;
-}
+import { resolveCatppuccinIconPresentation } from "./catppuccinIconPresentation";
 
 export function CatppuccinIcon({
     className,
@@ -24,32 +18,25 @@ export function CatppuccinIcon({
     readonly scaled?: boolean;
     readonly size?: number | string;
 }) {
-    const resolvedIconName = resolveAvailableCatppuccinIcon(
+    const { dimension, icon } = resolveCatppuccinIconPresentation(
         iconName,
-        FALLBACK_CATPPUCCIN_ICON,
+        size,
+        scaled,
     );
-    const icon = getCatppuccinIcon(resolvedIconName);
 
     if (!icon) {
         return null;
     }
-
-    const dim =
-        typeof size === "number"
-            ? scaled
-                ? scaleIconSize(size)
-                : `${size}px`
-            : size;
 
     return (
         <svg
             aria-hidden="true"
             className={className}
             focusable="false"
-            height={dim}
+            height={dimension}
             style={{ display: "block", flexShrink: 0, opacity }}
             viewBox={getCatppuccinViewBox(icon)}
-            width={dim}
+            width={dimension}
             xmlns="http://www.w3.org/2000/svg"
             dangerouslySetInnerHTML={{
                 __html: getThemedCatppuccinIconBody(icon.body),

--- a/apps/desktop/src/components/icons/catppuccinIconPresentation.ts
+++ b/apps/desktop/src/components/icons/catppuccinIconPresentation.ts
@@ -1,0 +1,67 @@
+import {
+    FALLBACK_CATPPUCCIN_ICON,
+    getCatppuccinIcon,
+    getCatppuccinViewBox,
+    getThemedCatppuccinIconBody,
+    resolveAvailableCatppuccinIcon,
+    type CatppuccinIconName,
+} from "./catppuccin-icons";
+
+function scaleIconSize(value: number): string {
+    return `calc(${value}px * var(--file-tree-scale, 1))`;
+}
+
+export function resolveCatppuccinIconPresentation(
+    iconName: CatppuccinIconName,
+    size: number | string,
+    scaled: boolean,
+) {
+    const resolvedIconName = resolveAvailableCatppuccinIcon(
+        iconName,
+        FALLBACK_CATPPUCCIN_ICON,
+    );
+    const icon = getCatppuccinIcon(resolvedIconName);
+    const dimension =
+        typeof size === "number"
+            ? scaled
+                ? scaleIconSize(size)
+                : `${size}px`
+            : size;
+
+    return { dimension, icon };
+}
+
+/** Creates the same icon SVG for imperative contenteditable surfaces. */
+export function createCatppuccinIconElement({
+    iconName,
+    opacity = 1,
+    scaled = false,
+    size = 16,
+}: {
+    readonly iconName: CatppuccinIconName;
+    readonly opacity?: number;
+    readonly scaled?: boolean;
+    readonly size?: number | string;
+}) {
+    const { dimension, icon } = resolveCatppuccinIconPresentation(
+        iconName,
+        size,
+        scaled,
+    );
+    if (!icon) return null;
+
+    const element = document.createElementNS(
+        "http://www.w3.org/2000/svg",
+        "svg",
+    );
+    element.setAttribute("aria-hidden", "true");
+    element.setAttribute("focusable", "false");
+    element.setAttribute("height", dimension);
+    element.setAttribute("viewBox", getCatppuccinViewBox(icon));
+    element.setAttribute("width", dimension);
+    element.style.display = "block";
+    element.style.flexShrink = "0";
+    element.style.opacity = String(opacity);
+    element.innerHTML = getThemedCatppuccinIconBody(icon.body);
+    return element;
+}

--- a/apps/desktop/src/features/ai/chatFileNavigation.ts
+++ b/apps/desktop/src/features/ai/chatFileNavigation.ts
@@ -16,6 +16,7 @@ import {
     openChatNoteByAbsolutePath,
     openChatResolvedNote,
 } from "./chatNoteNavigation";
+import { parseChatVaultReferenceTarget } from "./chatVaultReferenceTarget";
 
 function getVaultEntryByAbsolutePath(absPath: string) {
     return (
@@ -90,6 +91,8 @@ export function canOpenAiEditedFileEntry(entry: VaultEntryDto | null) {
 }
 
 export function canOpenAiEditedFileByAbsolutePath(absPath: string) {
+    const target = parseChatVaultReferenceTarget(absPath);
+    absPath = target.path;
     const note = useVaultStore
         .getState()
         .notes.find((entry) => entry.path === absPath);
@@ -107,19 +110,38 @@ export function canOpenAiEditedFileByAbsolutePath(absPath: string) {
 
 export async function openAiEditedFileByAbsolutePath(
     absPath: string,
-    options?: { newTab?: boolean },
+    options?: {
+        newTab?: boolean;
+        line?: number | null;
+        endLine?: number | null;
+    },
 ) {
+    const target = parseChatVaultReferenceTarget(absPath);
+    absPath = target.path;
+    const navigationOptions = {
+        ...options,
+        line: options?.line ?? target.line,
+        endLine: options?.endLine ?? target.endLine,
+    };
     const note = useVaultStore
         .getState()
         .notes.find((entry) => entry.path === absPath);
     if (note) {
-        return openChatNoteByAbsolutePath(absPath, options);
+        return openChatNoteByAbsolutePath(absPath, navigationOptions);
     }
 
     const entry = getVaultEntryByAbsolutePath(absPath);
     if (entry && canOpenAiEditedFileEntry(entry)) {
         if (entry.kind === "note") {
-            return openResolvedNoteEntry(entry, options);
+            const opened = await openResolvedNoteEntry(entry, options);
+            if (opened && navigationOptions.line) {
+                useEditorStore.getState().queueLineReveal({
+                    noteId: entry.id,
+                    line: navigationOptions.line,
+                    endLine: navigationOptions.endLine,
+                });
+            }
+            return opened;
         }
 
         await openVaultFileEntry(entry, options);
@@ -132,7 +154,15 @@ export async function openAiEditedFileByAbsolutePath(
     }
 
     if (resolvedEntry.kind === "note") {
-        return openResolvedNoteEntry(resolvedEntry, options);
+        const opened = await openResolvedNoteEntry(resolvedEntry, options);
+        if (opened && navigationOptions.line) {
+            useEditorStore.getState().queueLineReveal({
+                noteId: resolvedEntry.id,
+                line: navigationOptions.line,
+                endLine: navigationOptions.endLine,
+            });
+        }
+        return opened;
     }
     const title = getFileNameFromAbsolutePath(absPath);
     resolvedEntry.title ||= title.replace(/\.[^/.]+$/, "");

--- a/apps/desktop/src/features/ai/chatNoteNavigation.test.ts
+++ b/apps/desktop/src/features/ai/chatNoteNavigation.test.ts
@@ -2,9 +2,11 @@ import { invoke } from "@neverwrite/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore, isMapTab } from "../../app/store/editorStore";
 import { useVaultStore, type NoteDto } from "../../app/store/vaultStore";
+import { setEditorTabs } from "../../test/test-utils";
 import {
     findChatNoteByReference,
     openChatMapByReference,
+    openChatNoteByReference,
 } from "./chatNoteNavigation";
 
 function makeNote(
@@ -113,5 +115,31 @@ describe("findChatNoteByReference", () => {
         });
 
         expect(findChatNoteByReference("Brief")).toBeNull();
+    });
+
+    it("opens line references and queues the requested range for reveal", async () => {
+        const note = makeNote("CHANGELOG.md");
+        useVaultStore.setState({ notes: [note] });
+        setEditorTabs(
+            [
+                {
+                    id: "changelog-tab",
+                    noteId: note.id,
+                    title: note.title,
+                    content: "line 1\nline 2",
+                },
+            ],
+            "changelog-tab",
+        );
+        useEditorStore.setState({ pendingLineReveal: null });
+
+        await expect(
+            openChatNoteByReference("CHANGELOG.md#L66-L70"),
+        ).resolves.toBe(true);
+        expect(useEditorStore.getState().pendingLineReveal).toEqual({
+            noteId: "CHANGELOG.md",
+            line: 66,
+            endLine: 70,
+        });
     });
 });

--- a/apps/desktop/src/features/ai/chatNoteNavigation.ts
+++ b/apps/desktop/src/features/ai/chatNoteNavigation.ts
@@ -8,6 +8,7 @@ import {
 import { useVaultStore, type NoteDto } from "../../app/store/vaultStore";
 import { toVaultRelativePath } from "../../app/utils/vaultPaths";
 import { vaultInvoke } from "../../app/utils/vaultInvoke";
+import { parseChatVaultReferenceTarget } from "./chatVaultReferenceTarget";
 
 function normalizeReferencePath(value: string) {
     return value.trim().replace(/\\/g, "/").replace(/^\.\//, "");
@@ -47,7 +48,9 @@ function getUniqueMatch(
 // Resolve that form deliberately, but never choose an arbitrary note when a
 // basename is shared by multiple folders.
 export function findChatNoteByReference(reference: string) {
-    const rawReference = normalizeReferencePath(reference);
+    const rawReference = normalizeReferencePath(
+        parseChatVaultReferenceTarget(reference).path,
+    );
     if (!rawReference) return null;
     const canonicalReference = getCanonicalReference(rawReference);
     const canonicalBasename = getCanonicalReference(
@@ -145,24 +148,52 @@ export async function openChatNoteById(
 
 export async function openChatNoteByReference(
     reference: string,
-    options?: { newTab?: boolean },
+    options?: {
+        newTab?: boolean;
+        line?: number | null;
+        endLine?: number | null;
+    },
 ) {
+    const target = parseChatVaultReferenceTarget(reference);
     const note = findChatNoteByReference(reference);
     if (!note) return false;
 
-    return openChatResolvedNote(note.id, note.title, options);
+    const opened = await openChatResolvedNote(note.id, note.title, options);
+    const line = options?.line ?? target.line;
+    if (opened && line) {
+        useEditorStore.getState().queueLineReveal({
+            noteId: note.id,
+            line,
+            endLine: options?.endLine ?? target.endLine,
+        });
+    }
+    return opened;
 }
 
 export async function openChatNoteByAbsolutePath(
     absPath: string,
-    options?: { newTab?: boolean },
+    options?: {
+        newTab?: boolean;
+        line?: number | null;
+        endLine?: number | null;
+    },
 ) {
+    const target = parseChatVaultReferenceTarget(absPath);
     const note = useVaultStore
         .getState()
-        .notes.find((entry) => entry.path === absPath);
+        .notes.find((entry) => entry.path === target.path);
     if (!note) return false;
 
-    return openChatResolvedNote(note.id, note.title, options);
+    const opened = await openChatResolvedNote(note.id, note.title, options);
+    const line = options?.line ?? target.line;
+    if (opened && line) {
+        useEditorStore.getState().queueLineReveal({
+            noteId: note.id,
+            line,
+            endLine: options?.endLine ?? target.endLine,
+        });
+    }
+    return opened;
 }
 
 interface MapEntry {

--- a/apps/desktop/src/features/ai/chatVaultReferenceTarget.test.ts
+++ b/apps/desktop/src/features/ai/chatVaultReferenceTarget.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+    getChatVaultReferenceLabel,
+    parseChatVaultReferenceTarget,
+    serializeChatVaultReferenceTarget,
+} from "./chatVaultReferenceTarget";
+
+describe("chatVaultReferenceTarget", () => {
+    it.each([
+        ["CHANGELOG.md:66", 66, null],
+        ["CHANGELOG.md#L66", 66, null],
+        ["CHANGELOG.md#L66-L70", 66, 70],
+        ["CHANGELOG.md#L66-70", 66, 70],
+        ["CHANGELOG.md:66-70", 66, 70],
+    ])("parses %s", (reference, line, endLine) => {
+        expect(parseChatVaultReferenceTarget(reference)).toEqual({
+            path: "CHANGELOG.md",
+            line,
+            endLine,
+        });
+    });
+
+    it("leaves ordinary paths and Windows drive letters intact", () => {
+        expect(parseChatVaultReferenceTarget("C:/vault/CHANGELOG.md")).toEqual({
+            path: "C:/vault/CHANGELOG.md",
+            line: null,
+            endLine: null,
+        });
+    });
+
+    it("normalizes serialization and formats user-facing line labels", () => {
+        const target = parseChatVaultReferenceTarget("CHANGELOG.md:66-70");
+        expect(serializeChatVaultReferenceTarget(target)).toBe(
+            "CHANGELOG.md#L66-70",
+        );
+        expect(getChatVaultReferenceLabel("CHANGELOG.md", target)).toBe(
+            "CHANGELOG.md (lines 66–70)",
+        );
+        expect(
+            getChatVaultReferenceLabel("CHANGELOG.md (lines 66–70)", target),
+        ).toBe("CHANGELOG.md (lines 66–70)");
+    });
+});

--- a/apps/desktop/src/features/ai/chatVaultReferenceTarget.ts
+++ b/apps/desktop/src/features/ai/chatVaultReferenceTarget.ts
@@ -1,0 +1,54 @@
+export interface ChatVaultReferenceTarget {
+    path: string;
+    line: number | null;
+    endLine: number | null;
+}
+
+const LINE_SUFFIX_RE =
+    /^(.*?)(?:#L([1-9]\d*)(?:-L?([1-9]\d*))?|:([1-9]\d*)(?:-([1-9]\d*))?)$/i;
+
+export function parseChatVaultReferenceTarget(
+    reference: string,
+): ChatVaultReferenceTarget {
+    const trimmed = reference.trim();
+    const match = LINE_SUFFIX_RE.exec(trimmed);
+    if (!match?.[1]?.trim()) {
+        return { path: trimmed, line: null, endLine: null };
+    }
+
+    const line = Number(match[2] ?? match[4]);
+    const parsedEndLine = match[3] ?? match[5];
+    return {
+        path: match[1].trim(),
+        line,
+        endLine: parsedEndLine ? Number(parsedEndLine) : null,
+    };
+}
+
+export function serializeChatVaultReferenceTarget(
+    target: ChatVaultReferenceTarget,
+) {
+    if (!target.line) return target.path;
+    const range =
+        target.endLine && target.endLine !== target.line
+            ? `-${target.endLine}`
+            : "";
+    return `${target.path}#L${target.line}${range}`;
+}
+
+export function getChatVaultReferenceLabel(
+    label: string,
+    target: Pick<ChatVaultReferenceTarget, "line" | "endLine">,
+) {
+    if (!target.line) return label;
+    if (/\s+\((?:line|lines)\s+\d+(?:\s*[-–:]\s*\d+)?\)$/i.test(label)) {
+        return label;
+    }
+    return target.endLine && target.endLine !== target.line
+        ? `${label} (lines ${target.line}–${target.endLine})`
+        : `${label} (line ${target.line})`;
+}
+
+export function getChatVaultReferenceBasename(path: string) {
+    return path.replace(/\\/g, "/").split("/").at(-1) || path;
+}

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -136,6 +136,48 @@ function setCaret(node: Node, offset: number) {
 }
 
 describe("AIChatComposer mention picker", () => {
+    it("uses the shared icon-led reference style for notes, files, and folders", () => {
+        const { composer } = renderComposer({
+            parts: [
+                {
+                    id: "note-reference",
+                    type: "mention",
+                    noteId: "notes/alpha.md",
+                    label: "Alpha",
+                    path: "/vault/notes/alpha.md",
+                },
+                { id: "space-1", type: "text", text: " " },
+                {
+                    id: "file-reference",
+                    type: "file_mention",
+                    label: "watcher.rs",
+                    path: "/vault/src/watcher.rs",
+                    relativePath: "src/watcher.rs",
+                    mimeType: "text/rust",
+                },
+                { id: "space-2", type: "text", text: " " },
+                {
+                    id: "folder-reference",
+                    type: "folder_mention",
+                    label: "Clips",
+                    folderPath: "/vault/Clips",
+                },
+            ],
+        });
+
+        for (const kind of ["mention", "file_mention", "folder_mention"]) {
+            const reference = composer.querySelector<HTMLElement>(
+                `[data-kind="${kind}"]`,
+            );
+            expect(reference).not.toBeNull();
+            expect(reference).toHaveStyle({
+                background: "transparent",
+                padding: "0px",
+            });
+            expect(reference?.querySelector("svg")).not.toBeNull();
+        }
+    });
+
     it("keeps the composer shell full-width while capping the inner content", () => {
         renderComposer();
 

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -174,6 +174,14 @@ describe("AIChatComposer mention picker", () => {
                     startLine: 66,
                     endLine: 66,
                 },
+                { id: "space-4", type: "text", text: " " },
+                {
+                    id: "file-attachment-reference",
+                    type: "file_attachment",
+                    label: "vision-semanal-2026-06-22.html",
+                    filePath: "/vault/vision-semanal-2026-06-22.html",
+                    mimeType: "text/html",
+                },
             ],
         });
 
@@ -182,6 +190,7 @@ describe("AIChatComposer mention picker", () => {
             "file_mention",
             "folder_mention",
             "selection_mention",
+            "file_attachment",
         ]) {
             const reference = composer.querySelector<HTMLElement>(
                 `[data-kind="${kind}"]`,
@@ -194,6 +203,9 @@ describe("AIChatComposer mention picker", () => {
             expect(reference?.querySelector("svg")).not.toBeNull();
         }
         expect(screen.getByText("CHANGELOG.md (line 66)")).toBeInTheDocument();
+        expect(
+            screen.getByText("vision-semanal-2026-06-22.html"),
+        ).toBeInTheDocument();
     });
 
     it("opens composer selection references at their line in a new tab", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -31,6 +31,7 @@ afterEach(() => {
         });
     });
     setEditorTabs([], null);
+    useEditorStore.setState({ pendingLineReveal: null });
     setVaultNotes([]);
     setVaultEntries([]);
     vi.restoreAllMocks();
@@ -136,7 +137,7 @@ function setCaret(node: Node, offset: number) {
 }
 
 describe("AIChatComposer mention picker", () => {
-    it("uses the shared icon-led reference style for notes, files, and folders", () => {
+    it("uses the shared icon-led reference style for notes, files, folders, and selections", () => {
         const { composer } = renderComposer({
             parts: [
                 {
@@ -162,10 +163,26 @@ describe("AIChatComposer mention picker", () => {
                     label: "Clips",
                     folderPath: "/vault/Clips",
                 },
+                { id: "space-3", type: "text", text: " " },
+                {
+                    id: "selection-reference",
+                    type: "selection_mention",
+                    noteId: "CHANGELOG.md",
+                    label: "Selected changelog line",
+                    path: "/vault/CHANGELOG.md",
+                    selectedText: "Changed behavior",
+                    startLine: 66,
+                    endLine: 66,
+                },
             ],
         });
 
-        for (const kind of ["mention", "file_mention", "folder_mention"]) {
+        for (const kind of [
+            "mention",
+            "file_mention",
+            "folder_mention",
+            "selection_mention",
+        ]) {
             const reference = composer.querySelector<HTMLElement>(
                 `[data-kind="${kind}"]`,
             );
@@ -176,6 +193,56 @@ describe("AIChatComposer mention picker", () => {
             });
             expect(reference?.querySelector("svg")).not.toBeNull();
         }
+        expect(screen.getByText("CHANGELOG.md (line 66)")).toBeInTheDocument();
+    });
+
+    it("opens composer selection references at their line in a new tab", async () => {
+        setVaultNotes([
+            {
+                id: "CHANGELOG.md",
+                title: "CHANGELOG",
+                path: "/vault/CHANGELOG.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+        setEditorTabs([
+            {
+                id: "existing-changelog",
+                noteId: "CHANGELOG.md",
+                title: "CHANGELOG",
+                content: "# Changelog",
+            },
+        ]);
+        renderComposer({
+            parts: [
+                {
+                    id: "selection-reference",
+                    type: "selection_mention",
+                    noteId: "CHANGELOG.md",
+                    label: "Selected changelog line",
+                    path: "/vault/CHANGELOG.md",
+                    selectedText: "Changed behavior",
+                    startLine: 66,
+                    endLine: 66,
+                },
+            ],
+        });
+
+        fireEvent.contextMenu(screen.getByText("CHANGELOG.md (line 66)"), {
+            clientX: 40,
+            clientY: 60,
+        });
+        fireEvent.click(screen.getByText("Open in New Tab"));
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().tabs).toHaveLength(2);
+            expect(useEditorStore.getState().pendingLineReveal).toEqual({
+                noteId: "CHANGELOG.md",
+                line: 66,
+                endLine: null,
+            });
+        });
     });
 
     it("keeps the composer shell full-width while capping the inner content", () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -45,7 +45,10 @@ import type {
     ReactNode,
 } from "react";
 import { openChatNoteById } from "../chatNoteNavigation";
-import { openAiEditedFileByAbsolutePath } from "../chatFileNavigation";
+import {
+    canOpenAiEditedFileByAbsolutePath,
+    openAiEditedFileByAbsolutePath,
+} from "../chatFileNavigation";
 import { getEditorFontFamily } from "../../editor/editorExtensions";
 import {
     useVaultStore,
@@ -376,8 +379,14 @@ function createFileAttachmentNode(
     element.dataset.mimeType = part.mimeType;
     element.dataset.label = part.label;
     element.contentEditable = "false";
-    element.textContent = part.label;
-    applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.file);
+    presentComposerVaultReference(element, {
+        interactive: canOpenAiEditedFileByAbsolutePath(part.filePath),
+        kind: "file",
+        label: part.label,
+        metrics,
+        mimeType: part.mimeType,
+        path: part.filePath,
+    });
     return element;
 }
 
@@ -789,7 +798,7 @@ function getComposerPillElementFromNode(node: EventTarget | null) {
               : null;
     return (
         element?.closest<HTMLElement>(
-            "[data-kind='mention'], [data-kind='file_mention'], [data-kind='selection_mention']",
+            "[data-kind='mention'], [data-kind='file_mention'], [data-kind='selection_mention'], [data-kind='file_attachment']",
         ) ?? null
     );
 }
@@ -797,6 +806,9 @@ function getComposerPillElementFromNode(node: EventTarget | null) {
 function getComposerPillFileReference(element: HTMLElement | null) {
     if (element?.dataset.kind === "file_mention") {
         return element.dataset.path ?? null;
+    }
+    if (element?.dataset.kind === "file_attachment") {
+        return element.dataset.filePath ?? null;
     }
     if (
         element?.dataset.kind === "selection_mention" &&

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -24,6 +24,7 @@ import {
     type AIChatSlashCommand,
 } from "./AIChatCommandPicker";
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
+import { presentComposerVaultReference } from "./chatVaultReferenceDom";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";
@@ -246,8 +247,13 @@ function createMentionNode(
     element.dataset.label = part.label;
     element.dataset.path = part.path;
     element.contentEditable = "false";
-    element.textContent = part.label;
-    applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.accent);
+    presentComposerVaultReference(element, {
+        interactive: true,
+        kind: "note",
+        label: part.label,
+        metrics,
+        path: part.path,
+    });
     return element;
 }
 
@@ -264,8 +270,14 @@ function createFileMentionNode(
         element.dataset.mimeType = part.mimeType;
     }
     element.contentEditable = "false";
-    element.textContent = part.label;
-    applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.file);
+    presentComposerVaultReference(element, {
+        interactive: true,
+        kind: "file",
+        label: part.label,
+        metrics,
+        mimeType: part.mimeType,
+        path: part.path,
+    });
     return element;
 }
 
@@ -278,8 +290,12 @@ function createFolderMentionNode(
     element.dataset.folderPath = part.folderPath;
     element.dataset.label = part.label;
     element.contentEditable = "false";
-    element.textContent = part.label;
-    applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.folder);
+    presentComposerVaultReference(element, {
+        kind: "folder",
+        label: part.label,
+        metrics,
+        path: part.folderPath,
+    });
     return element;
 }
 

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -25,6 +25,10 @@ import {
 } from "./AIChatCommandPicker";
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
 import { presentComposerVaultReference } from "./chatVaultReferenceDom";
+import {
+    getChatVaultReferenceBasename,
+    serializeChatVaultReferenceTarget,
+} from "../chatVaultReferenceTarget";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
 import { CHAT_PILL_VARIANTS } from "./chatPillPalette";
 import { getChatPillMetrics, type ChatPillMetrics } from "./chatPillMetrics";
@@ -332,9 +336,14 @@ function createSelectionMentionNode(
     element.dataset.startLine = String(part.startLine);
     element.dataset.endLine = String(part.endLine);
     element.contentEditable = "false";
-    element.textContent = part.label;
-    applyComposerPillStyles(element, metrics, CHAT_PILL_VARIANTS.accent, {
-        compact: true,
+    presentComposerVaultReference(element, {
+        interactive: true,
+        kind: part.noteId ? "note" : "file",
+        label: getChatVaultReferenceBasename(part.path),
+        line: part.startLine,
+        endLine: part.endLine,
+        metrics,
+        path: part.path,
     });
     return element;
 }
@@ -780,9 +789,29 @@ function getComposerPillElementFromNode(node: EventTarget | null) {
               : null;
     return (
         element?.closest<HTMLElement>(
-            "[data-kind='mention'], [data-kind='file_mention']",
+            "[data-kind='mention'], [data-kind='file_mention'], [data-kind='selection_mention']",
         ) ?? null
     );
+}
+
+function getComposerPillFileReference(element: HTMLElement | null) {
+    if (element?.dataset.kind === "file_mention") {
+        return element.dataset.path ?? null;
+    }
+    if (
+        element?.dataset.kind === "selection_mention" &&
+        element.dataset.path &&
+        element.dataset.startLine
+    ) {
+        return serializeChatVaultReferenceTarget({
+            path: element.dataset.path,
+            line: Number(element.dataset.startLine),
+            endLine: element.dataset.endLine
+                ? Number(element.dataset.endLine)
+                : null,
+        });
+    }
+    return null;
 }
 
 function getComposerPillTargetFromContextMenuEvent(
@@ -793,11 +822,11 @@ function getComposerPillTargetFromContextMenuEvent(
         const mention = getComposerPillElementFromNode(node);
         if (mention) {
             return {
-                noteId: mention.dataset.noteId ?? null,
-                filePath:
-                    mention.dataset.kind === "file_mention"
-                        ? (mention.dataset.path ?? null)
+                noteId:
+                    mention.dataset.kind === "mention"
+                        ? (mention.dataset.noteId ?? null)
                         : null,
+                filePath: getComposerPillFileReference(mention),
             };
         }
     }
@@ -805,11 +834,11 @@ function getComposerPillTargetFromContextMenuEvent(
     const hovered = document.elementFromPoint(event.clientX, event.clientY);
     const mention = getComposerPillElementFromNode(hovered);
     return {
-        noteId: mention?.dataset.noteId ?? null,
-        filePath:
-            mention?.dataset.kind === "file_mention"
-                ? (mention.dataset.path ?? null)
+        noteId:
+            mention?.dataset.kind === "mention"
+                ? (mention.dataset.noteId ?? null)
                 : null,
+        filePath: getComposerPillFileReference(mention),
     };
 }
 

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -1475,6 +1475,32 @@ describe("AIChatMessageItem tool diffs", () => {
 });
 
 describe("AIChatMessageItem user mention pills", () => {
+    it("uses the shared icon-led reference style for notes, files, and folders", () => {
+        renderMessage({
+            id: "user:references",
+            role: "user",
+            kind: "text",
+            content:
+                "Use [@Alpha], [@📄 /vault/src/watcher.rs], and [@📁 Clips]",
+            timestamp: Date.now(),
+        });
+
+        const references = [
+            screen.getByRole("button", { name: "Alpha" }),
+            screen.getByRole("button", { name: "watcher.rs" }),
+            document.querySelector<HTMLElement>('[title="Clips"]'),
+        ];
+
+        for (const reference of references) {
+            expect(reference).not.toBeNull();
+            expect(reference).toHaveStyle({
+                background: "transparent",
+                padding: "0px",
+            });
+            expect(reference?.querySelector("svg")).not.toBeNull();
+        }
+    });
+
     it("opens the mention context menu in a new tab", async () => {
         setVaultNotes([
             {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -111,6 +111,7 @@ beforeEach(() => {
     useEditorStore.setState({
         tabs: [],
         activeTabId: null,
+        pendingLineReveal: null,
     });
 });
 
@@ -1499,6 +1500,51 @@ describe("AIChatMessageItem user mention pills", () => {
             });
             expect(reference?.querySelector("svg")).not.toBeNull();
         }
+    });
+
+    it("renders and opens sent line references with the shared style", async () => {
+        setVaultNotes([
+            {
+                id: "CHANGELOG.md",
+                title: "CHANGELOG",
+                path: "/vault/CHANGELOG.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+        setEditorTabs([
+            {
+                id: "changelog-tab",
+                noteId: "CHANGELOG.md",
+                title: "CHANGELOG",
+                content: "# Changelog",
+            },
+        ]);
+        renderMessage({
+            id: "user:line-reference",
+            role: "user",
+            kind: "text",
+            content: "Check [@📄 /vault/CHANGELOG.md#L66]",
+            timestamp: Date.now(),
+        });
+
+        const reference = screen.getByRole("button", {
+            name: "CHANGELOG.md (line 66)",
+        });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+        fireEvent.click(reference);
+
+        await waitFor(() => {
+            expect(useEditorStore.getState().pendingLineReveal).toEqual({
+                noteId: "CHANGELOG.md",
+                line: 66,
+                endLine: null,
+            });
+        });
     });
 
     it("opens the mention context menu in a new tab", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -1547,6 +1547,55 @@ describe("AIChatMessageItem user mention pills", () => {
         });
     });
 
+    it("renders sent file attachments with the shared icon-led style", () => {
+        setVaultEntries([
+            {
+                id: "vision-semanal-2026-06-22.html",
+                path: "/vault/vision-semanal-2026-06-22.html",
+                relative_path: "vision-semanal-2026-06-22.html",
+                title: "vision-semanal-2026-06-22.html",
+                file_name: "vision-semanal-2026-06-22.html",
+                extension: "html",
+                kind: "file",
+                modified_at: 0,
+                created_at: 0,
+                size: 32,
+                mime_type: "text/html",
+            },
+        ]);
+        // Sent composer attachments use the compact [📎 label] transcript token.
+        renderMessage({
+            id: "user:file-attachment-reference-serialized",
+            role: "user",
+            kind: "text",
+            content: "[📎 vision-semanal-2026-06-22.html] actualiza esto",
+            timestamp: Date.now(),
+            attachments: [
+                {
+                    id: "attachment:file-serialized",
+                    type: "file",
+                    noteId: null,
+                    label: "vision-semanal-2026-06-22.html",
+                    path: null,
+                    filePath: "/vault/vision-semanal-2026-06-22.html",
+                    mimeType: "text/html",
+                },
+            ],
+        });
+
+        const reference = screen.getByRole("button", {
+            name: "vision-semanal-2026-06-22.html",
+        });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+        expect(
+            screen.queryByText("📎 vision-semanal-2026-06-22.html"),
+        ).not.toBeInTheDocument();
+    });
+
     it("opens the mention context menu in a new tab", async () => {
         setVaultNotes([
             {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -20,6 +20,7 @@ import type {
     AIUserInputAction,
 } from "../types";
 import { ChatInlinePill } from "./ChatInlinePill";
+import { ChatVaultReference } from "./ChatVaultReference";
 import { MarkdownContent } from "./MarkdownContent";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 import type { ChatPillVariant } from "./chatPillPalette";
@@ -309,13 +310,14 @@ function renderUserContent(
         }
 
         if (token.startsWith("[@📁 ")) {
-            const folderLabel = token.slice(4, -1); // strip [@📁 and ]
+            const folderLabel = token.slice(5, -1); // strip [@📁 and ]
             parts.push(
-                <ChatInlinePill
+                <ChatVaultReference
                     key={key++}
+                    kind="folder"
                     label={folderLabel}
                     metrics={pillMetrics}
-                    variant="folder"
+                    path={folderLabel}
                 />,
             );
             lastIndex = match.index + token.length;
@@ -325,11 +327,12 @@ function renderUserContent(
         if (token.startsWith("[@📁|")) {
             const folderLabel = decodeSerializedPillValue(token.slice(5, -1));
             parts.push(
-                <ChatInlinePill
+                <ChatVaultReference
                     key={key++}
+                    kind="folder"
                     label={folderLabel}
                     metrics={pillMetrics}
-                    variant="folder"
+                    path={folderLabel}
                 />,
             );
             lastIndex = match.index + token.length;
@@ -344,12 +347,13 @@ function renderUserContent(
             ).trim();
             const fileLabel = filePath.split("/").pop() || filePath;
             parts.push(
-                <ChatInlinePill
+                <ChatVaultReference
                     key={key++}
+                    kind="file"
                     label={fileLabel}
                     metrics={pillMetrics}
                     interactive
-                    variant="file"
+                    path={filePath}
                     onClick={() => {
                         void openAiEditedFileByAbsolutePath(filePath);
                     }}
@@ -381,12 +385,13 @@ function renderUserContent(
         }
         const isNote = variant === "accent";
         parts.push(
-            <ChatInlinePill
+            <ChatVaultReference
                 key={key++}
+                kind={isNote ? "note" : "folder"}
                 label={noteLabel}
                 metrics={pillMetrics}
                 interactive={isNote}
-                variant={variant}
+                path={noteLabel}
                 onClick={
                     isNote
                         ? () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -246,8 +246,20 @@ function renderUserContent(
         event: MouseEvent<HTMLElement>,
         payload: UserMentionContextMenuPayload,
     ) => void,
+    attachments: AIChatAttachment[] = [],
 ): Array<string | ReactElement> {
     const parts: Array<string | ReactElement> = [];
+    const unmatchedFileAttachments = attachments.filter(
+        (attachment) =>
+            attachment.type === "file" && Boolean(attachment.filePath),
+    );
+    const takeFileAttachment = (label: string) => {
+        const index = unmatchedFileAttachments.findIndex(
+            (attachment) => attachment.label === label,
+        );
+        if (index < 0) return null;
+        return unmatchedFileAttachments.splice(index, 1)[0] ?? null;
+    };
     // New bracketed format: [@note], [@📄 /path/file.ts], [@📁 folder], [Screenshot ...], [📎 file]
     // Escaped variants use a pipe plus URL-encoded payload, e.g. [@|%5B%20%5D].
     // Legacy format (backward compat): @fetch, /plan, @📁word, @word
@@ -264,23 +276,58 @@ function renderUserContent(
 
         const token = match[0];
 
-        if (
-            token.startsWith("[Screenshot ") ||
-            token.startsWith("[Screenshot|") ||
-            token.startsWith("[📎 ") ||
-            token.startsWith("[📎|")
-        ) {
+        if (token.startsWith("[Screenshot ") || token.startsWith("[Screenshot|")) {
             const pillLabel = token.startsWith("[Screenshot|")
                 ? decodeSerializedPillValue(token.slice(12, -1))
-                : token.startsWith("[📎|")
-                  ? decodeSerializedPillValue(token.slice(4, -1))
-                  : token.slice(1, -1); // strip [ ]
+                : token.slice(1, -1); // strip [ ]
             parts.push(
                 <ChatInlinePill
                     key={key++}
                     label={pillLabel}
                     metrics={pillMetrics}
                     variant="file"
+                />,
+            );
+            lastIndex = match.index + token.length;
+            continue;
+        }
+
+        if (token.startsWith("[📎 ") || token.startsWith("[📎|")) {
+            const fileLabel = token.startsWith("[📎|")
+                ? decodeSerializedPillValue(token.slice(4, -1))
+                : token.slice(4, -1);
+            const attachment = takeFileAttachment(fileLabel);
+            const filePath = attachment?.filePath ?? fileLabel;
+            const canOpen = Boolean(
+                attachment?.filePath &&
+                    canOpenAiEditedFileByAbsolutePath(attachment.filePath),
+            );
+            parts.push(
+                <ChatVaultReference
+                    key={key++}
+                    kind="file"
+                    label={fileLabel}
+                    metrics={pillMetrics}
+                    mimeType={attachment?.mimeType}
+                    interactive={canOpen}
+                    path={filePath}
+                    onClick={
+                        canOpen
+                            ? () => {
+                                  void openAiEditedFileByAbsolutePath(filePath);
+                              }
+                            : undefined
+                    }
+                    onContextMenu={
+                        canOpen
+                            ? (event) =>
+                                  onMentionContextMenu(event, {
+                                      kind: "file",
+                                      label: fileLabel,
+                                      path: filePath,
+                                  })
+                            : undefined
+                    }
                 />,
             );
             lastIndex = match.index + token.length;
@@ -486,6 +533,7 @@ function UserTextMessage({
                             payload,
                         });
                     },
+                    message.attachments,
                 )}
                 <UserMessageAttachments attachments={message.attachments} />
             </div>

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -41,6 +41,10 @@ import {
     canOpenAiEditedFileByAbsolutePath,
     openAiEditedFileByAbsolutePath,
 } from "../chatFileNavigation";
+import {
+    getChatVaultReferenceBasename,
+    parseChatVaultReferenceTarget,
+} from "../chatVaultReferenceTarget";
 import { useEditorStore } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
@@ -344,13 +348,16 @@ function renderUserContent(
                 token.startsWith("[@📄|")
                     ? decodeSerializedPillValue(token.slice(5, -1))
                     : token.slice(4, -1)
-            ).trim();
-            const fileLabel = filePath.split("/").pop() || filePath;
+                ).trim();
+            const target = parseChatVaultReferenceTarget(filePath);
+            const fileLabel = getChatVaultReferenceBasename(target.path);
             parts.push(
                 <ChatVaultReference
                     key={key++}
                     kind="file"
                     label={fileLabel}
+                    line={target.line}
+                    endLine={target.endLine}
                     metrics={pillMetrics}
                     interactive
                     path={filePath}
@@ -383,15 +390,22 @@ function renderUserContent(
         } else {
             noteLabel = token.slice(1); // strip @
         }
+        const target = parseChatVaultReferenceTarget(noteLabel);
         const isNote = variant === "accent";
         parts.push(
             <ChatVaultReference
                 key={key++}
                 kind={isNote ? "note" : "folder"}
-                label={noteLabel}
+                label={
+                    target.line
+                        ? getChatVaultReferenceBasename(target.path)
+                        : noteLabel
+                }
+                line={target.line}
+                endLine={target.endLine}
                 metrics={pillMetrics}
                 interactive={isNote}
-                path={noteLabel}
+                path={target.path}
                 onClick={
                     isNote
                         ? () => {

--- a/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
+++ b/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
@@ -1,6 +1,7 @@
-import type { CSSProperties, MouseEventHandler, ReactNode } from "react";
+import type { MouseEventHandler, ReactNode } from "react";
 import { type ChatPillMetrics } from "./chatPillMetrics";
-import { CHAT_PILL_VARIANTS, type ChatPillVariant } from "./chatPillPalette";
+import type { ChatPillVariant } from "./chatPillPalette";
+import { getChatInlinePillStyle } from "./chatInlinePillStyle";
 
 interface ChatInlinePillProps {
     appearance?: "link" | "pill";
@@ -25,32 +26,13 @@ export function ChatInlinePill({
     onClick,
     onContextMenu,
 }: ChatInlinePillProps) {
-    const palette = CHAT_PILL_VARIANTS[variant];
     const clickable = interactive || typeof onClick === "function";
-    const isLink = appearance === "link";
-    const style: CSSProperties = {
-        display: "inline-flex",
-        alignItems: "center",
-        margin: `0 ${metrics.gapX}px`,
-        padding: isLink ? 0 : `${metrics.paddingY}px ${metrics.paddingX}px`,
-        maxInlineSize: "100%",
-        borderRadius: isLink ? 2 : metrics.radius,
-        background: isLink ? "transparent" : palette.background,
-        color: isLink ? "var(--accent)" : palette.color,
-        fontSize: metrics.fontSize,
-        lineHeight: metrics.lineHeight,
-        border: "none",
-        cursor: clickable ? "pointer" : "default",
-        fontFamily: "inherit",
-        verticalAlign: "baseline",
-        overflowWrap: "anywhere",
-        transform: `translateY(${isLink ? 2 : metrics.offsetY}px)`,
-        filter: "brightness(1)",
-        opacity: clickable ? 0.85 : 1,
-        transition: clickable
-            ? "opacity 80ms ease, filter 80ms ease"
-            : undefined,
-    };
+    const style = getChatInlinePillStyle({
+        appearance,
+        clickable,
+        metrics,
+        variant,
+    });
 
     const content = (
         <span

--- a/apps/desktop/src/features/ai/components/ChatVaultReference.tsx
+++ b/apps/desktop/src/features/ai/components/ChatVaultReference.tsx
@@ -3,6 +3,10 @@ import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 import { FolderTypeIcon } from "../../../components/icons/FolderTypeIcon";
 import { ChatInlinePill } from "./ChatInlinePill";
 import type { ChatPillMetrics } from "./chatPillMetrics";
+import {
+    getChatVaultReferenceLabel,
+    parseChatVaultReferenceTarget,
+} from "../chatVaultReferenceTarget";
 
 export type ChatVaultReferenceKind = "file" | "folder" | "note";
 
@@ -14,6 +18,8 @@ export function ChatVaultReference({
     interactive = false,
     kind,
     label,
+    line,
+    endLine,
     metrics,
     mimeType,
     onClick,
@@ -24,6 +30,8 @@ export function ChatVaultReference({
     interactive?: boolean;
     kind: ChatVaultReferenceKind;
     label: string;
+    line?: number | null;
+    endLine?: number | null;
     metrics: ChatPillMetrics;
     mimeType?: string | null;
     onClick?: () => void;
@@ -31,11 +39,17 @@ export function ChatVaultReference({
     path: string;
     title?: string;
 }) {
+    const parsedTarget = parseChatVaultReferenceTarget(path);
+    const target = {
+        path: parsedTarget.path,
+        line: line ?? parsedTarget.line,
+        endLine: endLine ?? parsedTarget.endLine,
+    };
     const size = referenceIconSize(metrics);
     const leadingVisual =
         kind === "folder" ? (
             <FolderTypeIcon
-                folderName={path}
+                folderName={target.path}
                 opacity={1}
                 open={false}
                 size={size}
@@ -43,9 +57,9 @@ export function ChatVaultReference({
         ) : (
             <FileTypeIcon
                 fileName={
-                    kind === "note" && !/\.md$/i.test(path)
-                        ? `${path}.md`
-                        : path
+                    kind === "note" && !/\.md$/i.test(target.path)
+                        ? `${target.path}.md`
+                        : target.path
                 }
                 kind={kind === "note" ? "note" : undefined}
                 mimeType={mimeType}
@@ -58,12 +72,12 @@ export function ChatVaultReference({
         <ChatInlinePill
             appearance="link"
             interactive={interactive}
-            label={label}
+            label={getChatVaultReferenceLabel(label, target)}
             leadingVisual={leadingVisual}
             metrics={metrics}
             onClick={onClick}
             onContextMenu={onContextMenu}
-            title={title ?? path}
+            title={title ?? target.path}
             variant={
                 kind === "folder"
                     ? "folder"

--- a/apps/desktop/src/features/ai/components/ChatVaultReference.tsx
+++ b/apps/desktop/src/features/ai/components/ChatVaultReference.tsx
@@ -1,0 +1,76 @@
+import type { MouseEventHandler } from "react";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
+import { FolderTypeIcon } from "../../../components/icons/FolderTypeIcon";
+import { ChatInlinePill } from "./ChatInlinePill";
+import type { ChatPillMetrics } from "./chatPillMetrics";
+
+export type ChatVaultReferenceKind = "file" | "folder" | "note";
+
+function referenceIconSize(metrics: ChatPillMetrics) {
+    return Math.max(11, Math.min(14, metrics.fontSize));
+}
+
+export function ChatVaultReference({
+    interactive = false,
+    kind,
+    label,
+    metrics,
+    mimeType,
+    onClick,
+    onContextMenu,
+    path,
+    title,
+}: {
+    interactive?: boolean;
+    kind: ChatVaultReferenceKind;
+    label: string;
+    metrics: ChatPillMetrics;
+    mimeType?: string | null;
+    onClick?: () => void;
+    onContextMenu?: MouseEventHandler<HTMLElement>;
+    path: string;
+    title?: string;
+}) {
+    const size = referenceIconSize(metrics);
+    const leadingVisual =
+        kind === "folder" ? (
+            <FolderTypeIcon
+                folderName={path}
+                opacity={1}
+                open={false}
+                size={size}
+            />
+        ) : (
+            <FileTypeIcon
+                fileName={
+                    kind === "note" && !/\.md$/i.test(path)
+                        ? `${path}.md`
+                        : path
+                }
+                kind={kind === "note" ? "note" : undefined}
+                mimeType={mimeType}
+                opacity={1}
+                size={size}
+            />
+        );
+
+    return (
+        <ChatInlinePill
+            appearance="link"
+            interactive={interactive}
+            label={label}
+            leadingVisual={leadingVisual}
+            metrics={metrics}
+            onClick={onClick}
+            onContextMenu={onContextMenu}
+            title={title ?? path}
+            variant={
+                kind === "folder"
+                    ? "folder"
+                    : kind === "file"
+                      ? "file"
+                      : "accent"
+            }
+        />
+    );
+}

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -104,6 +104,82 @@ describe("MarkdownContent", () => {
         expect(reference.querySelector("svg")).not.toBeNull();
     });
 
+    it("renders line fragments in the shared style and reveals note lines", async () => {
+        setVaultNotes([
+            {
+                id: "CHANGELOG.md",
+                title: "CHANGELOG",
+                path: "/vault/CHANGELOG.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+        setEditorTabs([
+            {
+                id: "changelog-tab",
+                noteId: "CHANGELOG.md",
+                title: "CHANGELOG",
+                content: "# Changelog",
+            },
+        ]);
+
+        renderComponent(
+            <MarkdownContent
+                content="See [CHANGELOG.md](CHANGELOG.md#L66)."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        const reference = screen.getByRole("button", {
+            name: "CHANGELOG.md (line 66)",
+        });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+
+        fireEvent.click(reference);
+        await waitFor(() => {
+            expect(useEditorStore.getState().pendingLineReveal).toEqual({
+                noteId: "CHANGELOG.md",
+                line: 66,
+                endLine: null,
+            });
+        });
+    });
+
+    it("renders line ranges for absolute text file references", () => {
+        setVaultEntries([
+            {
+                id: "src/main.ts",
+                path: "/vault/src/main.ts",
+                relative_path: "src/main.ts",
+                title: "main.ts",
+                file_name: "main.ts",
+                extension: "ts",
+                kind: "file",
+                modified_at: 0,
+                created_at: 0,
+                size: 32,
+                mime_type: "text/typescript",
+            },
+        ]);
+
+        renderComponent(
+            <MarkdownContent
+                content="See `/vault/src/main.ts#L10-L12`."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(
+            screen.getByRole("button", { name: "main.ts (lines 10–12)" }),
+        ).toBeInTheDocument();
+    });
+
     it("renders indexed folders as non-interactive icon links in every supported syntax", () => {
         setVaultEntries([
             {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -71,6 +71,117 @@ describe("MarkdownContent", () => {
         ).not.toBeInTheDocument();
     });
 
+    it("resolves unique extensionless note links and preserves line targets", async () => {
+        const title = "Petróleo - Ficha de análisis";
+        setVaultNotes([
+            {
+                id: "Análisis/Petróleo - Ficha de análisis.md",
+                title,
+                path: "/vault/Análisis/Petróleo - Ficha de análisis.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+        setEditorTabs([
+            {
+                id: "petroleo-tab",
+                noteId: "Análisis/Petróleo - Ficha de análisis.md",
+                title,
+                content: "# Petróleo",
+            },
+        ]);
+
+        renderComponent(
+            <MarkdownContent
+                content={`Revisa [${title}](${encodeURIComponent(title)}#L66).`}
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        const reference = screen.getByRole("button", {
+            name: `${title} (line 66)`,
+        });
+        expect(reference).toHaveStyle({
+            background: "transparent",
+            padding: "0px",
+        });
+        expect(reference.querySelector("svg")).not.toBeNull();
+
+        fireEvent.click(reference);
+        await waitFor(() => {
+            expect(useEditorStore.getState().pendingLineReveal).toEqual({
+                noteId: "Análisis/Petróleo - Ficha de análisis.md",
+                line: 66,
+                endLine: null,
+            });
+        });
+    });
+
+    it("does not choose an arbitrary extensionless note when titles are ambiguous", () => {
+        setVaultNotes([
+            {
+                id: "research/Brief.md",
+                title: "Brief",
+                path: "/vault/research/Brief.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+            {
+                id: "archive/Brief.md",
+                title: "Brief",
+                path: "/vault/archive/Brief.md",
+                modified_at: 0,
+                created_at: 0,
+            },
+        ]);
+
+        renderComponent(
+            <MarkdownContent
+                content="See [Brief](Brief)."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(document.body).toHaveTextContent("See Brief.");
+        expect(screen.queryByRole("button", { name: "Brief" })).toBeNull();
+        expect(screen.queryByRole("link", { name: "Brief" })).toBeNull();
+    });
+
+    it("keeps unresolved relative markdown links non-interactive", () => {
+        setVaultNotes([]);
+
+        renderComponent(
+            <MarkdownContent
+                content="See [missing note](missing-note)."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(document.body).toHaveTextContent("See missing note.");
+        expect(
+            screen.queryByRole("link", { name: "missing note" }),
+        ).toBeNull();
+    });
+
+    it("does not reinterpret external file-like URLs as vault references", () => {
+        renderComponent(
+            <MarkdownContent
+                content="Read [PDF docs](https://example.com/guide.pdf)."
+                fileReferenceAppearance="link"
+                pillMetrics={pillMetrics}
+            />,
+        );
+
+        expect(screen.getByRole("link", { name: "PDF docs" })).toHaveAttribute(
+            "href",
+            "https://example.com/guide.pdf",
+        );
+        expect(screen.queryByRole("button", { name: "PDF docs" })).toBeNull();
+    });
+
     it("renders chat file references as icon-led links", () => {
         setVaultEntries([
             {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -42,6 +42,10 @@ import {
 import { extractFenceLanguageToken } from "../../editor/codeLanguage";
 import { HighlightedCodeText } from "../../editor/staticCodeHighlight";
 import { useMarkdownCodeLanguageSupport } from "../../editor/useCodeLanguageSupport";
+import {
+    parseChatVaultReferenceTarget,
+    serializeChatVaultReferenceTarget,
+} from "../chatVaultReferenceTarget";
 
 interface MarkdownContentProps {
     content: string;
@@ -65,13 +69,11 @@ function safeDecodeUriComponent(value: string) {
 }
 
 function parseVaultReference(value: string) {
-    const trimmed = value.trim();
-    const match = /^(.*?\.md)(?::(\d+)|#L(\d+))?$/i.exec(trimmed);
-    if (!match) return null;
+    const target = parseChatVaultReferenceTarget(value);
+    if (!/\.md$/i.test(target.path)) return null;
 
     return {
-        path: match[1],
-        line: match[2] ?? match[3] ?? null,
+        ...target,
         kind: "note" as const,
     };
 }
@@ -114,35 +116,35 @@ function resolveVaultNoteReference(
 }
 
 function parseExcalidrawReference(value: string) {
-    const trimmed = value.trim();
-    if (!/\.excalidraw$/i.test(trimmed)) return null;
+    const target = parseChatVaultReferenceTarget(value);
+    if (!/\.excalidraw$/i.test(target.path)) return null;
     const fileName =
-        trimmed
+        target.path
             .split("/")
             .pop()
-            ?.replace(/\.excalidraw$/i, "") ?? trimmed;
-    return { path: trimmed, fileName };
+            ?.replace(/\.excalidraw$/i, "") ?? target.path;
+    return { ...target, fileName };
 }
 
 function parsePdfReference(value: string) {
-    const trimmed = value.trim();
-    if (!/\.pdf$/i.test(trimmed)) return null;
+    const target = parseChatVaultReferenceTarget(value);
+    if (!/\.pdf$/i.test(target.path)) return null;
     const fileName =
-        trimmed
+        target.path
             .split("/")
             .pop()
-            ?.replace(/\.pdf$/i, "") ?? trimmed;
-    return { path: trimmed, fileName };
+            ?.replace(/\.pdf$/i, "") ?? target.path;
+    return { ...target, fileName };
 }
 
 function parseTextFileReference(value: string) {
-    const trimmed = value.trim();
-    const resolvedPath = resolveVaultLocalPath(trimmed);
+    const target = parseChatVaultReferenceTarget(value);
+    const resolvedPath = resolveVaultLocalPath(target.path);
     if (!resolvedPath) return null;
     if (
         parseVaultReference(resolvedPath) ||
-        parseExcalidrawReference(trimmed) ||
-        parsePdfReference(trimmed)
+        parseExcalidrawReference(target.path) ||
+        parsePdfReference(target.path)
     ) {
         return null;
     }
@@ -163,19 +165,21 @@ function parseTextFileReference(value: string) {
     return {
         path: resolvedPath,
         fileName: resolvedPath.split("/").pop() ?? resolvedPath,
+        line: target.line,
+        endLine: target.endLine,
     };
 }
 
 function parseRelativeTextFileReference(value: string) {
-    const trimmed = value.trim();
-    const resolvedPath = resolveVaultLocalPath(trimmed, {
+    const target = parseChatVaultReferenceTarget(value);
+    const resolvedPath = resolveVaultLocalPath(target.path, {
         allowRelative: true,
     });
     if (!resolvedPath) return null;
     if (
         parseVaultReference(resolvedPath) ||
-        parseExcalidrawReference(trimmed) ||
-        parsePdfReference(trimmed)
+        parseExcalidrawReference(target.path) ||
+        parsePdfReference(target.path)
     ) {
         return null;
     }
@@ -196,6 +200,8 @@ function parseRelativeTextFileReference(value: string) {
     return {
         path: resolvedPath,
         fileName: resolvedPath.split("/").pop() ?? resolvedPath,
+        line: target.line,
+        endLine: target.endLine,
     };
 }
 
@@ -208,13 +214,14 @@ function parseVaultFolderReference(
     value: string,
     options?: { allowRelative?: boolean },
 ) {
-    const trimmed = value.trim();
-    const resolvedPath = resolveVaultLocalPath(trimmed, options);
+    const target = parseChatVaultReferenceTarget(value);
+    if (target.line) return null;
+    const resolvedPath = resolveVaultLocalPath(target.path, options);
     if (!resolvedPath) return null;
     if (
         parseVaultReference(resolvedPath) ||
-        parseExcalidrawReference(trimmed) ||
-        parsePdfReference(trimmed)
+        parseExcalidrawReference(target.path) ||
+        parsePdfReference(target.path)
     ) {
         return null;
     }
@@ -244,6 +251,8 @@ function renderReferencePill(params: {
     metrics: ChatPillMetrics;
     appearance: FileReferenceAppearance;
     iconPath: string;
+    line?: number | null;
+    endLine?: number | null;
     isFolder?: boolean;
     onClick?: () => void;
     onContextMenu?: MouseEventHandler<HTMLElement>;
@@ -261,6 +270,8 @@ function renderReferencePill(params: {
                           : "file"
                 }
                 label={params.label}
+                line={params.line}
+                endLine={params.endLine}
                 metrics={params.metrics}
                 onClick={params.onClick}
                 onContextMenu={params.onContextMenu}
@@ -282,6 +293,22 @@ function renderReferencePill(params: {
             variant={params.variant}
         />
     );
+}
+
+function noteReferenceLabel(reference: {
+    path: string;
+    line: number | null;
+}) {
+    const fileName = reference.path.split("/").pop() ?? reference.path;
+    return reference.line ? fileName : fileName.replace(/\.md$/i, "");
+}
+
+function serializedReference(reference: {
+    path: string;
+    line: number | null;
+    endLine: number | null;
+}) {
+    return serializeChatVaultReferenceTarget(reference);
 }
 
 function noteIconPath(reference: string) {
@@ -466,7 +493,7 @@ function renderInlineMarkdown(
     const parts: Array<string | ReactElement> = [];
     // Process: wikilinks, inline code, bold, italic, links, raw URLs, and absolute vault file paths.
     const inlineRegex =
-        /(\[\[[^\]]+\]\])|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))|(\bhttps?:\/\/[^\s<>"']+)|((?<![\w\u00C0-\u024F])(?:\/)[\w\u00C0-\u024F~.()/-]+(?::\d+|#L\d+)?)/g;
+        /(\[\[[^\]]+\]\])|(`[^`]+`)|(\*\*[^*]+\*\*)|(\*[^*]+\*)|(\[[^\]]+\]\([^)]+\))|(\bhttps?:\/\/[^\s<>"']+)|((?<![\w\u00C0-\u024F])(?:\/)[\w\u00C0-\u024F~.()/-]+(?::\d+(?:-\d+)?|#L\d+(?:-L?\d+)?)?)/g;
     let lastIndex = 0;
     let match: RegExpExecArray | null;
     let keyIndex = 0;
@@ -482,21 +509,25 @@ function renderInlineMarkdown(
         if (match[1]) {
             // wikilink [[Note Name]] or [[Note Name|Alias]]
             const inner = full.slice(2, -2);
-            const [target, alias] = inner.split("|");
-            const label = alias ?? target;
+            const [rawTarget, alias] = inner.split("|");
+            const target = parseChatVaultReferenceTarget(rawTarget);
+            const reference = serializeChatVaultReferenceTarget(target);
+            const label = alias ?? noteReferenceLabel(target);
             parts.push(
                 renderReferencePill({
                     key,
                     label: label.trim(),
-                    title: target.trim(),
+                    title: reference,
                     variant: "accent",
                     metrics: pillMetrics,
                     appearance,
-                    iconPath: noteIconPath(target.trim()),
+                    iconPath: noteIconPath(target.path),
+                    line: target.line,
+                    endLine: target.endLine,
                     onClick: () =>
-                        void openChatNoteByReference(target.trim()),
+                        void openChatNoteByReference(reference),
                     onContextMenu: (event) =>
-                        onNoteContextMenu(event, target.trim()),
+                        onNoteContextMenu(event, reference),
                 }),
             );
         } else if (match[2]) {
@@ -515,25 +546,22 @@ function renderInlineMarkdown(
                     ? parseVaultFolderReference(codeText)
                     : null;
             if (parsedReference) {
-                const fileName =
-                    parsedReference.path
-                        .split("/")
-                        .pop()
-                        ?.replace(/\.md$/i, "") ??
-                    parsedReference.path.replace(/\.md$/i, "");
+                const reference = serializedReference(parsedReference);
                 parts.push(
                     renderReferencePill({
                         key,
-                        label: fileName,
+                        label: noteReferenceLabel(parsedReference),
                         title: codeText,
                         variant: "accent",
                         metrics: pillMetrics,
                         appearance,
                         iconPath: parsedReference.path,
+                        line: parsedReference.line,
+                        endLine: parsedReference.endLine,
                         onClick: () =>
-                            void openChatNoteByReference(parsedReference.path),
+                            void openChatNoteByReference(reference),
                         onContextMenu: (event) =>
-                            onNoteContextMenu(event, parsedReference.path),
+                            onNoteContextMenu(event, reference),
                     }),
                 );
             } else if (pdfRef) {
@@ -562,13 +590,18 @@ function renderInlineMarkdown(
                         metrics: pillMetrics,
                         appearance,
                         iconPath: textFileRef.path,
+                        line: textFileRef.line,
+                        endLine: textFileRef.endLine,
                         onClick: () =>
                             void openAiEditedFileByAbsolutePath(
-                                textFileRef.path,
+                                serializedReference(textFileRef),
                             ),
                         onContextMenu: onFileContextMenu
                             ? (event) =>
-                                  onFileContextMenu(event, textFileRef.path)
+                                  onFileContextMenu(
+                                      event,
+                                      serializedReference(textFileRef),
+                                  )
                             : undefined,
                     }),
                 );
@@ -685,13 +718,18 @@ function renderInlineMarkdown(
                             metrics: pillMetrics,
                             appearance,
                             iconPath: textFileRef.path,
+                            line: textFileRef.line,
+                            endLine: textFileRef.endLine,
                             onClick: () =>
                                 void openAiEditedFileByAbsolutePath(
-                                    textFileRef.path,
+                                    serializedReference(textFileRef),
                                 ),
                             onContextMenu: onFileContextMenu
                                 ? (event) =>
-                                      onFileContextMenu(event, textFileRef.path)
+                                      onFileContextMenu(
+                                          event,
+                                          serializedReference(textFileRef),
+                                      )
                                 : undefined,
                         }),
                     );
@@ -709,26 +747,22 @@ function renderInlineMarkdown(
                         }),
                     );
                 } else if (parsedReference) {
-                    const fileName =
-                        parsedReference.path
-                            .split("/")
-                            .pop()
-                            ?.replace(/\.md$/, "") ?? linkMatch[1];
+                    const reference = serializedReference(parsedReference);
                     parts.push(
                         renderReferencePill({
                             key,
-                            label: fileName,
+                            label: noteReferenceLabel(parsedReference),
                             title: decoded,
                             variant: "accent",
                             metrics: pillMetrics,
                             appearance,
                             iconPath: parsedReference.path,
+                            line: parsedReference.line,
+                            endLine: parsedReference.endLine,
                             onClick: () =>
-                                void openChatNoteByReference(
-                                    parsedReference.path,
-                                ),
+                                void openChatNoteByReference(reference),
                             onContextMenu: (event) =>
-                                onNoteContextMenu(event, parsedReference.path),
+                                onNoteContextMenu(event, reference),
                         }),
                     );
                 } else {
@@ -796,13 +830,18 @@ function renderInlineMarkdown(
                         metrics: pillMetrics,
                         appearance,
                         iconPath: textFileRef.path,
+                        line: textFileRef.line,
+                        endLine: textFileRef.endLine,
                         onClick: () =>
                             void openAiEditedFileByAbsolutePath(
-                                textFileRef.path,
+                                serializedReference(textFileRef),
                             ),
                         onContextMenu: onFileContextMenu
                             ? (event) =>
-                                  onFileContextMenu(event, textFileRef.path)
+                                  onFileContextMenu(
+                                      event,
+                                      serializedReference(textFileRef),
+                                  )
                             : undefined,
                     }),
                 );
@@ -822,26 +861,22 @@ function renderInlineMarkdown(
             } else {
                 const parsedReference = parseVaultReference(filePath);
                 if (parsedReference) {
-                    const fileName =
-                        parsedReference.path
-                            .split("/")
-                            .pop()
-                            ?.replace(/\.md$/, "") ?? filePath;
+                    const reference = serializedReference(parsedReference);
                     parts.push(
                         renderReferencePill({
                             key,
-                            label: fileName,
+                            label: noteReferenceLabel(parsedReference),
                             title: filePath,
                             variant: "accent",
                             metrics: pillMetrics,
                             appearance,
                             iconPath: parsedReference.path,
+                            line: parsedReference.line,
+                            endLine: parsedReference.endLine,
                             onClick: () =>
-                                void openChatNoteByReference(
-                                    parsedReference.path,
-                                ),
+                                void openChatNoteByReference(reference),
                             onContextMenu: (event) =>
-                                onNoteContextMenu(event, parsedReference.path),
+                                onNoteContextMenu(event, reference),
                         }),
                     );
                 } else {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -27,6 +27,7 @@ import { ChatInlinePill } from "./ChatInlinePill";
 import { ChatVaultReference } from "./ChatVaultReference";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 import {
+    findChatNoteByReference,
     openChatNoteByReference,
     openChatMapByReference,
 } from "../chatNoteNavigation";
@@ -113,6 +114,31 @@ function resolveVaultNoteReference(
         ...parsed,
         path: resolvedPath,
     };
+}
+
+function resolveIndexedVaultNoteReference(
+    value: string,
+    options?: { allowRelative?: boolean },
+) {
+    const explicitReference = resolveVaultNoteReference(value, options);
+    if (explicitReference) return explicitReference;
+
+    const target = parseChatVaultReferenceTarget(value);
+    if (!target.path || isExternalReference(target.path)) return null;
+    if (!options?.allowRelative && !target.path.startsWith("/")) return null;
+
+    const note = findChatNoteByReference(target.path);
+    if (!note) return null;
+    return {
+        ...target,
+        path: note.path,
+        kind: "note" as const,
+    };
+}
+
+function isOpenableExternalReference(value: string) {
+    const trimmed = value.trim();
+    return /^(?:https?:|mailto:)/i.test(trimmed) || trimmed.startsWith("//");
 }
 
 function parseExcalidrawReference(value: string) {
@@ -643,28 +669,36 @@ function renderInlineMarkdown(
                 // Assistant output may include literal "%" characters in links.
                 // Keep rendering resilient when the URL is not valid URI-encoded text.
                 const decoded = safeDecodeUriComponent(url);
-                const parsedUrlReference = resolveVaultNoteReference(decoded, {
-                    allowRelative: true,
-                });
-                const parsedLabelReference = resolveVaultNoteReference(
-                    linkMatch[1],
-                    {
-                        allowRelative: true,
-                    },
-                );
+                const isExternalTarget = isExternalReference(decoded);
+                const parsedUrlReference = !isExternalTarget
+                    ? resolveIndexedVaultNoteReference(decoded, {
+                          allowRelative: true,
+                      })
+                    : null;
+                const parsedLabelReference = !isExternalTarget
+                    ? resolveIndexedVaultNoteReference(linkMatch[1], {
+                          allowRelative: true,
+                      })
+                    : null;
                 const parsedReference =
                     parsedUrlReference ?? parsedLabelReference;
-                const excalidrawRef =
-                    parseExcalidrawReference(decoded) ??
-                    parseExcalidrawReference(linkMatch[1]);
-                const pdfLinkRef =
-                    parsePdfReference(decoded) ??
-                    parsePdfReference(linkMatch[1]);
-                const textFileRef =
-                    parseRelativeTextFileReference(decoded) ??
-                    parseRelativeTextFileReference(linkMatch[1]);
+                const excalidrawRef = !isExternalTarget
+                    ? (parseExcalidrawReference(decoded) ??
+                      parseExcalidrawReference(linkMatch[1]))
+                    : null;
+                const pdfLinkRef = !isExternalTarget
+                    ? (parsePdfReference(decoded) ??
+                      parsePdfReference(linkMatch[1]))
+                    : null;
+                const textFileRef = !isExternalTarget
+                    ? (parseRelativeTextFileReference(decoded) ??
+                      parseRelativeTextFileReference(linkMatch[1]))
+                    : null;
                 const folderRef =
-                    !excalidrawRef && !pdfLinkRef && !textFileRef
+                    !isExternalTarget &&
+                    !excalidrawRef &&
+                    !pdfLinkRef &&
+                    !textFileRef
                         ? (parseVaultFolderReference(decoded, {
                               allowRelative: true,
                           }) ??
@@ -751,7 +785,7 @@ function renderInlineMarkdown(
                     parts.push(
                         renderReferencePill({
                             key,
-                            label: noteReferenceLabel(parsedReference),
+                            label: linkMatch[1].trim(),
                             title: decoded,
                             variant: "accent",
                             metrics: pillMetrics,
@@ -766,7 +800,11 @@ function renderInlineMarkdown(
                         }),
                     );
                 } else {
-                    parts.push(renderExternalLink(key, url, linkMatch[1]));
+                    parts.push(
+                        isOpenableExternalReference(url)
+                            ? renderExternalLink(key, url, linkMatch[1])
+                            : linkMatch[1],
+                    );
                 }
             }
         } else if (match[6]) {

--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -18,14 +18,13 @@ import {
 } from "../../../app/utils/vaultEntries";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { resolveVaultAbsolutePath } from "../../../app/utils/vaultPaths";
-import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
-import { FolderTypeIcon } from "../../../components/icons/FolderTypeIcon";
 import type { ChatPillVariant } from "./chatPillPalette";
 import {
     DIFF_PANEL_MAX_HEIGHT,
     computeUnifiedDiffLines,
 } from "../diff/reviewDiff";
 import { ChatInlinePill } from "./ChatInlinePill";
+import { ChatVaultReference } from "./ChatVaultReference";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 import {
     openChatNoteByReference,
@@ -232,10 +231,6 @@ function parseVaultFolderReference(
 
 type FileReferenceAppearance = "link" | "pill";
 
-function referenceIconSize(metrics: ChatPillMetrics) {
-    return Math.max(11, Math.min(14, metrics.fontSize));
-}
-
 /**
  * Single owner for inline vault references (notes, files, PDFs, drawings and
  * folders). Every parser branch funnels through here so the link appearance and
@@ -253,31 +248,33 @@ function renderReferencePill(params: {
     onClick?: () => void;
     onContextMenu?: MouseEventHandler<HTMLElement>;
 }): ReactElement {
-    const leadingVisual =
-        params.appearance === "link" ? (
-            params.isFolder ? (
-                <FolderTypeIcon
-                    folderName={params.iconPath}
-                    opacity={1}
-                    open={false}
-                    size={referenceIconSize(params.metrics)}
-                />
-            ) : (
-                <FileTypeIcon
-                    fileName={params.iconPath}
-                    opacity={1}
-                    size={referenceIconSize(params.metrics)}
-                />
-            )
-        ) : undefined;
+    if (params.appearance === "link") {
+        return (
+            <ChatVaultReference
+                interactive={params.onClick != null}
+                key={params.key}
+                kind={
+                    params.isFolder
+                        ? "folder"
+                        : params.variant === "accent"
+                          ? "note"
+                          : "file"
+                }
+                label={params.label}
+                metrics={params.metrics}
+                onClick={params.onClick}
+                onContextMenu={params.onContextMenu}
+                path={params.iconPath}
+                title={params.title}
+            />
+        );
+    }
 
     return (
         <ChatInlinePill
-            appearance={params.appearance}
             interactive={params.onClick != null}
             key={params.key}
             label={params.label}
-            leadingVisual={leadingVisual}
             metrics={params.metrics}
             onClick={params.onClick}
             onContextMenu={params.onContextMenu}

--- a/apps/desktop/src/features/ai/components/chatInlinePillStyle.test.ts
+++ b/apps/desktop/src/features/ai/components/chatInlinePillStyle.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { getChatInlinePillStyle } from "./chatInlinePillStyle";
+
+describe("getChatInlinePillStyle", () => {
+    it("keeps wrapped reference labels left-aligned", () => {
+        const style = getChatInlinePillStyle({
+            appearance: "link",
+            clickable: true,
+            metrics: {
+                fontSize: 12,
+                gapX: 1,
+                lineHeight: 1.4,
+                maxWidth: 200,
+                offsetY: 0,
+                paddingX: 4,
+                paddingY: 1,
+                radius: 4,
+            },
+            variant: "accent",
+        });
+
+        expect(style.textAlign).toBe("left");
+    });
+});

--- a/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
+++ b/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
@@ -29,6 +29,7 @@ export function getChatInlinePillStyle({
         border: "none",
         cursor: clickable ? "pointer" : "default",
         fontFamily: "inherit",
+        textAlign: "left",
         verticalAlign: "baseline",
         overflowWrap: "anywhere",
         transform: `translateY(${isLink ? 2 : metrics.offsetY}px)`,

--- a/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
+++ b/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
@@ -1,0 +1,41 @@
+import type { CSSProperties } from "react";
+import { CHAT_PILL_VARIANTS, type ChatPillVariant } from "./chatPillPalette";
+import type { ChatPillMetrics } from "./chatPillMetrics";
+
+export function getChatInlinePillStyle({
+    appearance,
+    clickable,
+    metrics,
+    variant,
+}: {
+    appearance: "link" | "pill";
+    clickable: boolean;
+    metrics: ChatPillMetrics;
+    variant: ChatPillVariant;
+}): CSSProperties {
+    const palette = CHAT_PILL_VARIANTS[variant];
+    const isLink = appearance === "link";
+    return {
+        display: "inline-flex",
+        alignItems: "center",
+        margin: `0 ${metrics.gapX}px`,
+        padding: isLink ? "0px" : `${metrics.paddingY}px ${metrics.paddingX}px`,
+        maxInlineSize: "100%",
+        borderRadius: `${isLink ? 2 : metrics.radius}px`,
+        background: isLink ? "transparent" : palette.background,
+        color: isLink ? "var(--accent)" : palette.color,
+        fontSize: `${metrics.fontSize}px`,
+        lineHeight: String(metrics.lineHeight),
+        border: "none",
+        cursor: clickable ? "pointer" : "default",
+        fontFamily: "inherit",
+        verticalAlign: "baseline",
+        overflowWrap: "anywhere",
+        transform: `translateY(${isLink ? 2 : metrics.offsetY}px)`,
+        filter: "brightness(1)",
+        opacity: String(clickable ? 0.85 : 1),
+        transition: clickable
+            ? "opacity 80ms ease, filter 80ms ease"
+            : undefined,
+    };
+}

--- a/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
+++ b/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
@@ -4,6 +4,10 @@ import { resolveCatppuccinFolderIcon } from "../../../components/icons/folderTyp
 import type { ChatVaultReferenceKind } from "./ChatVaultReference";
 import { getChatInlinePillStyle } from "./chatInlinePillStyle";
 import type { ChatPillMetrics } from "./chatPillMetrics";
+import {
+    getChatVaultReferenceLabel,
+    parseChatVaultReferenceTarget,
+} from "../chatVaultReferenceTarget";
 
 function referenceIconSize(metrics: ChatPillMetrics) {
     return Math.max(11, Math.min(14, metrics.fontSize));
@@ -16,6 +20,8 @@ export function presentComposerVaultReference(
         interactive = false,
         kind,
         label,
+        line,
+        endLine,
         metrics,
         mimeType,
         path,
@@ -23,11 +29,19 @@ export function presentComposerVaultReference(
         interactive?: boolean;
         kind: ChatVaultReferenceKind;
         label: string;
+        line?: number | null;
+        endLine?: number | null;
         metrics: ChatPillMetrics;
         mimeType?: string | null;
         path: string;
     },
 ) {
+    const parsedTarget = parseChatVaultReferenceTarget(path);
+    const target = {
+        path: parsedTarget.path,
+        line: line ?? parsedTarget.line,
+        endLine: endLine ?? parsedTarget.endLine,
+    };
     const variant =
         kind === "folder" ? "folder" : kind === "file" ? "file" : "accent";
     Object.assign(
@@ -42,9 +56,11 @@ export function presentComposerVaultReference(
 
     const iconName =
         kind === "folder"
-            ? resolveCatppuccinFolderIcon(path, false).iconName
+            ? resolveCatppuccinFolderIcon(target.path, false).iconName
             : resolveCatppuccinFileIcon(
-                  kind === "note" && !/\.md$/i.test(path) ? `${path}.md` : path,
+                  kind === "note" && !/\.md$/i.test(target.path)
+                      ? `${target.path}.md`
+                      : target.path,
                   { kind: kind === "note" ? "note" : undefined, mimeType },
               ).iconName;
     const icon = createCatppuccinIconElement({
@@ -61,7 +77,7 @@ export function presentComposerVaultReference(
     if (icon) content.append(icon);
 
     const labelElement = document.createElement("span");
-    labelElement.textContent = label;
+    labelElement.textContent = getChatVaultReferenceLabel(label, target);
     labelElement.style.display = "block";
     labelElement.style.maxWidth = "100%";
     labelElement.style.minWidth = "0";

--- a/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
+++ b/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
@@ -1,0 +1,73 @@
+import { createCatppuccinIconElement } from "../../../components/icons/catppuccinIconPresentation";
+import { resolveCatppuccinFileIcon } from "../../../components/icons/fileTypeIcons";
+import { resolveCatppuccinFolderIcon } from "../../../components/icons/folderTypeIcons";
+import type { ChatVaultReferenceKind } from "./ChatVaultReference";
+import { getChatInlinePillStyle } from "./chatInlinePillStyle";
+import type { ChatPillMetrics } from "./chatPillMetrics";
+
+function referenceIconSize(metrics: ChatPillMetrics) {
+    return Math.max(11, Math.min(14, metrics.fontSize));
+}
+
+/** Applies the shared reference presentation to imperative composer nodes. */
+export function presentComposerVaultReference(
+    element: HTMLSpanElement,
+    {
+        interactive = false,
+        kind,
+        label,
+        metrics,
+        mimeType,
+        path,
+    }: {
+        interactive?: boolean;
+        kind: ChatVaultReferenceKind;
+        label: string;
+        metrics: ChatPillMetrics;
+        mimeType?: string | null;
+        path: string;
+    },
+) {
+    const variant =
+        kind === "folder" ? "folder" : kind === "file" ? "file" : "accent";
+    Object.assign(
+        element.style,
+        getChatInlinePillStyle({
+            appearance: "link",
+            clickable: interactive,
+            metrics,
+            variant,
+        }),
+    );
+
+    const iconName =
+        kind === "folder"
+            ? resolveCatppuccinFolderIcon(path, false).iconName
+            : resolveCatppuccinFileIcon(
+                  kind === "note" && !/\.md$/i.test(path) ? `${path}.md` : path,
+                  { kind: kind === "note" ? "note" : undefined, mimeType },
+              ).iconName;
+    const icon = createCatppuccinIconElement({
+        iconName,
+        opacity: 1,
+        size: referenceIconSize(metrics),
+    });
+    const content = document.createElement("span");
+    content.style.alignItems = "center";
+    content.style.display = "inline-flex";
+    content.style.gap = "4px";
+    content.style.maxWidth = "100%";
+    content.style.minWidth = "0";
+    if (icon) content.append(icon);
+
+    const labelElement = document.createElement("span");
+    labelElement.textContent = label;
+    labelElement.style.display = "block";
+    labelElement.style.maxWidth = "100%";
+    labelElement.style.minWidth = "0";
+    labelElement.style.overflowWrap = "anywhere";
+    labelElement.style.whiteSpace = "normal";
+    labelElement.style.wordBreak = "break-word";
+    content.append(labelElement);
+    element.replaceChildren(content);
+}

--- a/apps/desktop/src/features/ai/composerParts.test.ts
+++ b/apps/desktop/src/features/ai/composerParts.test.ts
@@ -46,7 +46,7 @@ describe("serializeComposerPartsForAI", () => {
         ];
 
         expect(serializeComposerParts(parts)).toBe(
-            "Review [@Spec] and [@📁 docs] plus [@Lines 10-12] with [📎 guide.md]",
+            "Review [@Spec] and [@📁 docs] plus [@📄 /vault/notes/spec.md#L10-12] with [📎 guide.md]",
         );
         expect(serializeComposerPartsForAI(parts)).toBe(
             "Review /vault/notes/spec.md and /vault/docs plus /vault/notes/spec.md:10-12 with /vault/docs/guide.md",

--- a/apps/desktop/src/features/ai/composerParts.ts
+++ b/apps/desktop/src/features/ai/composerParts.ts
@@ -1,4 +1,10 @@
 import type { AIComposerPart } from "./types";
+import {
+    getChatVaultReferenceBasename,
+    getChatVaultReferenceLabel,
+    parseChatVaultReferenceTarget,
+    serializeChatVaultReferenceTarget,
+} from "./chatVaultReferenceTarget";
 
 const SERIALIZED_PILL_VALUE_RE = /[\]|]/;
 
@@ -53,6 +59,14 @@ function serializeScreenshotLabel(label: string) {
     return `[Screenshot|${encodeSerializedPillValue(label)}]`;
 }
 
+function cleanSerializedFileReference(value: string) {
+    const target = parseChatVaultReferenceTarget(value);
+    return getChatVaultReferenceLabel(
+        getChatVaultReferenceBasename(target.path),
+        target,
+    );
+}
+
 /**
  * Strip pill serialization markers from text, returning a clean readable string.
  * Useful for displaying content in compact UI areas (queue summaries, chat titles).
@@ -65,12 +79,10 @@ export function cleanPillMarkers(text: string): string {
         .replace(/\[@📁 ([^\]]+)\]/g, "$1")
         .replace(/\[@📄\|([^\]]+)\]/g, (_match, value: string) => {
             const decoded = decodeSerializedPillValue(value);
-            const normalized = decoded.split("/").pop();
-            return normalized || decoded;
+            return cleanSerializedFileReference(decoded);
         })
         .replace(/\[@📄 ([^\]]+)\]/g, (_match, value: string) => {
-            const normalized = String(value).split("/").pop();
-            return normalized || String(value);
+            return cleanSerializedFileReference(String(value));
         })
         .replace(/\[@\|([^\]]+)\]/g, (_match, value: string) =>
             decodeSerializedPillValue(value),
@@ -134,10 +146,22 @@ export function serializeComposerParts(parts: AIComposerPart[]): string {
                 return serializeFolderPillLabel(part.label);
             if (part.type === "file_mention")
                 return serializeFileMentionPath(part.path);
-            if (part.type === "mention")
-                return serializeNotePillLabel(part.label);
+            if (part.type === "mention") {
+                const target = parseChatVaultReferenceTarget(part.path);
+                return target.line
+                    ? serializeFileMentionPath(
+                          serializeChatVaultReferenceTarget(target),
+                      )
+                    : serializeNotePillLabel(part.label);
+            }
             if (part.type === "selection_mention")
-                return serializeNotePillLabel(part.label);
+                return serializeFileMentionPath(
+                    serializeChatVaultReferenceTarget({
+                        path: part.path,
+                        line: part.startLine,
+                        endLine: part.endLine,
+                    }),
+                );
             if (part.type === "screenshot")
                 return serializeScreenshotLabel(part.label);
             if (part.type === "file_attachment")


### PR DESCRIPTION
## Summary

- use one icon-led reference presentation for vault notes, files, folders, selections, and file attachments
- apply the shared style to assistant streaming, the composer, and sent user messages
- resolve unique extensionless Markdown note links against the vault index
- keep ambiguous or missing relative links non-interactive instead of navigating to the renderer
- keep external `http`, `https`, and `mailto` links distinct from vault references
- replace legacy paperclip pills with extension-aware file icons while preserving attachment paths
- preserve file and note navigation while keeping folder references non-interactive
- preserve line targets across composer serialization and sent-message rendering
- support `:66`, `:66-70`, `#L66`, `#L66-L70`, and `#L66-70` references
- reveal and select referenced note lines or ranges when opening links
- share Catppuccin icon rendering with imperative contenteditable composer nodes
- fix the leading whitespace in serialized folder mention labels

## Testing

- full desktop suite: 180 test files, 2,131 passing, 2 existing todo
- targeted ESLint validation for every touched TypeScript/React file
- `npm run build`
- `git diff --check`