### PR TITLE
Fix CSS Custom Highlight API build warnings

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -8295,9 +8295,9 @@
             }
         },
         "node_modules/lightningcss": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
-            "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+            "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
             "dev": true,
             "license": "MPL-2.0",
             "dependencies": {
@@ -8311,23 +8311,23 @@
                 "url": "https://opencollective.com/parcel"
             },
             "optionalDependencies": {
-                "lightningcss-android-arm64": "1.32.0",
-                "lightningcss-darwin-arm64": "1.32.0",
-                "lightningcss-darwin-x64": "1.32.0",
-                "lightningcss-freebsd-x64": "1.32.0",
-                "lightningcss-linux-arm-gnueabihf": "1.32.0",
-                "lightningcss-linux-arm64-gnu": "1.32.0",
-                "lightningcss-linux-arm64-musl": "1.32.0",
-                "lightningcss-linux-x64-gnu": "1.32.0",
-                "lightningcss-linux-x64-musl": "1.32.0",
-                "lightningcss-win32-arm64-msvc": "1.32.0",
-                "lightningcss-win32-x64-msvc": "1.32.0"
+                "lightningcss-android-arm64": "1.33.0",
+                "lightningcss-darwin-arm64": "1.33.0",
+                "lightningcss-darwin-x64": "1.33.0",
+                "lightningcss-freebsd-x64": "1.33.0",
+                "lightningcss-linux-arm-gnueabihf": "1.33.0",
+                "lightningcss-linux-arm64-gnu": "1.33.0",
+                "lightningcss-linux-arm64-musl": "1.33.0",
+                "lightningcss-linux-x64-gnu": "1.33.0",
+                "lightningcss-linux-x64-musl": "1.33.0",
+                "lightningcss-win32-arm64-msvc": "1.33.0",
+                "lightningcss-win32-x64-msvc": "1.33.0"
             }
         },
         "node_modules/lightningcss-android-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-            "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+            "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
             "cpu": [
                 "arm64"
             ],
@@ -8346,9 +8346,9 @@
             }
         },
         "node_modules/lightningcss-darwin-arm64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-            "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+            "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
             "cpu": [
                 "arm64"
             ],
@@ -8367,9 +8367,9 @@
             }
         },
         "node_modules/lightningcss-darwin-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-            "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+            "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
             "cpu": [
                 "x64"
             ],
@@ -8388,9 +8388,9 @@
             }
         },
         "node_modules/lightningcss-freebsd-x64": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-            "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+            "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
             "cpu": [
                 "x64"
             ],
@@ -8409,9 +8409,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm-gnueabihf": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-            "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+            "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
             "cpu": [
                 "arm"
             ],
@@ -8430,9 +8430,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-            "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+            "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
             "cpu": [
                 "arm64"
             ],
@@ -8451,9 +8451,9 @@
             }
         },
         "node_modules/lightningcss-linux-arm64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-            "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+            "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
             "cpu": [
                 "arm64"
             ],
@@ -8472,9 +8472,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-gnu": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
-            "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+            "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
             "cpu": [
                 "x64"
             ],
@@ -8493,9 +8493,9 @@
             }
         },
         "node_modules/lightningcss-linux-x64-musl": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-            "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+            "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
             "cpu": [
                 "x64"
             ],
@@ -8514,9 +8514,9 @@
             }
         },
         "node_modules/lightningcss-win32-arm64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-            "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+            "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
             "cpu": [
                 "arm64"
             ],
@@ -8535,9 +8535,9 @@
             }
         },
         "node_modules/lightningcss-win32-x64-msvc": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-            "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+            "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
             "cpu": [
                 "x64"
             ],

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -125,6 +125,7 @@
         "mermaid": {
             "uuid": "14.0.0"
         },
+        "lightningcss": "1.33.0",
         "react": "$react",
         "react-dom": "$react-dom",
         "react-resize-detector": "12.3.0"


### PR DESCRIPTION
## Summary
- override Lightning CSS to version 1.33.0 for the desktop build
- use the upstream release that supports `::highlight()` selectors

Closes #285

## Verification
- `npm run build` (from `apps/desktop`)
- confirmed the production-build output contains no `::highlight()` warnings