### PR TITLE
Fix inline review scroll stability

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -26,7 +26,7 @@
                 "@codemirror/merge": "^6.12.1",
                 "@codemirror/search": "^6.7.0",
                 "@codemirror/state": "^6.6.0",
-                "@codemirror/view": "^6.43.3",
+                "@codemirror/view": "^6.43.6",
                 "@excalidraw/excalidraw": "^0.18.1",
                 "@iconify-json/catppuccin": "^1.2.17",
                 "@lezer/common": "^1.5.2",
@@ -664,9 +664,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.43.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.3.tgz",
-            "integrity": "sha512-MwEwCAr/o0agJefhC2+reBv5kfOQpMcDRUNQrRYZgWlhH8IwQcerMZrpqWyUFSyO0ebgN2cnh/w87F7G4BGSng==",
+            "version": "6.43.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+            "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.7.0",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -53,7 +53,7 @@
         "@codemirror/merge": "^6.12.1",
         "@codemirror/search": "^6.7.0",
         "@codemirror/state": "^6.6.0",
-        "@codemirror/view": "^6.43.3",
+        "@codemirror/view": "^6.43.6",
         "@excalidraw/excalidraw": "^0.18.1",
         "@iconify-json/catppuccin": "^1.2.17",
         "@lezer/common": "^1.5.2",


### PR DESCRIPTION
## Summary

- update `@codemirror/view` from 6.43.3 to 6.43.6
- include upstream fixes for tile-tree corruption during DOM updates and zero-length content updates
- make the lockfile match the version used by CI and release builds

## Validation

- `npm test -- --run src/features/editor/extensions/mergeViewDiff.test.ts src/features/editor/mergeViewSync.test.ts`
- `npm run lint -- --max-warnings=0`
- `npm run build`

## Testing required

**Requires prolonged manual testing before merge.**

Please exercise long reviewed documents with repeated vertical scrolling, multiple hunks, selections, and stacked panes in a packaged Electron build. The issue involves CodeMirror DOM/compositor behavior that jsdom cannot reproduce fully.

Closes #318
