### PR TITLE
Separate development and release desktop identities

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ npm install
 npm run dev
 ```
 
+Local development runs as **NeverWrite Dev** with its own application profile, so an installed NeverWrite release can remain open at the same time. Files and hidden state inside a vault remain shared when both variants open that vault; use a disposable vault when testing write or review flows concurrently.
+
 The first start builds the native backend. Configure your preferred agent from the app settings; some providers require their own CLI login or API key.
 
 ## Development

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -126,6 +126,7 @@ const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
 const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
 const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
+const RUNTIME_SECRET_SERVICE_ENV: &str = "NEVERWRITE_AI_SECRET_SERVICE";
 const RUNTIME_SECRET_STORE_MODE_ENV: &str = "NEVERWRITE_AI_SECRET_STORE";
 const LEGACY_GEMINI_RUNTIME_ID: &str = "gemini-acp";
 const LEGACY_GEMINI_SECRET_ENV_KEYS: &[&str] = &["GEMINI_API_KEY", "GOOGLE_API_KEY"];
@@ -397,12 +398,22 @@ trait RuntimeSecretStore: Send + Sync {
 }
 
 #[derive(Debug)]
-struct OsRuntimeSecretStore;
+struct OsRuntimeSecretStore {
+    service_name: String,
+}
 
 impl OsRuntimeSecretStore {
-    fn entry(runtime_id: &str, env_key: &str) -> Result<keyring::Entry, String> {
+    fn from_env() -> Self {
+        Self {
+            service_name: runtime_secret_service_name(
+                std::env::var(RUNTIME_SECRET_SERVICE_ENV).ok().as_deref(),
+            ),
+        }
+    }
+
+    fn entry(&self, runtime_id: &str, env_key: &str) -> Result<keyring::Entry, String> {
         keyring::Entry::new(
-            RUNTIME_SECRET_SERVICE,
+            &self.service_name,
             &runtime_secret_account(runtime_id, env_key),
         )
         .map_err(|error| format!("Secure credential storage is unavailable: {error}"))
@@ -411,7 +422,7 @@ impl OsRuntimeSecretStore {
 
 impl RuntimeSecretStore for OsRuntimeSecretStore {
     fn get_secret(&self, runtime_id: &str, env_key: &str) -> Result<Option<String>, String> {
-        match Self::entry(runtime_id, env_key)?.get_password() {
+        match self.entry(runtime_id, env_key)?.get_password() {
             Ok(value) => Ok(normalize_optional_string(value)),
             Err(keyring::Error::NoEntry) => Ok(None),
             Err(error) => Err(format!(
@@ -421,7 +432,7 @@ impl RuntimeSecretStore for OsRuntimeSecretStore {
     }
 
     fn set_secret(&self, runtime_id: &str, env_key: &str, value: &str) -> Result<(), String> {
-        Self::entry(runtime_id, env_key)?
+        self.entry(runtime_id, env_key)?
             .set_password(value)
             .map_err(|error| {
                 format!("Failed to save AI provider secret to secure storage: {error}")
@@ -429,7 +440,7 @@ impl RuntimeSecretStore for OsRuntimeSecretStore {
     }
 
     fn delete_secret(&self, runtime_id: &str, env_key: &str) -> Result<(), String> {
-        match Self::entry(runtime_id, env_key)?.delete_credential() {
+        match self.entry(runtime_id, env_key)?.delete_credential() {
             Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
             Err(error) => Err(format!(
                 "Failed to remove AI provider secret from secure storage: {error}"
@@ -498,7 +509,7 @@ impl RuntimeSetupStore {
         match runtime_secret_store_mode_from_env(
             std::env::var(RUNTIME_SECRET_STORE_MODE_ENV).ok().as_deref(),
         ) {
-            RuntimeSecretStoreMode::OsKeyring => Arc::new(OsRuntimeSecretStore),
+            RuntimeSecretStoreMode::OsKeyring => Arc::new(OsRuntimeSecretStore::from_env()),
             // This is intentionally opt-in for CI/smoke tests that run without a
             // desktop keyring service. Production keeps using OS secure storage.
             RuntimeSecretStoreMode::InMemory => Arc::new(InMemoryRuntimeSecretStore::default()),
@@ -663,6 +674,14 @@ fn runtime_secret_store_mode_from_env(value: Option<&str>) -> RuntimeSecretStore
         Some("memory") => RuntimeSecretStoreMode::InMemory,
         _ => RuntimeSecretStoreMode::OsKeyring,
     }
+}
+
+fn runtime_secret_service_name(value: Option<&str>) -> String {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or(RUNTIME_SECRET_SERVICE)
+        .to_string()
 }
 
 impl Default for RuntimeSetupStore {
@@ -15341,6 +15360,26 @@ mod tests {
         assert_eq!(
             runtime_secret_store_mode_from_env(Some("plaintext")),
             RuntimeSecretStoreMode::OsKeyring
+        );
+    }
+
+    #[test]
+    fn runtime_secret_service_preserves_release_default_and_accepts_dev_namespace() {
+        assert_eq!(
+            runtime_secret_service_name(None),
+            "NeverWrite AI Provider Secrets"
+        );
+        assert_eq!(
+            runtime_secret_service_name(Some("")),
+            "NeverWrite AI Provider Secrets"
+        );
+        assert_eq!(
+            runtime_secret_service_name(Some(" NeverWrite Dev AI Provider Secrets ")),
+            "NeverWrite Dev AI Provider Secrets"
+        );
+        assert_ne!(
+            runtime_secret_service_name(None),
+            runtime_secret_service_name(Some("NeverWrite Dev AI Provider Secrets"))
         );
     }
 

--- a/apps/desktop/src-electron/main/appIdentity.test.ts
+++ b/apps/desktop/src-electron/main/appIdentity.test.ts
@@ -1,0 +1,143 @@
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import {
+    DEVELOPMENT_APP_ID,
+    DEVELOPMENT_APP_NAME,
+    DEVELOPMENT_SECRET_SERVICE,
+    RELEASE_APP_ID,
+    RELEASE_APP_NAME,
+    RELEASE_SECRET_SERVICE,
+    applyAppIdentity,
+    registerProductionProtocolClient,
+    resolveAppIdentity,
+} from "./appIdentity";
+
+function createAppMock() {
+    return {
+        getPath: vi.fn((name: string) => {
+            if (name === "appData") return "/Users/test/Library/Application Support";
+            if (name === "userData") {
+                return "/Users/test/Library/Application Support/NeverWrite";
+            }
+            throw new Error(`Unexpected path: ${name}`);
+        }),
+        getVersion: vi.fn(() => "0.5.0"),
+        setAboutPanelOptions: vi.fn(),
+        setAppUserModelId: vi.fn(),
+        setName: vi.fn(),
+        setPath: vi.fn(),
+    };
+}
+
+describe("resolveAppIdentity", () => {
+    it("preserves the canonical release identity and production integrations", () => {
+        expect(resolveAppIdentity({ isPackaged: true })).toEqual({
+            variant: "release",
+            displayName: RELEASE_APP_NAME,
+            appUserModelId: RELEASE_APP_ID,
+            userDataDirectoryName: RELEASE_APP_NAME,
+            ownsProductionDeepLinks: true,
+            enablesWebClipperServer: true,
+            secretServiceName: RELEASE_SECRET_SERVICE,
+        });
+    });
+
+    it("gives unpackaged development a fully separate identity", () => {
+        expect(resolveAppIdentity({ isPackaged: false })).toEqual({
+            variant: "development",
+            displayName: DEVELOPMENT_APP_NAME,
+            appUserModelId: DEVELOPMENT_APP_ID,
+            userDataDirectoryName: DEVELOPMENT_APP_NAME,
+            ownsProductionDeepLinks: false,
+            enablesWebClipperServer: false,
+            secretServiceName: DEVELOPMENT_SECRET_SERVICE,
+        });
+    });
+
+    it("keeps the packaging override release-only", () => {
+        expect(
+            resolveAppIdentity({
+                isPackaged: true,
+                releaseAppUserModelId: " com.example.release-smoke ",
+            }).appUserModelId,
+        ).toBe("com.example.release-smoke");
+        expect(
+            resolveAppIdentity({
+                isPackaged: false,
+                releaseAppUserModelId: "com.example.release-smoke",
+            }).appUserModelId,
+        ).toBe(DEVELOPMENT_APP_ID);
+    });
+});
+
+describe("applyAppIdentity", () => {
+    it("does not override the release userData path", () => {
+        const app = createAppMock();
+        const identity = resolveAppIdentity({ isPackaged: true });
+
+        applyAppIdentity(app, identity, "darwin");
+
+        expect(app.setName).toHaveBeenCalledWith(RELEASE_APP_NAME);
+        expect(app.setPath).not.toHaveBeenCalled();
+        expect(app.getPath).not.toHaveBeenCalled();
+        expect(app.setAboutPanelOptions).toHaveBeenCalledWith({
+            applicationName: RELEASE_APP_NAME,
+            applicationVersion: "0.5.0",
+        });
+    });
+
+    it("sets the development profile before later userData consumers run", () => {
+        const app = createAppMock();
+        const identity = resolveAppIdentity({ isPackaged: false });
+
+        applyAppIdentity(app, identity, "darwin");
+
+        expect(app.setName).toHaveBeenCalledWith(DEVELOPMENT_APP_NAME);
+        expect(app.setPath).toHaveBeenCalledWith(
+            "userData",
+            path.join(
+                "/Users/test/Library/Application Support",
+                DEVELOPMENT_APP_NAME,
+            ),
+        );
+        expect(app.setName.mock.invocationCallOrder[0]).toBeLessThan(
+            app.setPath.mock.invocationCallOrder[0]!,
+        );
+    });
+
+    it("uses the variant-specific Windows App User Model ID", () => {
+        const app = createAppMock();
+        const identity = resolveAppIdentity({ isPackaged: false });
+
+        applyAppIdentity(app, identity, "win32");
+
+        expect(app.setAppUserModelId).toHaveBeenCalledWith(DEVELOPMENT_APP_ID);
+        expect(app.setAboutPanelOptions).not.toHaveBeenCalled();
+    });
+});
+
+describe("registerProductionProtocolClient", () => {
+    it("leaves the production protocol owned by release", () => {
+        const setAsDefaultProtocolClient = vi.fn(() => true);
+
+        expect(
+            registerProductionProtocolClient(
+                { setAsDefaultProtocolClient },
+                resolveAppIdentity({ isPackaged: true }),
+            ),
+        ).toBe(true);
+        expect(setAsDefaultProtocolClient).toHaveBeenCalledWith("neverwrite");
+    });
+
+    it("does not register any protocol for development", () => {
+        const setAsDefaultProtocolClient = vi.fn(() => true);
+
+        expect(
+            registerProductionProtocolClient(
+                { setAsDefaultProtocolClient },
+                resolveAppIdentity({ isPackaged: false }),
+            ),
+        ).toBe(false);
+        expect(setAsDefaultProtocolClient).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/src-electron/main/appIdentity.ts
+++ b/apps/desktop/src-electron/main/appIdentity.ts
@@ -1,0 +1,101 @@
+import path from "node:path";
+import type { App } from "electron";
+
+export const RELEASE_APP_ID = "com.neverwrite";
+export const DEVELOPMENT_APP_ID = "com.neverwrite.dev";
+export const RELEASE_APP_NAME = "NeverWrite";
+export const DEVELOPMENT_APP_NAME = "NeverWrite Dev";
+export const RELEASE_SECRET_SERVICE = "NeverWrite AI Provider Secrets";
+export const DEVELOPMENT_SECRET_SERVICE =
+    "NeverWrite Dev AI Provider Secrets";
+
+export interface AppIdentity {
+    variant: "release" | "development";
+    displayName: typeof RELEASE_APP_NAME | typeof DEVELOPMENT_APP_NAME;
+    appUserModelId: string;
+    userDataDirectoryName:
+        | typeof RELEASE_APP_NAME
+        | typeof DEVELOPMENT_APP_NAME;
+    ownsProductionDeepLinks: boolean;
+    enablesWebClipperServer: boolean;
+    secretServiceName:
+        | typeof RELEASE_SECRET_SERVICE
+        | typeof DEVELOPMENT_SECRET_SERVICE;
+}
+
+export function resolveAppIdentity({
+    isPackaged,
+    releaseAppUserModelId,
+}: {
+    isPackaged: boolean;
+    releaseAppUserModelId?: string;
+}): AppIdentity {
+    if (!isPackaged) {
+        return {
+            variant: "development",
+            displayName: DEVELOPMENT_APP_NAME,
+            appUserModelId: DEVELOPMENT_APP_ID,
+            userDataDirectoryName: DEVELOPMENT_APP_NAME,
+            ownsProductionDeepLinks: false,
+            enablesWebClipperServer: false,
+            secretServiceName: DEVELOPMENT_SECRET_SERVICE,
+        };
+    }
+
+    return {
+        variant: "release",
+        displayName: RELEASE_APP_NAME,
+        appUserModelId:
+            releaseAppUserModelId?.trim() || RELEASE_APP_ID,
+        userDataDirectoryName: RELEASE_APP_NAME,
+        ownsProductionDeepLinks: true,
+        enablesWebClipperServer: true,
+        secretServiceName: RELEASE_SECRET_SERVICE,
+    };
+}
+
+export function applyAppIdentity(
+    electronApp: Pick<
+        App,
+        | "getPath"
+        | "getVersion"
+        | "setAboutPanelOptions"
+        | "setAppUserModelId"
+        | "setName"
+        | "setPath"
+    >,
+    identity: AppIdentity,
+    platform: NodeJS.Platform = process.platform,
+) {
+    electronApp.setName(identity.displayName);
+
+    // Release deliberately keeps Electron's existing userData resolution so
+    // installed users continue on the canonical NeverWrite profile unchanged.
+    if (identity.variant === "development") {
+        electronApp.setPath(
+            "userData",
+            path.join(
+                electronApp.getPath("appData"),
+                identity.userDataDirectoryName,
+            ),
+        );
+    }
+
+    if (platform === "win32") {
+        electronApp.setAppUserModelId(identity.appUserModelId);
+    }
+    if (platform === "darwin") {
+        electronApp.setAboutPanelOptions({
+            applicationName: identity.displayName,
+            applicationVersion: electronApp.getVersion(),
+        });
+    }
+}
+
+export function registerProductionProtocolClient(
+    electronApp: Pick<App, "setAsDefaultProtocolClient">,
+    identity: AppIdentity,
+) {
+    if (!identity.ownsProductionDeepLinks) return false;
+    return electronApp.setAsDefaultProtocolClient("neverwrite");
+}

--- a/apps/desktop/src-electron/main/index.ts
+++ b/apps/desktop/src-electron/main/index.ts
@@ -12,10 +12,19 @@ import {
     installProcessDiagnostics,
     writeAppLog,
 } from "./appLogger";
+import {
+    applyAppIdentity,
+    registerProductionProtocolClient,
+    resolveAppIdentity,
+} from "./appIdentity";
 import { installYouTubeEmbedIdentityHeaders } from "./youtubeEmbedIdentity";
 
-const WINDOWS_APP_USER_MODEL_ID =
-    process.env.NEVERWRITE_ELECTRON_APP_ID?.trim() || "com.neverwrite";
+const appIdentity = resolveAppIdentity({
+    isPackaged: app.isPackaged,
+    releaseAppUserModelId: process.env.NEVERWRITE_ELECTRON_APP_ID,
+});
+
+applyAppIdentity(app, appIdentity);
 
 protocol.registerSchemesAsPrivileged([
     {
@@ -29,24 +38,13 @@ protocol.registerSchemesAsPrivileged([
     },
 ]);
 
-function configureAppIdentity() {
-    app.setName("NeverWrite");
-    if (process.platform === "win32") {
-        app.setAppUserModelId(WINDOWS_APP_USER_MODEL_ID);
-    }
-    if (process.platform === "darwin") {
-        app.setAboutPanelOptions({
-            applicationName: "NeverWrite",
-            applicationVersion: app.getVersion(),
-        });
-    }
-}
-
-configureAppIdentity();
 initializeAppLogger(app.getPath("userData"));
 installConsoleLogCapture();
 installProcessDiagnostics();
 writeAppLog("main", "info", "NeverWrite main process starting", {
+    variant: appIdentity.variant,
+    applicationName: appIdentity.displayName,
+    userDataDirectoryName: appIdentity.userDataDirectoryName,
     version: app.getVersion(),
     packaged: app.isPackaged,
     platform: process.platform,
@@ -55,17 +53,19 @@ writeAppLog("main", "info", "NeverWrite main process starting", {
     chrome: process.versions.chrome,
     node: process.versions.node,
 });
-app.setAsDefaultProtocolClient("neverwrite");
+registerProductionProtocolClient(app, appIdentity);
 
 app.on("child-process-gone", (_event, details) => {
     writeAppLog("main", "error", "Electron child process gone", details);
 });
 
-app.on("open-url", (event, url) => {
-    event.preventDefault();
-    focusOrCreateMainWindow();
-    handleDeepLink(url);
-});
+if (appIdentity.ownsProductionDeepLinks) {
+    app.on("open-url", (event, url) => {
+        event.preventDefault();
+        focusOrCreateMainWindow();
+        handleDeepLink(url);
+    });
+}
 
 function focusOrCreateMainWindow() {
     const existing =
@@ -90,8 +90,10 @@ if (!hasLock) {
 } else {
     app.on("second-instance", (_event, argv) => {
         focusOrCreateMainWindow();
-        for (const url of extractDeepLinksFromArgv(argv)) {
-            handleDeepLink(url);
+        if (appIdentity.ownsProductionDeepLinks) {
+            for (const url of extractDeepLinksFromArgv(argv)) {
+                handleDeepLink(url);
+            }
         }
     });
 
@@ -99,11 +101,18 @@ if (!hasLock) {
         writeAppLog("main", "info", "Electron app ready");
         installYouTubeEmbedIdentityHeaders(session.defaultSession);
         protocol.handle("neverwrite-file", registerPreviewProtocolHandler());
-        registerIpcHandlers();
+        registerIpcHandlers({
+            enableProductionDeepLinks:
+                appIdentity.ownsProductionDeepLinks,
+            enableWebClipperServer: appIdentity.enablesWebClipperServer,
+            runtimeSecretServiceName: appIdentity.secretServiceName,
+        });
         void installNativeMenus();
         createAppWindow("main");
-        for (const url of extractDeepLinksFromArgv(process.argv)) {
-            handleDeepLink(url);
+        if (appIdentity.ownsProductionDeepLinks) {
+            for (const url of extractDeepLinksFromArgv(process.argv)) {
+                handleDeepLink(url);
+            }
         }
 
         app.on("activate", () => {

--- a/apps/desktop/src-electron/main/ipc.ts
+++ b/apps/desktop/src-electron/main/ipc.ts
@@ -24,6 +24,7 @@ import {
     resolvePreviewFilePath,
 } from "./vaultBackend";
 import { createNativeBackendSidecar } from "./nativeBackend";
+import { installProfileIntegrations } from "./profileIntegrations";
 import { getSystemUsername } from "./systemUser";
 import { ElectronAppUpdater } from "./updater";
 import { installWebClipperRuntime } from "./webClipper";
@@ -203,21 +204,33 @@ function registerAppLogHandlers() {
     });
 }
 
-function registerInvokeHandler() {
+interface IpcRegistrationOptions {
+    enableProductionDeepLinks: boolean;
+    enableWebClipperServer: boolean;
+    runtimeSecretServiceName: string;
+}
+
+function registerInvokeHandler(options: IpcRegistrationOptions) {
     const emitRuntimeEvent = (eventName: string, payload: unknown) => {
         for (const window of BrowserWindow.getAllWindows()) {
             if (window.isDestroyed()) continue;
             window.webContents.send(ELECTRON_IPC.event, { eventName, payload });
         }
     };
-    const nativeBackend = createNativeBackendSidecar(emitRuntimeEvent);
+    const nativeBackend = createNativeBackendSidecar(emitRuntimeEvent, {
+        runtimeSecretServiceName: options.runtimeSecretServiceName,
+    });
     const backend = new ElectronVaultBackend(
         emitRuntimeEvent,
         new ElectronAppUpdater(),
         nativeBackend,
     );
-    installWebClipperRuntime(backend, emitRuntimeEvent);
-    installDeepLinkRuntime(emitRuntimeEvent);
+    installProfileIntegrations(options, {
+        installProductionDeepLinks: () =>
+            installDeepLinkRuntime(emitRuntimeEvent),
+        installWebClipperServer: () =>
+            installWebClipperRuntime(backend, emitRuntimeEvent),
+    });
 
     ipcMain.handle(ELECTRON_IPC.invoke, async (_event, rawEnvelope) => {
         const envelope = asRecord(rawEnvelope) as Partial<IpcInvokeEnvelope>;
@@ -404,8 +417,8 @@ export function registerPreviewProtocolHandler() {
     };
 }
 
-export function registerIpcHandlers() {
-    registerInvokeHandler();
+export function registerIpcHandlers(options: IpcRegistrationOptions) {
+    registerInvokeHandler(options);
     registerDialogHandlers();
     registerOpenerHandlers();
     registerWindowHandlers();

--- a/apps/desktop/src-electron/main/nativeBackend.test.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import {
+    DEVELOPMENT_SECRET_SERVICE,
+    RELEASE_SECRET_SERVICE,
+} from "./appIdentity";
+import { buildNativeBackendProfileEnvironment } from "./nativeBackend";
+
+describe("buildNativeBackendProfileEnvironment", () => {
+    it("keeps the canonical release app data and keyring namespace", () => {
+        expect(
+            buildNativeBackendProfileEnvironment({
+                appDataDir: "/profiles/NeverWrite",
+                runtimeSecretServiceName: RELEASE_SECRET_SERVICE,
+            }),
+        ).toEqual({
+            NEVERWRITE_APP_DATA_DIR: "/profiles/NeverWrite",
+            NEVERWRITE_AI_SECRET_SERVICE: RELEASE_SECRET_SERVICE,
+        });
+    });
+
+    it("gives development separate app data and keyring namespaces", () => {
+        expect(
+            buildNativeBackendProfileEnvironment({
+                appDataDir: "/profiles/NeverWrite Dev",
+                runtimeSecretServiceName: DEVELOPMENT_SECRET_SERVICE,
+            }),
+        ).toEqual({
+            NEVERWRITE_APP_DATA_DIR: "/profiles/NeverWrite Dev",
+            NEVERWRITE_AI_SECRET_SERVICE: DEVELOPMENT_SECRET_SERVICE,
+        });
+    });
+
+    it("rejects an empty keyring namespace", () => {
+        expect(() =>
+            buildNativeBackendProfileEnvironment({
+                appDataDir: "/profiles/NeverWrite Dev",
+                runtimeSecretServiceName: "   ",
+            }),
+        ).toThrow("Native backend secret service name is required.");
+    });
+});

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -10,6 +10,8 @@ import readline from "node:readline";
 import { app } from "electron";
 import { getConfiguredLogDirectory, writeAppLog } from "./appLogger";
 
+const RUNTIME_SECRET_SERVICE_ENV = "NEVERWRITE_AI_SECRET_SERVICE";
+
 const SUPPORTED_COMMANDS = new Set([
     "ping",
     "open_vault",
@@ -153,6 +155,27 @@ export interface NativeBackendBridge {
     supports(command: string): boolean;
     invoke(command: string, args?: Record<string, unknown>): Promise<unknown>;
     dispose(): void;
+}
+
+interface NativeBackendLaunchOptions {
+    runtimeSecretServiceName: string;
+}
+
+export function buildNativeBackendProfileEnvironment({
+    appDataDir,
+    runtimeSecretServiceName,
+}: {
+    appDataDir: string;
+    runtimeSecretServiceName: string;
+}) {
+    const secretServiceName = runtimeSecretServiceName.trim();
+    if (!secretServiceName) {
+        throw new Error("Native backend secret service name is required.");
+    }
+    return {
+        NEVERWRITE_APP_DATA_DIR: appDataDir,
+        [RUNTIME_SECRET_SERVICE_ENV]: secretServiceName,
+    };
 }
 
 function nativeBackendExecutableName() {
@@ -306,12 +329,17 @@ class NativeBackendSidecar implements NativeBackendBridge {
     constructor(
         executablePath: string,
         emitEvent: (eventName: string, payload: unknown) => void,
+        options: NativeBackendLaunchOptions,
     ) {
         this.emitEvent = emitEvent;
         const workspaceRoot = resolveWorkspaceRoot();
         const sidecarPath = buildSidecarPath();
         const acpResourceDir = resolveAcpResourceDir(executablePath);
         const logDir = getConfiguredLogDirectory();
+        const profileEnvironment = buildNativeBackendProfileEnvironment({
+            appDataDir: app.getPath("userData"),
+            runtimeSecretServiceName: options.runtimeSecretServiceName,
+        });
         writeAppLog("native-backend", "info", "Starting native backend sidecar", {
             executablePath,
             workspaceRoot,
@@ -322,7 +350,7 @@ class NativeBackendSidecar implements NativeBackendBridge {
             env: {
                 ...process.env,
                 ...(sidecarPath ? { PATH: sidecarPath } : {}),
-                NEVERWRITE_APP_DATA_DIR: app.getPath("userData"),
+                ...profileEnvironment,
                 ...(logDir ? { NEVERWRITE_LOG_DIR: logDir } : {}),
                 ...(acpResourceDir
                     ? { NEVERWRITE_ELECTRON_ACP_RESOURCE_DIR: acpResourceDir }
@@ -485,6 +513,7 @@ class NativeBackendSidecar implements NativeBackendBridge {
 
 export function createNativeBackendSidecar(
     emitEvent: (eventName: string, payload: unknown) => void,
+    options: NativeBackendLaunchOptions,
 ): NativeBackendBridge | null {
     const resolution = resolveNativeBackendPath();
     const explicitlyEnabled =
@@ -508,7 +537,7 @@ export function createNativeBackendSidecar(
         return new UnavailableNativeBackendBridge(resolution.expectedPath);
     }
 
-    const sidecar = new NativeBackendSidecar(executablePath, emitEvent);
+    const sidecar = new NativeBackendSidecar(executablePath, emitEvent, options);
     app.once("before-quit", () => sidecar.dispose());
     app.once("will-quit", () => sidecar.dispose());
     process.once("exit", () => sidecar.dispose());

--- a/apps/desktop/src-electron/main/profileIntegrations.test.ts
+++ b/apps/desktop/src-electron/main/profileIntegrations.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import { installProfileIntegrations } from "./profileIntegrations";
+
+describe("installProfileIntegrations", () => {
+    it("installs production deep links and the Web Clipper for release", () => {
+        const installers = {
+            installProductionDeepLinks: vi.fn(),
+            installWebClipperServer: vi.fn(),
+        };
+
+        installProfileIntegrations(
+            {
+                enableProductionDeepLinks: true,
+                enableWebClipperServer: true,
+            },
+            installers,
+        );
+
+        expect(installers.installProductionDeepLinks).toHaveBeenCalledOnce();
+        expect(installers.installWebClipperServer).toHaveBeenCalledOnce();
+    });
+
+    it("does not let development register deep links or occupy the clipper port", () => {
+        const installers = {
+            installProductionDeepLinks: vi.fn(),
+            installWebClipperServer: vi.fn(),
+        };
+
+        installProfileIntegrations(
+            {
+                enableProductionDeepLinks: false,
+                enableWebClipperServer: false,
+            },
+            installers,
+        );
+
+        expect(installers.installProductionDeepLinks).not.toHaveBeenCalled();
+        expect(installers.installWebClipperServer).not.toHaveBeenCalled();
+    });
+});

--- a/apps/desktop/src-electron/main/profileIntegrations.ts
+++ b/apps/desktop/src-electron/main/profileIntegrations.ts
@@ -1,0 +1,19 @@
+export interface ProfileIntegrationCapabilities {
+    enableProductionDeepLinks: boolean;
+    enableWebClipperServer: boolean;
+}
+
+export function installProfileIntegrations(
+    capabilities: ProfileIntegrationCapabilities,
+    installers: {
+        installProductionDeepLinks: () => void;
+        installWebClipperServer: () => void;
+    },
+) {
+    if (capabilities.enableWebClipperServer) {
+        installers.installWebClipperServer();
+    }
+    if (capabilities.enableProductionDeepLinks) {
+        installers.installProductionDeepLinks();
+    }
+}

--- a/apps/desktop/src-electron/main/window.test.ts
+++ b/apps/desktop/src-electron/main/window.test.ts
@@ -4,8 +4,33 @@ import {
     getFrameNavigationAction,
     resolveRendererDevUrl,
     resolveWindowIconPath,
+    resolveWindowTitle,
     shouldOpenInSystemBrowser,
 } from "./window";
+
+describe("resolveWindowTitle", () => {
+    it("uses the configured application name for release and development", () => {
+        expect(resolveWindowTitle("main", undefined, "NeverWrite")).toBe(
+            "NeverWrite",
+        );
+        expect(resolveWindowTitle("main", undefined, "NeverWrite Dev")).toBe(
+            "NeverWrite Dev",
+        );
+        expect(
+            resolveWindowTitle("settings", undefined, "NeverWrite Dev"),
+        ).toBe("Settings - NeverWrite Dev");
+    });
+
+    it("preserves an explicit window title", () => {
+        expect(
+            resolveWindowTitle(
+                "note",
+                { title: "Roadmap - NeverWrite" },
+                "NeverWrite Dev",
+            ),
+        ).toBe("Roadmap - NeverWrite");
+    });
+});
 
 describe("resolveRendererDevUrl", () => {
     it("returns the dev URL for unpackaged builds", () => {

--- a/apps/desktop/src-electron/main/window.ts
+++ b/apps/desktop/src-electron/main/window.ts
@@ -139,12 +139,16 @@ function getSearchFromUrl(rawUrl: unknown) {
     }
 }
 
-function getTitle(label: string, options: Record<string, unknown> | undefined) {
+export function resolveWindowTitle(
+    label: string,
+    options: Record<string, unknown> | undefined,
+    applicationName: string,
+) {
     if (typeof options?.title === "string" && options.title.trim()) {
         return options.title;
     }
-    if (label === "settings") return "Settings - NeverWrite";
-    return "NeverWrite";
+    if (label === "settings") return `Settings - ${applicationName}`;
+    return applicationName;
 }
 
 function getBooleanOption(
@@ -402,7 +406,7 @@ export function createAppWindow(
         : "#1c1c1c";
 
     const window = new BrowserWindow({
-        title: getTitle(label, options),
+        title: resolveWindowTitle(label, options, app.getName()),
         icon: getWindowIconPath(),
         width: getNumberOption(options, "width", DEFAULT_WIDTH),
         height: getNumberOption(options, "height", DEFAULT_HEIGHT),

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -36,6 +36,8 @@ Electron's app data directory is usually:
 - macOS: `~/Library/Application Support/NeverWrite/`
 - Linux: `~/.config/NeverWrite/` for Electron-managed data such as logs.
 
+Unpackaged desktop development uses a separate `NeverWrite Dev` profile in the equivalent platform app-data location. The installed release keeps the paths above unchanged. Opening the same vault in both variants still shares the vault-owned `.neverwrite` and `.neverwrite-cache` directories described below.
+
 The native backend normally receives Electron's `userData` path through
 `NEVERWRITE_APP_DATA_DIR`, so its persisted app state is stored under the same
 app data directory when launched from the desktop app. If the native backend is


### PR DESCRIPTION
## Summary

- Fix a regression surfaced after the April 2026 Tauri-to-Electron migration: `npm run dev` identified itself as NeverWrite and shared release-level integrations.
- Run unpackaged builds as **NeverWrite Dev** with an isolated user-data profile and AI credential keychain namespace.
- Keep packaged releases on the existing **NeverWrite** profile without migration impact.
- Prevent development builds from registering or handling production `neverwrite://` links and from starting the release web clipper server.
- Reflect the active app identity in window and settings titles.

## Why

Development and release builds could previously collide when running together, sharing app state and external integrations. This change establishes a complete development/release boundary while vault-owned state remains intentionally shared.

## Testing

- Added coverage for app identity resolution and platform integration.
- Added coverage for native backend profile environment construction.
- Added coverage for profile-gated deep link and web clipper setup.
- Added coverage for identity-aware window titles.