### PR TITLE
Match live preview code fences to chat styling

### DIFF
--- a/apps/desktop/src/features/ai/components/MarkdownContent.tsx
+++ b/apps/desktop/src/features/ai/components/MarkdownContent.tsx
@@ -41,6 +41,7 @@ import {
     getChatCodeLabelFontSize,
 } from "./chatCodeSizing";
 import { extractFenceLanguageToken } from "../../editor/codeLanguage";
+import { formatCodeFenceLanguageLabel } from "../../editor/codeFencePresentation";
 import { HighlightedCodeText } from "../../editor/staticCodeHighlight";
 import { useMarkdownCodeLanguageSupport } from "../../editor/useCodeLanguageSupport";
 import {
@@ -1414,69 +1415,6 @@ function TextBlock({
     );
 }
 
-const codeLanguageLabels: Record<string, string> = {
-    bash: "Bash",
-    c: "C",
-    "c++": "C++",
-    cpp: "C++",
-    cs: "C#",
-    csharp: "C#",
-    css: "CSS",
-    diff: "Diff",
-    docker: "Dockerfile",
-    dockerfile: "Dockerfile",
-    gql: "GraphQL",
-    graphql: "GraphQL",
-    html: "HTML",
-    java: "Java",
-    javascript: "JavaScript",
-    js: "JavaScript",
-    json: "JSON",
-    jsonc: "JSONC",
-    jsx: "JSX",
-    make: "Makefile",
-    makefile: "Makefile",
-    markdown: "Markdown",
-    md: "Markdown",
-    mdx: "MDX",
-    php: "PHP",
-    powershell: "PowerShell",
-    ps1: "PowerShell",
-    pwsh: "PowerShell",
-    py: "Python",
-    python: "Python",
-    rb: "Ruby",
-    rs: "Rust",
-    ruby: "Ruby",
-    rust: "Rust",
-    scss: "SCSS",
-    sh: "Shell",
-    shell: "Shell",
-    sql: "SQL",
-    text: "Text",
-    ts: "TypeScript",
-    tsx: "TSX",
-    typescript: "TypeScript",
-    xml: "XML",
-    yaml: "YAML",
-    yml: "YAML",
-    zsh: "Zsh",
-};
-
-function formatCodeLanguageLabel(language?: string) {
-    const normalizedLanguage = language?.trim().toLowerCase();
-    if (!normalizedLanguage) return undefined;
-
-    return (
-        codeLanguageLabels[normalizedLanguage] ??
-        normalizedLanguage
-            .split(/[-_]+/)
-            .filter(Boolean)
-            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
-            .join(" ")
-    );
-}
-
 function CodeBlock({
     content,
     info,
@@ -1495,9 +1433,7 @@ function CodeBlock({
     const languageSupport = useMarkdownCodeLanguageSupport(info);
     const languageToken = extractFenceLanguageToken(info ?? "");
     const normalizedLanguage = languageToken?.toLowerCase();
-    const languageLabel = formatCodeLanguageLabel(
-        languageToken ?? info?.trim(),
-    );
+    const languageLabel = formatCodeFenceLanguageLabel(info);
     const isMarkdownFence =
         normalizedLanguage === "markdown" || normalizedLanguage === "md";
     const isUnifiedDiff =

--- a/apps/desktop/src/features/editor/codeFencePresentation.ts
+++ b/apps/desktop/src/features/editor/codeFencePresentation.ts
@@ -1,0 +1,64 @@
+import { extractFenceLanguageToken } from "./codeLanguage";
+
+const codeLanguageLabels: Record<string, string> = {
+    bash: "Bash",
+    c: "C",
+    "c++": "C++",
+    cpp: "C++",
+    cs: "C#",
+    csharp: "C#",
+    css: "CSS",
+    diff: "Diff",
+    docker: "Dockerfile",
+    dockerfile: "Dockerfile",
+    gql: "GraphQL",
+    graphql: "GraphQL",
+    html: "HTML",
+    java: "Java",
+    javascript: "JavaScript",
+    js: "JavaScript",
+    json: "JSON",
+    jsonc: "JSONC",
+    jsx: "JSX",
+    make: "Makefile",
+    makefile: "Makefile",
+    markdown: "Markdown",
+    md: "Markdown",
+    mdx: "MDX",
+    php: "PHP",
+    powershell: "PowerShell",
+    ps1: "PowerShell",
+    pwsh: "PowerShell",
+    py: "Python",
+    python: "Python",
+    rb: "Ruby",
+    rs: "Rust",
+    ruby: "Ruby",
+    rust: "Rust",
+    scss: "SCSS",
+    sh: "Shell",
+    shell: "Shell",
+    sql: "SQL",
+    text: "Text",
+    ts: "TypeScript",
+    tsx: "TSX",
+    typescript: "TypeScript",
+    xml: "XML",
+    yaml: "YAML",
+    yml: "YAML",
+    zsh: "Zsh",
+};
+
+export function formatCodeFenceLanguageLabel(info?: string) {
+    const language = extractFenceLanguageToken(info ?? "");
+    if (!language) return undefined;
+
+    return (
+        codeLanguageLabels[language] ??
+        language
+            .split(/[-_]+/)
+            .filter(Boolean)
+            .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+            .join(" ")
+    );
+}

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.test.ts
@@ -167,7 +167,7 @@ describe("code block live preview", () => {
         expect(view.dom.querySelector(".cm-mermaid-preview")).not.toBeNull();
         expect(headers).toHaveLength(1);
         expect(headers[0].dataset.codeBlockKind).toBe("code");
-        expect(headers[0].textContent).toContain("ts");
+        expect(headers[0].textContent).toContain("TypeScript");
 
         view.destroy();
         parent.remove();
@@ -433,7 +433,7 @@ describe("code block live preview", () => {
         parent.remove();
     });
 
-    it("shows the code block header even when the caret is on the fence line", () => {
+    it("shows the compact code frame even when the caret is on the fence line", () => {
         const parent = document.createElement("div");
         document.body.appendChild(parent);
 
@@ -455,8 +455,34 @@ describe("code block live preview", () => {
 
         const header = view.dom.querySelector(".cm-code-block-header");
         expect(header).not.toBeNull();
-        expect(header?.textContent).toContain("ts");
-        expect(header?.textContent).toContain("Copy");
+        expect(header?.textContent).toContain("TypeScript");
+        expect(header?.textContent).not.toContain("Copy");
+        const copyButton = header?.querySelector<HTMLButtonElement>(
+            '.cm-code-block-copy[aria-label="Copy code block"]',
+        );
+        expect(copyButton?.title).toBe("Copy");
+        expect(copyButton?.querySelector("svg")).not.toBeNull();
+
+        view.destroy();
+        parent.remove();
+    });
+
+    it("matches the chat treatment for unlabeled code fences", () => {
+        const parent = document.createElement("div");
+        document.body.appendChild(parent);
+
+        const view = new EditorView({
+            state: createLivePreviewState("```\nplain text\n```"),
+            parent,
+        });
+
+        expect(view.dom.querySelector(".cm-code-block-lang")).toBeNull();
+        expect(
+            view.dom.querySelector(".cm-code-block-header-unlabeled"),
+        ).not.toBeNull();
+        expect(
+            view.dom.querySelector(".cm-code-block-line-unlabeled"),
+        ).not.toBeNull();
 
         view.destroy();
         parent.remove();

--- a/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewBlocks.ts
@@ -53,6 +53,7 @@ import {
     renderEmbedPreview,
 } from "./notePreviewSource";
 import { renderMermaidDiagram } from "../mermaid/mermaidRenderer";
+import { formatCodeFenceLanguageLabel } from "../codeFencePresentation";
 
 const IMAGE_EXTENSIONS = /\.(png|jpe?g|gif|svg|webp|bmp|ico|avif)([?#].*)?$/i;
 const PDF_EXTENSION = /\.pdf([?#].*)?$/i;
@@ -87,7 +88,6 @@ type FencedCodeBlockKind = "code" | "mermaid";
 type FencedCodeBlockPreview = {
     kind: FencedCodeBlockKind;
     info: string;
-    language: string;
     code: string;
     hasContent: boolean;
     openEnd: number;
@@ -848,19 +848,19 @@ class NoteEmbedWidget extends WidgetType {
 
 class CodeBlockHeaderWidget extends WidgetType {
     private kind: FencedCodeBlockKind;
-    private language: string;
+    private languageLabel: string | undefined;
     private code: string;
     private hasContent: boolean;
 
     constructor(
         kind: FencedCodeBlockKind,
-        language: string,
+        languageLabel: string | undefined,
         code: string,
         hasContent: boolean,
     ) {
         super();
         this.kind = kind;
-        this.language = language;
+        this.languageLabel = languageLabel;
         this.code = code;
         this.hasContent = hasContent;
     }
@@ -868,7 +868,7 @@ class CodeBlockHeaderWidget extends WidgetType {
     eq(other: CodeBlockHeaderWidget) {
         return (
             this.kind === other.kind &&
-            this.language === other.language &&
+            this.languageLabel === other.languageLabel &&
             this.code === other.code &&
             this.hasContent === other.hasContent
         );
@@ -879,35 +879,51 @@ class CodeBlockHeaderWidget extends WidgetType {
         // CodeMirror block widgets are not included in its height map, which
         // makes pointer-to-caret mapping drift after repeated code cards.
         const shell = document.createElement("div");
-        shell.className = "cm-code-block-header-shell";
+        shell.className = [
+            "cm-code-block-header-shell",
+            this.languageLabel ? "" : "cm-code-block-header-shell-unlabeled",
+            !this.languageLabel && !this.hasContent
+                ? "cm-code-block-header-shell-unlabeled-empty"
+                : "",
+        ]
+            .filter(Boolean)
+            .join(" ");
         shell.setAttribute("contenteditable", "false");
 
         const bar = document.createElement("div");
-        bar.className = this.hasContent
-            ? "cm-code-block-header"
-            : "cm-code-block-header cm-code-block-header-only";
+        bar.className = [
+            "cm-code-block-header",
+            this.hasContent ? "" : "cm-code-block-header-only",
+            this.languageLabel ? "" : "cm-code-block-header-unlabeled",
+        ]
+            .filter(Boolean)
+            .join(" ");
         bar.dataset.codeBlockKind = this.kind;
         bar.setAttribute("contenteditable", "false");
 
-        const lang = document.createElement("span");
-        lang.className = "cm-code-block-lang";
-        lang.textContent = this.language || "text";
+        if (this.languageLabel) {
+            const lang = document.createElement("span");
+            lang.className = "cm-code-block-lang";
+            lang.textContent = this.languageLabel;
+            bar.appendChild(lang);
+        }
 
         const copyBtn = document.createElement("button");
         copyBtn.className = "cm-code-block-copy";
-        copyBtn.textContent = "Copy";
+        copyBtn.type = "button";
+        copyBtn.setAttribute("aria-label", "Copy code block");
+        setCodeBlockCopyButtonState(copyBtn, false);
         copyBtn.addEventListener("click", (e) => {
             e.preventDefault();
             e.stopPropagation();
             void navigator.clipboard.writeText(this.code).then(() => {
-                copyBtn.textContent = "Copied!";
+                setCodeBlockCopyButtonState(copyBtn, true);
                 setTimeout(() => {
-                    copyBtn.textContent = "Copy";
-                }, 1500);
+                    setCodeBlockCopyButtonState(copyBtn, false);
+                }, 1200);
             });
         });
 
-        bar.appendChild(lang);
         bar.appendChild(copyBtn);
         shell.appendChild(bar);
         return shell;
@@ -916,6 +932,49 @@ class CodeBlockHeaderWidget extends WidgetType {
     ignoreEvent() {
         return true;
     }
+}
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+function createCodeBlockCopyIcon(copied: boolean) {
+    const svg = document.createElementNS(SVG_NAMESPACE, "svg");
+    svg.setAttribute("width", "11");
+    svg.setAttribute("height", "11");
+    svg.setAttribute("viewBox", "0 0 14 14");
+    svg.setAttribute("fill", "none");
+    svg.setAttribute("stroke", "currentColor");
+    svg.setAttribute("stroke-width", "1.5");
+    svg.setAttribute("stroke-linecap", "round");
+    svg.setAttribute("stroke-linejoin", "round");
+    svg.setAttribute("aria-hidden", "true");
+
+    if (copied) {
+        const check = document.createElementNS(SVG_NAMESPACE, "path");
+        check.setAttribute("d", "M3 7l2.2 2.2L11 3.8");
+        svg.appendChild(check);
+        return svg;
+    }
+
+    const copy = document.createElementNS(SVG_NAMESPACE, "rect");
+    copy.setAttribute("x", "5");
+    copy.setAttribute("y", "3");
+    copy.setAttribute("width", "6");
+    copy.setAttribute("height", "8");
+    copy.setAttribute("rx", "1.2");
+
+    const underlay = document.createElementNS(SVG_NAMESPACE, "path");
+    underlay.setAttribute("d", "M3.5 9.5H3A1 1 0 012 8.5v-5A1.5 1.5 0 013.5 2H8");
+    svg.append(copy, underlay);
+    return svg;
+}
+
+function setCodeBlockCopyButtonState(
+    button: HTMLButtonElement,
+    copied: boolean,
+) {
+    button.dataset.copied = copied ? "true" : "false";
+    button.title = copied ? "Copied" : "Copy";
+    button.replaceChildren(createCodeBlockCopyIcon(copied));
 }
 
 class MermaidDiagramWidget extends WidgetType {
@@ -999,6 +1058,12 @@ const codeBlockLineLast = Decoration.line({
 });
 const codeBlockLineOnly = Decoration.line({
     class: "cm-code-block-line cm-code-block-line-first cm-code-block-line-last",
+});
+const codeBlockLineFirstUnlabeled = Decoration.line({
+    class: "cm-code-block-line cm-code-block-line-first cm-code-block-line-unlabeled",
+});
+const codeBlockLineOnlyUnlabeled = Decoration.line({
+    class: "cm-code-block-line cm-code-block-line-first cm-code-block-line-last cm-code-block-line-unlabeled",
 });
 const mermaidBlockSourceHidden = Decoration.line({
     class: "cm-code-block-fence-hidden cm-mermaid-source-hidden",
@@ -1091,7 +1156,6 @@ function getFencedCodeBlockPreview(
     return {
         kind: getFencedCodeBlockKind(info),
         info,
-        language: info,
         code,
         hasContent,
         openEnd,
@@ -1119,8 +1183,6 @@ function buildCodeBlockDecorations(
             ) {
                 return;
             }
-
-            const showHeader = true;
 
             const openLine = state.doc.lineAt(node.from);
 
@@ -1160,22 +1222,23 @@ function buildCodeBlockDecorations(
                 return;
             }
 
-            if (showHeader) {
-                decos.push({
-                    from: node.from,
-                    to: node.from,
-                    deco: Decoration.widget({
-                        widget: new CodeBlockHeaderWidget(
-                            previewBlock.kind,
-                            previewBlock.language,
-                            previewBlock.code,
-                            previewBlock.hasContent,
-                        ),
-                        block: true,
-                        side: -1,
-                    }),
-                });
-            }
+            const languageLabel = formatCodeFenceLanguageLabel(
+                previewBlock.info,
+            );
+            decos.push({
+                from: node.from,
+                to: node.from,
+                deco: Decoration.widget({
+                    widget: new CodeBlockHeaderWidget(
+                        previewBlock.kind,
+                        languageLabel,
+                        previewBlock.code,
+                        previewBlock.hasContent,
+                    ),
+                    block: true,
+                    side: -1,
+                }),
+            });
 
             // Collapse the opening fence line (```lang) so it takes no space
             decos.push({
@@ -1203,12 +1266,17 @@ function buildCodeBlockDecorations(
                 const isFirst =
                     lineNum === previewBlock.firstContentLineNumber;
                 const isLast = lineNum === previewBlock.lastContentLineNumber;
-                const needFirst = isFirst && !showHeader;
 
                 let deco: Decoration;
-                if (needFirst && isLast) deco = codeBlockLineOnly;
-                else if (needFirst) deco = codeBlockLineFirst;
-                else if (isLast) deco = codeBlockLineLast;
+                if (isFirst && isLast) {
+                    deco = languageLabel
+                        ? codeBlockLineOnly
+                        : codeBlockLineOnlyUnlabeled;
+                } else if (isFirst) {
+                    deco = languageLabel
+                        ? codeBlockLineFirst
+                        : codeBlockLineFirstUnlabeled;
+                } else if (isLast) deco = codeBlockLineLast;
                 else deco = codeBlockLine;
 
                 decos.push({ from: line.from, to: line.from, deco });

--- a/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
+++ b/apps/desktop/src/features/editor/extensions/livePreviewTheme.ts
@@ -849,61 +849,6 @@ export const livePreviewTheme = EditorView.baseTheme({
         fontSize: "0",
         overflow: "hidden",
     },
-    ".cm-code-block-header-shell": {
-        paddingTop: "8px",
-    },
-    ".cm-code-block-header": {
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        padding: "6px 12px",
-        background:
-            "color-mix(in srgb, var(--bg-tertiary) 80%, var(--bg-secondary))",
-        borderRadius: "8px 8px 0 0",
-        border: "1px solid var(--border)",
-        borderBottom: "none",
-        fontSize: "0.78em",
-        color: "var(--text-secondary)",
-    },
-    ".cm-code-block-header-only": {
-        borderBottom: "1px solid var(--border)",
-        borderRadius: "8px",
-    },
-    ".cm-code-block-lang": {
-        fontWeight: "600",
-        textTransform: "uppercase",
-        letterSpacing: "0.05em",
-    },
-    ".cm-code-block-copy": {
-        background: "none",
-        border: "1px solid var(--border)",
-        borderRadius: "4px",
-        padding: "2px 8px",
-        color: "var(--text-secondary)",
-        cursor: "pointer",
-        fontSize: "0.9em",
-    },
-    ".cm-code-block-copy:hover": {
-        background:
-            "color-mix(in srgb, var(--bg-secondary) 60%, var(--bg-tertiary))",
-    },
-    ".cm-code-block-line": {
-        background:
-            "color-mix(in srgb, var(--bg-tertiary) 50%, var(--bg-primary)) !important",
-        borderLeft: "1px solid var(--border)",
-        borderRight: "1px solid var(--border)",
-        paddingLeft: "12px !important",
-    },
-    ".cm-code-block-line-first": {
-        borderTop: "1px solid var(--border)",
-        borderRadius: "8px 8px 0 0",
-        paddingTop: "8px !important",
-    },
-    ".cm-code-block-line-last": {
-        borderBottom: "1px solid var(--border)",
-        borderRadius: "0 0 8px 8px",
-        paddingBottom: "8px !important",
-    },
     ".cm-mermaid-preview": {
         margin: "12px 0",
         maxWidth: "100%",

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -630,22 +630,38 @@ html[data-desktop-platform="windows"].dark {
     overflow-wrap: anywhere;
 }
 
-/* Code fences and streamed plans share one compact terminal-like surface. */
+/* Chat and Markdown live preview share one compact code-fence surface. */
+:root {
+    --code-fence-background: color-mix(
+        in srgb,
+        var(--bg-tertiary) 68%,
+        transparent
+    );
+    --code-fence-border-color: color-mix(
+        in srgb,
+        var(--border) 82%,
+        transparent
+    );
+    --code-fence-radius: 6px;
+    --code-fence-inline-size: min(100%, 68ch);
+}
+
 .chat-code-frame,
 .chat-plan-frame {
     /* Keep fenced content at a readable measure without overflowing narrow chat panes. */
-    inline-size: min(100%, 68ch);
+    inline-size: var(--code-fence-inline-size);
     margin-inline: auto;
-    border: 1px solid color-mix(in srgb, var(--border) 82%, transparent);
-    border-radius: 6px;
-    background: color-mix(in srgb, var(--bg-tertiary) 68%, transparent);
+    border: 1px solid var(--code-fence-border-color);
+    border-radius: var(--code-fence-radius);
+    background: var(--code-fence-background);
 }
 
 .chat-plan-frame {
     font-family: var(--font-mono), ui-monospace, monospace;
 }
 
-.chat-code-header {
+.chat-code-header,
+.cm-code-block-header {
     display: flex;
     min-height: 2.45em;
     align-items: center;
@@ -654,6 +670,73 @@ html[data-desktop-platform="windows"].dark {
     font-family: var(--font-mono);
     font-weight: 600;
     padding: 0.18em 2.75em 0 1em;
+}
+
+.cm-code-block-header-shell,
+.cm-code-block-line {
+    box-sizing: border-box;
+    inline-size: var(--code-fence-inline-size);
+    margin-inline: auto;
+}
+
+.cm-code-block-header-shell {
+    padding-top: 0.25rem;
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.93em;
+}
+
+.cm-code-block-header {
+    justify-content: space-between;
+    padding-right: 0.55em;
+    border: 1px solid var(--code-fence-border-color);
+    border-bottom: 0;
+    border-radius: var(--code-fence-radius) var(--code-fence-radius) 0 0;
+    background: var(--code-fence-background);
+    /* The shell matches the code body metrics so their 68ch widths align. */
+    font-size: 0.84em;
+}
+
+.cm-code-block-header-only {
+    border-bottom: 1px solid var(--code-fence-border-color);
+    border-radius: var(--code-fence-radius);
+}
+
+.cm-code-block-header-shell-unlabeled {
+    position: relative;
+    z-index: 10;
+    height: 0;
+    padding-top: 0;
+    pointer-events: none;
+}
+
+.cm-code-block-header-unlabeled {
+    position: absolute;
+    top: 0.55em;
+    right: 0.55em;
+    min-height: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
+}
+
+.cm-code-block-header-unlabeled .cm-code-block-copy {
+    pointer-events: auto;
+}
+
+.cm-code-block-header-shell-unlabeled-empty {
+    height: auto;
+    padding-top: 0.25rem;
+}
+
+.cm-code-block-header-unlabeled.cm-code-block-header-only {
+    position: static;
+    min-height: 2.45em;
+    justify-content: flex-end;
+    padding: 0.18em 0.55em 0;
+    border: 1px solid var(--code-fence-border-color);
+    border-radius: var(--code-fence-radius);
+    background: var(--code-fence-background);
+    pointer-events: auto;
 }
 
 .chat-code-actions {
@@ -688,7 +771,12 @@ html[data-desktop-platform="windows"].dark {
     border-radius: 2px;
 }
 
-.chat-code-copy-button {
+.chat-code-copy-button,
+.cm-code-block-copy {
+    display: inline-flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
     width: 20px;
     height: 20px;
     border: 0;
@@ -701,14 +789,24 @@ html[data-desktop-platform="windows"].dark {
         opacity 100ms ease;
 }
 
-.chat-code-copy-button:hover {
+.chat-code-copy-button:hover,
+.cm-code-block-copy:hover {
     color: var(--text-primary) !important;
     opacity: 1;
 }
 
-.chat-code-copy-button:focus-visible {
+.chat-code-copy-button:focus-visible,
+.cm-code-block-copy:focus-visible {
     outline: 2px solid color-mix(in srgb, var(--accent) 42%, transparent);
     outline-offset: 2px;
+}
+
+.cm-code-block-copy {
+    color: var(--text-secondary);
+}
+
+.cm-code-block-copy[data-copied="true"] {
+    color: var(--accent);
 }
 
 .chat-code-block {
@@ -723,6 +821,37 @@ html[data-desktop-platform="windows"].dark {
 .chat-code-frame--unlabeled .chat-code-block {
     padding-top: 0.85em;
     padding-right: 2.75em;
+}
+
+.cm-code-block-line {
+    padding-right: 1em !important;
+    padding-left: 1em !important;
+    border-right: 1px solid var(--code-fence-border-color);
+    border-left: 1px solid var(--code-fence-border-color);
+    background: var(--code-fence-background) !important;
+    font-family: var(--font-mono), ui-monospace, monospace;
+    font-size: 0.93em;
+}
+
+.cm-code-block-line-first {
+    padding-top: 0.3em !important;
+}
+
+.cm-code-block-line-unlabeled {
+    padding-top: 0.85em !important;
+    padding-right: 2.75em !important;
+    border-top: 1px solid var(--code-fence-border-color);
+    border-radius: var(--code-fence-radius) var(--code-fence-radius) 0 0;
+}
+
+.cm-code-block-line-last {
+    padding-bottom: 0.85em !important;
+    border-bottom: 1px solid var(--code-fence-border-color);
+    border-radius: 0 0 var(--code-fence-radius) var(--code-fence-radius);
+}
+
+.cm-code-block-line-unlabeled.cm-code-block-line-last {
+    border-radius: var(--code-fence-radius);
 }
 
 body.resizing-sidebar,


### PR DESCRIPTION
## Summary
- align Markdown live preview code fences with the chat code frame
- share language labels, surface tokens, and copy interaction

## Validation
- 101 targeted tests
- ESLint
- production build
- visual checks in light and dark themes