### PR TITLE
chore(runtime): promote embedded agent runtime to 0.144.6

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -9341,6 +9341,7 @@ mod tests {
         SessionConfigOptionCategory, SessionConfigSelectOption, SessionInfoUpdate,
         SessionNotification, SessionUpdate, StringPropertySchema, ToolCallContent, ToolCallId,
         Terminal, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+        UsageUpdate,
     };
     use std::fs;
     use std::sync::mpsc;
@@ -10431,6 +10432,36 @@ mod tests {
                 .and_then(|managed| managed.session.title.as_deref()),
             Some("Investigate startup crash")
         );
+    }
+
+    #[test]
+    fn usage_update_preserves_dynamic_context_window_size() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+
+        run_client_future(client.session_notification(SessionNotification::new(
+            "codex-session",
+            SessionUpdate::UsageUpdate(UsageUpdate::new(136_000, 272_000)),
+        )))
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("token usage event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_TOKEN_USAGE_EVENT);
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some("codex-session")
+        );
+        assert_eq!(payload.get("used").and_then(Value::as_u64), Some(136_000));
+        assert_eq!(payload.get("size").and_then(Value::as_u64), Some(272_000));
+        assert!(event_rx.try_recv().is_err());
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2550,13 +2550,19 @@ impl NativeAcpClient {
         if tool_call.status != ToolCallStatus::Failed {
             self.mark_agent_write_paths(session_id, &diffs);
         }
+        let summary = if tool_call.status == ToolCallStatus::Failed {
+            summarize_tool_content(tool_call)
+                .or_else(|| self.terminal_summary(session_id, &tool_call.tool_call_id.0))
+        } else {
+            self.terminal_summary(session_id, &tool_call.tool_call_id.0)
+        };
         self.emit(
             AI_TOOL_ACTIVITY_EVENT,
             map_tool_call(
                 session_id,
                 tool_call,
                 action,
-                self.terminal_summary(session_id, &tool_call.tool_call_id.0),
+                summary,
                 diffs,
             ),
         );
@@ -6284,15 +6290,29 @@ fn is_generated_image_artifact_path(path: &str) -> bool {
 }
 
 fn summarize_tool_content(tool_call: &ToolCall) -> Option<String> {
-    tool_call.content.iter().find_map(|item| match item {
-        ToolCallContent::Content(content) => match &content.content {
-            ContentBlock::Text(text) => Some(text.text.clone()),
+    tool_call
+        .content
+        .iter()
+        .find_map(|item| match item {
+            ToolCallContent::Content(content) => match &content.content {
+                ContentBlock::Text(text) => Some(text.text.clone()),
+                _ => None,
+            },
             _ => None,
-        },
-        ToolCallContent::Diff(diff) => Some(format!("Updated {}", diff.path.display())),
-        ToolCallContent::Terminal(_) => Some("Terminal output available.".to_string()),
-        _ => None,
-    })
+        })
+        .or_else(|| {
+            tool_call.content.iter().find_map(|item| match item {
+                ToolCallContent::Diff(diff) => Some(format!("Updated {}", diff.path.display())),
+                _ => None,
+            })
+        })
+        .or_else(|| {
+            tool_call
+                .content
+                .iter()
+                .any(|item| matches!(item, ToolCallContent::Terminal(_)))
+                .then(|| "Terminal output available.".to_string())
+        })
 }
 
 fn terminal_output_from_meta(meta: &Meta) -> Option<String> {
@@ -9320,7 +9340,7 @@ mod tests {
         PermissionOptionKind, PlanEntry, PromptCapabilities, SessionConfigOption,
         SessionConfigOptionCategory, SessionConfigSelectOption, SessionInfoUpdate,
         SessionNotification, SessionUpdate, StringPropertySchema, ToolCallContent, ToolCallId,
-        ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
+        Terminal, ToolCallUpdate, ToolCallUpdateFields, ToolKind, UnstructuredCommandInput,
     };
     use std::fs;
     use std::sync::mpsc;
@@ -14173,6 +14193,63 @@ mod tests {
 
         assert_eq!(payload.summary.as_deref(), Some("README.md"));
         assert!(payload.diffs.is_none());
+    }
+
+    #[test]
+    fn failed_tool_activity_prefers_acp_reason_over_terminal_exit_summary() {
+        const REJECTION_REASON: &str =
+            "rm -f style commands are not permitted. Use a safer approach";
+
+        let (event_tx, event_rx) = mpsc::channel();
+        let client = test_client(event_tx);
+        let started = ToolCall::new(ToolCallId::from("blocked-command"), "Running command")
+            .kind(ToolKind::Execute)
+            .status(ToolCallStatus::InProgress);
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCall(started),
+        )))
+        .unwrap();
+        let _ = event_rx.recv_timeout(StdDuration::from_millis(250));
+
+        let failed = ToolCallUpdate::new(
+            "blocked-command",
+            ToolCallUpdateFields::new()
+                .status(ToolCallStatus::Failed)
+                .content(vec![
+                    ToolCallContent::Terminal(Terminal::new("blocked-command")),
+                    ToolCallContent::from(REJECTION_REASON),
+                ]),
+        )
+        .meta(Meta::from_iter([(
+            "terminal_exit".to_string(),
+            json!({
+                "terminal_id": "blocked-command",
+                "exit_code": -1,
+                "signal": null,
+            }),
+        )]));
+        run_client_future(client.session_notification(SessionNotification::new(
+            "session-1",
+            SessionUpdate::ToolCallUpdate(failed),
+        )))
+        .unwrap();
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx
+            .recv_timeout(StdDuration::from_millis(250))
+            .expect("failed tool activity event")
+        else {
+            panic!("expected event");
+        };
+        assert_eq!(event_name, AI_TOOL_ACTIVITY_EVENT);
+        assert_eq!(payload.get("status").and_then(Value::as_str), Some("failed"));
+        assert_eq!(
+            payload.get("summary").and_then(Value::as_str),
+            Some(REJECTION_REASON)
+        );
     }
 
     #[test]

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import fs from "node:fs/promises";
+import http from "node:http";
 import os from "node:os";
 import path from "node:path";
 import readline from "node:readline";
@@ -155,155 +156,332 @@ async function findCodexAcpPath(sidecarPath) {
     return acpPath;
 }
 
-async function smokeCodeModeHost(hostPath) {
-    const child = spawn(hostPath, [], { stdio: ["pipe", "ignore", "pipe"] });
-    const stderrChunks = [];
-    let settled = false;
+function formatSse(events) {
+    return events
+        .map(
+            (event) =>
+                `event: ${event.type}\ndata: ${JSON.stringify(event)}\n\n`,
+        )
+        .join("");
+}
 
-    child.stderr.on("data", (chunk) => stderrChunks.push(String(chunk)));
+function responseCreated(id) {
+    return { type: "response.created", response: { id } };
+}
 
-    await new Promise((resolve, reject) => {
-        const startupTimer = setTimeout(() => {
-            cleanup();
-            resolve();
-        }, Math.min(smokeTimeoutMs, 1_000));
+function responseCompleted(id) {
+    return {
+        type: "response.completed",
+        response: {
+            id,
+            usage: {
+                input_tokens: 0,
+                input_tokens_details: null,
+                output_tokens: 0,
+                output_tokens_details: null,
+                total_tokens: 0,
+            },
+        },
+    };
+}
 
-        function cleanup() {
-            if (settled) return;
-            settled = true;
-            clearTimeout(startupTimer);
-            child.stdin.end();
-            if (!child.killed) child.kill("SIGTERM");
-        }
-
-        child.on("error", (error) => {
-            if (settled) return;
-            cleanup();
-            reject(
-                new Error(`Packaged Codex code-mode host could not start: ${hostPath}`, {
-                    cause: error,
-                }),
-            );
-        });
-        child.on("exit", (code, signal) => {
-            if (settled) return;
-            cleanup();
-            reject(
-                new Error(
-                    `Packaged Codex code-mode host exited before startup (${code ?? signal ?? "unknown"}).${formatStderr(stderrChunks)}`,
-                ),
-            );
-        });
+function readRequestBody(request) {
+    return new Promise((resolve, reject) => {
+        const chunks = [];
+        request.on("data", (chunk) => chunks.push(chunk));
+        request.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        request.on("error", reject);
     });
 }
 
-async function smokeCodexAcp(acpPath) {
-    // Keep the smoke isolated from a developer's login and persisted Codex state.
-    const codexHome = await fs.mkdtemp(
-        path.join(os.tmpdir(), "neverwrite-codex-acp-smoke-"),
-    );
-    const child = spawn(acpPath, [], {
-        stdio: ["pipe", "pipe", "pipe"],
-        env: { ...process.env, CODEX_HOME: codexHome },
+async function startResponsesMock(marker) {
+    const requests = [];
+    const server = http.createServer(async (request, response) => {
+        try {
+            if (request.method !== "POST" || request.url !== "/v1/responses") {
+                response.writeHead(404).end();
+                return;
+            }
+
+            if (
+                request.headers.authorization !==
+                "Bearer neverwrite-packaging-smoke"
+            ) {
+                throw new Error(
+                    "Responses request did not use the configured smoke API key",
+                );
+            }
+
+            const body = JSON.parse(await readRequestBody(request));
+            requests.push(body);
+            let events;
+            if (requests.length === 1) {
+                if (
+                    body.model !== "test-gpt-5.1-codex" ||
+                    body.stream !== true
+                ) {
+                    throw new Error(
+                        "Initial Responses request did not use the smoke configuration",
+                    );
+                }
+                events = [
+                    responseCreated("neverwrite-smoke-response-1"),
+                    {
+                        type: "response.output_item.done",
+                        item: {
+                            type: "custom_tool_call",
+                            call_id: "neverwrite-code-mode-call",
+                            name: "exec",
+                            input: `text(${JSON.stringify(marker)});`,
+                        },
+                    },
+                    responseCompleted("neverwrite-smoke-response-1"),
+                ];
+            } else if (requests.length === 2) {
+                const toolOutput = body.input?.find(
+                    (item) =>
+                        item.type === "custom_tool_call_output" &&
+                        item.call_id === "neverwrite-code-mode-call",
+                );
+                if (!JSON.stringify(toolOutput).includes(marker)) {
+                    throw new Error(
+                        "Code-mode output did not contain the expected marker",
+                    );
+                }
+                events = [
+                    responseCreated("neverwrite-smoke-response-2"),
+                    {
+                        type: "response.output_item.done",
+                        item: {
+                            type: "message",
+                            role: "assistant",
+                            id: "neverwrite-smoke-message",
+                            // The mock only reaches this response after receiving the host's
+                            // custom-tool output, so this message proves the full code-mode loop.
+                            content: [{ type: "output_text", text: marker }],
+                        },
+                    },
+                    responseCompleted("neverwrite-smoke-response-2"),
+                ];
+            } else {
+                throw new Error(`Unexpected Responses request ${requests.length}`);
+            }
+
+            response.writeHead(200, {
+                "content-type": "text/event-stream",
+                "cache-control": "no-cache",
+            });
+            response.end(formatSse(events));
+        } catch (error) {
+            response.writeHead(500, { "content-type": "application/json" });
+            response.end(JSON.stringify({ error: String(error) }));
+        }
     });
-    const stderrChunks = [];
-    let settled = false;
 
-    child.stderr.on("data", (chunk) => stderrChunks.push(String(chunk)));
+    await new Promise((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+            server.off("error", reject);
+            resolve();
+        });
+    });
 
-    try {
-        await new Promise((resolve, reject) => {
-            const lines = readline.createInterface({ input: child.stdout });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+        throw new Error("Responses mock server did not expose a TCP address");
+    }
+
+    return {
+        baseUrl: `http://127.0.0.1:${address.port}/v1`,
+        requests,
+        close: () =>
+            new Promise((resolve, reject) =>
+                server.close((error) => (error ? reject(error) : resolve())),
+            ),
+    };
+}
+
+class AcpClient {
+    constructor(executablePath, env) {
+        this.child = spawn(executablePath, [], {
+            stdio: ["pipe", "pipe", "pipe"],
+            env,
+        });
+        this.nextId = 1;
+        this.pending = new Map();
+        this.notifications = [];
+        this.stderrChunks = [];
+        this.stopped = false;
+        this.lines = readline.createInterface({ input: this.child.stdout });
+
+        this.child.stderr.on("data", (chunk) =>
+            this.stderrChunks.push(String(chunk)),
+        );
+        this.lines.on("line", (line) => this.receive(line));
+        this.child.on("error", (error) => this.failPending(error));
+        this.child.on("exit", (code, signal) => {
+            if (!this.stopped) {
+                this.failPending(
+                    new Error(
+                        `Packaged Codex ACP runtime exited (${code ?? signal ?? "unknown"}).${formatStderr(this.stderrChunks)}`,
+                    ),
+                );
+            }
+        });
+    }
+
+    receive(line) {
+        let message;
+        try {
+            message = JSON.parse(line);
+        } catch (error) {
+            this.failPending(
+                new Error(`Invalid JSON from packaged Codex ACP runtime: ${error}`),
+            );
+            return;
+        }
+
+        if (message.id !== undefined) {
+            const pending = this.pending.get(message.id);
+            if (!pending) return;
+            this.pending.delete(message.id);
+            clearTimeout(pending.timeout);
+            if (message.error) {
+                pending.reject(
+                    new Error(
+                        `ACP ${pending.method} failed: ${JSON.stringify(message.error)}`,
+                    ),
+                );
+            } else {
+                pending.resolve(message.result);
+            }
+            return;
+        }
+
+        if (message.method === "session/update") {
+            this.notifications.push(message.params);
+        }
+    }
+
+    failPending(error) {
+        for (const pending of this.pending.values()) {
+            clearTimeout(pending.timeout);
+            pending.reject(error);
+        }
+        this.pending.clear();
+    }
+
+    request(method, params) {
+        const id = this.nextId++;
+        return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
-                cleanup();
+                this.pending.delete(id);
                 reject(
                     new Error(
-                        `Timed out waiting for packaged Codex ACP initialization.${formatStderr(stderrChunks)}`,
+                        `Timed out waiting for ACP ${method}.${formatStderr(this.stderrChunks)}`,
                     ),
                 );
             }, smokeTimeoutMs);
-
-            function cleanup() {
-                if (settled) return;
-                settled = true;
-                clearTimeout(timeout);
-                lines.close();
-                child.stdin.destroy();
-                if (!child.killed) child.kill("SIGTERM");
-            }
-
-            child.on("error", (error) => {
-                if (settled) return;
-                cleanup();
-                reject(
-                    new Error(`Packaged Codex ACP runtime could not start: ${acpPath}`, {
-                        cause: error,
-                    }),
-                );
-            });
-            child.on("exit", (code, signal) => {
-                if (settled || child.killed) return;
-                cleanup();
-                reject(
-                    new Error(
-                        `Packaged Codex ACP runtime exited before initialization (${code ?? signal ?? "unknown"}).${formatStderr(stderrChunks)}`,
-                    ),
-                );
-            });
-            lines.on("line", (line) => {
-                if (settled) return;
-                let message;
-                try {
-                    message = JSON.parse(line);
-                } catch (error) {
-                    cleanup();
-                    reject(
-                        new Error(
-                            `Invalid JSON response from packaged Codex ACP runtime: ${error}`,
-                        ),
-                    );
-                    return;
-                }
-
-                if (
-                    message?.id === 1 &&
-                    message?.result?.agentInfo?.name === "codex-acp" &&
-                    message?.result?.protocolVersion === 1
-                ) {
-                    cleanup();
-                    resolve();
-                    return;
-                }
-
-                cleanup();
-                reject(
-                    new Error(
-                        `Unexpected Codex ACP initialization response: ${line}`,
-                    ),
-                );
-            });
-
-            child.stdin.write(
-                `${JSON.stringify({
-                    jsonrpc: "2.0",
-                    id: 1,
-                    method: "initialize",
-                    params: {
-                        protocolVersion: 1,
-                        clientCapabilities: {},
-                        clientInfo: {
-                            name: "NeverWrite packaging smoke",
-                            version: "0.0.0",
-                        },
-                    },
-                })}\n`,
+            this.pending.set(id, { method, resolve, reject, timeout });
+            this.child.stdin.write(
+                `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
             );
         });
-    } finally {
-        if (child.exitCode === null) {
-            await new Promise((resolve) => child.once("exit", resolve));
+    }
+
+    async close() {
+        this.stopped = true;
+        this.failPending(new Error("Packaged Codex ACP runtime was stopped"));
+        this.lines.close();
+        this.child.stdin.end();
+        if (this.child.exitCode === null && !this.child.killed) {
+            this.child.kill("SIGTERM");
         }
-        await fs.rm(codexHome, { recursive: true, force: true });
+        if (this.child.exitCode === null) {
+            await new Promise((resolve) => this.child.once("exit", resolve));
+        }
+    }
+}
+
+async function smokeCodexAcpCodeMode(acpPath, hostPath) {
+    const marker = "neverwrite_code_mode_packaged_smoke";
+    const codexHome = await fs.mkdtemp(
+        path.join(os.tmpdir(), "neverwrite-codex-acp-smoke-"),
+    );
+    const workspace = await fs.mkdtemp(
+        path.join(os.tmpdir(), "neverwrite-code-mode-workspace-"),
+    );
+    let mock;
+    let client;
+
+    try {
+        mock = await startResponsesMock(marker);
+        await fs.writeFile(
+            path.join(codexHome, "config.toml"),
+            `model = "test-gpt-5.1-codex"\nmodel_provider = "neverwrite-packaging-smoke"\nsuppress_unstable_features_warning = true\n\n[features]\ncode_mode = true\n\n[model_providers.neverwrite-packaging-smoke]\nname = "NeverWrite packaging smoke"\nbase_url = "${mock.baseUrl}"\nenv_key = "NEVERWRITE_PACKAGING_SMOKE_API_KEY"\nwire_api = "responses"\n`,
+        );
+        client = new AcpClient(acpPath, {
+            ...process.env,
+            CODEX_HOME: codexHome,
+            CODEX_CODE_MODE_HOST_PATH: hostPath,
+            NEVERWRITE_PACKAGING_SMOKE_API_KEY: "neverwrite-packaging-smoke",
+        });
+
+        const initialized = await client.request("initialize", {
+            protocolVersion: 1,
+            clientCapabilities: {},
+            clientInfo: { name: "NeverWrite packaging smoke", version: "0.0.0" },
+        });
+        if (
+            initialized?.agentInfo?.name !== "codex-acp" ||
+            initialized?.protocolVersion !== 1
+        ) {
+            throw new Error(
+                `Unexpected ACP initialize response: ${JSON.stringify(initialized)}`,
+            );
+        }
+
+        const session = await client.request("session/new", {
+            cwd: workspace,
+            mcpServers: [],
+        });
+        const sessionId = session?.sessionId;
+        if (typeof sessionId !== "string" || sessionId.length === 0) {
+            throw new Error(
+                `ACP did not return a session ID: ${JSON.stringify(session)}`,
+            );
+        }
+
+        const prompt = await client.request("session/prompt", {
+            sessionId,
+            prompt: [
+                { type: "text", text: "Run the packaging code-mode smoke." },
+            ],
+        });
+        if (prompt?.stopReason !== "end_turn") {
+            throw new Error(
+                `Code-mode prompt did not finish normally: ${JSON.stringify(prompt)}`,
+            );
+        }
+        if (mock.requests.length !== 2) {
+            throw new Error(`Expected two Responses requests, received ${mock.requests.length}`);
+        }
+
+        const sawCodeModeResult = client.notifications.some(
+            (notification) =>
+                notification?.update?.sessionUpdate === "agent_message_chunk" &&
+                notification.update.content?.text === marker,
+        );
+        if (!sawCodeModeResult) {
+            throw new Error("ACP did not publish the packaged code-mode result");
+        }
+    } finally {
+        await client?.close();
+        await mock?.close();
+        await Promise.all([
+            fs.rm(codexHome, { recursive: true, force: true }),
+            fs.rm(workspace, { recursive: true, force: true }),
+        ]);
     }
 }
 
@@ -397,10 +575,9 @@ if (!stats.isFile()) {
 assertExecutableMode(stats, sidecarPath, "sidecar");
 const codexAcpPath = await findCodexAcpPath(sidecarPath);
 const codeModeHostPath = await findCodeModeHostPath(sidecarPath);
-await smokeCodexAcp(codexAcpPath);
-await smokeCodeModeHost(codeModeHostPath);
+await smokeCodexAcpCodeMode(codexAcpPath, codeModeHostPath);
 await smokePing(sidecarPath);
 
-console.log(`Packaged Codex ACP runtime initialized: ${codexAcpPath}`);
-console.log(`Packaged Codex code-mode host started: ${codeModeHostPath}`);
+console.log(`Packaged Codex ACP completed a code-mode turn: ${codexAcpPath}`);
+console.log(`Packaged Codex code-mode host executed JavaScript: ${codeModeHostPath}`);
 console.log(`Packaged native backend sidecar responded to ping: ${sidecarPath}`);

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -273,8 +273,9 @@ async function startResponsesMock(marker) {
             });
             response.end(formatSse(events));
         } catch (error) {
+            console.error("Responses mock request failed:", error);
             response.writeHead(500, { "content-type": "application/json" });
-            response.end(JSON.stringify({ error: String(error) }));
+            response.end(JSON.stringify({ error: "Internal server error" }));
         }
     });
 

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -5,6 +5,90 @@ import { renderComponent } from "../../../test/test-utils";
 import { AIChatAgentControls } from "./AIChatAgentControls";
 
 describe("AIChatAgentControls", () => {
+    it("shows contextual safety help only for Codex Full Access", () => {
+        const fullAccessDescription =
+            "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.";
+        const modes = [
+            {
+                id: "auto",
+                runtimeId: "codex-acp",
+                name: "Default",
+                description: "Work inside the current workspace.",
+                disabled: false,
+            },
+            {
+                id: "full-access",
+                runtimeId: "codex-acp",
+                name: "Full Access",
+                description: fullAccessDescription,
+                disabled: false,
+            },
+        ];
+        const view = renderComponent(
+            <AIChatAgentControls
+                runtimeId="codex-acp"
+                modelId=""
+                modeId="full-access"
+                effortsByModel={{}}
+                models={[]}
+                modes={modes}
+                configOptions={[]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={() => {}}
+            />,
+        );
+
+        const help = screen.getByRole("button", {
+            name: "Full Access safety policy",
+        });
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+        fireEvent.mouseEnter(help);
+        expect(screen.getByRole("tooltip")).toHaveTextContent(
+            "Some destructive command forms may still be blocked by Codex safety policy.",
+        );
+        fireEvent.mouseLeave(help);
+        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+        fireEvent.focus(help);
+        expect(screen.getByRole("tooltip")).toBeInTheDocument();
+        fireEvent.blur(help);
+
+        fireEvent.click(screen.getByTitle("Approval Preset"));
+        const fullAccessOption = screen
+            .getAllByRole("button", { name: "Full Access" })
+            .find(
+                (option) =>
+                    option.getAttribute("title") === fullAccessDescription,
+            );
+        expect(fullAccessOption).toHaveAttribute(
+            "title",
+            fullAccessDescription,
+        );
+
+        view.unmount();
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="codex-acp"
+                modelId=""
+                modeId="auto"
+                effortsByModel={{}}
+                models={[]}
+                modes={modes}
+                configOptions={[]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={() => {}}
+            />,
+        );
+        expect(
+            screen.queryByRole("button", {
+                name: "Full Access safety policy",
+            }),
+        ).not.toBeInTheDocument();
+    });
+
     it("filters reasoning efforts to the selected model", () => {
         renderComponent(
             <AIChatAgentControls

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 import type { AIConfigOption, AIModeOption, AIModelOption } from "../types";
 
 interface AIChatAgentControlsProps {
@@ -42,6 +42,53 @@ const SEARCHABLE_MODEL_RUNTIME_IDS = new Set([
 const GROK_RUNTIME_ID = "grok-acp";
 const CLAUDE_RUNTIME_ID = "claude-acp";
 const CLAUDE_FAST_OPTION_ID = "fast";
+const CODEX_RUNTIME_ID = "codex-acp";
+const CODEX_FULL_ACCESS_MODE_ID = "full-access";
+const CODEX_FULL_ACCESS_POLICY_HELP =
+    "Some destructive command forms may still be blocked by Codex safety policy.";
+
+function FullAccessPolicyHelp() {
+    const [open, setOpen] = useState(false);
+    const descriptionId = useId();
+
+    return (
+        <div className="relative flex shrink-0 items-center">
+            <button
+                aria-describedby={open ? descriptionId : undefined}
+                aria-label="Full Access safety policy"
+                className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
+                onBlur={() => setOpen(false)}
+                onFocus={() => setOpen(true)}
+                onMouseEnter={() => setOpen(true)}
+                onMouseLeave={() => setOpen(false)}
+                style={{
+                    backgroundColor: "transparent",
+                    border: "1px solid var(--border)",
+                    color: "var(--text-secondary)",
+                }}
+                type="button"
+            >
+                ?
+            </button>
+            {open ? (
+                <div
+                    className="absolute bottom-full left-0 z-50 mb-1 w-72 rounded-lg px-3 py-2 text-xs"
+                    id={descriptionId}
+                    role="tooltip"
+                    style={{
+                        backgroundColor: "var(--bg-secondary)",
+                        border: "1px solid var(--border)",
+                        boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+                        color: "var(--text-primary)",
+                        lineHeight: 1.4,
+                    }}
+                >
+                    {CODEX_FULL_ACCESS_POLICY_HELP}
+                </div>
+            ) : null}
+        </div>
+    );
+}
 
 function shouldUseSearchableModelMenu(runtimeId?: string) {
     return (
@@ -526,6 +573,8 @@ export function AIChatAgentControls({
                 .filter(({ options }) => options.length > 0),
         [effortsByModel, extraConfigs, runtimeId, selectedModelId],
     );
+    const showFullAccessPolicyHelp =
+        runtimeId === CODEX_RUNTIME_ID && modeId === CODEX_FULL_ACCESS_MODE_ID;
 
     return (
         <div className="flex min-w-0 flex-wrap items-center gap-1">
@@ -543,6 +592,7 @@ export function AIChatAgentControls({
                     onChange={onModeChange}
                 />
             ) : null}
+            {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
             {lockedModelOptions.length > 0 ? (
                 <DropdownField
                     disabled={disabled}

--- a/apps/desktop/src/features/ai/components/AIChatContextUsageBar.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatContextUsageBar.test.tsx
@@ -9,8 +9,8 @@ describe("AIChatContextUsageBar", () => {
             <AIChatContextUsageBar
                 usage={{
                     session_id: "session-1",
-                    used: 170_000,
-                    size: 200_000,
+                    used: 136_000,
+                    size: 272_000,
                     cost: {
                         amount: 0.0421,
                         currency: "USD",
@@ -21,14 +21,14 @@ describe("AIChatContextUsageBar", () => {
         );
 
         const bar = screen.getByRole("progressbar", {
-            name: /Context window 85% used/i,
+            name: /Context window 50% used/i,
         });
-        expect(bar).toHaveAttribute("aria-valuenow", "85");
+        expect(bar).toHaveAttribute("aria-valuenow", "50");
         expect(bar).toHaveAttribute("aria-valuemin", "0");
         expect(bar).toHaveAttribute("aria-valuemax", "100");
         expect(bar).toHaveAttribute(
             "title",
-            expect.stringContaining("170k / 200k tokens"),
+            expect.stringContaining("136k / 272k tokens"),
         );
         expect(bar).toHaveAttribute(
             "title",

--- a/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/ToolActivityItem.test.tsx
@@ -194,6 +194,36 @@ describe("ToolActivityItem", () => {
         ).toHaveAttribute("data-tool-activity-status", "failed");
     });
 
+    it("expands a definitive command policy rejection with its reason", () => {
+        const reason =
+            "rm -f style commands are not permitted. Use a safer approach";
+        const view = renderComponent(
+            <ToolActivityItem
+                message={createTool("tool:blocked-command", {
+                    content: reason,
+                    meta: {
+                        status: "failed",
+                        tool: "execute",
+                    },
+                    title: "Running command",
+                })}
+                sessionId="session-1"
+            />,
+        );
+
+        const row = view.container.querySelector(
+            '[data-tool-activity-row="attention"]',
+        );
+        expect(row).toHaveAttribute("data-tool-activity-status", "failed");
+        expect(screen.getByText("Failed")).toBeInTheDocument();
+        expect(screen.queryByText(reason)).not.toBeInTheDocument();
+
+        fireEvent.click(row!);
+
+        expect(screen.getByText(reason)).toBeInTheDocument();
+        expect(row).toHaveAttribute("aria-expanded", "true");
+    });
+
     it("preserves the open-session breadcrumb for subagent activity", () => {
         renderComponent(
             <ToolActivityItem

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -11201,8 +11201,8 @@ describe("chatStore", () => {
 
         useChatStore.getState().applyTokenUsage({
             session_id: activeSessionId,
-            used: 170_000,
-            size: 200_000,
+            used: 136_000,
+            size: 272_000,
             cost: {
                 amount: 0.0421,
                 currency: "USD",
@@ -11213,8 +11213,8 @@ describe("chatStore", () => {
             useChatStore.getState().tokenUsageBySessionId[activeSessionId],
         ).toMatchObject({
             session_id: activeSessionId,
-            used: 170_000,
-            size: 200_000,
+            used: 136_000,
+            size: 272_000,
             cost: {
                 amount: 0.0421,
                 currency: "USD",

--- a/apps/desktop/src/features/ai/useAiChatEventBridge.test.tsx
+++ b/apps/desktop/src/features/ai/useAiChatEventBridge.test.tsx
@@ -1,0 +1,84 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AITokenUsagePayload } from "./types";
+
+const listeners = vi.hoisted(() => ({
+    tokenUsage: undefined as
+        | ((payload: AITokenUsagePayload) => void)
+        | undefined,
+}));
+
+const unlisten = vi.hoisted(() => vi.fn());
+const noOpListener = vi.hoisted(() => vi.fn(async () => unlisten));
+const tokenUsageListener = vi.hoisted(() =>
+    vi.fn(async (callback: (payload: AITokenUsagePayload) => void) => {
+        listeners.tokenUsage = callback;
+        return unlisten;
+    }),
+);
+
+vi.mock("./api", () => ({
+    listenToAiAvailableCommandsUpdated: noOpListener,
+    listenToAiImageGeneration: noOpListener,
+    listenToAiMessageCompleted: noOpListener,
+    listenToAiMessageDelta: noOpListener,
+    listenToAiMessageStarted: noOpListener,
+    listenToAiPermissionRequest: noOpListener,
+    listenToAiPlanUpdated: noOpListener,
+    listenToAiRuntimeConnection: noOpListener,
+    listenToAiSessionCreated: noOpListener,
+    listenToAiSessionError: noOpListener,
+    listenToAiSessionUpdated: noOpListener,
+    listenToAiStatusEvent: noOpListener,
+    listenToAiThinkingCompleted: noOpListener,
+    listenToAiThinkingDelta: noOpListener,
+    listenToAiThinkingStarted: noOpListener,
+    listenToAiTokenUsage: tokenUsageListener,
+    listenToAiToolActivity: noOpListener,
+    listenToAiUrlElicitationRequest: noOpListener,
+    listenToAiUserInputRequest: noOpListener,
+}));
+
+import { resetChatStore, useChatStore } from "./store/chatStore";
+import { useAiChatEventBridge } from "./useAiChatEventBridge";
+
+describe("useAiChatEventBridge", () => {
+    beforeEach(() => {
+        resetChatStore();
+        listeners.tokenUsage = undefined;
+        unlisten.mockClear();
+        noOpListener.mockClear();
+        tokenUsageListener.mockClear();
+        useChatStore.setState({
+            sessionsById: { "session-1": {} as never },
+        });
+    });
+
+    afterEach(() => {
+        resetChatStore();
+    });
+
+    it("applies the dynamic context window payload from the native event", async () => {
+        const { unmount } = renderHook(() => useAiChatEventBridge());
+
+        await waitFor(() => expect(listeners.tokenUsage).toBeTypeOf("function"));
+
+        act(() => {
+            listeners.tokenUsage?.({
+                session_id: "session-1",
+                used: 136_000,
+                size: 272_000,
+            });
+        });
+
+        expect(useChatStore.getState().tokenUsageBySessionId["session-1"])
+            .toMatchObject({
+                session_id: "session-1",
+                used: 136_000,
+                size: 272_000,
+        });
+
+        unmount();
+        expect(unlisten).toHaveBeenCalledTimes(19);
+    });
+});

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -48,10 +48,10 @@ That means the directory is intentionally reproducible, but not yet minimal.
   - synced against upstream commit `863d433fc91855d0b5427372bf635c894bf68cb6`
   - latest upstream sync from `0.14.0` brought in 5 commits:
     `d9bf1c1`, `0c2d828`, `8aef91b`, `f67ca5f`, `863d433`
-  - OpenAI Codex Rust crates: `rust-v0.144.0`
-    (`767822446c7a594caa19609ca435281a9ec67e0d`)
+  - OpenAI Codex Rust crates: `rust-v0.144.6`
+    (`5d1fbf26c43abc65a203928b2e31561cb039e06d`)
   - vendor ACP SDK: `agent-client-protocol` `0.14.0`
-  - includes a local `vendor/codex-utils-pty/` snapshot at `0.144.0` plus the
+  - includes a local `vendor/codex-utils-pty/` snapshot at `0.144.6` plus the
     matching `[patch."https://github.com/openai/codex"]` entry required by the
     OpenAI Codex crate graph
   - local NeverWrite delta remains intentionally bounded and currently lives in:
@@ -79,8 +79,8 @@ That means the directory is intentionally reproducible, but not yet minimal.
 ## Current Codex Delta
 
 The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility
-baseline is OpenAI Codex `rust-v0.144.0`, resolved to
-`767822446c7a594caa19609ca435281a9ec67e0d` in `Cargo.lock`.
+baseline is OpenAI Codex `rust-v0.144.6`, resolved to
+`5d1fbf26c43abc65a203928b2e31561cb039e06d` in `Cargo.lock`.
 
 The remaining NeverWrite-specific delta exists to preserve desktop product behavior:
 
@@ -111,7 +111,7 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
   breadcrumbs, child lifecycle, and receiver-owned inter-agent transcripts
 - per-turn coalescing of equivalent subagent waits; only fully terminal status sets
   complete the ACP activity
-- a local `codex-utils-pty` 0.144 snapshot with process-group signaling and
+- a local `codex-utils-pty` 0.144.6 snapshot with process-group signaling and
   Windows input/ConPTY compatibility tests
 
 The 0.144 API shapes for deferred turn items are handled as localized
@@ -128,12 +128,14 @@ The remaining deferred work is:
 
 The desktop release pipeline packages `codex-acp` and its `codex-code-mode-host`
 companion for macOS universal, Windows x64/ARM64, and Linux x64/ARM64. Each
-release build is lockfile-pinned; runnable targets initialize the packaged ACP
-runtime in their platform smoke test before release assets are published.
+release build is lockfile-pinned. Its packaged smoke now drives an ACP
+`initialize`, `session/new`, and `session/prompt` exchange through the packaged
+code-mode host, with a deterministic local Responses mock; it verifies both the
+tool completion and the assistant response.
 
 When updating Codex again, treat upstream ACP commit
 `863d433fc91855d0b5427372bf635c894bf68cb6`, OpenAI Codex tag
-`rust-v0.144.0`, and the local PTY `0.144.0` snapshot as the comparison base.
+`rust-v0.144.6`, and the local PTY `0.144.6` snapshot as the comparison base.
 Review the bounded delta file by file instead of replacing the vendor tree.
 
 Canonical compatibility checks:
@@ -142,6 +144,70 @@ Canonical compatibility checks:
 cargo check --locked --manifest-path vendor/codex-acp/Cargo.toml
 cargo test --locked --manifest-path vendor/codex-acp/Cargo.toml
 ```
+
+## Codex 0.144.6 Compatibility Baseline
+
+The embedded runtime is pinned to OpenAI Codex `rust-v0.144.6`. Every Codex git
+dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it
+to `5d1fbf26c43abc65a203928b2e31561cb039e06d`. The local
+`codex-utils-pty` snapshot is also `0.144.6`; it is part of the same runtime
+baseline, not an independently updatable crate.
+
+The vendor toolchain inherits Rust `1.96.0` from the repository-root
+`rust-toolchain.toml`. This promotion deliberately does not change these
+protocol boundaries:
+
+- the `codex-acp` adapter package remains `0.16.0`
+- the vendored ACP Rust SDK remains `agent-client-protocol` `0.14.0`
+- the desktop native backend remains `agent-client-protocol` `1.2.0`, which it
+  communicates through the serialized ACP protocol rather than a shared Rust
+  crate boundary
+
+### Product behavior covered by this baseline
+
+- Code mode retains the 0.144 host/fallback compatibility path. The standalone
+  `codex-code-mode-host` is packaged with the ACP sidecar, and the smoke forces
+  that exact packaged host so an in-process fallback cannot hide a missing host.
+- A definitive dangerous-command policy rejection is projected as a failed,
+  terminal ACP tool activity with its visible reason; it never becomes an ACP
+  permission request.
+- Thread metadata now synchronizes both a selected reasoning effort and an
+  explicit clearing of it, preventing a stale value after load, resume, or fork.
+- Model context-window metadata remains dynamic. Regression coverage exercises
+  the 272K context window reported for Sol, Terra, and Luna without hard-coding
+  that size into the runtime.
+- The public Full Access label and its ACP description remain unchanged. The UI
+  adds only contextual help explaining that Codex safety policy can still block
+  some destructive command forms.
+
+### Packaged code-mode smoke matrix
+
+| Package target | Executes the functional ACP code-mode smoke | Coverage when it cannot execute |
+| --- | --- | --- |
+| macOS universal | Yes, on a native runner slice | Both packaged host slices are staged |
+| Windows x64 and ARM64 | Yes | — |
+| Linux x64 | Yes | — |
+| Linux ARM64 | No, because it is cross-compiled | Packaging, sidecar staging, and architecture checks run without executing the foreign binary |
+
+The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock,
+and an explicit `CODEX_CODE_MODE_HOST_PATH`. It asserts a real ACP turn reaches
+both a code-mode tool completion and a final assistant response; it does not
+require credentials or a network service.
+
+### Follow-up and rollback
+
+The App Server adapter `1.1.4` is an architectural follow-up, not a replacement
+made by this baseline. It must demonstrate parity for sessions, configuration
+and permissions, review, inline changes, and accept/reject flows before it can
+replace the current adapter.
+
+#### Historical rollback baseline
+
+To roll this runtime back, return `vendor/codex-acp/Cargo.toml`,
+`vendor/codex-acp/Cargo.lock`, and `vendor/codex-acp/vendor/codex-utils-pty/`
+together to OpenAI Codex `rust-v0.144.0`
+(`767822446c7a594caa19609ca435281a9ec67e0d`) and its matching PTY snapshot.
+Never roll back a single Codex crate or the PTY snapshot independently.
 
 The desktop backend now supports a mixed ACP world: current ACP integration for
 Claude, Codex, Kilo, and OpenCode, plus the vendored

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -407,7 +407,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -418,7 +418,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1829,8 +1829,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -1840,8 +1840,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1859,8 +1859,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1879,8 +1879,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -1910,8 +1910,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "clap",
@@ -1936,8 +1936,8 @@ dependencies = [
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1952,8 +1952,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1972,8 +1972,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -1981,8 +1981,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -1995,8 +1995,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2008,8 +2008,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2024,8 +2024,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2036,8 +2036,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
  "serde",
@@ -2048,13 +2048,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 
 [[package]]
 name = "codex-config"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2098,8 +2098,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-config",
@@ -2114,8 +2114,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2123,8 +2123,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2226,8 +2226,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2270,8 +2270,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-skills"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-analytics",
@@ -2303,8 +2303,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "arc-swap",
  "axum",
@@ -2342,8 +2342,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -2357,8 +2357,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "clap",
@@ -2373,8 +2373,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2383,8 +2383,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -2396,8 +2396,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2407,8 +2407,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2420,8 +2420,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-login",
@@ -2434,8 +2434,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "clap",
@@ -2449,8 +2449,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2462,8 +2462,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2487,8 +2487,8 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -2497,8 +2497,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2519,8 +2519,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2545,8 +2545,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2571,8 +2571,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -2580,8 +2580,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "keyring",
  "tracing",
@@ -2589,8 +2589,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -2611,8 +2611,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2644,8 +2644,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2677,8 +2677,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2704,8 +2704,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -2714,8 +2714,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -2735,8 +2735,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2747,8 +2747,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2766,8 +2766,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2801,8 +2801,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2832,8 +2832,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -2845,16 +2845,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -2867,8 +2867,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2906,8 +2906,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2917,8 +2917,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "axum",
@@ -2954,8 +2954,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2978,8 +2978,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -2993,8 +2993,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-network-proxy",
  "codex-protocol",
@@ -3013,8 +3013,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "age",
  "anyhow",
@@ -3032,8 +3032,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3052,8 +3052,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "clap",
@@ -3071,8 +3071,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-utils-absolute-path",
  "include_dir",
@@ -3081,8 +3081,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3104,16 +3104,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "chrono",
  "codex-git-utils",
@@ -3132,8 +3132,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-code-mode",
  "codex-connectors",
@@ -3156,8 +3156,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "dirs",
  "dunce",
@@ -3168,16 +3168,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "lru",
  "sha1 0.10.7",
@@ -3186,8 +3186,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3198,8 +3198,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3207,8 +3207,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3220,8 +3220,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3229,8 +3229,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3238,8 +3238,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3248,8 +3248,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -3263,8 +3263,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-exec-server",
  "codex-utils-absolute-path",
@@ -3275,7 +3275,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.144.0"
+version = "0.144.6"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3290,21 +3290,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "regex-lite",
  "serde",
@@ -3313,13 +3313,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -3332,8 +3332,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.144.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.144.0#767822446c7a594caa19609ca435281a9ec67e0d"
+version = "0.144.6"
+source = "git+https://github.com/openai/codex?tag=rust-v0.144.6#5d1fbf26c43abc65a203928b2e31561cb039e06d"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4150,7 +4150,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4452,7 +4452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6331,7 +6331,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7601,7 +7601,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8652,7 +8652,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8691,9 +8691,9 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9553,7 +9553,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9612,7 +9612,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10443,7 +10443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -11016,7 +11016,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -11069,7 +11069,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11753,7 +11753,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -12263,7 +12263,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -25,25 +25,25 @@ path = "src/lib.rs"
 agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
 anyhow = "1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
-codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.144.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.144.6" }
 allocative = "=0.3.6"
 diffy = { version = "0.5.0", features = ["std"] }
 itertools = "0.14.0"

--- a/vendor/codex-acp/rust-toolchain.toml
+++ b/vendor/codex-acp/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "stable"
-components = ["clippy", "rustfmt", "rust-src"]

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -6515,7 +6515,7 @@ mod tests {
     use codex_protocol::models::AgentMessageInputContent;
     use codex_protocol::{
         config_types::{CollaborationMode, ModeKind, Settings},
-        protocol::ThreadSettingsAppliedEvent,
+        protocol::{ThreadSettingsAppliedEvent, TokenUsage, TokenUsageInfo},
     };
     use codex_shell_command::is_dangerous_command::{
         DangerousCommandMatch, dangerous_command_match,
@@ -7730,6 +7730,55 @@ mod tests {
             ],
             "notifications={notifications:?}"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn token_count_projects_dynamic_context_window_usage() -> anyhow::Result<()> {
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut prompt_state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                EventMsg::TokenCount(TokenCountEvent {
+                    info: Some(TokenUsageInfo {
+                        total_token_usage: TokenUsage::default(),
+                        last_token_usage: TokenUsage {
+                            input_tokens: 100_000,
+                            cached_input_tokens: 20_000,
+                            output_tokens: 16_000,
+                            reasoning_output_tokens: 0,
+                            total_tokens: 136_000,
+                        },
+                        model_context_window: Some(272_000),
+                    }),
+                    rate_limits: None,
+                }),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let usage = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::UsageUpdate(update) => Some(update),
+                _ => None,
+            })
+            .expect("token count should produce an ACP usage update");
+        assert_eq!(usage.used, 136_000);
+        assert_eq!(usage.size, 272_000);
 
         Ok(())
     }

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -566,6 +566,7 @@ struct ActiveCommand {
     tool_call_id: ToolCallId,
     terminal_output: bool,
     output: String,
+    observed_output: bool,
     file_extension: Option<String>,
     /// Snapshots of file contents taken before the command executes.
     /// Key = absolute path, Value = file content (None if file didn't exist).
@@ -3482,6 +3483,7 @@ impl PromptState {
                 terminal_output,
                 tool_call_id: tool_call_id.clone(),
                 output: String::new(),
+                observed_output: false,
                 file_extension,
                 file_snapshots: HashMap::new(),
             },
@@ -3623,9 +3625,11 @@ impl PromptState {
             .pending_command_output
             .remove(&call_id)
             .unwrap_or_default();
+        let observed_output = !pending_output.is_empty();
         let mut active_command = ActiveCommand {
             tool_call_id: tool_call_id.clone(),
             output: pending_output,
+            observed_output,
             file_extension,
             terminal_output,
             file_snapshots,
@@ -3695,6 +3699,7 @@ impl PromptState {
         // Stream output bytes to the display-only terminal via ToolCallUpdate meta.
         let data_str = String::from_utf8_lossy(&chunk).to_string();
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
+            active_command.observed_output |= !data_str.is_empty();
             if client.supports_terminal_output(active_command) {
                 let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
@@ -3743,6 +3748,24 @@ impl PromptState {
         }
     }
 
+    fn declined_command_reason(
+        status: &ExecCommandStatus,
+        observed_output: bool,
+        formatted_output: &str,
+        aggregated_output: &str,
+        stderr: &str,
+    ) -> Option<String> {
+        if status != &ExecCommandStatus::Declined || observed_output {
+            return None;
+        }
+
+        [formatted_output, aggregated_output, stderr]
+            .into_iter()
+            .map(str::trim)
+            .find(|output| !output.is_empty())
+            .map(str::to_string)
+    }
+
     async fn exec_command_end(&mut self, client: &SessionClient, event: ExecCommandEndEvent) {
         let raw_output = serde_json::json!(&event);
         let ExecCommandEndEvent {
@@ -3755,15 +3778,22 @@ impl PromptState {
             call_id,
             exit_code,
             stdout: _,
-            stderr: _,
-            aggregated_output: _,
+            stderr,
+            aggregated_output,
             duration: _,
-            formatted_output: _,
+            formatted_output,
             process_id: _,
             status,
             ..
         } = event;
         if let Some(active_command) = self.active_commands.remove(&call_id) {
+            let declined_reason = Self::declined_command_reason(
+                &status,
+                active_command.observed_output,
+                &formatted_output,
+                &aggregated_output,
+                &stderr,
+            );
             let is_success = exit_code == 0;
 
             let status = match status {
@@ -3782,19 +3812,24 @@ impl PromptState {
             let should_emit_accumulated_output = !client.supports_terminal_output(&active_command)
                 && !active_command.output.is_empty();
 
-            let content: Option<Vec<ToolCallContent>> =
-                if !exec_diffs.is_empty() || should_emit_accumulated_output {
-                    let mut items: Vec<ToolCallContent> = Vec::new();
-                    if client.supports_terminal_output(&active_command) {
-                        items.push(ToolCallContent::Terminal(Terminal::new(call_id.clone())));
-                    } else if !active_command.output.is_empty() {
-                        items.push(Self::command_output_content(&active_command).into());
-                    }
-                    items.extend(exec_diffs);
-                    Some(items)
-                } else {
-                    None
-                };
+            let content: Option<Vec<ToolCallContent>> = if !exec_diffs.is_empty()
+                || should_emit_accumulated_output
+                || declined_reason.is_some()
+            {
+                let mut items: Vec<ToolCallContent> = Vec::new();
+                if client.supports_terminal_output(&active_command) {
+                    items.push(ToolCallContent::Terminal(Terminal::new(call_id.clone())));
+                } else if !active_command.output.is_empty() {
+                    items.push(Self::command_output_content(&active_command).into());
+                }
+                items.extend(exec_diffs);
+                if let Some(reason) = declined_reason {
+                    items.push(reason.into());
+                }
+                Some(items)
+            } else {
+                None
+            };
 
             let fields = ToolCallUpdateFields::new()
                 .status(status)
@@ -3822,6 +3857,13 @@ impl PromptState {
         } else {
             // No later event can consume this buffer once the command has ended.
             self.pending_command_output.remove(&call_id);
+            let declined_reason = Self::declined_command_reason(
+                &status,
+                false,
+                &formatted_output,
+                &aggregated_output,
+                &stderr,
+            );
             let status = match status {
                 ExecCommandStatus::Completed if exit_code == 0 => ToolCallStatus::Completed,
                 ExecCommandStatus::Completed => ToolCallStatus::Failed,
@@ -3833,6 +3875,7 @@ impl PromptState {
                     call_id,
                     ToolCallUpdateFields::new()
                         .status(status)
+                        .content(declined_reason.map(|reason| vec![ToolCallContent::from(reason)]))
                         .raw_output(raw_output),
                 ),
                 "Running command",
@@ -3853,9 +3896,11 @@ impl PromptState {
             stdin,
         } = event;
 
+        let has_stdin = !stdin.is_empty();
         let stdin = format!("\n{stdin}\n");
         // Stream output bytes to the display-only terminal via ToolCallUpdate meta.
         if let Some(active_command) = self.active_commands.get_mut(&call_id) {
+            active_command.observed_output |= has_stdin;
             if client.supports_terminal_output(active_command) {
                 let update = ToolCallUpdate::new(
                     active_command.tool_call_id.clone(),
@@ -6435,6 +6480,9 @@ mod tests {
     use codex_features::Feature;
     use codex_protocol::config_types::ModeKind;
     use codex_protocol::models::AgentMessageInputContent;
+    use codex_shell_command::is_dangerous_command::{
+        DangerousCommandMatch, dangerous_command_match,
+    };
     use tokio::sync::{Mutex, mpsc::UnboundedSender};
 
     use super::*;
@@ -8759,6 +8807,163 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(windows))]
+    #[tokio::test]
+    async fn full_access_forced_rm_rejection_is_visible_without_permission_request()
+    -> anyhow::Result<()> {
+        const REJECTION_REASON: &str =
+            "rm -f style commands are not permitted. Use a safer approach";
+
+        let temp_dir =
+            std::env::temp_dir().join(format!("neverwrite-full-access-policy-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(&temp_dir)?;
+        let sentinel = temp_dir.join("sentinel.txt");
+        std::fs::write(&sentinel, "must survive")?;
+
+        let command = vec![
+            "rm".to_string(),
+            "-rf".to_string(),
+            temp_dir.display().to_string(),
+        ];
+        assert_eq!(
+            dangerous_command_match(&command),
+            Some(DangerousCommandMatch::ForcedRm)
+        );
+        let full_access = APPROVAL_PRESETS
+            .iter()
+            .find(|preset| preset.id == "full-access")
+            .expect("full access preset should exist");
+        assert!(matches!(
+            &full_access.approval,
+            codex_protocol::protocol::AskForApproval::Never
+        ));
+        assert!(matches!(
+            &full_access.permission_profile,
+            PermissionProfile::Disabled
+        ));
+
+        let session_id = SessionId::new("test");
+        let client = Arc::new(StubClient::new());
+        let session_client = SessionClient::with_client(session_id, client.clone(), Arc::default());
+        let thread = Arc::new(StubCodexThread::new());
+        let (resolution_tx, _resolution_rx) = mpsc::unbounded_channel();
+        let (response_tx, _response_rx) = oneshot::channel();
+        let mut state = PromptState::new(
+            "submission-1".to_string(),
+            thread,
+            resolution_tx,
+            response_tx,
+        );
+        let cwd = codex_utils_path_uri::PathUri::from_host_native_path(&temp_dir)
+            .expect("temporary directory should be representable as a path URI");
+
+        state
+            .exec_command_begin(
+                &session_client,
+                ExecCommandBeginEvent {
+                    call_id: "blocked-forced-rm".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    started_at_ms: 0,
+                    command: command.clone(),
+                    cwd: cwd.clone(),
+                    parsed_cmd: vec![ParsedCommand::Unknown {
+                        cmd: command.join(" "),
+                    }],
+                    source: Default::default(),
+                    interaction_input: None,
+                },
+            )
+            .await;
+        state
+            .exec_command_end(
+                &session_client,
+                ExecCommandEndEvent {
+                    call_id: "blocked-forced-rm".to_string(),
+                    process_id: None,
+                    turn_id: "turn-1".to_string(),
+                    completed_at_ms: 1,
+                    command,
+                    cwd,
+                    parsed_cmd: vec![],
+                    source: Default::default(),
+                    interaction_input: None,
+                    stdout: String::new(),
+                    stderr: REJECTION_REASON.to_string(),
+                    aggregated_output: REJECTION_REASON.to_string(),
+                    exit_code: -1,
+                    duration: std::time::Duration::ZERO,
+                    formatted_output: REJECTION_REASON.to_string(),
+                    status: ExecCommandStatus::Declined,
+                },
+            )
+            .await;
+
+        assert!(sentinel.exists(), "the rejected command must never execute");
+        assert_eq!(
+            client
+                .permission_requests
+                .load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "a definitive policy rejection must not become an ACP permission request"
+        );
+        let notifications = client.notifications.lock().unwrap();
+        let update = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update)
+                    if update.tool_call_id.0.as_ref() == "blocked-forced-rm" =>
+                {
+                    Some(update)
+                }
+                _ => None,
+            })
+            .expect("blocked command should emit a terminal tool update");
+        assert_eq!(update.fields.status, Some(ToolCallStatus::Failed));
+        let visible_reason = update
+            .fields
+            .content
+            .as_ref()
+            .and_then(|content| content.first())
+            .and_then(|content| match content {
+                ToolCallContent::Content(Content {
+                    content: ContentBlock::Text(TextContent { text, .. }),
+                    ..
+                }) => Some(text.as_str()),
+                _ => None,
+            });
+        assert_eq!(visible_reason, Some(REJECTION_REASON));
+        drop(notifications);
+
+        std::fs::remove_dir_all(temp_dir)?;
+        Ok(())
+    }
+
+    #[test]
+    fn declined_command_reason_is_not_duplicated_after_visible_output() {
+        let reason = "blocked by policy";
+        assert_eq!(
+            PromptState::declined_command_reason(
+                &ExecCommandStatus::Declined,
+                false,
+                reason,
+                "aggregated fallback",
+                "stderr fallback",
+            ),
+            Some(reason.to_string())
+        );
+        assert_eq!(
+            PromptState::declined_command_reason(
+                &ExecCommandStatus::Declined,
+                true,
+                reason,
+                "aggregated fallback",
+                "stderr fallback",
+            ),
+            None
+        );
+    }
+
     #[tokio::test]
     async fn early_command_output_is_replayed_to_terminal_clients() -> anyhow::Result<()> {
         let session_id = SessionId::new("test");
@@ -9341,12 +9546,14 @@ mod tests {
 
     struct StubClient {
         notifications: std::sync::Mutex<Vec<SessionNotification>>,
+        permission_requests: AtomicUsize,
     }
 
     impl StubClient {
         fn new() -> Self {
             StubClient {
                 notifications: std::sync::Mutex::default(),
+                permission_requests: AtomicUsize::new(0),
             }
         }
     }
@@ -9362,6 +9569,8 @@ mod tests {
             _args: RequestPermissionRequest,
         ) -> Pin<Box<dyn Future<Output = Result<RequestPermissionResponse, Error>> + Send + '_>>
         {
+            self.permission_requests
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             Box::pin(async { unimplemented!() })
         }
     }

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -46,9 +46,9 @@ use codex_protocol::protocol::{
     PatchApplyStatus, PatchApplyUpdatedEvent, PlanDeltaEvent, ReasoningContentDeltaEvent,
     ReasoningRawContentDeltaEvent, ReviewDecision, ReviewOutputEvent, ReviewRequest, ReviewTarget,
     StreamErrorEvent, TerminalInteractionEvent, ThreadGoalStatus, ThreadGoalUpdatedEvent,
-    ThreadSettingsOverrides, TokenCountEvent, TurnAbortedEvent, TurnCompleteEvent,
-    TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent, WebSearchBeginEvent,
-    WebSearchEndEvent,
+    ThreadSettingsOverrides, ThreadSettingsSnapshot, TokenCountEvent, TurnAbortedEvent,
+    TurnCompleteEvent, TurnStartedEvent, UserMessageEvent, ViewImageToolCallEvent, WarningEvent,
+    WebSearchBeginEvent, WebSearchEndEvent,
 };
 use codex_protocol::review_format::format_review_findings_block;
 use codex_protocol::{
@@ -5725,6 +5725,14 @@ impl<A: Auth> ThreadActor<A> {
     }
 
     async fn handle_event(&mut self, Event { id, msg }: Event) {
+        if let EventMsg::ThreadSettingsApplied(event) = &msg {
+            if let Err(error) = self.sync_config_with_thread_settings(&event.thread_settings) {
+                warn!("Failed to synchronize ACP session configuration: {error:?}");
+            } else {
+                self.maybe_emit_config_options_update().await;
+            }
+        }
+
         if let Some(submission) = self.submissions.get_mut(&id) {
             submission.handle_event(&self.client, msg).await;
         } else {
@@ -5744,6 +5752,32 @@ impl<A: Auth> ThreadActor<A> {
                 self.remember_closed_event_projection(id);
             }
         }
+    }
+
+    fn sync_config_with_thread_settings(
+        &mut self,
+        settings: &ThreadSettingsSnapshot,
+    ) -> Result<(), Error> {
+        self.config.cwd = settings.cwd.clone();
+        self.config.model = Some(settings.model.clone());
+        self.config.model_provider_id = settings.model_provider_id.clone();
+        self.config.model_reasoning_effort = settings.reasoning_effort.clone();
+        self.config.service_tier = settings.service_tier.clone();
+        self.config
+            .permissions
+            .approval_policy
+            .set(settings.approval_policy)
+            .map_err(Error::into_internal_error)?;
+        self.config
+            .permissions
+            .set_permission_profile_from_session_snapshot(
+                PermissionProfileSnapshot::from_session_snapshot(
+                    settings.permission_profile.clone(),
+                    settings.active_permission_profile.clone(),
+                ),
+            )
+            .map_err(Error::into_internal_error)?;
+        Ok(())
     }
 
     fn remember_closed_event_projection(&mut self, id: String) {
@@ -6478,8 +6512,11 @@ mod tests {
     };
     use codex_core::{config::ConfigOverrides, test_support::all_model_presets};
     use codex_features::Feature;
-    use codex_protocol::config_types::ModeKind;
     use codex_protocol::models::AgentMessageInputContent;
+    use codex_protocol::{
+        config_types::{CollaborationMode, ModeKind, Settings},
+        protocol::ThreadSettingsAppliedEvent,
+    };
     use codex_shell_command::is_dangerous_command::{
         DangerousCommandMatch, dangerous_command_match,
     };
@@ -9249,6 +9286,98 @@ mod tests {
         );
 
         Ok((actor, client, conversation))
+    }
+
+    fn thread_settings_applied_event(
+        config: &Config,
+        reasoning_effort: Option<ReasoningEffort>,
+    ) -> EventMsg {
+        let model = config
+            .model
+            .clone()
+            .expect("test configuration must select a model");
+        EventMsg::ThreadSettingsApplied(ThreadSettingsAppliedEvent {
+            thread_settings: ThreadSettingsSnapshot {
+                model: model.clone(),
+                model_provider_id: config.model_provider_id.clone(),
+                service_tier: config.service_tier.clone(),
+                approval_policy: config.permissions.approval_policy.get().clone(),
+                approvals_reviewer: config.approvals_reviewer.clone(),
+                permission_profile: config.permissions.permission_profile().clone(),
+                active_permission_profile: config.permissions.active_permission_profile().clone(),
+                cwd: config.cwd.clone(),
+                reasoning_effort: reasoning_effort.clone(),
+                reasoning_summary: None,
+                personality: config.personality.clone(),
+                collaboration_mode: CollaborationMode {
+                    mode: ModeKind::Default,
+                    settings: Settings {
+                        model,
+                        reasoning_effort,
+                        developer_instructions: None,
+                    },
+                },
+            },
+        })
+    }
+
+    #[tokio::test]
+    async fn thread_settings_clear_updates_live_config_once() -> anyhow::Result<()> {
+        let preset = all_model_presets()
+            .iter()
+            .find(|preset| {
+                preset
+                    .supported_reasoning_efforts
+                    .iter()
+                    .any(|effort| effort.effort != preset.default_reasoning_effort)
+            })
+            .expect("a preset with a non-default reasoning effort should exist")
+            .clone();
+        let persisted_effort = preset
+            .supported_reasoning_efforts
+            .iter()
+            .find(|effort| effort.effort != preset.default_reasoning_effort)
+            .expect("selected preset should expose a non-default effort")
+            .effort
+            .clone();
+
+        let (mut actor, client, _) = setup_actor(|config| {
+            config.model = Some(preset.model.clone());
+            config.model_reasoning_effort = Some(persisted_effort.clone());
+        })
+        .await?;
+
+        actor
+            .handle_event(Event {
+                id: "settings-clear".to_string(),
+                msg: thread_settings_applied_event(&actor.config, None),
+            })
+            .await;
+
+        assert_eq!(actor.config.model_reasoning_effort, None);
+
+        actor
+            .handle_event(Event {
+                id: "settings-clear-repeat".to_string(),
+                msg: thread_settings_applied_event(&actor.config, None),
+            })
+            .await;
+
+        let config_updates = client
+            .notifications
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|notification| {
+                matches!(notification.update, SessionUpdate::ConfigOptionUpdate(_))
+            })
+            .count();
+        assert_eq!(
+            config_updates, 1,
+            "a repeated snapshot must not re-emit options"
+        );
+
+        Ok(())
     }
 
     struct StubAuth;

--- a/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
+++ b/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 license = "Apache-2.0"
 name = "codex-utils-pty"
-version = "0.144.0"
+version = "0.144.6"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
## Summary

- Promote the embedded OpenAI Codex Rust runtime to `rust-v0.144.6`, resolved in the lockfile to `5d1fbf26c43abc65a203928b2e31561cb039e06d`, with the matching local `codex-utils-pty` `0.144.6` snapshot.
- Preserve the existing adapter and ACP protocol boundaries: `codex-acp` remains `0.16.0`, its vendored ACP SDK remains `0.14.0`, and the native backend remains on ACP Rust `1.2.0` over serialized ACP.
- Project definitive dangerous-command policy rejections as terminal failed ACP tool activities with their visible reason, never as a permission request.
- Synchronize an explicit clearing of reasoning effort from thread metadata so load, resume, and fork cannot retain a stale setting.
- Cover dynamic context-window metadata with the 272K regression cases for Sol, Terra, and Luna without baking that limit into production behavior.
- Replace the startup-only packaged code-mode smoke with a deterministic functional ACP turn through the exact packaged `codex-code-mode-host` and a local Responses mock.
- Document the reproducible runtime baseline, the packaged-smoke execution matrix, the unchanged compatibility boundaries, the App Server follow-up, and the atomic rollback procedure.

## Full Access dangerous-command behavior

OpenAI Codex `rust-v0.144.6` changes the behavior of dangerous-command heuristics under Full Access. Forced removal commands such as `rm -f` and `rm -rf` were already classified as dangerous in `rust-v0.144.0`, but the earlier runtime allowed them when approvals and the sandbox were explicitly disabled. In `rust-v0.144.6`, an unmatched dangerous command is rejected when Full Access combines `AskForApproval::Never` with `PermissionProfile::Disabled`. Since approval prompts are disabled, the rejection is definitive rather than an ACP permission request.

The newer runtime also recognizes more forced-removal forms, including `--force`, combined force flags, absolute executable paths, and commands reached through wrappers such as `sudo`, `env`, `trap`, or literal nested shell scripts. This PR does not introduce or remove that upstream policy. It preserves the runtime decision and makes its rejection reason available as a failed ACP tool activity.

## Local opt-out with Codex command rules

A runtime fork is not required to authorize trusted command prefixes locally. Codex loads execution-policy files from the active configuration layers, including `~/.codex/rules/default.rules`. A user can explicitly allow direct `rm` invocations with:

```python
prefix_rule(
    pattern = ["rm"],
    decision = "allow",
    justification = "Explicitly allowed by the user for full-access sessions",
)
```

Rules match command argument prefixes. Separate rules may therefore be required for forms that use an absolute executable path or a wrapper, for example:

```python
prefix_rule(pattern = ["/bin/rm"], decision = "allow")
prefix_rule(pattern = ["env", "rm"], decision = "allow")
prefix_rule(pattern = ["sudo", "rm"], decision = "allow")
```

Restart the Codex-backed session after changing the rules so the active configuration is reloaded. Rules are currently experimental, and the most restrictive matching decision wins (`forbidden` > `prompt` > `allow`). Managed or project-level policy can therefore continue to forbid a command even when the user layer contains an `allow` rule. Broad `rm` rules grant significant destructive capability and should only be added deliberately; narrower argument prefixes are preferable where practical.

For interactive handling instead, a session using `approval_policy = "on-request"` can prompt for dangerous commands. Full Access uses `approval_policy = "never"`, so unmatched dangerous commands cannot prompt and are rejected unless an explicit execution-policy rule allows them.

A downstream runtime patch remains an option only if the product needs to remove the heuristic globally or expose semantics that cannot be expressed with command rules. Such a safety-boundary change should remain separate from this runtime promotion.

## Known UI limitation

The runtime rejection reaches the agent, but a real Full Access session showed that some pre-execution rejections do not currently persist as individual failed terminal activities. In that path, the user only sees the rejection if the agent reports it in its final response. The ACP projection tests in this PR cover declined command-end events, but they do not yet prove that every upstream pre-execution rejection produces a durable failed activity in the application UI.

## Validation

- `git diff --check`
- `cd apps/desktop && npm run electron:sidecar:smoke:packaged`
