### PR TITLE
Add per-vault AI change review controls

### DIFF
--- a/apps/desktop/src/app/store/aiReviewEvents.ts
+++ b/apps/desktop/src/app/store/aiReviewEvents.ts
@@ -1,0 +1,6 @@
+export const AI_REVIEW_DISABLED_EVENT = "neverwrite:ai-review-disabled";
+
+export function notifyAiReviewDisabled() {
+    if (typeof window === "undefined") return;
+    window.dispatchEvent(new Event(AI_REVIEW_DISABLED_EVENT));
+}

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2597,13 +2597,15 @@ describe("editorStore tab management", () => {
         expect(state.activeTabId).toBe("tab-a");
     });
 
-    it("blocks and closes review tabs when AI change review is disabled", () => {
+    it("closes review tabs when AI change review is disabled by a synced settings update", () => {
         useEditorStore.getState().openReview("session-1");
         expect(
             useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
         ).toBe(true);
 
-        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+        // Settings normally change in a separate window, which applies this
+        // update through storage synchronization instead of setSetting().
+        useSettingsStore.setState({ aiReviewEnabled: false });
 
         expect(
             useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2618,6 +2618,76 @@ describe("editorStore tab management", () => {
         ).toBe(false);
     });
 
+    it("invalidates closed review tabs when AI change review is disabled", () => {
+        useEditorStore.getState().openReview("session-1");
+        const reviewTab = useEditorStore
+            .getState()
+            .tabs.find((tab) => isReviewTab(tab));
+        expect(reviewTab).toBeDefined();
+
+        useEditorStore.getState().closeTab(reviewTab!.id);
+        expect(
+            useEditorStore
+                .getState()
+                .recentlyClosedTabs.some((entry) => isReviewTab(entry.tab)),
+        ).toBe(true);
+
+        useSettingsStore.setState({ aiReviewEnabled: false });
+
+        expect(
+            useEditorStore
+                .getState()
+                .recentlyClosedTabs.some((entry) => isReviewTab(entry.tab)),
+        ).toBe(false);
+
+        useEditorStore.getState().reopenLastClosedTab();
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(false);
+    });
+
+    it("does not restore a stale closed review tab while AI change review is disabled", () => {
+        useSettingsStore.setState({ aiReviewEnabled: false });
+        useEditorStore.setState({
+            recentlyClosedTabs: [
+                {
+                    tab: {
+                        id: "stale-review",
+                        kind: "ai-review",
+                        sessionId: "session-1",
+                        title: "Review",
+                    },
+                    index: 0,
+                },
+            ],
+        });
+
+        useEditorStore.getState().reopenLastClosedTab();
+
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(false);
+        expect(useEditorStore.getState().recentlyClosedTabs).toEqual([]);
+    });
+
+    it("restores a manually closed review tab while AI change review is enabled", () => {
+        useEditorStore.getState().openReview("session-1");
+        const reviewTab = useEditorStore
+            .getState()
+            .tabs.find((tab) => isReviewTab(tab));
+        expect(reviewTab).toBeDefined();
+
+        useEditorStore.getState().closeTab(reviewTab!.id);
+        useEditorStore.getState().reopenLastClosedTab();
+
+        expect(
+            useEditorStore.getState().tabs.find((tab) => isReviewTab(tab)),
+        ).toMatchObject({
+            id: reviewTab!.id,
+            sessionId: "session-1",
+        });
+    });
+
     it("switches to a tab in another pane and focuses that pane", () => {
         useEditorStore.getState().hydrateWorkspace(
             [

--- a/apps/desktop/src/app/store/editorStore.test.ts
+++ b/apps/desktop/src/app/store/editorStore.test.ts
@@ -2597,6 +2597,25 @@ describe("editorStore tab management", () => {
         expect(state.activeTabId).toBe("tab-a");
     });
 
+    it("blocks and closes review tabs when AI change review is disabled", () => {
+        useEditorStore.getState().openReview("session-1");
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(true);
+
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(false);
+
+        useEditorStore.getState().openReview("session-2");
+
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(false);
+    });
+
     it("switches to a tab in another pane and focuses that pane", () => {
         useEditorStore.getState().hydrateWorkspace(
             [

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -9,6 +9,7 @@ import {
     createEditorWorkspaceSlice,
     type EditorWorkspaceStore,
 } from "./editorWorkspace";
+import { AI_REVIEW_DISABLED_EVENT } from "./aiReviewEvents";
 import { useVaultStore } from "./vaultStore";
 
 export {
@@ -181,3 +182,11 @@ useEditorStore.subscribe((state) => {
         _lastSessionJson = json;
     }, 500);
 });
+
+// Review tabs are a transient decision surface. Do not leave a stale tab open
+// when the active vault disables AI change review through Settings.
+if (typeof window !== "undefined") {
+    window.addEventListener(AI_REVIEW_DISABLED_EVENT, () => {
+        useEditorStore.getState().closeAllReviewTabs();
+    });
+}

--- a/apps/desktop/src/app/store/editorStore.ts
+++ b/apps/desktop/src/app/store/editorStore.ts
@@ -183,8 +183,8 @@ useEditorStore.subscribe((state) => {
     }, 500);
 });
 
-// Review tabs are a transient decision surface. Do not leave a stale tab open
-// when the active vault disables AI change review through Settings.
+// Review tabs are a transient decision surface. Settings emits this event for
+// every local, synchronized, and vault-scoped transition to disabled.
 if (typeof window !== "undefined") {
     window.addEventListener(AI_REVIEW_DISABLED_EVENT, () => {
         useEditorStore.getState().closeAllReviewTabs();

--- a/apps/desktop/src/app/store/editorWorkspace.ts
+++ b/apps/desktop/src/app/store/editorWorkspace.ts
@@ -2536,12 +2536,62 @@ export function createEditorWorkspaceSlice<TState extends EditorWorkspaceStore>(
         },
 
         closeAllReviewTabs: () => {
-            const reviewTabIds = selectEditorWorkspaceTabs(get())
-                .filter(isReviewTab)
-                .map((tab) => tab.id);
-            for (const tabId of reviewTabIds) {
-                get().closeTab(tabId, { reason: "cleanup" });
-            }
+            set((state) => {
+                const workspace = getEffectivePaneWorkspace(state);
+                let panesChanged = false;
+                const removedReviewTabIds = new Set<string>();
+                const panes = workspace.panes.map((pane) => {
+                    const reviewTabIds = pane.tabs
+                        .filter(isReviewTab)
+                        .map((tab) => tab.id);
+                    if (reviewTabIds.length === 0) {
+                        return pane;
+                    }
+
+                    panesChanged = true;
+                    for (const tabId of reviewTabIds) {
+                        removedReviewTabIds.add(tabId);
+                    }
+                    let nextPane = pane;
+                    for (const tabId of reviewTabIds) {
+                        nextPane = createEditorPaneState(
+                            pane.id,
+                            removeTabFromWorkspaceState(nextPane, tabId),
+                        );
+                    }
+                    return nextPane;
+                });
+                const recentlyClosedTabs = state.recentlyClosedTabs.filter(
+                    (entry) => !isReviewTab(entry.tab),
+                );
+                const recentlyClosedTabsChanged =
+                    recentlyClosedTabs.length !== state.recentlyClosedTabs.length;
+
+                if (!panesChanged && !recentlyClosedTabsChanged) {
+                    return state;
+                }
+
+                const workspaceSnapshot = panesChanged
+                    ? buildWorkspaceSnapshot({
+                          panes,
+                          focusedPaneId: workspace.focusedPaneId,
+                          layoutTree: workspace.layoutTree,
+                      })
+                    : {};
+
+                return {
+                    ...state,
+                    ...workspaceSnapshot,
+                    recentlyClosedTabs,
+                    dirtyTabIds: panesChanged
+                        ? new Set(
+                              [...state.dirtyTabIds].filter(
+                                  (tabId) => !removedReviewTabIds.has(tabId),
+                              ),
+                          )
+                        : state.dirtyTabIds,
+                };
+            });
         },
 
         openChat: (sessionId, options) => {
@@ -3080,21 +3130,32 @@ export function createEditorWorkspaceSlice<TState extends EditorWorkspaceStore>(
 
         reopenLastClosedTab: () => {
             set((state) => {
+                // Disabled review tabs are not a valid restore target. This
+                // also cleans up any stale entry that predates invalidation.
+                const recentlyClosedTabs = isAiReviewEnabledForCurrentVault()
+                    ? state.recentlyClosedTabs
+                    : state.recentlyClosedTabs.filter(
+                          (entry) => !isReviewTab(entry.tab),
+                      );
                 const closed =
-                    state.recentlyClosedTabs[
-                        state.recentlyClosedTabs.length - 1
-                    ];
-                if (!closed) return state;
+                    recentlyClosedTabs[recentlyClosedTabs.length - 1];
+                if (!closed) {
+                    return recentlyClosedTabs === state.recentlyClosedTabs
+                        ? state
+                        : { recentlyClosedTabs };
+                }
                 const projection = mutateFocusedPaneWorkspace(state, (pane) =>
                     insertNormalizedTab(pane, closed.tab, closed.index),
                 );
                 if (!projection) {
-                    return state;
+                    return recentlyClosedTabs === state.recentlyClosedTabs
+                        ? state
+                        : { recentlyClosedTabs };
                 }
 
                 return {
                     ...projection,
-                    recentlyClosedTabs: state.recentlyClosedTabs.slice(0, -1),
+                    recentlyClosedTabs: recentlyClosedTabs.slice(0, -1),
                 };
             });
         },

--- a/apps/desktop/src/app/store/editorWorkspace.ts
+++ b/apps/desktop/src/app/store/editorWorkspace.ts
@@ -1,5 +1,6 @@
 import type { StoreApi } from "zustand";
 import type { EditorTarget } from "../../features/editor/editorTargetResolver";
+import { isAiReviewEnabledForCurrentVault } from "../../features/editor/editorReviewGate";
 import {
     buildChatTabFromHistory,
     buildTabFromHistory,
@@ -181,6 +182,7 @@ export interface EditorWorkspaceActions {
         options?: { background?: boolean; title?: string },
     ) => void;
     closeReview: (sessionId: string) => void;
+    closeAllReviewTabs: () => void;
     openChat: (
         sessionId: string,
         options?: {
@@ -2423,6 +2425,10 @@ export function createEditorWorkspaceSlice<TState extends EditorWorkspaceStore>(
         },
 
         openReview: (sessionId, options) => {
+            if (!isAiReviewEnabledForCurrentVault()) {
+                return;
+            }
+
             set((state) => {
                 const workspace = getEffectivePaneWorkspace(state);
                 const existingPane = workspace.panes.find((pane) =>
@@ -2527,6 +2533,15 @@ export function createEditorWorkspaceSlice<TState extends EditorWorkspaceStore>(
                 (t) => isReviewTab(t) && t.sessionId === sessionId,
             );
             if (tab) get().closeTab(tab.id);
+        },
+
+        closeAllReviewTabs: () => {
+            const reviewTabIds = selectEditorWorkspaceTabs(get())
+                .filter(isReviewTab)
+                .map((tab) => tab.id);
+            for (const tabId of reviewTabIds) {
+                get().closeTab(tabId, { reason: "cleanup" });
+            }
         },
 
         openChat: (sessionId, options) => {

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -38,6 +38,7 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().claudeCodeContinueSession).toBe(
             false,
         );
+        expect(useSettingsStore.getState().aiReviewEnabled).toBe(true);
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(true);
         expect(useSettingsStore.getState().pdfFilter).toBe("none");
         expect(useSettingsStore.getState().pdfDefaultZoom).toBe("fit-width");
@@ -129,12 +130,14 @@ describe("settingsStore", () => {
     it("persists settings per vault", () => {
         useVaultStore.setState({ vaultPath: "/vaults/devtools" });
 
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
         useSettingsStore.getState().setSetting("inlineReviewEnabled", false);
         useSettingsStore.getState().setSetting("pdfFilter", "sepia");
         useSettingsStore.getState().setSetting("fileTreeStickyFolders", false);
         useSettingsStore.getState().setSetting("agentsSidebarScale", 125);
         useSettingsStore.getState().setSetting("editorAutosaveDelayMs", 750);
 
+        expect(useSettingsStore.getState().aiReviewEnabled).toBe(false);
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
         expect(useSettingsStore.getState().pdfFilter).toBe("sepia");
         expect(useSettingsStore.getState().fileTreeStickyFolders).toBe(false);
@@ -146,6 +149,7 @@ describe("settingsStore", () => {
             ),
         ).toMatchObject({
             state: {
+                aiReviewEnabled: false,
                 inlineReviewEnabled: false,
                 pdfFilter: "sepia",
                 fileTreeStickyFolders: false,
@@ -153,6 +157,18 @@ describe("settingsStore", () => {
                 editorAutosaveDelayMs: 750,
             },
         });
+    });
+
+    it("keeps AI change review enabled for older vault settings", () => {
+        localStorage.setItem(
+            "neverwrite:settings:/vaults/legacy-review",
+            JSON.stringify({ state: { inlineReviewEnabled: false } }),
+        );
+
+        useVaultStore.setState({ vaultPath: "/vaults/legacy-review" });
+
+        expect(useSettingsStore.getState().aiReviewEnabled).toBe(true);
+        expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
     });
 
     it("persists the document status toggle per vault", () => {

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -21,6 +21,7 @@ export interface Settings {
     editorActiveLineHighlight: boolean;
     justifyText: boolean;
     livePreviewEnabled: boolean;
+    aiReviewEnabled: boolean;
     inlineReviewEnabled: boolean;
     hoverPreviewEnabled: boolean;
     hoverPreviewDelayMs: number; // 0–2000
@@ -194,6 +195,7 @@ const defaults: Settings = {
     editorActiveLineHighlight: true,
     justifyText: false,
     livePreviewEnabled: true,
+    aiReviewEnabled: true,
     inlineReviewEnabled: true,
     hoverPreviewEnabled: true,
     hoverPreviewDelayMs: 300,
@@ -482,6 +484,8 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             justifyText: parsed.state.justifyText ?? defaults.justifyText,
             livePreviewEnabled:
                 parsed.state.livePreviewEnabled ?? defaults.livePreviewEnabled,
+            aiReviewEnabled:
+                parsed.state.aiReviewEnabled ?? defaults.aiReviewEnabled,
             inlineReviewEnabled:
                 parsed.state.inlineReviewEnabled ??
                 defaults.inlineReviewEnabled,
@@ -620,6 +624,7 @@ function pickSettings(state: SettingsStore): Settings {
         editorActiveLineHighlight: state.editorActiveLineHighlight,
         justifyText: state.justifyText,
         livePreviewEnabled: state.livePreviewEnabled,
+        aiReviewEnabled: state.aiReviewEnabled,
         inlineReviewEnabled: state.inlineReviewEnabled,
         hoverPreviewEnabled: state.hoverPreviewEnabled,
         hoverPreviewDelayMs: state.hoverPreviewDelayMs,

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -5,6 +5,7 @@ import {
     safeStorageSetItem,
     subscribeSafeStorage,
 } from "../utils/safeStorage";
+import { notifyAiReviewDisabled } from "./aiReviewEvents";
 import { useVaultStore } from "./vaultStore";
 
 export interface Settings {
@@ -843,9 +844,14 @@ function readInitialVaultPath(): string | null {
     }
 }
 
-export const useSettingsStore = create<SettingsStore>()((set) => ({
+export const useSettingsStore = create<SettingsStore>()((set, get) => ({
     ...defaults,
-    setSetting: (key, value) =>
+    setSetting: (key, value) => {
+        const shouldCloseReviewTabs =
+            key === "aiReviewEnabled" &&
+            value === false &&
+            get().aiReviewEnabled;
+
         set((state) => {
             if (
                 key === "spellcheckPrimaryLanguage" ||
@@ -874,7 +880,12 @@ export const useSettingsStore = create<SettingsStore>()((set) => ({
             }
 
             return { [key]: value } as Partial<Settings>;
-        }),
+        });
+
+        if (shouldCloseReviewTabs) {
+            notifyAiReviewDisabled();
+        }
+    },
     reset: () => set(defaults),
 }));
 

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -844,14 +844,9 @@ function readInitialVaultPath(): string | null {
     }
 }
 
-export const useSettingsStore = create<SettingsStore>()((set, get) => ({
+export const useSettingsStore = create<SettingsStore>()((set) => ({
     ...defaults,
-    setSetting: (key, value) => {
-        const shouldCloseReviewTabs =
-            key === "aiReviewEnabled" &&
-            value === false &&
-            get().aiReviewEnabled;
-
+    setSetting: (key, value) =>
         set((state) => {
             if (
                 key === "spellcheckPrimaryLanguage" ||
@@ -880,14 +875,18 @@ export const useSettingsStore = create<SettingsStore>()((set, get) => ({
             }
 
             return { [key]: value } as Partial<Settings>;
-        });
-
-        if (shouldCloseReviewTabs) {
-            notifyAiReviewDisabled();
-        }
-    },
+        }),
     reset: () => set(defaults),
 }));
+
+// Settings can be changed directly, synchronized from another window, or
+// reloaded for a different vault. Emit the transition in the receiving window
+// so review tabs are consistently closed regardless of the update source.
+useSettingsStore.subscribe((state, previousState) => {
+    if (previousState.aiReviewEnabled && !state.aiReviewEnabled) {
+        notifyAiReviewDisabled();
+    }
+});
 
 // Track the current vault path so the save subscriber always writes to the right key
 let _currentVaultPath: string | null = null;

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -678,6 +678,24 @@ describe("AIChatMessageItem tool diffs", () => {
         expect(screen.getByText(/new line/)).toBeInTheDocument();
     });
 
+    it("keeps streaming tool diffs visible when AI change review is disabled", () => {
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        renderMessage(
+            createDiffMessage("tool:review-disabled", {
+                path: "/vault/notes/streamed.md",
+                kind: "update",
+                old_text: "before stream",
+                new_text: "after stream",
+            }),
+        );
+
+        const rail = expectChangeReviewRail("/vault/notes/streamed.md");
+        expandChangeReviewRail("/vault/notes/streamed.md");
+        expect(within(rail).getByText("Edited")).toBeInTheDocument();
+        expect(screen.getByText(/after stream/)).toBeInTheDocument();
+    });
+
     it("opens the diff's own file when a tool reports multiple changes", () => {
         const firstPath = "/vault/notes/first.md";
         const secondPath = "/vault/notes/second.md";

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -3,6 +3,7 @@ import { invoke } from "@neverwrite/runtime";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
+import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { renderComponent } from "../../../test/test-utils";
 import { resetChatStore, useChatStore } from "../store/chatStore";
@@ -157,6 +158,7 @@ function expectColumnAncestor(testId: string) {
 describe("AIChatSessionView", () => {
     beforeEach(() => {
         resetChatStore();
+        useSettingsStore.getState().reset();
         composerMockState.onPasteImage = undefined;
         messageListMockState.props = [];
         useVaultStore.setState({
@@ -333,6 +335,17 @@ describe("AIChatSessionView", () => {
                 .getByTestId("chat-composer")
                 .closest('[data-testid="chat-content-column"]'),
         ).toBeNull();
+    });
+
+    it("hides the Edited files panel when AI change review is disabled", () => {
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        expect(screen.queryByTestId("edited-files-panel")).toBeNull();
+        expect(screen.getByTestId("chat-message-list")).toBeInTheDocument();
+        expect(screen.getByTestId("chat-composer")).toBeInTheDocument();
     });
 
     it("keeps the composer flexible while it is expanded", () => {

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -27,6 +27,7 @@ import {
     selectPaneTab,
     useEditorStore,
 } from "../../../app/store/editorStore";
+import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import {
     isTextLikeVaultEntry,
@@ -152,6 +153,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     // Actions ref — avoids subscribing to every action
     const chatActions = useRef(useChatStore.getState()).current;
     const refreshEntries = useVaultStore((state) => state.refreshEntries);
+    const aiReviewEnabled = useSettingsStore((state) => state.aiReviewEnabled);
 
     // Session data
     const {
@@ -917,9 +919,11 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                 />
             </ChatContentColumn>
 
-            <ChatContentColumn>
-                <EditedFilesBufferPanel sessionId={sessionId} />
-            </ChatContentColumn>
+            {aiReviewEnabled ? (
+                <ChatContentColumn>
+                    <EditedFilesBufferPanel sessionId={sessionId} />
+                </ChatContentColumn>
+            ) : null}
 
             <div
                 className={

--- a/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, screen } from "@testing-library/react";
 import { waitFor } from "@testing-library/react";
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { isReviewTab, useEditorStore } from "../../../app/store/editorStore";
+import { useSettingsStore } from "../../../app/store/settingsStore";
 import {
     renderComponent,
     setVaultEntries,
@@ -152,6 +153,7 @@ describe("AIReviewView", () => {
     beforeEach(() => {
         localStorage.clear();
         resetChatStore();
+        useSettingsStore.getState().reset();
         useEditorStore.setState({
             panes: [
                 {
@@ -180,6 +182,24 @@ describe("AIReviewView", () => {
     it("shows fallback when no review tab is active", () => {
         renderComponent(<AIReviewView />);
         expect(screen.getByText("No review tab active")).toBeInTheDocument();
+    });
+
+    it("does not expose a restored review tab while AI change review is disabled", () => {
+        const sessionId = "disabled-review";
+        const file = makeTrackedFile();
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+        setupReviewTab(sessionId);
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: { [sessionId]: makeSession(sessionId, [file]) },
+        }));
+
+        const view = renderComponent(<AIReviewView />);
+
+        expect(view.container).toBeEmptyDOMElement();
+        expect(
+            useChatStore.getState().sessionsById[sessionId]?.actionLog,
+        ).toEqual(makeSession(sessionId, [file]).actionLog);
     });
 
     it("renders the review session from the requested pane even when another pane is focused", () => {

--- a/apps/desktop/src/features/ai/components/AIReviewView.tsx
+++ b/apps/desktop/src/features/ai/components/AIReviewView.tsx
@@ -167,12 +167,17 @@ interface AIReviewViewProps {
 }
 
 export function AIReviewView({ paneId, tabId }: AIReviewViewProps) {
+    const aiReviewEnabled = useSettingsStore((state) => state.aiReviewEnabled);
     const tab = useEditorStore((state) => {
         const current = tabId
             ? selectPaneTab(state, paneId, tabId)
             : selectEditorPaneActiveTab(state, paneId);
         return current && isReviewTab(current) ? current : null;
     });
+
+    if (!aiReviewEnabled) {
+        return null;
+    }
 
     if (!tab) {
         return (

--- a/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
+++ b/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
@@ -314,11 +314,10 @@ describe("multi-session review integration", () => {
         expect(secondA).toBe(firstA);
     });
 
-    it("preserves pending changes and inline preference across an AI review transition", async () => {
+    it("clears pending changes while preserving inline preference across an AI review transition", async () => {
         const session = createSession("session-transition", [
             createTrackedFile("/vault/notes/transition.md", 10),
         ]);
-        const originalActionLog = session.actionLog;
 
         renderComponent(<MultiSessionReviewHarness />);
 
@@ -349,7 +348,7 @@ describe("multi-session review integration", () => {
         ).toBe(false);
         expect(
             useChatStore.getState().sessionsById[session.sessionId]?.actionLog,
-        ).toBe(originalActionLog);
+        ).toBeUndefined();
 
         await act(async () => {
             useSettingsStore.getState().setSetting("aiReviewEnabled", true);
@@ -359,7 +358,7 @@ describe("multi-session review integration", () => {
         expect(shouldEnableInlineReviewMergeView("source")).toBe(true);
         expect(
             useChatStore.getState().sessionsById[session.sessionId]?.actionLog,
-        ).toBe(originalActionLog);
+        ).toBeUndefined();
         expect(
             useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
         ).toBe(true);

--- a/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
+++ b/apps/desktop/src/features/ai/components/reviewMultiSessionIntegration.test.tsx
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore, isReviewTab } from "../../../app/store/editorStore";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
+import { shouldEnableInlineReviewMergeView } from "../../editor/editorReviewGate";
 import { renderComponent, setVaultEntries } from "../../../test/test-utils";
 import { AIReviewView } from "./AIReviewView";
 import { EditedFilesBufferPanel } from "./EditedFilesBufferPanel";
@@ -162,7 +163,11 @@ describe("multi-session review integration", () => {
             notes: [],
             entries: [],
         });
-        useSettingsStore.setState({ lineWrapping: true });
+        useSettingsStore.setState({
+            aiReviewEnabled: true,
+            inlineReviewEnabled: true,
+            lineWrapping: true,
+        });
     });
 
     it("mounts review and panel with two active sessions while switching between review tabs", async () => {
@@ -307,6 +312,57 @@ describe("multi-session review integration", () => {
         expect(firstA.map((file) => file.path)).toEqual(["/vault/notes/a.md"]);
         expect(firstB.map((file) => file.path)).toEqual(["/vault/notes/b.md"]);
         expect(secondA).toBe(firstA);
+    });
+
+    it("preserves pending changes and inline preference across an AI review transition", async () => {
+        const session = createSession("session-transition", [
+            createTrackedFile("/vault/notes/transition.md", 10),
+        ]);
+        const originalActionLog = session.actionLog;
+
+        renderComponent(<MultiSessionReviewHarness />);
+
+        await act(async () => {
+            useChatStore.setState((state) => ({
+                ...state,
+                runtimes,
+                activeSessionId: session.sessionId,
+                sessionsById: { [session.sessionId]: session },
+            }));
+            openReviewTab(session, runtimes);
+        });
+
+        expect(shouldEnableInlineReviewMergeView("source")).toBe(true);
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(true);
+
+        await act(async () => {
+            useSettingsStore
+                .getState()
+                .setSetting("aiReviewEnabled", false);
+        });
+
+        expect(shouldEnableInlineReviewMergeView("source")).toBe(false);
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(false);
+        expect(
+            useChatStore.getState().sessionsById[session.sessionId]?.actionLog,
+        ).toBe(originalActionLog);
+
+        await act(async () => {
+            useSettingsStore.getState().setSetting("aiReviewEnabled", true);
+            openReviewTab(session, runtimes);
+        });
+
+        expect(shouldEnableInlineReviewMergeView("source")).toBe(true);
+        expect(
+            useChatStore.getState().sessionsById[session.sessionId]?.actionLog,
+        ).toBe(originalActionLog);
+        expect(
+            useEditorStore.getState().tabs.some((tab) => isReviewTab(tab)),
+        ).toBe(true);
     });
 
     it("disables line wrapping inside pending review diffs when editor line wrapping is disabled", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7,6 +7,7 @@ import {
     isReviewTab,
     useEditorStore,
 } from "../../../app/store/editorStore";
+import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { serializeComposerParts } from "../composerParts";
 import type {
@@ -533,6 +534,10 @@ function expectTrackedFileToMatchAccumulatedDiff(
 
 describe("chatStore", () => {
     beforeEach(() => {
+        useSettingsStore.setState({
+            aiReviewEnabled: true,
+            inlineReviewEnabled: true,
+        });
         disposeChatStoreRuntime();
         initializeChatStoreRuntime();
         resetClaudeCodeInstalledCacheForTests();
@@ -7782,6 +7787,159 @@ describe("chatStore", () => {
                 diffBase: "old line",
                 currentText: "new line",
                 isText: true,
+            },
+        ]);
+    });
+
+    it("stops tracking new tool diffs immediately when AI change review is disabled", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-review-disabled",
+            title: "Edit watcher",
+            kind: "edit",
+            status: "completed",
+            target: "/vault/src/watcher.rs",
+            summary: "Updated watcher.rs",
+            diffs: [
+                {
+                    path: "/vault/src/watcher.rs",
+                    kind: "update",
+                    old_text: "old line",
+                    new_text: "new line",
+                },
+            ],
+        });
+
+        expect(getVisibleBuffer(activeSessionId)).toHaveLength(0);
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        expect(session.actionLog).toBeUndefined();
+        expect(
+            session.messages.find(
+                (message) => message.id === "tool:tool-review-disabled",
+            )?.diffs,
+        ).toEqual([
+            {
+                path: "/vault/src/watcher.rs",
+                kind: "update",
+                old_text: "old line",
+                new_text: "new line",
+            },
+        ]);
+
+        useSettingsStore.getState().setSetting("aiReviewEnabled", true);
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-review-reenabled",
+            title: "Edit watcher again",
+            kind: "edit",
+            status: "completed",
+            target: "/vault/src/watcher.rs",
+            summary: "Updated watcher.rs again",
+            diffs: [
+                {
+                    path: "/vault/src/watcher.rs",
+                    kind: "update",
+                    old_text: "new line",
+                    new_text: "final line",
+                },
+            ],
+        });
+
+        expect(getVisibleBuffer(activeSessionId)).toMatchObject([
+            {
+                path: "/vault/src/watcher.rs",
+                diffBase: "new line",
+                currentText: "final line",
+            },
+        ]);
+    });
+
+    it("clears existing review tracking as soon as AI change review is disabled", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-before-review-disabled",
+            title: "Edit watcher",
+            kind: "edit",
+            status: "completed",
+            target: "/vault/src/watcher.rs",
+            summary: "Updated watcher.rs",
+            diffs: [
+                {
+                    path: "/vault/src/watcher.rs",
+                    kind: "update",
+                    old_text: "old line",
+                    new_text: "new line",
+                },
+            ],
+        });
+
+        expect(getVisibleBuffer(activeSessionId)).toHaveLength(1);
+
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        expect(getVisibleBuffer(activeSessionId)).toHaveLength(0);
+        expect(
+            useChatStore.getState().sessionsById[activeSessionId]?.actionLog,
+        ).toBeUndefined();
+    });
+
+    it("does not track permission-request diffs when AI change review is disabled", async () => {
+        await useChatStore.getState().initialize();
+        const activeSessionId = getActiveSessionId();
+
+        useChatStore.getState().applyToolActivity({
+            session_id: activeSessionId,
+            tool_call_id: "tool-before-disabled-permission",
+            title: "Read watcher",
+            kind: "read",
+            status: "completed",
+            summary: "watcher.rs",
+        });
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        useChatStore.getState().applyPermissionRequest({
+            session_id: activeSessionId,
+            request_id: "permission-review-disabled",
+            tool_call_id: "tool-permission-review-disabled",
+            title: "Edit watcher",
+            target: "/vault/src/watcher.rs",
+            options: [],
+            diffs: [
+                {
+                    path: "/vault/src/watcher.rs",
+                    kind: "update",
+                    old_text: "old line",
+                    new_text: "new line",
+                },
+            ],
+        });
+
+        expect(getVisibleBuffer(activeSessionId)).toHaveLength(0);
+        expect(
+            useChatStore.getState().sessionsById[activeSessionId]?.actionLog,
+        ).toBeUndefined();
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById[activeSessionId]?.messages.find(
+                    (message) =>
+                        message.permissionRequestId ===
+                        "permission-review-disabled",
+                )?.diffs,
+        ).toEqual([
+            {
+                path: "/vault/src/watcher.rs",
+                kind: "update",
+                old_text: "old line",
+                new_text: "new line",
             },
         ]);
     });

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2,7 +2,9 @@ import { create } from "zustand";
 import { openUrl } from "@neverwrite/runtime";
 import {
     normalizeEditorFontFamily,
+    readSettingsForVault,
     type EditorFontFamily,
+    useSettingsStore,
 } from "../../../app/store/settingsStore";
 import {
     aiCancelTurn,
@@ -1555,6 +1557,7 @@ interface ChatStore {
     rejectAllEditedFiles: (sessionId: string) => Promise<void>;
     keepEditedFile: (sessionId: string, identityKey: string) => void;
     keepAllEditedFiles: (sessionId: string) => void;
+    clearAiReviewTrackingForVault: (vaultPath: string | null) => void;
     resolveReviewHunks: (
         sessionId: string,
         identityKey: string,
@@ -4352,6 +4355,10 @@ function ensureActionLog(session: AIChatSession): AIChatSession {
 
 function diffCanBeTracked(diff: AIFileDiff) {
     return diff.is_text !== false && diff.reversible !== false;
+}
+
+function isAiReviewTrackingEnabledForSession(session: AIChatSession) {
+    return readSettingsForVault(getSessionVaultPath(session)).aiReviewEnabled;
 }
 
 function replaceTextExactlyOnce(
@@ -9105,6 +9112,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             scheduleStaleStreamingCheck(payload.session_id);
             const eventTimestamp = Date.now();
             let workCycleId: string | null | undefined = null;
+            let didConsolidate = false;
 
             set((state) => {
                 const session = state.sessionsById[payload.session_id];
@@ -9119,7 +9127,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 const shouldConsolidate =
                     payload.status === "completed" &&
                     (payload.diffs?.some(diffCanBeTracked) ?? false) &&
-                    Boolean(workCycleId);
+                    Boolean(workCycleId) &&
+                    isAiReviewTrackingEnabledForSession(nextSession);
 
                 const messageId = `tool:${payload.tool_call_id}`;
 
@@ -9133,6 +9142,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     useVaultStore.getState().vaultPath;
                 let reviewDiffs = freezeMessageReviewDiffs(messageDiffs);
                 if (shouldConsolidate) {
+                    didConsolidate = true;
                     consolidated = ensureActionLog(consolidated);
                     const currentFiles = getTrackedFilesForSession(
                         consolidated.actionLog,
@@ -9203,7 +9213,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 void persistSession(updatedSession);
             }
             if (
-                payload.status === "completed" &&
+                didConsolidate &&
                 updatedSession?.actionLog &&
                 (payload.diffs?.some(diffCanBeTracked) ?? false)
             ) {
@@ -9390,7 +9400,8 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 workCycleId = nextSession.activeWorkCycleId;
                 const hasDiffs =
                     payload.diffs.some(diffCanBeTracked) &&
-                    Boolean(workCycleId);
+                    Boolean(workCycleId) &&
+                    isAiReviewTrackingEnabledForSession(nextSession);
                 let sessionWithBuffer = nextSession;
                 let messageDiffs = payload.diffs;
                 let reviewVaultPath =
@@ -11854,6 +11865,40 @@ export const useChatStore = create<ChatStore>((set, get) => {
             }
         },
 
+        clearAiReviewTrackingForVault: (vaultPath) => {
+            const sessionsToPersist: AIChatSession[] = [];
+
+            set((state) => {
+                let changed = false;
+                const sessionsById = { ...state.sessionsById };
+
+                for (const [sessionId, session] of Object.entries(
+                    state.sessionsById,
+                )) {
+                    if (
+                        !session.actionLog ||
+                        getSessionVaultPath(session) !== vaultPath
+                    ) {
+                        continue;
+                    }
+
+                    // The agent's current text is already on disk. Clearing
+                    // review ownership accepts it without writing the file.
+                    const { actionLog: _actionLog, ...withoutActionLog } =
+                        session;
+                    sessionsById[sessionId] = withoutActionLog;
+                    sessionsToPersist.push(withoutActionLog);
+                    changed = true;
+                }
+
+                return changed ? { sessionsById } : state;
+            });
+
+            for (const session of sessionsToPersist) {
+                void persistSession(session);
+            }
+        },
+
         resolveReviewHunks: async (
             sessionId,
             identityKey,
@@ -12987,6 +13032,17 @@ export const useChatStore = create<ChatStore>((set, get) => {
             }
         },
     };
+});
+
+// Stop retaining agent-owned review state as soon as the current vault turns
+// AI change review off. File writes and the ordinary vault watcher are not
+// involved in this cleanup.
+useSettingsStore.subscribe((state, previousState) => {
+    if (previousState.aiReviewEnabled && !state.aiReviewEnabled) {
+        useChatStore
+            .getState()
+            .clearAiReviewTrackingForVault(useVaultStore.getState().vaultPath);
+    }
 });
 
 let chatRuntimeInitialized = false;

--- a/apps/desktop/src/features/editor/Editor.test.tsx
+++ b/apps/desktop/src/features/editor/Editor.test.tsx
@@ -2784,6 +2784,30 @@ describe("Editor", () => {
         expect(getEditorView().state.doc.toString()).toBe("new line");
     });
 
+    it("clears merge view when AI change review is turned off in source mode", async () => {
+        setEditorTabs([
+            {
+                id: "tab-1",
+                noteId: "notes/current",
+                title: "Current",
+                content: "new line",
+            },
+        ]);
+        useSettingsStore.getState().setSetting("livePreviewEnabled", false);
+        seedTrackedDiff("notes/current.md", "old line", "new line");
+
+        renderComponent(<Editor />);
+        expect(getChunks(getEditorView().state)?.chunks.length).toBe(1);
+
+        await act(async () => {
+            useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+            await flushPromises();
+        });
+
+        expect(getChunks(getEditorView().state)).toBeNull();
+        expect(getEditorView().state.doc.toString()).toBe("new line");
+    });
+
     it("keeps tracked files in the review store while inline review stays disabled and the editor remains unprojected", async () => {
         setEditorTabs([
             {

--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -510,7 +510,9 @@ export function Editor({
     );
     const justifyText = useSettingsStore((s) => s.justifyText);
     const livePreviewEnabled = useSettingsStore((s) => s.livePreviewEnabled);
-    const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
+    const inlineReviewEnabled = useSettingsStore(
+        (s) => s.aiReviewEnabled && s.inlineReviewEnabled,
+    );
     const hoverPreviewEnabled = useSettingsStore(
         (s) => s.hoverPreviewEnabled,
     );

--- a/apps/desktop/src/features/editor/FileTabView.test.tsx
+++ b/apps/desktop/src/features/editor/FileTabView.test.tsx
@@ -1278,6 +1278,51 @@ describe("FileTabView", () => {
         expect(view!.state.doc.toString()).toBe('name = "NeverWrite"');
     });
 
+    it("clears merge view for text files when AI change review is turned off", async () => {
+        setEditorTabs(
+            [
+                {
+                    id: "text-tab-1",
+                    kind: "file",
+                    relativePath: "src/config.toml",
+                    title: "config.toml",
+                    path: "/vault/src/config.toml",
+                    mimeType: "application/toml",
+                    viewer: "text",
+                    content: 'name = "NeverWrite"',
+                },
+            ],
+            "text-tab-1",
+        );
+        seedTrackedDiff(
+            "/vault/src/config.toml",
+            'name = "Old"',
+            'name = "NeverWrite"',
+        );
+
+        await act(async () => {
+            renderComponent(<FileTabView />);
+            await Promise.resolve();
+        });
+        let view = EditorView.findFromDOM(
+            document.querySelector(".cm-editor") as HTMLElement,
+        );
+        expect(view).not.toBeNull();
+        expect(getChunks(view!.state)?.chunks.length).toBe(1);
+
+        await act(async () => {
+            useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+            await Promise.resolve();
+        });
+
+        view = EditorView.findFromDOM(
+            document.querySelector(".cm-editor") as HTMLElement,
+        );
+        expect(view).not.toBeNull();
+        expect(getChunks(view!.state)).toBeNull();
+        expect(view!.state.doc.toString()).toBe('name = "NeverWrite"');
+    });
+
     it("does not leak edits from one text file tab into a different text file tab", async () => {
         vi.useFakeTimers();
         setEditorTabs(

--- a/apps/desktop/src/features/editor/FileTextTabView.tsx
+++ b/apps/desktop/src/features/editor/FileTextTabView.tsx
@@ -194,7 +194,9 @@ export function FileTextTabView({ paneId, tabId }: FileTextTabViewProps) {
     const editorActiveLineHighlight = useSettingsStore(
         (s) => s.editorActiveLineHighlight,
     );
-    const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
+    const inlineReviewEnabled = useSettingsStore(
+        (s) => s.aiReviewEnabled && s.inlineReviewEnabled,
+    );
     const vaultPath = useVaultStore((state) => state.vaultPath);
     const sessionsById = useChatStore((state) => state.sessionsById);
     const getCurrentContent = useCallback(

--- a/apps/desktop/src/features/editor/editorReviewGate.test.ts
+++ b/apps/desktop/src/features/editor/editorReviewGate.test.ts
@@ -6,6 +6,7 @@ import {
 } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import {
+    isAiReviewEnabledForCurrentVault,
     isInlineReviewEnabledForCurrentVault,
     shouldEnableInlineReviewMergeView,
     shouldSyncTrackedEditorReviewTarget,
@@ -32,6 +33,7 @@ describe("editorReviewGate", () => {
     });
 
     it("defaults inline review to enabled for the current vault", () => {
+        expect(isAiReviewEnabledForCurrentVault()).toBe(true);
         expect(isInlineReviewEnabledForCurrentVault()).toBe(true);
         expect(shouldEnableInlineReviewMergeView("source")).toBe(true);
         expect(shouldEnableInlineReviewMergeView("preview")).toBe(false);
@@ -46,6 +48,20 @@ describe("editorReviewGate", () => {
         expect(shouldEnableInlineReviewMergeView("source")).toBe(false);
         expect(shouldEnableInlineReviewMergeView("preview")).toBe(false);
         expect(shouldSyncTrackedEditorReviewTarget()).toBe(false);
+    });
+
+    it("disables all editor review access when AI change review is disabled", () => {
+        useVaultStore.setState({ vaultPath: "/vaults/ai-review-off" });
+        useSettingsStore.getState().setSetting("aiReviewEnabled", false);
+
+        expect(isAiReviewEnabledForCurrentVault()).toBe(false);
+        expect(isInlineReviewEnabledForCurrentVault()).toBe(false);
+        expect(shouldEnableInlineReviewMergeView("source")).toBe(false);
+        expect(shouldSyncTrackedEditorReviewTarget()).toBe(false);
+
+        useSettingsStore.getState().setSetting("aiReviewEnabled", true);
+
+        expect(isInlineReviewEnabledForCurrentVault()).toBe(true);
     });
 
     it("tracks vault changes through the shared settings store", () => {

--- a/apps/desktop/src/features/editor/editorReviewGate.ts
+++ b/apps/desktop/src/features/editor/editorReviewGate.ts
@@ -6,22 +6,36 @@ import { useVaultStore } from "../../app/store/vaultStore";
 
 export type EditorReviewMode = "source" | "preview";
 
-// Inline review is a per-vault setting. This helper must keep working both
-// inside the live app runtime and in direct call sites used by tests/utilities.
-export function isInlineReviewEnabledForCurrentVault() {
+function getCurrentVaultReviewSettings() {
     const vaultState = useVaultStore.getState();
     const vaultPath =
         vaultState.vaultPath ??
         (vaultState.isLoading ? vaultState.vaultOpenState.path : null);
-    const inlineReviewEnabled =
-        readSettingsForVault(vaultPath).inlineReviewEnabled;
+    const persistedSettings = readSettingsForVault(vaultPath);
+    const activeSettings = useSettingsStore.getState();
 
     // Keep the fast path through the live store when runtime sync is active,
     // but fall back to the persisted per-vault snapshot for direct callers.
-    return useSettingsStore.getState().inlineReviewEnabled ===
-        inlineReviewEnabled
-        ? useSettingsStore.getState().inlineReviewEnabled
-        : inlineReviewEnabled;
+    if (
+        activeSettings.aiReviewEnabled === persistedSettings.aiReviewEnabled &&
+        activeSettings.inlineReviewEnabled ===
+            persistedSettings.inlineReviewEnabled
+    ) {
+        return activeSettings;
+    }
+
+    return persistedSettings;
+}
+
+// AI change review is a per-vault setting. This helper must keep working both
+// inside the live app runtime and in direct call sites used by tests/utilities.
+export function isAiReviewEnabledForCurrentVault() {
+    return getCurrentVaultReviewSettings().aiReviewEnabled;
+}
+
+export function isInlineReviewEnabledForCurrentVault() {
+    const settings = getCurrentVaultReviewSettings();
+    return settings.aiReviewEnabled && settings.inlineReviewEnabled;
 }
 
 export function shouldEnableInlineReviewMergeView(mode: EditorReviewMode) {

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -674,6 +674,15 @@ describe("SettingsPanel", () => {
 
         fireEvent.click(screen.getByRole("button", { name: "AI" }));
 
+        const reviewLabel = screen.getByText("AI change review");
+        const reviewRow = reviewLabel.parentElement?.parentElement;
+        expect(reviewRow).not.toBeNull();
+
+        const reviewToggle = within(reviewRow as HTMLElement).getByRole(
+            "switch",
+        );
+        expect(reviewToggle).toHaveAttribute("aria-checked", "true");
+
         const label = screen.getByText("Inline review in editor");
         const row = label.parentElement?.parentElement;
         expect(row).not.toBeNull();
@@ -685,6 +694,13 @@ describe("SettingsPanel", () => {
 
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
         expect(toggle).toHaveAttribute("aria-checked", "false");
+
+        fireEvent.click(reviewToggle);
+
+        expect(useSettingsStore.getState().aiReviewEnabled).toBe(false);
+        expect(reviewToggle).toHaveAttribute("aria-checked", "false");
+        expect(toggle).toBeDisabled();
+        expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
     });
 
     it("renders and persists the wikilink hover preview toggle in editor settings", () => {

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3941,7 +3941,7 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         [
             [
                 "AI change review",
-                "Show the Edits panel, Review tabs, and inline accept/reject controls. Chat diff updates remain visible.",
+                "Track AI file changes for review. Turning this off accepts and clears pending review changes. Chat diff updates remain visible.",
                 "review",
                 "edits",
                 "changes",
@@ -4022,7 +4022,7 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
                 searchQuery={searchQuery}
                 section="Context"
                 label="AI change review"
-                description="Show the Edits panel, Review tabs, and inline accept/reject controls. Chat diff updates remain visible."
+                description="Track AI file changes for review. Turning this off accepts and clears pending review changes. Chat diff updates remain visible."
                 keywords={["review", "edits", "changes", "accept", "reject"]}
                 control={
                     <Toggle

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -3892,6 +3892,7 @@ function ShortcutsSettings({
 }
 
 function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
+    const aiReviewEnabled = useSettingsStore((s) => s.aiReviewEnabled);
     const inlineReviewEnabled = useSettingsStore((s) => s.inlineReviewEnabled);
     const setSetting = useSettingsStore((s) => s.setSetting);
     const requireCmdEnterToSend = useChatStore((s) => s.requireCmdEnterToSend);
@@ -3938,6 +3939,15 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
         searchQuery,
         "Context",
         [
+            [
+                "AI change review",
+                "Show the Edits panel, Review tabs, and inline accept/reject controls. Chat diff updates remain visible.",
+                "review",
+                "edits",
+                "changes",
+                "accept",
+                "reject",
+            ],
             [
                 "Inline review in editor",
                 "Show AI file changes inline in editors with accept and reject controls. Available only in source mode. This preference is saved per vault.",
@@ -4011,12 +4021,28 @@ function AISettings({ searchQuery }: { searchQuery: SettingsSearchQuery }) {
             <SearchableRow
                 searchQuery={searchQuery}
                 section="Context"
+                label="AI change review"
+                description="Show the Edits panel, Review tabs, and inline accept/reject controls. Chat diff updates remain visible."
+                keywords={["review", "edits", "changes", "accept", "reject"]}
+                control={
+                    <Toggle
+                        value={aiReviewEnabled}
+                        onChange={(value) =>
+                            setSetting("aiReviewEnabled", value)
+                        }
+                    />
+                }
+            />
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Context"
                 label="Inline review in editor"
                 description="Show AI file changes inline in editors with accept and reject controls. Available only in source mode. This preference is saved per vault."
                 keywords={["review", "accept", "reject"]}
                 control={
                     <Toggle
                         value={inlineReviewEnabled}
+                        disabled={!aiReviewEnabled}
                         onChange={(value) =>
                             setSetting("inlineReviewEnabled", value)
                         }

--- a/docs/ai-change-control.md
+++ b/docs/ai-change-control.md
@@ -113,8 +113,10 @@ There are three review surfaces:
 
 The Review tab and Edits surface are available only while the current vault's
 `aiReviewEnabled` setting is enabled. Disabling it closes open Review tabs,
-hides Edits, and disables inline decisions without mutating pending ActionLog
-state. Chat activity rows remain available so streamed diffs stay visible.
+hides Edits, and accepts then clears pending ActionLog state without writing
+the current file content back to disk. New agent changes are not added to the
+ActionLog while review is disabled. Chat activity rows remain available so
+streamed diffs stay visible.
 
 The Review tab and Edits surface render shared rows through
 [`EditedFilesReviewList.tsx`](../apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx)

--- a/docs/ai-change-control.md
+++ b/docs/ai-change-control.md
@@ -111,6 +111,11 @@ There are three review surfaces:
 - Compact Edits surface: [`EditedFilesBufferPanel.tsx`](../apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx) appears in the chat sidebar and offers compact keep/reject/review/undo actions.
 - Chat activity rows: [`ChangeReviewToolRail.tsx`](../apps/desktop/src/features/ai/components/ChangeReviewToolRail.tsx) renders change-review progress and diff previews in the conversation timeline. It is a navigation and inspection surface; keep/reject state and actions still derive from the same canonical ActionLog projection.
 
+The Review tab and Edits surface are available only while the current vault's
+`aiReviewEnabled` setting is enabled. Disabling it closes open Review tabs,
+hides Edits, and disables inline decisions without mutating pending ActionLog
+state. Chat activity rows remain available so streamed diffs stay visible.
+
 The Review tab and Edits surface render shared rows through
 [`EditedFilesReviewList.tsx`](../apps/desktop/src/features/ai/components/EditedFilesReviewList.tsx)
 and derive file items from the same tracked-file projection. Chat activity rows
@@ -129,8 +134,10 @@ Review projection groups spans into hunks and chunks:
 
 Inline review is gated by vault settings in
 [`editorReviewGate.ts`](../apps/desktop/src/features/editor/editorReviewGate.ts).
-It is enabled only for source mode and when `inlineReviewEnabled` is true for
-the current vault.
+It is enabled only for source mode and when both `aiReviewEnabled` and
+`inlineReviewEnabled` are true for the current vault. Disabling AI change
+review preserves the inline preference so it resumes when review is enabled
+again.
 
 Editor synchronization happens in two layers:
 

--- a/docs/review-hardening-checklist.md
+++ b/docs/review-hardening-checklist.md
@@ -80,6 +80,13 @@ back to the agent.
       view UI disappear.
 - [ ] Disable inline review for the vault and confirm Review tab/Edits panel
       still work while inline controls stay hidden.
+- [ ] Disable AI change review for the vault and confirm existing Review tabs
+      close, Edits and inline controls disappear, and pending changes are not
+      accepted or rejected implicitly.
+- [ ] While AI change review is disabled, run an agent edit and confirm the
+      chat timeline still shows its streamed diff.
+- [ ] Re-enable AI change review and confirm pending changes and the previous
+      inline-review preference are available again.
 - [ ] Edit non-agent-owned text while pending AI changes exist.
 - [ ] Confirm pending ranges rebase and only agent-owned spans remain in
       review.

--- a/docs/review-hardening-checklist.md
+++ b/docs/review-hardening-checklist.md
@@ -81,8 +81,8 @@ back to the agent.
 - [ ] Disable inline review for the vault and confirm Review tab/Edits panel
       still work while inline controls stay hidden.
 - [ ] Disable AI change review for the vault and confirm existing Review tabs
-      close, Edits and inline controls disappear, and pending changes are not
-      accepted or rejected implicitly.
+      close, Edits and inline controls disappear, and pending changes are
+      accepted and cleared without changing file content.
 - [ ] While AI change review is disabled, run an agent edit and confirm the
       chat timeline still shows its streamed diff.
 - [ ] Re-enable AI change review and confirm pending changes and the previous

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -83,7 +83,8 @@ the same Settings stores.
 | Editor / Preview | `hoverPreviewDelayMs` | Global | `300` | `neverwrite:settings` | Open delay for the hover preview; clamped to `0..2000`. |
 | Editor / Layout | `editorContentWidth` | Per-vault | `940` | `neverwrite:settings:<vault-path>` | Clamped to `600..1200`. |
 | PDF toolbar | `pdfFilter` | Per-vault | `none` | `neverwrite:settings:<vault-path>` | Cycled from the PDF tab toolbar. Valid values are `none`, `dark`, `sepia`, and `grayscale`. |
-| AI / Context | `inlineReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates inline review in source mode. This is a review-system correctness setting. |
+| AI / Context | `aiReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates the Edits panel, Review tabs, and inline review controls. Chat diff updates remain visible. |
+| AI / Context | `inlineReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates inline review in source mode when AI change review is enabled. This is a review-system correctness setting. |
 | AI / Context | `autoContextEnabled` | Per-vault, global fallback | `false` | `neverwrite.ai.auto-context:<vault-path>` | Legacy `neverwrite.ai.preferences.autoContextEnabled` is still read as fallback. |
 | AI / Chat | `chatFontFamily` | Global | `system` | `neverwrite.ai.preferences` | Validated with editor font-family normalization. |
 | AI / Chat | `chatFontSize` | Global | `14` | `neverwrite.ai.preferences` | Chat transcript font size. |

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -83,7 +83,7 @@ the same Settings stores.
 | Editor / Preview | `hoverPreviewDelayMs` | Global | `300` | `neverwrite:settings` | Open delay for the hover preview; clamped to `0..2000`. |
 | Editor / Layout | `editorContentWidth` | Per-vault | `940` | `neverwrite:settings:<vault-path>` | Clamped to `600..1200`. |
 | PDF toolbar | `pdfFilter` | Per-vault | `none` | `neverwrite:settings:<vault-path>` | Cycled from the PDF tab toolbar. Valid values are `none`, `dark`, `sepia`, and `grayscale`. |
-| AI / Context | `aiReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates the Edits panel, Review tabs, and inline review controls. Chat diff updates remain visible. |
+| AI / Context | `aiReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Tracks AI changes for Edits, Review tabs, and inline controls. Disabling it accepts and clears pending review state; chat diff updates remain visible. |
 | AI / Context | `inlineReviewEnabled` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Gates inline review in source mode when AI change review is enabled. This is a review-system correctness setting. |
 | AI / Context | `autoContextEnabled` | Per-vault, global fallback | `false` | `neverwrite.ai.auto-context:<vault-path>` | Legacy `neverwrite.ai.preferences.autoContextEnabled` is still read as fallback. |
 | AI / Chat | `chatFontFamily` | Global | `system` | `neverwrite.ai.preferences` | Validated with editor font-family normalization. |


### PR DESCRIPTION
## Summary
- add a per-vault AI change review preference that gates Edits, Review tabs, and inline decisions
- preserve pending ActionLog state and the user's inline-review preference while review is disabled
- keep streamed chat diff rails visible and close stale Review tabs when the setting is turned off

## Validation
- `npm run test -- src/app/store/settingsStore.test.ts src/features/settings/SettingsPanel.test.tsx src/features/editor/editorReviewGate.test.ts src/features/editor/mergeViewSync.test.ts src/features/editor/extensions/mergeViewDiff.test.ts src/features/ai/components/EditedFilesBufferPanel.test.tsx src/features/ai/components/AIReviewView.test.tsx src/features/ai/components/reviewMultiSessionIntegration.test.tsx src/features/ai/components/AIChatMessageItem.test.tsx`
- `npm run lint`
- `npm run build`