### PR TITLE
Polish AI chat interactions and guard against runtime prompt echoes

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2930,6 +2930,19 @@ impl NativeAcpClient {
             .unwrap_or(false)
     }
 
+    fn is_root_session(&self, session_id: &str) -> bool {
+        self.session_state
+            .lock()
+            .ok()
+            .and_then(|state| {
+                state
+                    .sessions
+                    .get(session_id)
+                    .map(|managed| managed.session.parent_session_id.is_none())
+            })
+            .unwrap_or(false)
+    }
+
     fn resolve_app_session_id(&self, runtime_session_id: &str, meta: Option<&Meta>) -> String {
         if let Some(session_id) = self.find_app_session_id(runtime_session_id) {
             return session_id;
@@ -3464,6 +3477,13 @@ impl NativeAcpClient {
                 content: ContentBlock::Text(text),
                 ..
             }) => {
+                // The composer owns user messages in root sessions. Some runtimes echo the
+                // expanded prompt here, which can contain internal attachment context and local
+                // paths. User chunks remain meaningful for subagents, whose prompts are not
+                // created by the local composer.
+                if self.is_root_session(&session_id) {
+                    return Ok(());
+                }
                 if self.should_suppress_internal_text_chunk_for_session(&session_id, &text.text) {
                     return Ok(());
                 }
@@ -10638,6 +10658,27 @@ mod tests {
         assert!(!client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::User));
         assert!(client.has_active_text_message(CHILD_RUNTIME_SESSION_ID, MessageRole::Assistant));
         assert!(!client.has_active_text_message(PARENT_RUNTIME_SESSION_ID, MessageRole::Assistant));
+    }
+
+    #[test]
+    fn root_user_message_chunks_do_not_echo_expanded_runtime_prompts() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let session_state = Arc::new(Mutex::new(NativeAiInner::default()));
+        insert_test_managed_session(&session_state, GROK_RUNTIME_ID, "grok-session");
+        let client = test_client_with_state(event_tx, session_state);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "grok-session",
+            SessionUpdate::UserMessageChunk(ContentChunk::new(ContentBlock::from(
+                "<attached_folder name=\"Daily note\" path=\"Analysis/June 2026\" />\n\n/private/vault/Analysis/June 2026",
+            ))),
+        )))
+        .unwrap();
+
+        assert!(event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .is_err());
+        assert!(!client.has_active_text_message("grok-session", MessageRole::User));
     }
 
     #[test]

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -102,6 +102,7 @@ import {
     useChatTabsStore,
 } from "./features/ai/store/chatTabsStore";
 import { resetChatStore, useChatStore } from "./features/ai/store/chatStore";
+import { useChatFoldersStore } from "./features/ai/store/chatFoldersStore";
 import { useTerminalRuntimeStore } from "./features/terminal/terminalRuntimeStore";
 import { shouldAllowNativeContextMenu } from "./features/spellcheck/contextMenu";
 import { YouTubeModalHost } from "./features/editor/YouTubeModalHost";
@@ -1666,6 +1667,7 @@ export default function App() {
     useEffect(() => {
         if (windowMode !== "main") return;
 
+        useChatFoldersStore.getState().setVaultPath(vaultPath);
         resetChatStore();
         resetChatTabsStore();
 

--- a/apps/desktop/src/app/utils/menuPosition.test.ts
+++ b/apps/desktop/src/app/utils/menuPosition.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { getComposerAnchoredPickerWidth } from "./menuPosition";
+
+describe("getComposerAnchoredPickerWidth", () => {
+    it("matches the chat width while retaining a viewport gutter", () => {
+        expect(getComposerAnchoredPickerWidth(640, 1440)).toBe(640);
+        expect(getComposerAnchoredPickerWidth(640, 500)).toBe(484);
+    });
+
+    it("uses a practical fallback before the chat has been measured", () => {
+        expect(getComposerAnchoredPickerWidth(0, 1440)).toBe(320);
+    });
+});

--- a/apps/desktop/src/app/utils/menuPosition.ts
+++ b/apps/desktop/src/app/utils/menuPosition.ts
@@ -14,6 +14,23 @@ export function getViewportSafeMenuPosition(
     };
 }
 
+export const CHAT_COMPOSER_PICKER_MAX_HEIGHT = 360;
+
+/**
+ * Keeps composer pickers aligned with the chat column while reserving a small
+ * viewport gutter for narrow windows and detached panes.
+ */
+export function getComposerAnchoredPickerWidth(
+    anchorWidth: number,
+    viewportWidth: number,
+    fallbackWidth = 320,
+    padding = 8,
+): number {
+    const safeViewportWidth = Math.max(0, viewportWidth - padding * 2);
+    const requestedWidth = Math.ceil(anchorWidth) || fallbackWidth;
+    return Math.min(requestedWidth, safeViewportWidth);
+}
+
 export function getViewportSafeCenteredPosition({
     centerX,
     topY,

--- a/apps/desktop/src/components/layout/SidebarFilterInput.tsx
+++ b/apps/desktop/src/components/layout/SidebarFilterInput.tsx
@@ -30,22 +30,15 @@ export function SidebarFilterInput({
     // Mirrors Comando's `.sidebar-search` (styles.css:626): padding-based
     // sizing (no fixed height), 12px/18px text, 12px icon, 6px gap. Keeps
     // the bar quietly translucent so it blends into the sidebar vibrancy.
+    // Interactive states (hover, focus-within, clear-button press) live in
+    // the `.nw-sidebar-filter*` rules in index.css.
     return (
         <div
-            className="flex items-center rounded-md"
-            style={{
-                gap: 6,
-                padding: "4px 8px",
-                backgroundColor:
-                    "color-mix(in srgb, var(--bg-tertiary) 85%, transparent)",
-                border:
-                    "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
-                transition:
-                    "background-color 120ms ease, border-color 120ms ease",
-            }}
+            className="nw-sidebar-filter flex items-center gap-1.5 rounded-md px-2 py-1"
             onClick={() => inputRef.current?.focus()}
         >
             <svg
+                className="nw-sidebar-filter-icon shrink-0"
                 width="12"
                 height="12"
                 viewBox="0 0 16 16"
@@ -54,10 +47,6 @@ export function SidebarFilterInput({
                 strokeWidth="1.3"
                 strokeLinecap="round"
                 strokeLinejoin="round"
-                style={{
-                    color: "var(--text-secondary)",
-                    flexShrink: 0,
-                }}
             >
                 <circle cx="7" cy="7" r="4.5" />
                 <path d="M10.5 10.5L14 14" />
@@ -91,13 +80,7 @@ export function SidebarFilterInput({
                     }}
                     title="Clear filter"
                     aria-label="Clear filter"
-                    className="flex items-center justify-center rounded-[3px] transition-colors"
-                    style={{
-                        color: "var(--text-secondary)",
-                        width: 16,
-                        height: 16,
-                        flexShrink: 0,
-                    }}
+                    className="nw-sidebar-filter-clear flex size-4 shrink-0 items-center justify-center rounded-[3px]"
                 >
                     <svg
                         width="10"

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -103,6 +103,7 @@ describe("AgentsSidebarPanel", () => {
         usePinnedChatsStore.setState({ entries: {} });
         useChatFoldersStore.setState({
             folders: {},
+            folderOrder: [],
             sessionFolderIds: {},
             collapsedFolderIds: [],
         });
@@ -246,6 +247,59 @@ describe("AgentsSidebarPanel", () => {
         expect(screen.getByTestId("agent-sidebar-item")).toHaveTextContent(
             "Alpha task",
         );
+    });
+
+    it("reorders folders by dragging their headers", () => {
+        const first = useChatFoldersStore.getState().createFolder("First");
+        const second = useChatFoldersStore.getState().createFolder("Second");
+        expect(first).toBeTruthy();
+        expect(second).toBeTruthy();
+        const session = createSession("session-alpha", "Alpha task");
+        useChatFoldersStore.getState().moveSession(session.sessionId, first);
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: { [session.sessionId]: session },
+            sessionOrder: [session.sessionId],
+        }));
+        renderComponent(<AgentsSidebarPanel />);
+
+        const firstHeader = document.querySelector<HTMLElement>(
+            `[data-chat-folder-header="${first}"]`,
+        );
+        const secondHeader = document.querySelector<HTMLElement>(
+            `[data-chat-folder-header="${second}"]`,
+        );
+        expect(firstHeader).not.toBeNull();
+        expect(secondHeader).not.toBeNull();
+        Object.defineProperty(document, "elementFromPoint", {
+            configurable: true,
+            value: vi.fn(() => secondHeader),
+        });
+        vi.spyOn(secondHeader!, "getBoundingClientRect").mockReturnValue({
+            top: 100,
+            height: 20,
+        } as DOMRect);
+
+        firePointer(firstHeader!, "pointerdown", {
+            clientX: 10,
+            clientY: 10,
+            pointerId: 7,
+        });
+        firePointer(window, "pointermove", {
+            clientX: 10,
+            clientY: 115,
+            pointerId: 7,
+        });
+        firePointer(window, "pointerup", {
+            clientX: 10,
+            clientY: 115,
+            pointerId: 7,
+        });
+
+        expect(useChatFoldersStore.getState().folderOrder).toEqual([
+            second,
+            first,
+        ]);
     });
 
     it("opens Claude Code from the plus menu as a terminal runtime", async () => {

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -135,6 +135,29 @@ describe("AgentsSidebarPanel", () => {
                 },
             ],
             selectedRuntimeId: "codex-acp",
+            sessionInventoryLoaded: true,
+        });
+    });
+
+    it("does not prune persisted folder assignments while cold-start inventory is loading", () => {
+        useChatFoldersStore.setState({
+            folders: {
+                research: { id: "research", name: "Research", createdAt: 1 },
+            },
+            folderOrder: ["research"],
+            sessionFolderIds: { "saved-session": "research" },
+            collapsedFolderIds: [],
+        });
+        useChatStore.setState({
+            sessionsById: {},
+            sessionOrder: [],
+            sessionInventoryLoaded: false,
+        });
+
+        renderComponent(<AgentsSidebarPanel />);
+
+        expect(useChatFoldersStore.getState().sessionFolderIds).toEqual({
+            "saved-session": "research",
         });
     });
 

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -240,6 +240,15 @@ describe("AgentsSidebarPanel", () => {
 
         renderComponent(<AgentsSidebarPanel />);
 
+        expect(
+            document.querySelector('[data-chat-folder-icon]'),
+        ).toBeInTheDocument();
+        expect(
+            document.querySelector<HTMLElement>(
+                `[data-chat-folder-contents="${folderId}"]`,
+            ),
+        ).toHaveStyle({ marginLeft: "8px" });
+
         fireEvent.click(screen.getByTitle("Collapse folder"));
         expect(screen.queryByTestId("agent-sidebar-item")).toBeNull();
 

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -1064,7 +1064,7 @@ export function AgentsSidebarPanel() {
             <section
                 key={folder.id}
                 data-chat-folder-id={folder.id}
-                className="mt-3 flex flex-col rounded"
+                className="mt-1 flex flex-col rounded"
                 style={{
                     backgroundColor:
                         dragOverFolderId === folder.id
@@ -1096,7 +1096,7 @@ export function AgentsSidebarPanel() {
                         color: "var(--text-secondary)",
                         opacity: 0.8,
                         fontSize: metrics.header.fontSize,
-                        padding: `${metrics.header.paddingTop}px ${metrics.header.paddingX}px ${metrics.header.paddingBottom}px`,
+                        padding: `${scaleMetric(4, agentsSidebarScale / 100, 3)}px ${metrics.header.paddingX}px ${scaleMetric(3, agentsSidebarScale / 100, 2)}px`,
                     }}
                     title={collapsed ? "Expand folder" : "Collapse folder"}
                     onClick={() => {
@@ -1117,8 +1117,8 @@ export function AgentsSidebarPanel() {
                     }}
                 >
                     <svg
-                        width="11"
-                        height="11"
+                        width="9"
+                        height="9"
                         viewBox="0 0 16 16"
                         fill="none"
                         stroke="currentColor"
@@ -1133,6 +1133,21 @@ export function AgentsSidebarPanel() {
                         }}
                     >
                         <path d="m4 6 4 4 4-4" />
+                    </svg>
+                    <svg
+                        data-chat-folder-icon
+                        aria-hidden="true"
+                        width="12"
+                        height="12"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        className="shrink-0"
+                    >
+                        <path d="M1.75 4.25a1.5 1.5 0 0 1 1.5-1.5h3l1.4 1.75h5.1a1.5 1.5 0 0 1 1.5 1.5v5.25a1.5 1.5 0 0 1-1.5 1.5h-9.5a1.5 1.5 0 0 1-1.5-1.5Z" />
                     </svg>
                     {isRenaming ? (
                         <input
@@ -1174,7 +1189,17 @@ export function AgentsSidebarPanel() {
                     <span style={{ opacity: 0.7 }}>{groups.length}</span>
                 </div>
                 {!collapsed ? (
-                    <div className="flex flex-col gap-0.5">
+                    <div
+                        data-chat-folder-contents={folder.id}
+                        className="flex min-w-0 flex-col gap-0.5"
+                        style={{
+                            marginLeft: scaleMetric(
+                                8,
+                                agentsSidebarScale / 100,
+                                7,
+                            ),
+                        }}
+                    >
                         {groups.length > 0 ? (
                             groups.map(renderGroup)
                         ) : (

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -312,6 +312,9 @@ export function AgentsSidebarPanel() {
     const sessionOrder = useChatStore((state) => state.sessionOrder);
     const runtimes = useChatStore((state) => state.runtimes);
     const selectedRuntimeId = useChatStore((state) => state.selectedRuntimeId);
+    const sessionInventoryLoaded = useChatStore(
+        (state) => state.sessionInventoryLoaded,
+    );
     const deleteSession = useChatStore((state) => state.deleteSession);
     const renameSession = useChatStore((state) => state.renameSession);
 
@@ -459,8 +462,9 @@ export function AgentsSidebarPanel() {
         reconcilePinned(hierarchy.rootSessionIds);
     }, [hierarchy.rootSessionIds, reconcilePinned]);
     useEffect(() => {
+        if (!sessionInventoryLoaded) return;
         reconcileFolders(hierarchy.rootSessionIds);
-    }, [hierarchy.rootSessionIds, reconcileFolders]);
+    }, [hierarchy.rootSessionIds, reconcileFolders, sessionInventoryLoaded]);
 
     // Shortcut sections are mutually exclusive with each other. They are not
     // a partition of folder navigation: a foldered chat may intentionally

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -1011,10 +1011,7 @@ export function AgentsSidebarPanel() {
 
     return (
         <div className="flex h-full min-h-0 flex-col">
-            <div
-                className="shrink-0 px-2 pt-2 pb-2"
-                style={{ borderBottom: "1px solid var(--border)" }}
-            >
+            <div className="shrink-0 px-2 pt-2 pb-2">
                 <SidebarFilterInput
                     value={filterText}
                     onChange={setFilterText}

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -5,6 +5,7 @@ import {
     useRef,
     useState,
     type MouseEvent as ReactMouseEvent,
+    type PointerEvent as ReactPointerEvent,
 } from "react";
 import { createPortal } from "react-dom";
 import { confirm } from "@neverwrite/runtime";
@@ -92,6 +93,11 @@ type AgentDragPreview = {
 type EditingFolder = {
     folderId: string;
     name: string;
+};
+
+type FolderDropTarget = {
+    folderId: string;
+    position: "before" | "after";
 };
 
 type ChatSidebarDropTarget =
@@ -320,9 +326,11 @@ export function AgentsSidebarPanel() {
     const collapsedFolderIds = useChatFoldersStore(
         (state) => state.collapsedFolderIds,
     );
+    const folderOrder = useChatFoldersStore((state) => state.folderOrder);
     const createFolder = useChatFoldersStore((state) => state.createFolder);
     const renameFolder = useChatFoldersStore((state) => state.renameFolder);
     const deleteFolder = useChatFoldersStore((state) => state.deleteFolder);
+    const reorderFolder = useChatFoldersStore((state) => state.reorderFolder);
     const moveSessionToFolder = useChatFoldersStore(
         (state) => state.moveSession,
     );
@@ -489,11 +497,22 @@ export function AgentsSidebarPanel() {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [hierarchy.groups, pinnedEntries, workingOrderRevision]);
     const orderedFolders = useMemo(
-        () =>
-            Object.values(chatFolders).sort(
+        () => {
+            const unordered = Object.values(chatFolders).sort(
                 (left, right) => left.createdAt - right.createdAt,
-            ),
-        [chatFolders],
+            );
+            const byId = new Map(unordered.map((folder) => [folder.id, folder]));
+            const ordered = folderOrder.flatMap((id) => {
+                const folder = byId.get(id);
+                if (!folder) return [];
+                byId.delete(id);
+                return [folder];
+            });
+            // This also makes an interrupted migration harmless: folders that
+            // have not reached folderOrder remain visible and usable.
+            return [...ordered, ...unordered.filter((folder) => byId.has(folder.id))];
+        },
+        [chatFolders, folderOrder],
     );
     // Folders are the chat's organizational home. Keep every group eligible
     // here (including pinned/open groups) so the folder projection remains
@@ -614,6 +633,147 @@ export function AgentsSidebarPanel() {
         null,
     );
     const [isDraggingOverUnfiled, setIsDraggingOverUnfiled] = useState(false);
+    const folderDragRef = useRef<{
+        pointerId: number;
+        folderId: string;
+        startX: number;
+        startY: number;
+        active: boolean;
+        folderIds: string[];
+    } | null>(null);
+    const folderDragCleanupRef = useRef<(() => void) | null>(null);
+    const suppressFolderClickRef = useRef(false);
+    const [draggedFolderId, setDraggedFolderId] = useState<string | null>(null);
+    const [folderDropTarget, setFolderDropTarget] =
+        useState<FolderDropTarget | null>(null);
+
+    useEffect(
+        () => () => {
+            folderDragCleanupRef.current?.();
+            folderDragCleanupRef.current = null;
+        },
+        [],
+    );
+
+    const clearFolderDrag = useCallback(() => {
+        folderDragRef.current = null;
+        folderDragCleanupRef.current?.();
+        folderDragCleanupRef.current = null;
+        setDraggedFolderId(null);
+        setFolderDropTarget(null);
+    }, []);
+
+    const handleFolderPointerDown = useCallback(
+        (event: ReactPointerEvent<HTMLElement>, folderId: string) => {
+            if (event.button !== 0 || editingFolder?.folderId === folderId) return;
+
+            const target = event.target;
+            if (target instanceof Element && target.closest("input,button")) return;
+
+            folderDragCleanupRef.current?.();
+            const state = {
+                pointerId: event.pointerId,
+                folderId,
+                startX: event.clientX,
+                startY: event.clientY,
+                active: false,
+                folderIds: orderedFolders.map((folder) => folder.id),
+            };
+            folderDragRef.current = state;
+
+            const updateTarget = (moveEvent: PointerEvent) => {
+                const current = folderDragRef.current;
+                if (!current || current.pointerId !== moveEvent.pointerId) return;
+                if (!current.active) {
+                    if (
+                        Math.hypot(
+                            moveEvent.clientX - current.startX,
+                            moveEvent.clientY - current.startY,
+                        ) < 5
+                    ) {
+                        return;
+                    }
+                    current.active = true;
+                    setDraggedFolderId(current.folderId);
+                }
+                moveEvent.preventDefault();
+                const element = document.elementFromPoint(
+                    moveEvent.clientX,
+                    moveEvent.clientY,
+                );
+                const header = element?.closest<HTMLElement>(
+                    "[data-chat-folder-header]",
+                );
+                const targetFolderId = header?.dataset.chatFolderHeader;
+                if (!targetFolderId || targetFolderId === current.folderId) {
+                    setFolderDropTarget(null);
+                    return;
+                }
+                const rect = header.getBoundingClientRect();
+                setFolderDropTarget({
+                    folderId: targetFolderId,
+                    position:
+                        moveEvent.clientY < rect.top + rect.height / 2
+                            ? "before"
+                            : "after",
+                });
+            };
+            const finish = (upEvent: PointerEvent, cancelled = false) => {
+                const current = folderDragRef.current;
+                if (!current || current.pointerId !== upEvent.pointerId) return;
+                // Calculate from the final pointer position instead of React
+                // state, which can be stale inside this window listener.
+                const element = document.elementFromPoint(
+                    upEvent.clientX,
+                    upEvent.clientY,
+                );
+                const header = element?.closest<HTMLElement>(
+                    "[data-chat-folder-header]",
+                );
+                const targetFolderId = header?.dataset.chatFolderHeader;
+                const rect = header?.getBoundingClientRect();
+                const finalTarget =
+                    targetFolderId && targetFolderId !== current.folderId && rect
+                        ? {
+                              folderId: targetFolderId,
+                              position:
+                                  upEvent.clientY < rect.top + rect.height / 2
+                                      ? ("before" as const)
+                                      : ("after" as const),
+                          }
+                        : null;
+                const wasActive = current.active;
+                clearFolderDrag();
+                if (!wasActive || cancelled || !finalTarget) return;
+
+                const remainingIds = current.folderIds.filter(
+                    (id) => id !== current.folderId,
+                );
+                const targetIndex = remainingIds.indexOf(finalTarget.folderId);
+                if (targetIndex < 0) return;
+                reorderFolder(
+                    current.folderId,
+                    targetIndex + (finalTarget.position === "after" ? 1 : 0),
+                );
+                suppressFolderClickRef.current = true;
+                window.requestAnimationFrame(() => {
+                    suppressFolderClickRef.current = false;
+                });
+            };
+            const onMove = (moveEvent: PointerEvent) => updateTarget(moveEvent);
+            const onUp = (upEvent: PointerEvent) => finish(upEvent);
+            const onCancel = (cancelEvent: PointerEvent) => finish(cancelEvent, true);
+            window.addEventListener("pointermove", onMove);
+            window.addEventListener("pointerup", onUp);
+            window.addEventListener("pointercancel", onCancel);
+            folderDragCleanupRef.current = () => {
+                window.removeEventListener("pointermove", onMove);
+                window.removeEventListener("pointerup", onUp);
+                window.removeEventListener("pointercancel", onCancel);
+            };
+        },
+        [clearFolderDrag, editingFolder?.folderId, orderedFolders, reorderFolder],
+    );
 
     const newChatMenuEntries = useMemo<ContextMenuEntry[]>(() => {
         const sortedRuntimes = [...runtimes].sort((left, right) => {
@@ -910,9 +1070,21 @@ export function AgentsSidebarPanel() {
                         dragOverFolderId === folder.id
                             ? "1px solid color-mix(in srgb, var(--accent) 55%, transparent)"
                             : "1px solid transparent",
+                    borderTop:
+                        folderDropTarget?.folderId === folder.id &&
+                        folderDropTarget.position === "before"
+                            ? "2px solid var(--accent)"
+                            : "2px solid transparent",
+                    borderBottom:
+                        folderDropTarget?.folderId === folder.id &&
+                        folderDropTarget.position === "after"
+                            ? "2px solid var(--accent)"
+                            : "2px solid transparent",
+                    opacity: draggedFolderId === folder.id ? 0.55 : 1,
                 }}
             >
                 <div
+                    data-chat-folder-header={folder.id}
                     role="button"
                     tabIndex={0}
                     className="flex items-center gap-1.5 px-2 text-left text-[10px] font-semibold uppercase tracking-[0.09em]"
@@ -923,7 +1095,13 @@ export function AgentsSidebarPanel() {
                         padding: `${metrics.header.paddingTop}px ${metrics.header.paddingX}px ${metrics.header.paddingBottom}px`,
                     }}
                     title={collapsed ? "Expand folder" : "Collapse folder"}
-                    onClick={() => toggleFolderCollapsed(folder.id)}
+                    onClick={() => {
+                        if (suppressFolderClickRef.current) return;
+                        toggleFolderCollapsed(folder.id);
+                    }}
+                    onPointerDown={(event) =>
+                        handleFolderPointerDown(event, folder.id)
+                    }
                     onContextMenu={(event) =>
                         handleFolderContextMenu(event, folder)
                     }

--- a/apps/desktop/src/features/ai/chatMentionSearch.ts
+++ b/apps/desktop/src/features/ai/chatMentionSearch.ts
@@ -1,0 +1,178 @@
+import type {
+    AIChatFileSummary,
+    AIChatNoteSummary,
+    AIMentionSuggestion,
+} from "./types";
+
+const FETCH_KEYWORDS = ["fetch", "web", "search", "buscar", "internet"];
+
+function normalizeForSearch(value: string): string {
+    return value
+        .normalize("NFD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .trim();
+}
+
+function getNoteFileNameForSearch(note: AIChatNoteSummary) {
+    return note.path.split("/").pop() ?? note.path;
+}
+
+function getNoteMentionLabel(
+    note: AIChatNoteSummary,
+    showExtensions: boolean,
+    preferFileName: boolean,
+) {
+    if (!preferFileName) return note.title;
+
+    const fileName = getNoteFileNameForSearch(note);
+    return showExtensions ? fileName : fileName.replace(/\.md$/i, "");
+}
+
+function getFileMentionLabel(file: AIChatFileSummary, showExtensions: boolean) {
+    return showExtensions ? file.fileName : file.title || file.fileName;
+}
+
+function getFuzzySearchScore(query: string, candidate: string) {
+    let queryIndex = 0;
+    let lastMatchIndex = -1;
+    let gaps = 0;
+
+    for (let index = 0; index < candidate.length; index += 1) {
+        if (candidate[index] !== query[queryIndex]) continue;
+        if (lastMatchIndex >= 0) gaps += index - lastMatchIndex - 1;
+        lastMatchIndex = index;
+        queryIndex += 1;
+        if (queryIndex === query.length) return gaps + lastMatchIndex;
+    }
+
+    return null;
+}
+
+function getMentionSearchScore(
+    query: string,
+    primaryValues: string[],
+    secondaryValue: string,
+) {
+    if (!query) return 0;
+
+    const normalizedPrimary = primaryValues.map(normalizeForSearch);
+    const normalizedSecondary = normalizeForSearch(secondaryValue);
+    const segmentStart = (value: string) =>
+        value.split(/[\\/._\-\s]+/).some((segment) => segment.startsWith(query));
+
+    if (normalizedPrimary.some((value) => value === query)) return 0;
+    if (normalizedPrimary.some((value) => value.startsWith(query))) return 10;
+    if (normalizedPrimary.some(segmentStart)) return 20;
+    if (normalizedPrimary.some((value) => value.includes(query))) return 30;
+    if (normalizedSecondary.startsWith(query)) return 40;
+    if (segmentStart(normalizedSecondary)) return 50;
+    if (normalizedSecondary.includes(query)) return 60;
+
+    const primaryFuzzyScores = normalizedPrimary
+        .map((value) => getFuzzySearchScore(query, value))
+        .filter((score): score is number => score !== null);
+    if (primaryFuzzyScores.length > 0) {
+        return 100 + Math.min(...primaryFuzzyScores);
+    }
+
+    const secondaryFuzzyScore = getFuzzySearchScore(query, normalizedSecondary);
+    return secondaryFuzzyScore === null ? null : 200 + secondaryFuzzyScore;
+}
+
+interface RankedMentionSuggestion {
+    item: AIMentionSuggestion;
+    label: string;
+    rank: number;
+    secondary: string;
+    typeRank: number;
+}
+
+export function getMentionSuggestions(
+    notes: AIChatNoteSummary[],
+    files: AIChatFileSummary[],
+    folderPaths: string[],
+    query: string,
+    includeFiles: boolean,
+    preferFileName: boolean,
+    showExtensions: boolean,
+    limit = 10,
+): AIMentionSuggestion[] {
+    const normalizedQuery = normalizeForSearch(query);
+    const results: AIMentionSuggestion[] = [];
+
+    if (
+        !normalizedQuery ||
+        FETCH_KEYWORDS.some(
+            (keyword) => keyword.startsWith(normalizedQuery),
+        )
+    ) {
+        results.push({ kind: "fetch" });
+    }
+
+    const candidates: RankedMentionSuggestion[] = [];
+    for (const folderPath of folderPaths) {
+        const name = folderPath.split("/").pop() ?? folderPath;
+        const rank = getMentionSearchScore(
+            normalizedQuery,
+            [name],
+            folderPath,
+        );
+        if (rank === null) continue;
+        candidates.push({
+            item: { kind: "folder", folderPath, name },
+            label: name,
+            rank,
+            secondary: folderPath,
+            typeRank: 0,
+        });
+    }
+
+    for (const note of notes) {
+        const label = getNoteMentionLabel(note, showExtensions, preferFileName);
+        const rank = getMentionSearchScore(
+            normalizedQuery,
+            preferFileName
+                ? [getNoteFileNameForSearch(note), note.title]
+                : [note.title, getNoteFileNameForSearch(note)],
+            note.path,
+        );
+        if (rank === null) continue;
+        candidates.push({
+            item: { kind: "note", note, label },
+            label,
+            rank,
+            secondary: note.path,
+            typeRank: 1,
+        });
+    }
+
+    if (includeFiles) {
+        for (const file of files) {
+            const label = getFileMentionLabel(file, showExtensions);
+            const rank = getMentionSearchScore(
+                normalizedQuery,
+                [file.fileName, file.title],
+                file.relativePath,
+            );
+            if (rank === null) continue;
+            candidates.push({
+                item: { kind: "file", file, label },
+                label,
+                rank,
+                secondary: file.relativePath,
+                typeRank: 2,
+            });
+        }
+    }
+
+    candidates.sort(
+        (left, right) =>
+            left.rank - right.rank ||
+            left.typeRank - right.typeRank ||
+            left.label.localeCompare(right.label) ||
+            left.secondary.localeCompare(right.secondary),
+    );
+
+    return [...results, ...candidates.map(({ item }) => item)].slice(0, limit);
+}

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -206,11 +206,36 @@ function DropdownField({
                 >
                     {searchable && (
                         <div
-                            className="px-1.5 pb-1"
+                            className="mx-1 mb-1 flex items-center gap-1.5 rounded-md"
                             style={{
-                                borderBottom: "1px solid var(--border)",
+                                backgroundColor: "var(--bg-primary)",
+                                border: "1px solid var(--border)",
+                                height: 24,
+                                padding: "0 7px",
                             }}
                         >
+                            <svg
+                                width="10"
+                                height="10"
+                                viewBox="0 0 16 16"
+                                fill="none"
+                                style={{ opacity: 0.4, flexShrink: 0 }}
+                                aria-hidden="true"
+                            >
+                                <circle
+                                    cx="7"
+                                    cy="7"
+                                    r="5"
+                                    stroke="currentColor"
+                                    strokeWidth="1.5"
+                                />
+                                <path
+                                    d="m13 13-2.5-2.5"
+                                    stroke="currentColor"
+                                    strokeWidth="1.5"
+                                    strokeLinecap="round"
+                                />
+                            </svg>
                             <input
                                 ref={searchInputRef}
                                 type="text"
@@ -223,17 +248,28 @@ function DropdownField({
                                 }}
                                 placeholder={searchPlaceholder}
                                 aria-label={`${label} search`}
-                                className="mt-0.5 w-full rounded px-1 py-0 text-[7px]"
+                                className="min-w-0 flex-1 bg-transparent text-xs outline-none"
                                 style={{
                                     color: "var(--text-primary)",
-                                    backgroundColor: "var(--bg-primary)",
-                                    border: "1px solid var(--border)",
-                                    height: 16,
-                                    outline: "none",
-                                    minHeight: 16,
-                                    lineHeight: "12px",
+                                    border: "none",
+                                    fontFamily: "inherit",
+                                    // The global `input { font: inherit }` reset in
+                                    // index.css lives outside Tailwind's cascade
+                                    // layers, so it always wins over the `text-xs`
+                                    // utility here regardless of specificity. Pin
+                                    // the size/line-height inline to match the
+                                    // option rows, which aren't affected (buttons
+                                    // aren't targeted by that reset).
+                                    fontSize: "0.75rem",
+                                    lineHeight: "calc(1 / 0.75)",
                                 }}
                             />
+                            <span
+                                className="shrink-0 font-mono text-[9px]"
+                                style={{ color: "var(--text-secondary)" }}
+                            >
+                                {filteredOptions.length}/{options.length}
+                            </span>
                         </div>
                     )}
                     <div

--- a/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { getViewportSafeMenuPosition } from "../../../app/utils/menuPosition";
+import { useComposerPickerPosition } from "./useComposerPickerPosition";
 
 export interface AIChatSlashCommand {
     id: string;
@@ -30,9 +30,6 @@ function CommandIcon() {
 
 interface AIChatCommandPickerProps {
     open: boolean;
-    x: number;
-    y: number;
-    query: string;
     selectedIndex: number;
     items: AIChatSlashCommand[];
     anchorElement: HTMLElement | null;
@@ -43,8 +40,6 @@ interface AIChatCommandPickerProps {
 
 export function AIChatCommandPicker({
     open,
-    x,
-    y,
     selectedIndex,
     items,
     anchorElement,
@@ -54,23 +49,12 @@ export function AIChatCommandPicker({
 }: AIChatCommandPickerProps) {
     const ref = useRef<HTMLDivElement>(null);
     const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-    const [position, setPosition] = useState({ x, y });
-
-    useLayoutEffect(() => {
-        if (!open) return;
-        const element = ref.current;
-        if (!element) return;
-
-        const rect = element.getBoundingClientRect();
-        setPosition(
-            getViewportSafeMenuPosition(
-                x,
-                y - rect.height - 8,
-                rect.width,
-                rect.height,
-            ),
-        );
-    }, [open, x, y, items.length]);
+    const position = useComposerPickerPosition(
+        anchorElement,
+        ref.current,
+        open,
+        items.length,
+    );
 
     useEffect(() => {
         if (!open) return;
@@ -99,18 +83,18 @@ export function AIChatCommandPicker({
             ref={ref}
             style={{
                 position: "fixed",
-                top: position.y,
-                left: position.x,
+                top: position?.y ?? 8,
+                left: position?.x ?? 8,
                 zIndex: 10010,
-                width: 420,
-                maxWidth: "min(420px, calc(100vw - 24px))",
-                maxHeight: 280,
+                width: position?.width ?? 320,
+                maxHeight: position?.maxHeight ?? 360,
                 overflow: "hidden",
                 borderRadius: 10,
                 border: "1px solid color-mix(in srgb, var(--border) 86%, transparent)",
                 background:
                     "color-mix(in srgb, var(--bg-elevated) 97%, transparent)",
-                boxShadow: "0 8px 24px rgba(15, 23, 42, 0.12)",
+                boxShadow:
+                    "0 12px 32px rgba(15, 23, 42, 0.16), 0 0 0 1px color-mix(in srgb, var(--border) 40%, transparent)",
                 backdropFilter: "blur(10px)",
             }}
         >
@@ -121,7 +105,7 @@ export function AIChatCommandPicker({
                     display: "flex",
                     flexDirection: "column",
                     gap: 1,
-                    maxHeight: 280,
+                    maxHeight: position?.maxHeight ?? 360,
                 }}
             >
                 {items.length ? (
@@ -149,7 +133,7 @@ export function AIChatCommandPicker({
                                     background: isActive
                                         ? "color-mix(in srgb, var(--accent) 10%, var(--bg-secondary))"
                                         : "transparent",
-                                    padding: "6px 10px",
+                                    padding: "7px 10px",
                                     textAlign: "left",
                                     cursor: "pointer",
                                     width: "100%",
@@ -160,14 +144,15 @@ export function AIChatCommandPicker({
                                 <CommandIcon />
                                 <span
                                     style={{
-                                        color: "var(--accent)",
-                                        fontSize: 13,
-                                        fontWeight: 600,
+                                        color: "var(--text-primary)",
+                                        fontFamily: "var(--font-mono, monospace)",
+                                        fontSize: 12.5,
+                                        fontWeight: 500,
                                         whiteSpace: "nowrap",
                                         overflow: "hidden",
                                         textOverflow: "ellipsis",
                                         flex: "0 0 auto",
-                                        maxWidth: "46%",
+                                        maxWidth: "44%",
                                         minWidth: 0,
                                     }}
                                 >
@@ -175,7 +160,7 @@ export function AIChatCommandPicker({
                                 </span>
                                 <span
                                     style={{
-                                        fontSize: 11,
+                                        fontSize: 11.5,
                                         color: "var(--text-secondary)",
                                         opacity: 0.6,
                                         flex: "1 1 0",

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -17,6 +17,7 @@ import {
     MAX_IMAGE_ATTACHMENTS_PER_MESSAGE,
     MAX_IMAGE_ATTACHMENT_BYTES,
 } from "../imageAttachments";
+import { getMentionSuggestions } from "../chatMentionSearch";
 import { AIChatComposer } from "./AIChatComposer";
 import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 import { getComposerPillLayoutStyle } from "./chatPillLayout";
@@ -137,6 +138,54 @@ function setCaret(node: Node, offset: number) {
 }
 
 describe("AIChatComposer mention picker", () => {
+    it("finds files through path segments and fuzzy file-name matches", () => {
+        const files = [
+            {
+                id: "composer",
+                title: "Composer",
+                path: "/vault/src/features/ai/AIChatComposer.tsx",
+                relativePath: "src/features/ai/AIChatComposer.tsx",
+                fileName: "AIChatComposer.tsx",
+                mimeType: "text/typescript",
+            },
+            {
+                id: "panel",
+                title: "Panel",
+                path: "/vault/src/features/ai/ReviewPanel.tsx",
+                relativePath: "src/features/ai/ReviewPanel.tsx",
+                fileName: "ReviewPanel.tsx",
+                mimeType: "text/typescript",
+            },
+        ];
+
+        const fuzzyMatches = getMentionSuggestions(
+            [],
+            files,
+            [],
+            "aichcmp",
+            true,
+            true,
+            true,
+        );
+        const pathMatches = getMentionSuggestions(
+            [],
+            files,
+            [],
+            "features",
+            true,
+            true,
+            true,
+        );
+
+        expect(fuzzyMatches).toEqual([
+            expect.objectContaining({
+                kind: "file",
+                label: "AIChatComposer.tsx",
+            }),
+        ]);
+        expect(pathMatches.map((item) => item.kind)).toEqual(["file", "file"]);
+    });
+
     it("uses the shared icon-led reference style for notes, files, folders, and selections", () => {
         const { composer } = renderComposer({
             parts: [

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -24,6 +24,7 @@ import {
     type AIChatSlashCommand,
 } from "./AIChatCommandPicker";
 import { AIChatMentionPicker } from "./AIChatMentionPicker";
+import { getMentionSuggestions } from "../chatMentionSearch";
 import { presentComposerVaultReference } from "./chatVaultReferenceDom";
 import {
     getChatVaultReferenceBasename,
@@ -113,8 +114,6 @@ interface MentionState {
     query: string;
     selectedIndex: number;
     items: AIMentionSuggestion[];
-    x: number;
-    y: number;
     range: Range | null;
 }
 
@@ -130,8 +129,6 @@ interface SlashState {
     query: string;
     selectedIndex: number;
     items: AIChatSlashCommand[];
-    x: number;
-    y: number;
     range: Range | null;
 }
 
@@ -140,8 +137,6 @@ const EMPTY_MENTION_STATE: MentionState = {
     query: "",
     selectedIndex: 0,
     items: [],
-    x: 0,
-    y: 0,
     range: null,
 };
 
@@ -150,8 +145,6 @@ const EMPTY_SLASH_STATE: SlashState = {
     query: "",
     selectedIndex: 0,
     items: [],
-    x: 0,
-    y: 0,
     range: null,
 };
 
@@ -854,14 +847,6 @@ function getComposerPillTargetFromContextMenuEvent(
     };
 }
 
-function normalizeForSearch(value: string): string {
-    return value
-        .normalize("NFD")
-        .replace(/[\u0300-\u036f]/g, "")
-        .toLowerCase()
-        .trim();
-}
-
 function getTextPositionForOffset(root: HTMLElement, charOffset: number) {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
     let traversed = 0;
@@ -934,194 +919,6 @@ function getInlineTriggerMatch(root: HTMLElement, pattern: RegExp) {
     };
 }
 
-const FETCH_KEYWORDS = ["fetch", "web", "search", "buscar", "internet"];
-function getNoteFileNameForSearch(note: AIChatNoteSummary) {
-    return note.path.split("/").pop() ?? note.path;
-}
-
-function getNoteMentionLabel(
-    note: AIChatNoteSummary,
-    showExtensions: boolean,
-    preferFileName: boolean,
-) {
-    if (!preferFileName) {
-        return note.title;
-    }
-
-    const fileName = getNoteFileNameForSearch(note);
-    return showExtensions ? fileName : fileName.replace(/\.md$/i, "");
-}
-
-function getFileMentionLabel(file: AIChatFileSummary, showExtensions: boolean) {
-    if (showExtensions) {
-        return file.fileName;
-    }
-
-    return file.title || file.fileName;
-}
-
-function getNoteMentionSuggestions(
-    notes: AIChatNoteSummary[],
-    query: string,
-    limit: number,
-    preferFileName: boolean,
-) {
-    const normalizedQuery = normalizeForSearch(query);
-
-    return [...notes]
-        .map((note) => {
-            const normalizedTitle = normalizeForSearch(note.title);
-            const normalizedPath = normalizeForSearch(note.path);
-            const normalizedFileName = normalizeForSearch(
-                getNoteFileNameForSearch(note),
-            );
-            let rank = 2;
-            if (normalizedQuery.length > 0) {
-                if (preferFileName) {
-                    rank = normalizedFileName.startsWith(normalizedQuery)
-                        ? 0
-                        : normalizedPath.startsWith(normalizedQuery)
-                          ? 1
-                          : normalizedFileName.includes(normalizedQuery)
-                            ? 2
-                            : normalizedPath.includes(normalizedQuery)
-                              ? 3
-                              : normalizedTitle.startsWith(normalizedQuery)
-                                ? 4
-                                : 5;
-                } else {
-                    rank = normalizedTitle.startsWith(normalizedQuery)
-                        ? 0
-                        : normalizedPath.startsWith(normalizedQuery)
-                          ? 1
-                          : 2;
-                }
-            }
-            const matches =
-                !normalizedQuery ||
-                (preferFileName
-                    ? normalizedFileName.includes(normalizedQuery) ||
-                      normalizedPath.includes(normalizedQuery) ||
-                      normalizedTitle.includes(normalizedQuery)
-                    : normalizedTitle.includes(normalizedQuery)) ||
-                normalizedPath.includes(normalizedQuery);
-
-            return {
-                note,
-                matches,
-                rank,
-            };
-        })
-        .filter((item) => item.matches)
-        .sort((left, right) => {
-            if (left.rank !== right.rank) {
-                return left.rank - right.rank;
-            }
-            const leftPrimary = preferFileName
-                ? getNoteFileNameForSearch(left.note)
-                : left.note.title;
-            const rightPrimary = preferFileName
-                ? getNoteFileNameForSearch(right.note)
-                : right.note.title;
-            return leftPrimary.localeCompare(rightPrimary);
-        })
-        .slice(0, limit)
-        .map((item) => item.note);
-}
-
-function getMentionSuggestions(
-    notes: AIChatNoteSummary[],
-    files: AIChatFileSummary[],
-    folderPaths: string[],
-    query: string,
-    includeFiles: boolean,
-    preferFileName: boolean,
-    showExtensions: boolean,
-    limit = 10,
-): AIMentionSuggestion[] {
-    const nq = normalizeForSearch(query);
-    const results: AIMentionSuggestion[] = [];
-
-    // Always show @fetch at the top when query is empty or matches fetch keywords
-    if (
-        !nq ||
-        FETCH_KEYWORDS.some(
-            (kw) => kw.startsWith(nq) || nq.startsWith(kw.slice(0, nq.length)),
-        )
-    ) {
-        results.push({ kind: "fetch" });
-    }
-
-    // Match folders
-    for (const fp of folderPaths) {
-        const name = fp.split("/").pop() ?? fp;
-        const normalized = normalizeForSearch(name);
-        const normalizedFull = normalizeForSearch(fp);
-        if (!nq || normalized.includes(nq) || normalizedFull.includes(nq)) {
-            results.push({ kind: "folder", folderPath: fp, name });
-        }
-    }
-
-    // Match notes
-    const noteSuggestions = getNoteMentionSuggestions(
-        notes,
-        query,
-        limit,
-        preferFileName,
-    );
-    for (const note of noteSuggestions) {
-        results.push({
-            kind: "note",
-            note,
-            label: getNoteMentionLabel(note, showExtensions, preferFileName),
-        });
-    }
-
-    if (includeFiles) {
-        const fileSuggestions = [...files]
-            .map((file) => {
-                const normalizedFileName = normalizeForSearch(file.fileName);
-                const normalizedRelativePath = normalizeForSearch(
-                    file.relativePath,
-                );
-                const primaryStartsWith =
-                    nq.length > 0 && normalizedFileName.startsWith(nq);
-                const pathStartsWith =
-                    nq.length > 0 && normalizedRelativePath.startsWith(nq);
-                const matches =
-                    !nq ||
-                    normalizedFileName.includes(nq) ||
-                    normalizedRelativePath.includes(nq);
-
-                return {
-                    file,
-                    matches,
-                    rank: primaryStartsWith ? 0 : pathStartsWith ? 1 : 2,
-                };
-            })
-            .filter((item) => item.matches)
-            .sort((left, right) => {
-                if (left.rank !== right.rank) {
-                    return left.rank - right.rank;
-                }
-
-                return left.file.fileName.localeCompare(right.file.fileName);
-            })
-            .slice(0, limit);
-
-        for (const item of fileSuggestions) {
-            results.push({
-                kind: "file",
-                file: item.file,
-                label: getFileMentionLabel(item.file, showExtensions),
-            });
-        }
-    }
-
-    // Fetch first, then folders, then matching notes/files, limited.
-    return results.slice(0, limit);
-}
-
 export function AIChatComposer({
     sessionId,
     parts,
@@ -1164,7 +961,7 @@ export function AIChatComposer({
     const composerRef = useRef<HTMLDivElement>(null);
     const shellRef = useRef<HTMLDivElement>(null);
     const fileSizeByPathRef = useRef<Map<string, number>>(new Map());
-    const [composerElement, setComposerElement] =
+    const [composerContentColumnElement, setComposerContentColumnElement] =
         useState<HTMLDivElement | null>(null);
     const [mentionState, setMentionState] =
         useState<MentionState>(EMPTY_MENTION_STATE);
@@ -1268,10 +1065,15 @@ export function AIChatComposer({
     );
     const bindComposerRef = useCallback((element: HTMLDivElement | null) => {
         composerRef.current = element;
-        setComposerElement((current) =>
-            current === element ? current : element,
-        );
     }, []);
+    const bindContentColumnRef = useCallback(
+        (element: HTMLDivElement | null) => {
+            setComposerContentColumnElement((current) =>
+                current === element ? current : element,
+            );
+        },
+        [],
+    );
 
     useEffect(() => {
         const composer = composerRef.current;
@@ -1381,14 +1183,11 @@ export function AIChatComposer({
             fileTreeShowExtensions,
             10,
         );
-        const rect = trigger.range.getBoundingClientRect();
         setMentionState({
             open: true,
             query: trigger.query,
             selectedIndex: 0,
             items: suggestions,
-            x: rect.left,
-            y: rect.top,
             range: trigger.range.cloneRange(),
         });
     };
@@ -1425,14 +1224,11 @@ export function AIChatComposer({
                 .toLowerCase();
             return haystack.includes(normalizedQuery);
         });
-        const rect = trigger.range.getBoundingClientRect();
         setSlashState({
             open: true,
             query: trigger.query,
             selectedIndex: 0,
             items,
-            x: rect.left,
-            y: rect.top,
             range: trigger.range.cloneRange(),
         });
         closeMentionPicker();
@@ -1878,6 +1674,7 @@ export function AIChatComposer({
                 }}
             >
                 <div
+                    ref={bindContentColumnRef}
                     className={contentColumnClassName}
                     data-testid="chat-composer-content-column"
                     style={AI_CHAT_CONTENT_COLUMN_STYLE}
@@ -2362,12 +2159,9 @@ export function AIChatComposer({
                 </div>
                 <AIChatMentionPicker
                     open={mentionState.open}
-                    x={mentionState.x}
-                    y={mentionState.y}
-                    query={mentionState.query}
                     selectedIndex={mentionState.selectedIndex}
                     items={mentionState.items}
-                    anchorElement={composerElement}
+                    anchorElement={composerContentColumnElement}
                     onHoverIndex={(index) =>
                         setMentionState((state) => ({
                             ...state,
@@ -2379,12 +2173,9 @@ export function AIChatComposer({
                 />
                 <AIChatCommandPicker
                     open={slashState.open}
-                    x={slashState.x}
-                    y={slashState.y}
-                    query={slashState.query}
                     selectedIndex={slashState.selectedIndex}
                     items={slashState.items}
-                    anchorElement={composerElement}
+                    anchorElement={composerContentColumnElement}
                     onHoverIndex={(index) =>
                         setSlashState((state) => ({
                             ...state,

--- a/apps/desktop/src/features/ai/components/AIChatMentionPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMentionPicker.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
-import { getViewportSafeMenuPosition } from "../../../app/utils/menuPosition";
+import { FileTypeIcon } from "../../../components/icons/FileTypeIcon";
 import type { AIMentionSuggestion } from "../types";
+import { useComposerPickerPosition } from "./useComposerPickerPosition";
 
 function suggestionKey(item: AIMentionSuggestion) {
     if (item.kind === "fetch") return "fetch";
@@ -9,6 +10,23 @@ function suggestionKey(item: AIMentionSuggestion) {
     if (item.kind === "note") return `note:${item.note.id}`;
     if (item.kind === "file") return `file:${item.file.path}`;
     return `folder:${item.folderPath}`;
+}
+
+function getSuggestionSecondary(item: AIMentionSuggestion) {
+    if (item.kind === "fetch") return "Web search";
+    if (item.kind === "plan") return "Planning";
+    if (item.kind === "file") {
+        return getParentDirectoryLabel(item.file.relativePath);
+    }
+    if (item.kind === "note") {
+        return getParentDirectoryLabel(item.note.id || item.note.path);
+    }
+    return getParentDirectoryLabel(item.folderPath);
+}
+
+function getParentDirectoryLabel(path: string) {
+    const lastSlashIndex = path.lastIndexOf("/");
+    return lastSlashIndex < 0 ? "" : path.slice(0, lastSlashIndex);
 }
 
 function FolderIcon() {
@@ -29,33 +47,6 @@ function FolderIcon() {
     );
 }
 
-function NoteIcon({ color = "var(--text-secondary)" }: { color?: string }) {
-    return (
-        <svg
-            width="13"
-            height="13"
-            viewBox="0 0 14 14"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.3"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="shrink-0"
-            style={{
-                color,
-                opacity: color === "var(--text-secondary)" ? 0.6 : 1,
-            }}
-        >
-            <path d="M8 1.5H3.5a1 1 0 0 0-1 1v9a1 1 0 0 0 1 1h7a1 1 0 0 0 1-1V5L8 1.5z" />
-            <path d="M8 1.5V5h3.5" />
-        </svg>
-    );
-}
-
-function FileIcon() {
-    return <NoteIcon color="var(--accent)" />;
-}
-
 function FetchIcon() {
     return (
         <svg
@@ -68,7 +59,7 @@ function FetchIcon() {
             strokeLinecap="round"
             strokeLinejoin="round"
             className="shrink-0"
-            style={{ color: "#10b981" }}
+            style={{ color: "var(--text-secondary)", opacity: 0.72 }}
         >
             <circle cx="7" cy="7" r="5.5" />
             <path d="M1.5 7h11M7 1.5a8.5 8.5 0 0 1 2 5.5 8.5 8.5 0 0 1-2 5.5M7 1.5a8.5 8.5 0 0 0-2 5.5 8.5 8.5 0 0 0 2 5.5" />
@@ -118,9 +109,6 @@ function PlanIcon() {
 
 interface AIChatMentionPickerProps {
     open: boolean;
-    x: number;
-    y: number;
-    query: string;
     selectedIndex: number;
     items: AIMentionSuggestion[];
     anchorElement: HTMLElement | null;
@@ -131,8 +119,6 @@ interface AIChatMentionPickerProps {
 
 export function AIChatMentionPicker({
     open,
-    x,
-    y,
     selectedIndex,
     items,
     anchorElement,
@@ -142,23 +128,12 @@ export function AIChatMentionPicker({
 }: AIChatMentionPickerProps) {
     const ref = useRef<HTMLDivElement>(null);
     const itemRefs = useRef<Array<HTMLButtonElement | null>>([]);
-    const [position, setPosition] = useState({ x, y });
-
-    useLayoutEffect(() => {
-        if (!open) return;
-        const element = ref.current;
-        if (!element) return;
-
-        const rect = element.getBoundingClientRect();
-        setPosition(
-            getViewportSafeMenuPosition(
-                x,
-                y - rect.height - 8,
-                rect.width,
-                rect.height,
-            ),
-        );
-    }, [open, x, y, items.length]);
+    const position = useComposerPickerPosition(
+        anchorElement,
+        ref.current,
+        open,
+        items.length,
+    );
 
     useEffect(() => {
         if (!open) return;
@@ -187,18 +162,18 @@ export function AIChatMentionPicker({
             ref={ref}
             style={{
                 position: "fixed",
-                top: position.y,
-                left: position.x,
+                top: position?.y ?? 8,
+                left: position?.x ?? 8,
                 zIndex: 10010,
-                width: 340,
-                maxWidth: "min(340px, calc(100vw - 24px))",
-                maxHeight: 280,
+                width: position?.width ?? 320,
+                maxHeight: position?.maxHeight ?? 360,
                 overflow: "hidden",
                 borderRadius: 10,
                 border: "1px solid color-mix(in srgb, var(--border) 86%, transparent)",
                 background:
                     "color-mix(in srgb, var(--bg-elevated) 97%, transparent)",
-                boxShadow: "0 8px 24px rgba(15, 23, 42, 0.12)",
+                boxShadow:
+                    "0 12px 32px rgba(15, 23, 42, 0.16), 0 0 0 1px color-mix(in srgb, var(--border) 40%, transparent)",
                 backdropFilter: "blur(10px)",
             }}
         >
@@ -209,7 +184,7 @@ export function AIChatMentionPicker({
                     display: "flex",
                     flexDirection: "column",
                     gap: 1,
-                    maxHeight: 280,
+                    maxHeight: position?.maxHeight ?? 360,
                 }}
             >
                 {items.length ? (
@@ -217,8 +192,7 @@ export function AIChatMentionPicker({
                         const isActive = index === selectedIndex;
                         const isFetch = item.kind === "fetch";
                         const isPlan = item.kind === "plan";
-                        const isNote = item.kind === "note";
-                        const isFile = item.kind === "file";
+                        const secondary = getSuggestionSecondary(item);
                         return (
                             <button
                                 key={suggestionKey(item)}
@@ -238,19 +212,12 @@ export function AIChatMentionPicker({
                                     border: "none",
                                     borderRadius: 7,
                                     background: isActive
-                                        ? isFetch
-                                            ? "color-mix(in srgb, #10b981 10%, var(--bg-secondary))"
-                                            : isPlan
-                                              ? "color-mix(in srgb, var(--accent) 12%, var(--bg-secondary))"
-                                              : isNote
-                                                ? "color-mix(in srgb, #d97706 10%, var(--bg-secondary))"
-                                                : isFile
-                                                  ? "color-mix(in srgb, var(--accent) 10%, var(--bg-secondary))"
-                                                  : "color-mix(in srgb, var(--accent) 10%, var(--bg-secondary))"
+                                        ? "color-mix(in srgb, var(--accent) 14%, var(--bg-primary))"
                                         : "transparent",
-                                    padding: "6px 10px",
+                                    padding: "5px 10px",
                                     textAlign: "left",
                                     cursor: "pointer",
+                                    width: "100%",
                                     minWidth: 0,
                                     transition: "background-color 80ms ease",
                                 }}
@@ -262,29 +229,28 @@ export function AIChatMentionPicker({
                                 ) : item.kind === "folder" ? (
                                     <FolderIcon />
                                 ) : item.kind === "file" ? (
-                                    <FileIcon />
+                                    <FileTypeIcon
+                                        fileName={item.file.fileName}
+                                        mimeType={item.file.mimeType}
+                                        opacity={isActive ? 0.92 : 0.6}
+                                        size={14}
+                                    />
                                 ) : (
-                                    <NoteIcon color="#d97706" />
+                                    <FileTypeIcon
+                                        fileName={
+                                            item.note.path.split("/").pop() ??
+                                            item.note.title
+                                        }
+                                        mimeType="text/markdown"
+                                        opacity={isActive ? 0.92 : 0.6}
+                                        size={14}
+                                    />
                                 )}
                                 <span
                                     style={{
-                                        color: isFetch
-                                            ? "#10b981"
-                                            : isPlan
-                                              ? "var(--accent)"
-                                              : isNote
-                                                ? "#d97706"
-                                                : isFile
-                                                  ? "var(--accent)"
-                                                  : "var(--text-primary)",
+                                        color: "var(--text-primary)",
                                         fontSize: 13,
-                                        fontWeight:
-                                            isFetch ||
-                                            isPlan ||
-                                            isNote ||
-                                            isFile
-                                                ? 600
-                                                : 500,
+                                        fontWeight: 400,
                                         whiteSpace: "nowrap",
                                         overflow: "hidden",
                                         textOverflow: "ellipsis",
@@ -302,18 +268,24 @@ export function AIChatMentionPicker({
                                               ? item.label
                                               : item.name}
                                 </span>
-                                {(isFetch || isPlan) && (
+                                {secondary ? (
                                     <span
                                         style={{
                                             fontSize: 11,
                                             color: "var(--text-secondary)",
                                             opacity: 0.6,
-                                            flexShrink: 0,
+                                            fontFamily:
+                                                "var(--font-mono, monospace)",
+                                            flex: "0 1 48%",
+                                            minWidth: 0,
+                                            overflow: "hidden",
+                                            textOverflow: "ellipsis",
+                                            whiteSpace: "nowrap",
                                         }}
                                     >
-                                        {isFetch ? "web search" : "planning"}
+                                        {secondary}
                                     </span>
-                                )}
+                                ) : null}
                             </button>
                         );
                     })

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -577,6 +577,12 @@ describe("AIChatMessageItem plan message", () => {
         expect(screen.getByText("Review state")).toHaveStyle(
             "text-decoration: line-through",
         );
+        expect(document.querySelector('[data-plan-surface="true"]')).toHaveClass(
+            "chat-plan-frame",
+        );
+        expect(
+            document.querySelectorAll('[data-activity-rail-decoration="branch"]'),
+        ).toHaveLength(2);
     });
 
     it("collapses and expands the plan body", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -856,20 +856,16 @@ export function PlanMessage({
 
     return (
         <div
-            className="min-w-0 max-w-full overflow-hidden rounded-xl"
-            style={{
-                border: "1px solid color-mix(in srgb, var(--border) 88%, transparent)",
-                backgroundColor:
-                    "color-mix(in srgb, var(--bg-tertiary) 84%, transparent)",
-            }}
+            className="chat-plan-frame min-w-0 max-w-full overflow-hidden"
+            data-plan-surface="true"
         >
-            <div className="flex items-center gap-1 px-1 py-1">
+            <div className="flex items-center gap-1 px-2.5 py-2">
                 <button
                     type="button"
                     onClick={() => {
                         if (canExpand) setExpanded((value) => !value);
                     }}
-                    className="flex min-w-0 flex-1 items-center gap-2.5 rounded-lg px-1.5 py-0.5 text-left"
+                    className="flex min-w-0 flex-1 items-baseline gap-2 rounded-sm text-left"
                     aria-expanded={expanded}
                     style={{
                         backgroundColor: "transparent",
@@ -878,22 +874,22 @@ export function PlanMessage({
                     }}
                 >
                     <span
-                        className="inline-flex shrink-0 items-center justify-center rounded-md px-1.5 py-0.5 text-xs"
+                        className="inline-block w-3 shrink-0 text-center"
                         style={{
                             color: "var(--text-secondary)",
-                            backgroundColor:
-                                "color-mix(in srgb, var(--bg-secondary) 74%, transparent)",
-                            border: "1px solid color-mix(in srgb, var(--border) 82%, transparent)",
+                            fontSize: "0.78em",
                             fontWeight: 500,
+                            lineHeight: 1.5,
                         }}
                     >
-                        {canExpand ? (expanded ? "▾" : "▸") : "•"}
+                        {canExpand ? (expanded ? "⌄" : ">") : "·"}
                     </span>
                     <span
                         className="min-w-0 flex-1 font-medium"
                         style={{
                             color: "var(--text-secondary)",
-                            fontSize: "0.875rem",
+                            fontSize: "0.78em",
+                            lineHeight: 1.5,
                         }}
                     >
                         {message.title ?? "Plan"}
@@ -901,7 +897,7 @@ export function PlanMessage({
                     <span
                         style={{
                             color: "var(--text-secondary)",
-                            fontSize: "0.76em",
+                            fontSize: "0.72em",
                         }}
                     >
                         {statusLabel}
@@ -933,12 +929,7 @@ export function PlanMessage({
 
             {expanded && detail ? (
                 <div
-                    className="mx-2.5 mb-1.5 rounded-md px-2 py-1.5"
-                    style={{
-                        backgroundColor:
-                            "color-mix(in srgb, var(--bg-secondary) 74%, transparent)",
-                        border: "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
-                    }}
+                    className="px-7 pb-2"
                 >
                     <div
                         style={{
@@ -959,11 +950,9 @@ export function PlanMessage({
 
             {expanded && entries.length > 0 ? (
                 <div
-                    className="flex flex-col"
-                    style={{
-                        borderTop:
-                            "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
-                    }}
+                    className="activity-tree flex min-w-0 flex-col gap-1.5 px-2.5 pb-2.5"
+                    data-plan-tree="true"
+                    role="list"
                 >
                     {entries.map((entry, index) => {
                         const isCompleted = entry.status === "completed";
@@ -971,33 +960,38 @@ export function PlanMessage({
                         return (
                             <div
                                 key={`${entry.content}:${index}`}
-                                className="flex min-w-0 items-start gap-2.5 px-2.5 py-1.5"
+                                className="activity-tree-branch min-w-0 pl-10"
+                                data-activity-rail-decoration="branch"
+                                data-plan-entry-status={entry.status}
+                                role="listitem"
                                 style={{
-                                    borderTop:
-                                        index === 0
-                                            ? "none"
-                                            : "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
                                     color: isCompleted
                                         ? "var(--text-secondary)"
                                         : "var(--text-primary)",
                                     opacity: isCompleted ? 0.74 : 1,
                                 }}
                             >
-                                <span
-                                    className="mt-0.75 inline-flex h-1.5 w-1.5 shrink-0 rounded-full"
-                                    style={{
-                                        backgroundColor: isCompleted
-                                            ? "#84cc16"
-                                            : isActive
-                                              ? "var(--accent)"
-                                              : "var(--text-secondary)",
-                                        opacity: isCompleted ? 0.9 : 0.8,
-                                    }}
-                                />
-                                <div className="min-w-0 flex-1">
-                                    <div
+                                <div className="flex min-w-0 items-start gap-2 py-0.5">
+                                    <span
+                                        aria-hidden="true"
+                                        className="mt-1 inline-flex h-2 w-2 shrink-0 rounded-full"
                                         style={{
-                                            fontSize: "0.8em",
+                                            backgroundColor: isCompleted
+                                                ? "#84cc16"
+                                                : isActive
+                                                  ? "var(--accent)"
+                                                  : "transparent",
+                                            border: isCompleted || isActive
+                                                ? "none"
+                                                : "1px solid color-mix(in srgb, var(--text-secondary) 58%, transparent)",
+                                            opacity: isCompleted ? 0.9 : 0.8,
+                                        }}
+                                    />
+                                    <div
+                                        className="min-w-0 flex-1"
+                                        style={{
+                                            fontSize: "0.76em",
+                                            lineHeight: 1.5,
                                             overflowWrap: "anywhere",
                                             wordBreak: "break-word",
                                             textDecoration: isCompleted

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -838,13 +838,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 />
             )}
             {visiblePinnedPlan && (
-                <div
-                    className="shrink-0 px-3 pt-2 pb-1"
-                    style={{
-                        borderBottom:
-                            "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
-                    }}
-                >
+                <div className="shrink-0 px-3 pt-2 pb-1">
                     <div
                         className="min-w-0"
                         data-testid="chat-pinned-plan-column"

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -893,6 +893,31 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             )}
 
             <ChatContentColumn>
+                <QueuedMessagesPanel
+                    items={queuedMessages}
+                    editingItem={queuedMessageEdit?.item ?? null}
+                    onCancel={(messageId) => {
+                        chatActions.removeQueuedMessage(sessionId, messageId);
+                    }}
+                    onClearAll={() => {
+                        chatActions.clearSessionQueue(sessionId);
+                    }}
+                    onEdit={(messageId) => {
+                        chatActions.editQueuedMessage(sessionId, messageId);
+                    }}
+                    onSendNow={(messageId) => {
+                        void chatActions.sendQueuedMessageNow(
+                            sessionId,
+                            messageId,
+                        );
+                    }}
+                    onCancelEdit={() => {
+                        chatActions.cancelQueuedMessageEdit(sessionId);
+                    }}
+                />
+            </ChatContentColumn>
+
+            <ChatContentColumn>
                 <EditedFilesBufferPanel sessionId={sessionId} />
             </ChatContentColumn>
 
@@ -903,33 +928,6 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                         : "pt-2"
                 }
             >
-                <ChatContentColumn>
-                    <QueuedMessagesPanel
-                        items={queuedMessages}
-                        editingItem={queuedMessageEdit?.item ?? null}
-                        onCancel={(messageId) => {
-                            chatActions.removeQueuedMessage(
-                                sessionId,
-                                messageId,
-                            );
-                        }}
-                        onClearAll={() => {
-                            chatActions.clearSessionQueue(sessionId);
-                        }}
-                        onEdit={(messageId) => {
-                            chatActions.editQueuedMessage(sessionId, messageId);
-                        }}
-                        onSendNow={(messageId) => {
-                            void chatActions.sendQueuedMessageNow(
-                                sessionId,
-                                messageId,
-                            );
-                        }}
-                        onCancelEdit={() => {
-                            chatActions.cancelQueuedMessageEdit(sessionId);
-                        }}
-                    />
-                </ChatContentColumn>
                 <AIChatComposer
                     key={sessionId}
                     sessionId={sessionId}

--- a/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
+++ b/apps/desktop/src/features/ai/components/ChatInlinePill.tsx
@@ -1,7 +1,10 @@
 import type { MouseEventHandler, ReactNode } from "react";
 import { type ChatPillMetrics } from "./chatPillMetrics";
 import type { ChatPillVariant } from "./chatPillPalette";
-import { getChatInlinePillStyle } from "./chatInlinePillStyle";
+import {
+    getChatInlineLeadingVisualStyle,
+    getChatInlinePillStyle,
+} from "./chatInlinePillStyle";
 
 interface ChatInlinePillProps {
     appearance?: "link" | "pill";
@@ -37,7 +40,7 @@ export function ChatInlinePill({
     const content = (
         <span
             style={{
-                alignItems: "center",
+                alignItems: "flex-start",
                 display: "inline-flex",
                 gap: leadingVisual ? 4 : 0,
                 minWidth: 0,
@@ -47,7 +50,7 @@ export function ChatInlinePill({
             {leadingVisual ? (
                 <span
                     aria-hidden="true"
-                    style={{ display: "inline-flex", flexShrink: 0 }}
+                    style={getChatInlineLeadingVisualStyle(metrics)}
                 >
                     {leadingVisual}
                 </span>

--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
@@ -10,12 +10,7 @@ import {
     selectVisibleTrackedFiles,
 } from "../store/editedFilesBufferModel";
 import { EditedFilesReviewList } from "./EditedFilesReviewList";
-import {
-    COMPACT_REVIEW_MAX_LIST_HEIGHT_PX,
-    getAccentButtonStyle,
-    getDangerButtonStyle,
-    getNeutralButtonStyle,
-} from "./editedFilesReviewStyles";
+import { COMPACT_REVIEW_MAX_LIST_HEIGHT_PX } from "./editedFilesReviewStyles";
 import {
     deriveReviewItems,
     deriveReviewSummary,
@@ -38,25 +33,27 @@ function CollapseToggle({
             aria-label={expanded ? "Collapse edits" : "Expand edits"}
             title={expanded ? "Collapse edits" : "Expand edits"}
             onClick={onToggle}
-            className="shrink-0"
+            className="nw-strip-icon-btn flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent p-0"
             style={{
                 width: 16,
                 height: 16,
-                border: "none",
-                padding: 0,
-                cursor: "pointer",
-                background: "transparent",
                 color: "var(--text-secondary)",
-                display: "inline-flex",
-                alignItems: "center",
-                justifyContent: "center",
+                opacity: 0.75,
                 fontSize: 12,
                 lineHeight: 1,
-                transition: "transform 140ms ease, color 140ms ease",
-                transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+                cursor: "pointer",
             }}
         >
-            <span aria-hidden="true">&gt;</span>
+            <span
+                aria-hidden="true"
+                style={{
+                    display: "inline-flex",
+                    transition: "transform 140ms ease",
+                    transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+                }}
+            >
+                &gt;
+            </span>
         </button>
     );
 }
@@ -181,8 +178,12 @@ export function EditedFilesBufferPanel({
                         type="button"
                         title="Undo last reject"
                         onClick={() => void undoLastReject(activeSessionId)}
-                        className="review-action-btn rounded-sm p-1"
-                        style={getNeutralButtonStyle()}
+                        className="nw-strip-icon-btn flex items-center justify-center rounded-sm border-0 bg-transparent p-1"
+                        style={{
+                            color: "var(--text-secondary)",
+                            opacity: 0.75,
+                            cursor: "pointer",
+                        }}
                     >
                         <svg
                             width="13"
@@ -304,8 +305,12 @@ export function EditedFilesBufferPanel({
                             type="button"
                             title="Undo last reject"
                             onClick={() => void undoLastReject(activeSessionId)}
-                            className="rounded-sm p-1"
-                            style={getNeutralButtonStyle()}
+                            className="nw-strip-icon-btn flex items-center justify-center rounded-sm border-0 bg-transparent p-1"
+                            style={{
+                                color: "var(--text-secondary)",
+                                opacity: 0.75,
+                                cursor: "pointer",
+                            }}
                         >
                             <svg
                                 width="13"
@@ -334,14 +339,11 @@ export function EditedFilesBufferPanel({
                                 ),
                             })
                         }
-                        className="review-action-btn rounded-sm px-2 py-0.5"
+                        className="nw-strip-text-btn rounded-sm border-0 bg-transparent px-1.5 py-0.5 uppercase"
                         style={{
-                            ...getNeutralButtonStyle(),
-                            fontSize: "10.5px",
+                            fontSize: "0.62em",
                             fontWeight: 600,
-                            lineHeight: "16px",
-                            letterSpacing: "0.04em",
-                            textTransform: "uppercase",
+                            letterSpacing: "0.1em",
                         }}
                     >
                         Review
@@ -354,8 +356,15 @@ export function EditedFilesBufferPanel({
                             void rejectAllEditedFiles(activeSessionId)
                         }
                         disabled={rejectableCount === 0}
-                        className="review-action-btn rounded-sm p-1"
-                        style={getDangerButtonStyle(rejectableCount === 0)}
+                        className="nw-strip-icon-btn flex items-center justify-center rounded-sm border-0 bg-transparent p-1"
+                        style={{
+                            color: "var(--diff-remove)",
+                            opacity: rejectableCount === 0 ? 0.35 : 0.75,
+                            cursor:
+                                rejectableCount === 0
+                                    ? "not-allowed"
+                                    : "pointer",
+                        }}
                     >
                         <svg
                             width="13"
@@ -376,8 +385,12 @@ export function EditedFilesBufferPanel({
                         type="button"
                         title="Keep All"
                         onClick={() => keepAllEditedFiles(activeSessionId)}
-                        className="review-action-btn rounded-sm p-1"
-                        style={getAccentButtonStyle()}
+                        className="nw-strip-icon-btn flex items-center justify-center rounded-sm border-0 bg-transparent p-1"
+                        style={{
+                            color: "var(--accent)",
+                            opacity: 0.75,
+                            cursor: "pointer",
+                        }}
                     >
                         <svg
                             width="13"

--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
@@ -44,16 +44,25 @@ function CollapseToggle({
                 cursor: "pointer",
             }}
         >
-            <span
+            <svg
+                width="9"
+                height="9"
+                viewBox="0 0 10 10"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.6"
+                strokeLinecap="round"
+                strokeLinejoin="round"
                 aria-hidden="true"
                 style={{
-                    display: "inline-flex",
-                    transition: "transform 140ms ease",
-                    transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+                    transform: expanded
+                        ? "rotate(0deg)"
+                        : "rotate(-90deg)",
+                    transition: "transform 0.15s ease",
                 }}
             >
-                &gt;
-            </span>
+                <path d="M2.5 4L5 6.5L7.5 4" />
+            </svg>
         </button>
     );
 }

--- a/apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx
@@ -27,15 +27,6 @@ const FULL_ROW_ACTION_BUTTON_STYLE: React.CSSProperties = {
     textTransform: "uppercase",
 };
 
-const COMPACT_ACTION_BUTTON_STYLE: React.CSSProperties = {
-    width: 24,
-    height: 24,
-    padding: 0,
-    display: "inline-flex",
-    alignItems: "center",
-    justifyContent: "center",
-};
-
 function FullRowActionButton({
     title,
     variant,
@@ -331,7 +322,7 @@ function CompactRow({
     return (
         <div
             data-testid="edited-files-buffer-row"
-            className="overflow-hidden"
+            className="nw-strip-row overflow-hidden"
             style={{
                 borderTop:
                     "1px solid color-mix(in srgb, var(--border) 72%, transparent)",
@@ -344,7 +335,7 @@ function CompactRow({
             <div
                 style={{
                     display: "grid",
-                    gridTemplateColumns: "6px 14px minmax(0, 1fr) auto auto",
+                    gridTemplateColumns: "14px minmax(0, 1fr) auto auto",
                     columnGap: 8,
                     alignItems: "center",
                     height: "100%",
@@ -352,10 +343,6 @@ function CompactRow({
                     minWidth: 0,
                 }}
             >
-                <div
-                    className="h-1.5 w-1.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: tone.accent }}
-                />
                 <FileTypeIcon fileName={file.path} opacity={0.74} size={12} />
                 <span
                     className="min-w-0 truncate"
@@ -425,15 +412,14 @@ function CompactRow({
                             void openAiEditedFileByAbsolutePath(file.path);
                         }}
                         disabled={!canOpen}
-                        className="review-action-btn shrink-0 rounded-md"
+                        className="nw-strip-icon-btn flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent"
                         style={{
-                            ...getAccentButtonStyle(
-                                canOpen
-                                    ? tone.accent
-                                    : "var(--text-secondary)",
-                            ),
-                            ...COMPACT_ACTION_BUTTON_STYLE,
-                            opacity: canOpen ? 1 : 0.45,
+                            width: 24,
+                            height: 24,
+                            color: canOpen
+                                ? tone.accent
+                                : "var(--text-secondary)",
+                            opacity: canOpen ? 0.75 : 0.35,
                             cursor: canOpen ? "pointer" : "not-allowed",
                         }}
                     >
@@ -458,10 +444,13 @@ function CompactRow({
                             type="button"
                             title="Reject"
                             onClick={onReject}
-                            className="review-action-btn shrink-0 rounded-md"
+                            className="nw-strip-icon-btn flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent"
                             style={{
-                                ...getDangerButtonStyle(),
-                                ...COMPACT_ACTION_BUTTON_STYLE,
+                                width: 24,
+                                height: 24,
+                                color: "var(--diff-remove)",
+                                opacity: 0.75,
+                                cursor: "pointer",
                             }}
                         >
                             <svg
@@ -484,10 +473,13 @@ function CompactRow({
                         type="button"
                         title="Keep"
                         onClick={onKeep}
-                        className="review-action-btn shrink-0 rounded-md"
+                        className="nw-strip-icon-btn flex shrink-0 items-center justify-center rounded-sm border-0 bg-transparent"
                         style={{
-                            ...getAccentButtonStyle(),
-                            ...COMPACT_ACTION_BUTTON_STYLE,
+                            width: 24,
+                            height: 24,
+                            color: "var(--accent)",
+                            opacity: 0.75,
+                            cursor: "pointer",
                         }}
                     >
                         <svg

--- a/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.test.tsx
@@ -106,7 +106,12 @@ describe("MarkdownContent", () => {
             background: "transparent",
             padding: "0px",
         });
-        expect(reference.querySelector("svg")).not.toBeNull();
+        const icon = reference.querySelector("svg");
+        expect(icon).not.toBeNull();
+        expect(reference.firstElementChild).toHaveStyle({
+            alignItems: "flex-start",
+        });
+        expect(icon?.parentElement).toHaveStyle({ height: "1.3em" });
 
         fireEvent.click(reference);
         await waitFor(() => {

--- a/apps/desktop/src/features/ai/components/QueuedMessagesPanel.tsx
+++ b/apps/desktop/src/features/ai/components/QueuedMessagesPanel.tsx
@@ -42,20 +42,12 @@ function StripIconButton({
     onClick: () => void;
     children: React.ReactElement;
 }) {
-    const [hovered, setHovered] = useState(false);
-    const interactive = !disabled;
-    const accent =
+    const color =
         variant === "danger"
             ? "var(--diff-remove)"
             : variant === "accent"
               ? "var(--accent)"
               : "var(--text-secondary)";
-
-    const baseColor = interactive
-        ? variant === "neutral"
-            ? "var(--text-secondary)"
-            : accent
-        : "var(--text-secondary)";
 
     return (
         <button
@@ -64,18 +56,11 @@ function StripIconButton({
             aria-label={ariaLabel ?? title}
             disabled={disabled}
             onClick={onClick}
-            onMouseEnter={() => interactive && setHovered(true)}
-            onMouseLeave={() => setHovered(false)}
-            className="flex h-6 w-6 items-center justify-center rounded-sm transition-colors"
+            className="nw-strip-icon-btn flex h-6 w-6 items-center justify-center rounded-sm border-0 bg-transparent"
             style={{
-                color: baseColor,
-                opacity: interactive ? (hovered ? 1 : 0.75) : 0.35,
-                backgroundColor:
-                    hovered && interactive
-                        ? `color-mix(in srgb, ${accent} 14%, transparent)`
-                        : "transparent",
-                border: "none",
-                cursor: interactive ? "pointer" : "not-allowed",
+                color,
+                opacity: disabled ? 0.35 : 0.75,
+                cursor: disabled ? "not-allowed" : "pointer",
             }}
         >
             {children}
@@ -91,7 +76,6 @@ const STRIP_PANEL_STYLE: React.CSSProperties = {
 };
 
 const STRIP_HEADER_LABEL_STYLE: React.CSSProperties = {
-    color: "var(--text-secondary)",
     fontSize: "0.68em",
     letterSpacing: "0.12em",
     fontWeight: 600,
@@ -127,8 +111,7 @@ export function QueuedMessagesPanel({
                     <button
                         type="button"
                         onClick={() => setCollapsed((value) => !value)}
-                        className="inline-flex items-center gap-1.5 bg-transparent p-0"
-                        style={{ border: "none", cursor: "pointer" }}
+                        className="nw-strip-text-btn inline-flex items-center gap-1.5 border-0 bg-transparent p-0"
                         aria-label={
                             effectiveCollapsed
                                 ? "Expand queue"
@@ -147,7 +130,6 @@ export function QueuedMessagesPanel({
                             strokeLinejoin="round"
                             aria-hidden="true"
                             style={{
-                                color: "var(--text-secondary)",
                                 transform: effectiveCollapsed
                                     ? "rotate(-90deg)"
                                     : "rotate(0deg)",
@@ -166,16 +148,11 @@ export function QueuedMessagesPanel({
                     <button
                         type="button"
                         onClick={onClearAll}
-                        className="rounded-sm px-1.5 py-0.5 uppercase"
+                        className="nw-strip-text-btn rounded-sm border-0 bg-transparent px-1.5 py-0.5 uppercase"
                         style={{
-                            color: "var(--text-secondary)",
-                            backgroundColor: "transparent",
-                            border: "none",
-                            cursor: "pointer",
                             fontSize: "0.62em",
                             letterSpacing: "0.1em",
                             fontWeight: 600,
-                            opacity: 0.85,
                         }}
                     >
                         Clear All
@@ -216,12 +193,8 @@ export function QueuedMessagesPanel({
                     <button
                         type="button"
                         onClick={onCancelEdit}
-                        className="shrink-0 rounded-sm px-1.5 py-0.5 uppercase"
+                        className="nw-strip-text-btn shrink-0 rounded-sm border-0 bg-transparent px-1.5 py-0.5 uppercase"
                         style={{
-                            color: "var(--text-secondary)",
-                            backgroundColor: "transparent",
-                            border: "none",
-                            cursor: "pointer",
                             fontSize: "0.62em",
                             letterSpacing: "0.1em",
                             fontWeight: 600,
@@ -234,20 +207,14 @@ export function QueuedMessagesPanel({
 
             {!effectiveCollapsed && (
                 <div className="flex flex-col">
-                    {items.map((item, index) => {
+                    {items.map((item) => {
                         const sending = item.status === "sending";
                         const summary = summarizeContent(item.content);
 
                         return (
                             <div
                                 key={item.id}
-                                className="flex items-center gap-2 px-3 py-1"
-                                style={{
-                                    borderTop:
-                                        index === 0 && !editingItem
-                                            ? "none"
-                                            : "1px solid color-mix(in srgb, var(--border) 25%, transparent)",
-                                }}
+                                className="nw-strip-row nw-queue-tree-branch flex items-center gap-2 py-1 pr-3 pl-4"
                             >
                                 <span
                                     aria-hidden="true"

--- a/apps/desktop/src/features/ai/components/chatInlinePillStyle.test.ts
+++ b/apps/desktop/src/features/ai/components/chatInlinePillStyle.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { getChatInlinePillStyle } from "./chatInlinePillStyle";
+import {
+    getChatInlineLeadingVisualStyle,
+    getChatInlinePillStyle,
+} from "./chatInlinePillStyle";
 
 describe("getChatInlinePillStyle", () => {
     it("keeps wrapped reference labels left-aligned", () => {
@@ -20,5 +23,25 @@ describe("getChatInlinePillStyle", () => {
         });
 
         expect(style.textAlign).toBe("left");
+    });
+
+    it("aligns leading visuals with the first label line", () => {
+        const style = getChatInlineLeadingVisualStyle({
+            fontSize: 12,
+            gapX: 1,
+            lineHeight: 1.4,
+            maxWidth: 200,
+            offsetY: 0,
+            paddingX: 4,
+            paddingY: 1,
+            radius: 4,
+        });
+
+        expect(style).toMatchObject({
+            alignItems: "center",
+            display: "inline-flex",
+            flexShrink: 0,
+            height: "1.4em",
+        });
     });
 });

--- a/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
+++ b/apps/desktop/src/features/ai/components/chatInlinePillStyle.ts
@@ -2,6 +2,18 @@ import type { CSSProperties } from "react";
 import { CHAT_PILL_VARIANTS, type ChatPillVariant } from "./chatPillPalette";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 
+export function getChatInlineLeadingVisualStyle(
+    metrics: ChatPillMetrics,
+): CSSProperties {
+    return {
+        alignItems: "center",
+        display: "inline-flex",
+        flexShrink: 0,
+        // Keep the icon centered against the first line when the label wraps.
+        height: `${metrics.lineHeight}em`,
+    };
+}
+
 export function getChatInlinePillStyle({
     appearance,
     clickable,

--- a/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
+++ b/apps/desktop/src/features/ai/components/chatVaultReferenceDom.ts
@@ -2,7 +2,10 @@ import { createCatppuccinIconElement } from "../../../components/icons/catppucci
 import { resolveCatppuccinFileIcon } from "../../../components/icons/fileTypeIcons";
 import { resolveCatppuccinFolderIcon } from "../../../components/icons/folderTypeIcons";
 import type { ChatVaultReferenceKind } from "./ChatVaultReference";
-import { getChatInlinePillStyle } from "./chatInlinePillStyle";
+import {
+    getChatInlineLeadingVisualStyle,
+    getChatInlinePillStyle,
+} from "./chatInlinePillStyle";
 import type { ChatPillMetrics } from "./chatPillMetrics";
 import {
     getChatVaultReferenceLabel,
@@ -69,12 +72,20 @@ export function presentComposerVaultReference(
         size: referenceIconSize(metrics),
     });
     const content = document.createElement("span");
-    content.style.alignItems = "center";
+    content.style.alignItems = "flex-start";
     content.style.display = "inline-flex";
     content.style.gap = "4px";
     content.style.maxWidth = "100%";
     content.style.minWidth = "0";
-    if (icon) content.append(icon);
+    if (icon) {
+        const iconContainer = document.createElement("span");
+        Object.assign(
+            iconContainer.style,
+            getChatInlineLeadingVisualStyle(metrics),
+        );
+        iconContainer.append(icon);
+        content.append(iconContainer);
+    }
 
     const labelElement = document.createElement("span");
     labelElement.textContent = getChatVaultReferenceLabel(label, target);

--- a/apps/desktop/src/features/ai/components/useComposerPickerPosition.ts
+++ b/apps/desktop/src/features/ai/components/useComposerPickerPosition.ts
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import {
+    CHAT_COMPOSER_PICKER_MAX_HEIGHT,
+    getComposerAnchoredPickerWidth,
+    getViewportSafeMenuPosition,
+} from "../../../app/utils/menuPosition";
+
+const VIEWPORT_PADDING = 8;
+const COMPOSER_PICKER_GAP = 8;
+
+interface ComposerPickerPosition {
+    maxHeight: number;
+    width: number;
+    x: number;
+    y: number;
+}
+
+/**
+ * Positions an inline picker as a full-width extension of the chat composer.
+ * Keeping this shared prevents the @ and / menus from drifting apart.
+ */
+export function useComposerPickerPosition(
+    anchorElement: HTMLElement | null,
+    pickerElement: HTMLElement | null,
+    open: boolean,
+    itemCount: number,
+): ComposerPickerPosition | null {
+    const [position, setPosition] = useState<ComposerPickerPosition | null>(
+        null,
+    );
+
+    const updatePosition = useCallback(() => {
+        if (!anchorElement) return;
+
+        const anchorRect = anchorElement.getBoundingClientRect();
+        const width = getComposerAnchoredPickerWidth(
+            anchorRect.width,
+            window.innerWidth,
+        );
+        const estimatedHeight = Math.min(
+            CHAT_COMPOSER_PICKER_MAX_HEIGHT,
+            itemCount * 32 + 8,
+        );
+        const measuredHeight = Math.ceil(
+            pickerElement?.getBoundingClientRect().height ?? estimatedHeight,
+        );
+        const availableAbove = Math.max(
+            0,
+            anchorRect.top - COMPOSER_PICKER_GAP - VIEWPORT_PADDING,
+        );
+        const availableBelow = Math.max(
+            0,
+            window.innerHeight -
+                anchorRect.bottom -
+                COMPOSER_PICKER_GAP -
+                VIEWPORT_PADDING,
+        );
+        const openAbove =
+            availableAbove >= measuredHeight || availableAbove >= availableBelow;
+        // JSDOM and a just-mounted detached pane can briefly report no usable
+        // viewport geometry. Keep the picker visible until the next layout pass.
+        const maxHeight =
+            availableAbove === 0 && availableBelow === 0
+                ? CHAT_COMPOSER_PICKER_MAX_HEIGHT
+                : Math.min(
+                      CHAT_COMPOSER_PICKER_MAX_HEIGHT,
+                      openAbove ? availableAbove : availableBelow,
+                  );
+        const height = Math.min(maxHeight, measuredHeight);
+        const safeX = getViewportSafeMenuPosition(
+            anchorRect.left,
+            VIEWPORT_PADDING,
+            width,
+            0,
+            VIEWPORT_PADDING,
+        ).x;
+
+        setPosition({
+            maxHeight,
+            width,
+            x: safeX,
+            y: openAbove
+                ? Math.max(VIEWPORT_PADDING, anchorRect.top - height - COMPOSER_PICKER_GAP)
+                : Math.min(
+                      window.innerHeight - height - VIEWPORT_PADDING,
+                      anchorRect.bottom + COMPOSER_PICKER_GAP,
+                  ),
+        });
+    }, [anchorElement, itemCount, pickerElement]);
+
+    useLayoutEffect(() => {
+        if (!open) return;
+        updatePosition();
+    }, [open, updatePosition]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleViewportChange = () => updatePosition();
+        window.addEventListener("resize", handleViewportChange);
+        window.addEventListener("scroll", handleViewportChange, true);
+        return () => {
+            window.removeEventListener("resize", handleViewportChange);
+            window.removeEventListener("scroll", handleViewportChange, true);
+        };
+    }, [open, updatePosition]);
+
+    return position;
+}

--- a/apps/desktop/src/features/ai/store/chatFoldersStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatFoldersStore.test.ts
@@ -1,10 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useChatFoldersStore } from "./chatFoldersStore";
 
-const CHAT_FOLDERS_KEY = "neverwrite.chats.folders";
+const LEGACY_CHAT_FOLDERS_KEY = "neverwrite.chats.folders";
+const VAULT_PATH = "/vault/research";
+const CHAT_FOLDERS_KEY = `${LEGACY_CHAT_FOLDERS_KEY}:${encodeURIComponent(VAULT_PATH)}`;
 
 function resetFoldersStore() {
     useChatFoldersStore.setState({
+        vaultPath: null,
         folders: {},
         folderOrder: [],
         sessionFolderIds: {},
@@ -16,6 +19,7 @@ describe("chatFoldersStore", () => {
     beforeEach(() => {
         localStorage.clear();
         resetFoldersStore();
+        useChatFoldersStore.getState().setVaultPath(VAULT_PATH);
     });
 
     afterEach(() => {
@@ -101,6 +105,23 @@ describe("chatFoldersStore", () => {
         });
     });
 
+    it("keeps assignments when a cold-start chat has a persisted identity", () => {
+        useChatFoldersStore.setState({
+            folders: {
+                research: { id: "research", name: "Research", createdAt: 1 },
+            },
+            folderOrder: ["research"],
+            sessionFolderIds: { "history-1": "research" },
+            collapsedFolderIds: [],
+        });
+
+        useChatFoldersStore.getState().reconcile(["persisted:history-1"]);
+
+        expect(useChatFoldersStore.getState().sessionFolderIds).toEqual({
+            "persisted:history-1": "research",
+        });
+    });
+
     it("persists a manual folder order", () => {
         useChatFoldersStore.setState({
             folders: {
@@ -145,6 +166,7 @@ describe("chatFoldersStore", () => {
         const { useChatFoldersStore: hydratedStore } = await import(
             "./chatFoldersStore"
         );
+        hydratedStore.getState().setVaultPath(VAULT_PATH);
 
         expect(hydratedStore.getState()).toMatchObject({
             folders: {
@@ -154,5 +176,48 @@ describe("chatFoldersStore", () => {
             sessionFolderIds: { "session-a": "valid" },
             collapsedFolderIds: ["valid"],
         });
+    });
+
+    it("keeps folder assignments isolated per vault", () => {
+        const folderId = useChatFoldersStore.getState().createFolder("Research");
+        expect(folderId).toBeTruthy();
+        useChatFoldersStore.getState().moveSession("session-a", folderId);
+
+        useChatFoldersStore.getState().setVaultPath("/vault/other");
+        expect(useChatFoldersStore.getState()).toMatchObject({
+            folders: {},
+            sessionFolderIds: {},
+        });
+
+        useChatFoldersStore.getState().setVaultPath(VAULT_PATH);
+        expect(useChatFoldersStore.getState().sessionFolderIds).toEqual({
+            "session-a": folderId,
+        });
+    });
+
+    it("migrates the legacy global catalog into the first opened vault", async () => {
+        localStorage.clear();
+        localStorage.setItem(
+            LEGACY_CHAT_FOLDERS_KEY,
+            JSON.stringify({
+                folders: {
+                    research: { id: "research", name: "Research", createdAt: 1 },
+                },
+                folderOrder: ["research"],
+                sessionFolderIds: { "session-a": "research" },
+                collapsedFolderIds: [],
+            }),
+        );
+        vi.resetModules();
+
+        const { useChatFoldersStore: migratedStore } = await import(
+            "./chatFoldersStore"
+        );
+        migratedStore.getState().setVaultPath(VAULT_PATH);
+
+        expect(migratedStore.getState().sessionFolderIds).toEqual({
+            "session-a": "research",
+        });
+        expect(localStorage.getItem(CHAT_FOLDERS_KEY)).toBeTruthy();
     });
 });

--- a/apps/desktop/src/features/ai/store/chatFoldersStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatFoldersStore.test.ts
@@ -6,6 +6,7 @@ const CHAT_FOLDERS_KEY = "neverwrite.chats.folders";
 function resetFoldersStore() {
     useChatFoldersStore.setState({
         folders: {},
+        folderOrder: [],
         sessionFolderIds: {},
         collapsedFolderIds: [],
     });
@@ -56,6 +57,7 @@ describe("chatFoldersStore", () => {
                 research: { id: "research", name: "Research", createdAt: 1 },
                 archive: { id: "archive", name: "Archive", createdAt: 2 },
             },
+            folderOrder: ["research", "archive"],
             sessionFolderIds: {
                 "session-a": "research",
                 "session-b": "archive",
@@ -69,6 +71,7 @@ describe("chatFoldersStore", () => {
             folders: {
                 archive: { id: "archive", name: "Archive", createdAt: 2 },
             },
+            folderOrder: ["archive"],
             sessionFolderIds: { "session-b": "archive" },
             collapsedFolderIds: ["archive"],
         });
@@ -80,6 +83,7 @@ describe("chatFoldersStore", () => {
                 research: { id: "research", name: "Research", createdAt: 1 },
                 archive: { id: "archive", name: "Archive", createdAt: 2 },
             },
+            folderOrder: ["research", "archive"],
             sessionFolderIds: {
                 pending: "research",
                 live: "archive",
@@ -95,6 +99,30 @@ describe("chatFoldersStore", () => {
         expect(useChatFoldersStore.getState().sessionFolderIds).toEqual({
             live: "research",
         });
+    });
+
+    it("persists a manual folder order", () => {
+        useChatFoldersStore.setState({
+            folders: {
+                research: { id: "research", name: "Research", createdAt: 1 },
+                archive: { id: "archive", name: "Archive", createdAt: 2 },
+                later: { id: "later", name: "Later", createdAt: 3 },
+            },
+            folderOrder: ["research", "archive", "later"],
+        });
+
+        useChatFoldersStore.getState().reorderFolder("later", 0);
+
+        expect(useChatFoldersStore.getState().folderOrder).toEqual([
+            "later",
+            "research",
+            "archive",
+        ]);
+        expect(JSON.parse(localStorage.getItem(CHAT_FOLDERS_KEY) ?? "{}")).toEqual(
+            expect.objectContaining({
+                folderOrder: ["later", "research", "archive"],
+            }),
+        );
     });
 
     it("hydrates only valid folders, assignments, and collapse state", async () => {
@@ -122,6 +150,7 @@ describe("chatFoldersStore", () => {
             folders: {
                 valid: { id: "valid", name: "Research", createdAt: 4 },
             },
+            folderOrder: ["valid"],
             sessionFolderIds: { "session-a": "valid" },
             collapsedFolderIds: ["valid"],
         });

--- a/apps/desktop/src/features/ai/store/chatFoldersStore.ts
+++ b/apps/desktop/src/features/ai/store/chatFoldersStore.ts
@@ -8,7 +8,12 @@ import { logWarn } from "../../../app/utils/runtimeLog";
 // Folder membership is a local sidebar preference, like pinned chats. Keeping
 // it separate from AIChatSession means adding folders never rewrites provider
 // history or changes what existing users see.
-const CHAT_FOLDERS_KEY = "neverwrite.chats.folders";
+const LEGACY_CHAT_FOLDERS_KEY = "neverwrite.chats.folders";
+const CHAT_FOLDERS_MIGRATION_KEY = "neverwrite.chats.folders.vault-migrated";
+
+function getChatFoldersKey(vaultPath: string) {
+    return `${LEGACY_CHAT_FOLDERS_KEY}:${encodeURIComponent(vaultPath)}`;
+}
 
 export interface ChatFolder {
     id: string;
@@ -24,6 +29,8 @@ interface PersistedChatFolders {
 }
 
 interface ChatFoldersStore extends PersistedChatFolders {
+    vaultPath: string | null;
+    setVaultPath: (vaultPath: string | null) => void;
     createFolder: (name: string) => string | null;
     renameFolder: (folderId: string, name: string) => void;
     deleteFolder: (folderId: string) => void;
@@ -59,8 +66,7 @@ function getOrderedFolderIds(
     ];
 }
 
-function readHydratedState(): PersistedChatFolders {
-    const raw = safeStorageGetItem(CHAT_FOLDERS_KEY);
+function parsePersistedState(raw: string | null): PersistedChatFolders {
     if (!raw) return EMPTY_STATE;
     try {
         const parsed = JSON.parse(raw) as Partial<PersistedChatFolders>;
@@ -111,8 +117,24 @@ function readHydratedState(): PersistedChatFolders {
     }
 }
 
-function persistState(state: PersistedChatFolders) {
-    safeStorageSetItem(CHAT_FOLDERS_KEY, JSON.stringify(state));
+function readHydratedState(vaultPath: string | null): PersistedChatFolders {
+    if (!vaultPath) return EMPTY_STATE;
+    const key = getChatFoldersKey(vaultPath);
+    let raw = safeStorageGetItem(key);
+
+    // Existing installations had one global folder catalog. Let the first
+    // opened vault claim it once, then keep all subsequent state vault-scoped.
+    if (!raw && !safeStorageGetItem(CHAT_FOLDERS_MIGRATION_KEY)) {
+        raw = safeStorageGetItem(LEGACY_CHAT_FOLDERS_KEY);
+        if (raw) safeStorageSetItem(key, raw);
+        safeStorageSetItem(CHAT_FOLDERS_MIGRATION_KEY, "1");
+    }
+    return parsePersistedState(raw);
+}
+
+function persistState(vaultPath: string | null, state: PersistedChatFolders) {
+    if (!vaultPath) return;
+    safeStorageSetItem(getChatFoldersKey(vaultPath), JSON.stringify(state));
 }
 
 function getPersistedState(state: ChatFoldersStore): PersistedChatFolders {
@@ -125,7 +147,13 @@ function getPersistedState(state: ChatFoldersStore): PersistedChatFolders {
 }
 
 export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
-    ...readHydratedState(),
+    ...EMPTY_STATE,
+    vaultPath: null,
+    setVaultPath: (vaultPath) =>
+        set((state) => {
+            if (state.vaultPath === vaultPath) return state;
+            return { vaultPath, ...readHydratedState(vaultPath) };
+        }),
     createFolder: (rawName) => {
         const name = normalizeFolderName(rawName);
         if (!name) return null;
@@ -142,7 +170,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                     id,
                 ],
             };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         });
         return id;
@@ -160,7 +188,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                     [folderId]: { ...folder, name },
                 },
             };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         });
     },
@@ -185,7 +213,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                     (id) => id !== folderId,
                 ),
             };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
     reorderFolder: (folderId, destinationIndex) =>
@@ -208,7 +236,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                 return state;
             }
             const next = { ...getPersistedState(state), folderOrder };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
     moveSession: (sessionId, folderId) =>
@@ -219,7 +247,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
             if (folderId) sessionFolderIds[sessionId] = folderId;
             else delete sessionFolderIds[sessionId];
             const next = { ...getPersistedState(state), sessionFolderIds };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
     replaceSessionId: (fromSessionId, toSessionId) =>
@@ -236,7 +264,7 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
             // transition, so the source assignment intentionally wins.
             sessionFolderIds[toSessionId] = folderId;
             const next = { ...getPersistedState(state), sessionFolderIds };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
     toggleFolderCollapsed: (folderId) =>
@@ -249,26 +277,42 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                 ...getPersistedState(state),
                 collapsedFolderIds: [...collapsed],
             };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
     reconcile: (existingRootSessionIds) =>
         set((state) => {
             const existing = new Set(existingRootSessionIds);
-            const sessionFolderIds = Object.fromEntries(
-                Object.entries(state.sessionFolderIds).filter(
-                    ([sessionId, folderId]) =>
-                        existing.has(sessionId) && Boolean(state.folders[folderId]),
-                ),
-            );
+            const sessionFolderIds: Record<string, string> = {};
+            for (const [sessionId, folderId] of Object.entries(
+                state.sessionFolderIds,
+            )) {
+                if (!state.folders[folderId]) continue;
+                if (existing.has(sessionId)) {
+                    sessionFolderIds[sessionId] = folderId;
+                    continue;
+                }
+
+                // A history-only chat is represented as `persisted:<history id>`
+                // after a cold start. Preserve its folder while the runtime id
+                // is absent; replaceSessionId will migrate it again on resume.
+                const persistedSessionId = `persisted:${sessionId}`;
+                if (existing.has(persistedSessionId)) {
+                    sessionFolderIds[persistedSessionId] = folderId;
+                }
+            }
             if (
                 Object.keys(sessionFolderIds).length ===
-                Object.keys(state.sessionFolderIds).length
+                    Object.keys(state.sessionFolderIds).length &&
+                Object.entries(sessionFolderIds).every(
+                    ([sessionId, folderId]) =>
+                        state.sessionFolderIds[sessionId] === folderId,
+                )
             ) {
                 return state;
             }
             const next = { ...getPersistedState(state), sessionFolderIds };
-            persistState(next);
+            persistState(state.vaultPath, next);
             return next;
         }),
 }));

--- a/apps/desktop/src/features/ai/store/chatFoldersStore.ts
+++ b/apps/desktop/src/features/ai/store/chatFoldersStore.ts
@@ -18,6 +18,7 @@ export interface ChatFolder {
 
 interface PersistedChatFolders {
     folders: Record<string, ChatFolder>;
+    folderOrder: string[];
     sessionFolderIds: Record<string, string>;
     collapsedFolderIds: string[];
 }
@@ -26,6 +27,7 @@ interface ChatFoldersStore extends PersistedChatFolders {
     createFolder: (name: string) => string | null;
     renameFolder: (folderId: string, name: string) => void;
     deleteFolder: (folderId: string) => void;
+    reorderFolder: (folderId: string, destinationIndex: number) => void;
     moveSession: (sessionId: string, folderId: string | null) => void;
     replaceSessionId: (fromSessionId: string, toSessionId: string) => void;
     toggleFolderCollapsed: (folderId: string) => void;
@@ -34,12 +36,27 @@ interface ChatFoldersStore extends PersistedChatFolders {
 
 const EMPTY_STATE: PersistedChatFolders = {
     folders: {},
+    folderOrder: [],
     sessionFolderIds: {},
     collapsedFolderIds: [],
 };
 
 function normalizeFolderName(name: string) {
     return name.trim().replace(/\s+/g, " ").slice(0, 80);
+}
+
+function getOrderedFolderIds(
+    folders: Record<string, ChatFolder>,
+    requestedOrder: readonly string[],
+) {
+    const legacyOrder = Object.values(folders)
+        .sort((left, right) => left.createdAt - right.createdAt)
+        .map((folder) => folder.id);
+    const knownRequestedIds = requestedOrder.filter((id) => Boolean(folders[id]));
+    return [
+        ...new Set(knownRequestedIds),
+        ...legacyOrder.filter((id) => !knownRequestedIds.includes(id)),
+    ];
 }
 
 function readHydratedState(): PersistedChatFolders {
@@ -68,8 +85,17 @@ function readHydratedState(): PersistedChatFolders {
                 sessionFolderIds[sessionId] = folderId;
             }
         }
+        // Older persisted state did not have an explicit order. Preserve the
+        // historical created-at ordering when it is first read.
+        const requestedOrder = Array.isArray(parsed.folderOrder)
+            ? parsed.folderOrder.filter(
+                  (id): id is string => typeof id === "string" && Boolean(folders[id]),
+              )
+            : [];
+        const folderOrder = getOrderedFolderIds(folders, requestedOrder);
         return {
             folders,
+            folderOrder,
             sessionFolderIds,
             collapsedFolderIds: Array.isArray(parsed.collapsedFolderIds)
                 ? parsed.collapsedFolderIds.filter((id): id is string =>
@@ -92,6 +118,7 @@ function persistState(state: PersistedChatFolders) {
 function getPersistedState(state: ChatFoldersStore): PersistedChatFolders {
     return {
         folders: state.folders,
+        folderOrder: state.folderOrder,
         sessionFolderIds: state.sessionFolderIds,
         collapsedFolderIds: state.collapsedFolderIds,
     };
@@ -110,6 +137,10 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
                     ...state.folders,
                     [id]: { id, name, createdAt: Date.now() },
                 },
+                folderOrder: [
+                    ...getOrderedFolderIds(state.folders, state.folderOrder),
+                    id,
+                ],
             };
             persistState(next);
             return next;
@@ -145,11 +176,38 @@ export const useChatFoldersStore = create<ChatFoldersStore>((set) => ({
             );
             const next = {
                 folders,
+                folderOrder: getOrderedFolderIds(
+                    folders,
+                    state.folderOrder.filter((id) => id !== folderId),
+                ),
                 sessionFolderIds,
                 collapsedFolderIds: state.collapsedFolderIds.filter(
                     (id) => id !== folderId,
                 ),
             };
+            persistState(next);
+            return next;
+        }),
+    reorderFolder: (folderId, destinationIndex) =>
+        set((state) => {
+            if (!state.folders[folderId]) return state;
+            const currentOrder = getOrderedFolderIds(
+                state.folders,
+                state.folderOrder,
+            ).filter((id) => id !== folderId);
+            const nextIndex = Math.max(
+                0,
+                Math.min(destinationIndex, currentOrder.length),
+            );
+            const folderOrder = [...currentOrder];
+            folderOrder.splice(nextIndex, 0, folderId);
+            if (
+                folderOrder.length === state.folderOrder.length &&
+                folderOrder.every((id, index) => id === state.folderOrder[index])
+            ) {
+                return state;
+            }
+            const next = { ...getPersistedState(state), folderOrder };
             persistState(next);
             return next;
         }),

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1377,6 +1377,7 @@ interface ChatStore {
     defaultRuntimeId: string | null;
     selectedRuntimeId: string | null;
     isInitializing: boolean;
+    sessionInventoryLoaded: boolean;
     notePickerOpen: boolean;
     autoContextEnabled: boolean;
     requireCmdEnterToSend: boolean;
@@ -7555,6 +7556,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         defaultRuntimeId: null,
         selectedRuntimeId: null,
         isInitializing: false,
+        sessionInventoryLoaded: false,
         notePickerOpen: false,
         autoContextEnabled: false,
         requireCmdEnterToSend: DEFAULT_AI_PREFERENCES.requireCmdEnterToSend,
@@ -7628,7 +7630,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             const defaultRuntimePreferenceVersionAtStart =
                 _defaultRuntimePreferenceVersion;
 
-            set({ isInitializing: true });
+            set({ isInitializing: true, sessionInventoryLoaded: false });
 
             try {
                 const backendRuntimes = hydrateRuntimesFromCache(
@@ -7909,6 +7911,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                             hydratedActiveSessionId,
                         );
                     }
+                    set({ sessionInventoryLoaded: true });
                     return { sessionInventoryLoaded: true };
                 }
 
@@ -7920,6 +7923,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     );
                     if (runtimeId) {
                         if (setupStatus?.onboardingRequired) {
+                            set({ sessionInventoryLoaded: true });
                             return { sessionInventoryLoaded: true };
                         }
                         await get().newSession(runtimeId);
@@ -7952,6 +7956,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 set({ isInitializing: false });
             }
 
+            set({ sessionInventoryLoaded: true });
             return { sessionInventoryLoaded: true };
         },
 
@@ -13112,6 +13117,7 @@ export function resetChatStore() {
         defaultRuntimeId: null,
         selectedRuntimeId: null,
         isInitializing: false,
+        sessionInventoryLoaded: false,
         notePickerOpen: false,
         autoContextEnabled: loadAutoContextPreference(
             useVaultStore.getState().vaultPath,

--- a/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
+++ b/apps/desktop/src/features/bookmarks/BookmarksPanel.tsx
@@ -702,10 +702,7 @@ export function BookmarksPanel() {
     return (
         <div className="h-full flex flex-col overflow-hidden">
             {/* Header */}
-            <div
-                className="shrink-0"
-                style={{ borderBottom: "1px solid var(--border)" }}
-            >
+            <div className="shrink-0">
                 <div className="flex items-center justify-between px-3 py-2">
                     <span
                         className="text-xs font-semibold uppercase tracking-wider"

--- a/apps/desktop/src/features/maps/MapsPanel.tsx
+++ b/apps/desktop/src/features/maps/MapsPanel.tsx
@@ -396,10 +396,7 @@ export function MapsPanel() {
 
     return (
         <div className="flex flex-col h-full">
-            <div
-                className="shrink-0"
-                style={{ borderBottom: "1px solid var(--border)" }}
-            >
+            <div className="shrink-0">
                 <div className="flex items-center justify-between px-3 py-2">
                     <span
                         className="text-xs font-semibold uppercase tracking-wider"

--- a/apps/desktop/src/features/tags/TagsPanel.tsx
+++ b/apps/desktop/src/features/tags/TagsPanel.tsx
@@ -179,10 +179,7 @@ export function TagsPanel() {
     return (
         <div className="h-full flex flex-col overflow-hidden">
             {/* Header */}
-            <div
-                className="shrink-0"
-                style={{ borderBottom: "1px solid var(--border)" }}
-            >
+            <div className="shrink-0">
                 <div className="flex items-center justify-between px-3 py-2">
                     <span
                         className="text-xs font-semibold uppercase tracking-wider"

--- a/apps/desktop/src/features/vault/FileTree.tsx
+++ b/apps/desktop/src/features/vault/FileTree.tsx
@@ -5660,10 +5660,7 @@ export function FileTree() {
             {/* Persistent filter. Wrapper styling matches the other
                 left-sidebar panels so the bar reads identical across the
                 whole sidebar. */}
-            <div
-                className="shrink-0 px-2 pt-2 pb-2"
-                style={{ borderBottom: "1px solid var(--border)" }}
-            >
+            <div className="shrink-0 px-2 pt-2 pb-2">
                 <SidebarFilterInput
                     value={filterText}
                     onChange={setFilterText}

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -632,6 +632,9 @@ html[data-desktop-platform="windows"].dark {
 
 /* Chat fences share Comando's compact, single-surface code frame. */
 .chat-code-frame {
+    /* Keep fenced content at a readable measure without overflowing narrow chat panes. */
+    inline-size: min(100%, 68ch);
+    margin-inline: auto;
     border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
     border-radius: 6px;
     background: color-mix(in srgb, var(--bg-tertiary) 68%, transparent);

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1416,6 +1416,53 @@ body.dragging-tab * {
     outline-offset: 1px;
 }
 
+/* Sidebar filter bar (file tree, tags, maps, bookmarks, agents). Idle state
+   stays a quiet translucent pill; hover lifts it slightly and focus draws an
+   accent ring so keyboard users get feedback even though the native outline
+   is suppressed on the input itself. */
+.nw-sidebar-filter {
+    background-color: color-mix(in srgb, var(--bg-tertiary) 85%, transparent);
+    border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+    transition:
+        background-color 120ms ease-out,
+        border-color 120ms ease-out,
+        box-shadow 120ms ease-out;
+}
+.nw-sidebar-filter:hover {
+    border-color: color-mix(in srgb, var(--text-primary) 16%, var(--border));
+}
+.nw-sidebar-filter:focus-within {
+    background-color: color-mix(in srgb, var(--bg-tertiary) 96%, transparent);
+    border-color: color-mix(in srgb, var(--accent) 46%, var(--border));
+    box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent);
+}
+.nw-sidebar-filter-icon {
+    color: var(--text-secondary);
+    transition: color 120ms ease-out;
+}
+.nw-sidebar-filter:focus-within .nw-sidebar-filter-icon {
+    color: var(--accent);
+}
+.nw-sidebar-filter-clear {
+    color: var(--text-secondary);
+    transition:
+        background-color 100ms ease-out,
+        color 100ms ease-out,
+        transform 80ms ease-out;
+}
+.nw-sidebar-filter-clear:hover {
+    background-color: color-mix(in srgb, var(--text-primary) 12%, transparent);
+    color: var(--text-primary);
+}
+.nw-sidebar-filter-clear:active {
+    transform: scale(0.88);
+    transition-duration: 60ms;
+}
+.nw-sidebar-filter-clear:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 60%, transparent);
+    outline-offset: 1px;
+}
+
 /* "Find in chat" matches, painted via the CSS Custom Highlight API. The active
    match is distinguished by a stronger background. ::highlight() only supports a
    small subset of properties (background-color, color, text-decoration).

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -630,14 +630,19 @@ html[data-desktop-platform="windows"].dark {
     overflow-wrap: anywhere;
 }
 
-/* Chat fences share Comando's compact, single-surface code frame. */
-.chat-code-frame {
+/* Code fences and streamed plans share one compact terminal-like surface. */
+.chat-code-frame,
+.chat-plan-frame {
     /* Keep fenced content at a readable measure without overflowing narrow chat panes. */
     inline-size: min(100%, 68ch);
     margin-inline: auto;
     border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
     border-radius: 6px;
     background: color-mix(in srgb, var(--bg-tertiary) 68%, transparent);
+}
+
+.chat-plan-frame {
+    font-family: var(--font-mono), ui-monospace, monospace;
 }
 
 .chat-code-header {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1500,6 +1500,102 @@ body.dragging-tab * {
     outline-offset: 2px;
 }
 
+/* Composer strips (queued messages, pending edits). Deliberately flat and
+   quiet — a terminal-like list, not a card UI — so feedback comes from a
+   soft currentColor tint and a quick scale-down press rather than shadows
+   or lifts. Shared between QueuedMessagesPanel and the compact Edits tray. */
+.nw-strip-icon-btn {
+    cursor: pointer;
+    transition:
+        background-color 100ms ease-out,
+        opacity 100ms ease-out,
+        transform 80ms ease-out;
+}
+.nw-strip-icon-btn:disabled {
+    cursor: not-allowed;
+}
+.nw-strip-icon-btn:hover:not(:disabled) {
+    background-color: color-mix(in srgb, currentColor 14%, transparent);
+    opacity: 1;
+}
+.nw-strip-icon-btn:active:not(:disabled) {
+    transform: scale(0.86);
+    transition-duration: 60ms;
+}
+.nw-strip-icon-btn:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+    outline-offset: 1px;
+}
+
+.nw-strip-text-btn {
+    color: var(--text-secondary);
+    cursor: pointer;
+    transition:
+        color 100ms ease-out,
+        opacity 100ms ease-out,
+        transform 80ms ease-out;
+}
+.nw-strip-text-btn:hover {
+    color: var(--text-primary);
+    opacity: 1;
+}
+.nw-strip-text-btn:active {
+    transform: scale(0.96);
+    transition-duration: 60ms;
+}
+.nw-strip-text-btn:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+    outline-offset: 1px;
+    border-radius: 3px;
+}
+
+.nw-strip-row {
+    transition: background-color 100ms ease-out;
+}
+.nw-strip-row:hover {
+    background-color: color-mix(in srgb, var(--bg-tertiary) 40%, transparent);
+}
+
+/* Queued-messages tree guide. A tight dotted rail + elbow per row, echoing
+   the AI activity rail's `.activity-tree-branch` so the queue reads as a
+   terminal listing (like `tree`'s `├──`) instead of a stack of cards. Kept
+   as its own rule (rather than reusing .activity-tree-branch) since the
+   offsets are tuned to the queue's own compact row height. */
+.nw-queue-tree-branch {
+    position: relative;
+}
+.nw-queue-tree-branch::before,
+.nw-queue-tree-branch::after {
+    content: "";
+    pointer-events: none;
+    position: absolute;
+}
+.nw-queue-tree-branch::before {
+    background: repeating-linear-gradient(
+        to bottom,
+        color-mix(in srgb, var(--text-secondary) 30%, transparent) 0 2px,
+        transparent 2px 5px
+    );
+    left: 0.5rem;
+    top: 0;
+    bottom: 0;
+    width: 1px;
+}
+.nw-queue-tree-branch::after {
+    background: repeating-linear-gradient(
+        to right,
+        color-mix(in srgb, var(--text-secondary) 30%, transparent) 0 2px,
+        transparent 2px 5px
+    );
+    height: 1px;
+    left: 0.5rem;
+    top: 50%;
+    width: 0.5rem;
+}
+.nw-queue-tree-branch:last-child::before {
+    bottom: 50%;
+}
+
 .ub-tab:not([data-active="true"]):hover {
     background-color: color-mix(
         in srgb,

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -190,7 +190,7 @@ preferences, workspace state, or privacy-relevant local state.
 | `neverwrite.fileTree.clipboard` | Global transient state | None | `fileTreeClipboard.ts` | File tree copy/cut payload. |
 | `neverwrite.search.history` | Global preference/state | `[]` | `searchHistory.ts` | Recent search queries. |
 | `neverwrite.chats.pinnedIds` | Global preference/state | `[]` | `pinnedChatsStore.ts` | Pinned chat session ids. |
-| `neverwrite.chats.folders` | Global preference/state | Empty folders, assignments, and collapsed state | `chatFoldersStore.ts` | Agents sidebar folder definitions, root-session-to-folder assignments, and collapsed folder ids. Folder names are global; assignments are reconciled against the root sessions available in the active vault. A Claude Code terminal pseudo-session can be assigned while live, but the assignment is removed when its terminal ends. |
+| `neverwrite.chats.folders` | Global preference/state | Empty folders, order, assignments, and collapsed state | `chatFoldersStore.ts` | Agents sidebar folder definitions, manual folder order, root-session-to-folder assignments, and collapsed folder ids. Folder names are global; assignments are reconciled against the root sessions available in the active vault. A Claude Code terminal pseudo-session can be assigned while live, but the assignment is removed when its terminal ends. |
 | `neverwrite.ai.agentsSidebar.collapsedParents` | Global UI state | `[]` | `AgentsSidebarPanel.tsx` | Collapsed parent groups in the agents sidebar. |
 | `neverwrite.ai.runtime-catalog` | Global cache | `{}` | `chatStore.ts` | Cached runtime models, modes, and config option catalogs. |
 | `neverwrite:debug-log-scopes` | Global developer preference | None | `runtimeLog.ts` | Enables scoped debug logging. |


### PR DESCRIPTION
## Summary

- Improve the chat composer pickers by anchoring @ mentions and / commands to the chat content column, adapting their placement to available viewport space, and keeping them safe in narrow or detached panes.
- Extract and improve mention ranking with accent-insensitive, segment, substring, and fuzzy matching; show consistent file-type icons and path context.
- Prevent ACP runtimes from echoing expanded user prompts into root chat sessions, while preserving user-message chunks for subagent sessions.
- Refine inline reference alignment, the searchable model picker, sidebar filters, and chat code-fence width.
- Place queued messages before pending edits and unify compact queue and change-review controls.

## Validation

- npx vitest run src/app/utils/menuPosition.test.ts src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/MarkdownContent.test.tsx src/features/ai/components/chatInlinePillStyle.test.ts src/features/ai/components/EditedFilesBufferPanel.test.tsx src/features/ai/AgentsSidebarPanel.test.tsx src/features/vault/FileTree.test.tsx
  - 8 files passed, 190 tests passed
- cargo test -p neverwrite-native-backend root_user_message_chunks_do_not_echo_expanded_runtime_prompts
- npm run build (apps/desktop)