### PR TITLE
fix: update adm-zip security dependency

### DIFF
--- a/apps/web-clipper/pnpm-lock.yaml
+++ b/apps/web-clipper/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  adm-zip: 0.6.0
   esbuild: 0.28.1
   node-notifier>uuid: 11.1.1
   shell-quote: 1.8.4
@@ -807,9 +808,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -2890,7 +2891,7 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 
@@ -3255,7 +3256,7 @@ snapshots:
 
   firefox-profile@4.7.0:
     dependencies:
-      adm-zip: 0.5.17
+      adm-zip: 0.6.0
       fs-extra: 11.3.5
       ini: 4.1.3
       minimist: 1.2.8

--- a/apps/web-clipper/pnpm-workspace.yaml
+++ b/apps/web-clipper/pnpm-workspace.yaml
@@ -2,6 +2,7 @@ packages:
     - .
 
 overrides:
+    adm-zip: 0.6.0
     esbuild: 0.28.1
     node-notifier>uuid: 11.1.1
     shell-quote: 1.8.4


### PR DESCRIPTION
## Summary
- override the transitive adm-zip dependency to version 0.6.0
- regenerate the web clipper lockfile
- resolve CVE-2026-39244 (GHSA-xcpc-8h2w-3j85)

## Validation
- pnpm --dir apps/web-clipper check