### PR TITLE
Prepare 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,29 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.5.1] - 2026-07-22
+
+### Added
+
+- Added a per-vault **AI change review** setting that can disable review tracking, close review tabs, and accept and clear pending review state while keeping streamed chat diffs visible.
+- Added contextual safety-policy guidance for Codex sessions using **Full Access** mode.
+
+### Changed
+
+- Unified the AI chat composer into a single contextual action that switches between Send, Queue, Stop, and transition states without shifting the composer layout.
+- Polished Markdown Live Preview code fences with human-readable language labels, compact copy controls, and cleaner presentation for unlabeled and empty blocks.
+- Updated the embedded Claude ACP runtime to `0.59.0` and the embedded Codex runtime to `0.144.6`, improving background subagent handling, tool attribution, result delivery, context usage reporting, and packaged code-mode compatibility.
+
+### Fixed
+
+- Fixed inline AI change review instability by updating the editor runtime and hardened review cleanup across vault switches, synchronized settings, and stale review tabs.
+- Fixed definitive Codex command-policy blocks so failed tool activity exposes the reason instead of appearing as an unexplained failure.
+- Fixed chat search highlights being dropped from packaged desktop styles.
+
+### Security
+
+- Patched known dependency vulnerabilities across the desktop app and web clipper, including denial-of-service, archive handling, and HTML sanitization advisories.
+
 ## [0.5.0] - 2026-07-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.5.0",
+            "version": "0.5.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.5.0",
+    "version": "0.5.1",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.5.0",
+    "version": "0.5.1",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- add the user-facing 0.5.1 changelog
- align desktop, native backend, lockfile, and Web Clipper versions at 0.5.1
- prepare release metadata for the v0.5.1 tag

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.5.1`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`