### PR TITLE
Prepare 0.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.5.2] - 2026-07-24
+
+### Added
+
+- Added Google Vertex AI as a Claude provider, with configurable endpoint, project, region, and Google Application Default Credentials authentication.
+
+### Changed
+
+- Widened Markdown Live Preview code fences for more comfortable reading of long code lines.
+- Updated the embedded Claude ACP runtime to `0.62.0`, including explicit provider routing and improved session configuration support.
+- Updated SDK for Opus 5 support.
+
 ## [0.5.1] - 2026-07-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1755,7 +1755,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.5.1",
+            "version": "0.5.2",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.5.1",
+    "version": "0.5.2",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.5.1",
+    "version": "0.5.2",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary
- update release metadata to version 0.5.2
- document the 0.5.2 user-facing changes
- support for Opus 5

## Validation
- node scripts/validate-release-metadata.mjs --tag v0.5.2
- cargo check --locked -p neverwrite-native-backend
- node --test scripts/release-metadata.test.mjs