### PR TITLE
Require npm installs for the desktop app

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -9,6 +9,7 @@
         "node": ">=22.12.0"
     },
     "scripts": {
+        "preinstall": "node scripts/require-npm.mjs",
         "dev": "node scripts/run-electron-dev.mjs",
         "renderer:dev": "vite",
         "build": "tsc -b && vite build",

--- a/apps/desktop/scripts/require-npm.mjs
+++ b/apps/desktop/scripts/require-npm.mjs
@@ -1,0 +1,8 @@
+const userAgent = process.env.npm_config_user_agent ?? "";
+
+if (!userAgent.startsWith("npm/")) {
+    console.error(
+        "The desktop app must be installed with npm. Run `npm ci` from apps/desktop.",
+    );
+    process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- reject pnpm installs in `apps/desktop` before dependencies are written
- keep the desktop dependency tree aligned with its npm lockfile

## Verification
- `npm ci`
- `npm run build`
- verified the install guard rejects a pnpm user agent