### PR TITLE
Fix PostCSS and updater dependency vulnerabilities

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -39,7 +39,7 @@
                 "@xterm/addon-web-links": "^0.12.0",
                 "@xterm/addon-webgl": "^0.19.0",
                 "@xterm/xterm": "^6.0.0",
-                "electron-updater": "^6.8.3",
+                "electron-updater": "^6.8.9",
                 "katex": "^0.16.45",
                 "mermaid": "^11.16.0",
                 "papaparse": "^5.5.3",
@@ -4798,20 +4798,6 @@
                 "node": "18 || 20 || >=22"
             }
         },
-        "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/app-builder-lib/node_modules/ci-info": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -5190,23 +5176,9 @@
             }
         },
         "node_modules/builder-util-runtime": {
-            "version": "9.5.1",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
-            "integrity": "sha512-qt41tMfgHTllhResqM5DcnHyDIWNgzHvuY2jDcYP9iaGpkWxTUzV6GQjDeLnlR1/DtdlcsWQbA7sByMpmJFTLQ==",
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/builder-util/node_modules/builder-util-runtime": {
             "version": "9.7.0",
             "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
             "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.3.4",
@@ -6565,20 +6537,6 @@
                 "electron-winstaller": "5.4.0"
             }
         },
-        "node_modules/electron-builder/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/electron-publish": {
             "version": "26.15.3",
             "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
@@ -6597,20 +6555,6 @@
                 "mime": "^2.5.2"
             }
         },
-        "node_modules/electron-publish/node_modules/builder-util-runtime": {
-            "version": "9.7.0",
-            "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
-            "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "debug": "^4.3.4",
-                "sax": "^1.2.4"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.373",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.373.tgz",
@@ -6619,12 +6563,12 @@
             "license": "ISC"
         },
         "node_modules/electron-updater": {
-            "version": "6.8.3",
-            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.3.tgz",
-            "integrity": "sha512-Z6sgw3jgbikWKXei1ENdqFOxBP0WlXg3TtKfz0rgw2vIZFJUyI4pD7ZN7jrkm7EoMK+tcm/qTnPUdqfZukBlBQ==",
+            "version": "6.8.9",
+            "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+            "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
             "license": "MIT",
             "dependencies": {
-                "builder-util-runtime": "9.5.1",
+                "builder-util-runtime": "9.7.0",
                 "fs-extra": "^10.1.0",
                 "js-yaml": "^4.1.0",
                 "lazy-val": "^1.0.5",
@@ -9612,9 +9556,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.23",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+            "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
             "dev": true,
             "funding": [
                 {
@@ -9632,7 +9576,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },
@@ -9641,9 +9585,9 @@
             }
         },
         "node_modules/postcss/node_modules/nanoid": {
-            "version": "3.3.12",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-            "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -66,7 +66,7 @@
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
-        "electron-updater": "^6.8.3",
+        "electron-updater": "^6.8.9",
         "katex": "^0.16.45",
         "mermaid": "^11.16.0",
         "papaparse": "^5.5.3",

--- a/apps/web-clipper/pnpm-lock.yaml
+++ b/apps/web-clipper/pnpm-lock.yaml
@@ -1631,8 +1631,8 @@ packages:
     resolution: {integrity: sha512-yTW+2okrElHiH4fsiz/+/zc0EDo9BDDoC3iKk8dpv1GeRc9nUWzUZHx6TofMWErchhUQR8hY9/Eu1Uja9x1nqA==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -1744,8 +1744,8 @@ packages:
   pkg-types@2.3.1:
     resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
-  postcss@8.5.15:
-    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   powershell-utils@0.1.0:
@@ -3652,7 +3652,7 @@ snapshots:
 
   nano-spawn@2.1.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   nanospinner@1.2.2:
     dependencies:
@@ -3783,9 +3783,9 @@ snapshots:
       exsolve: 1.0.8
       pathe: 2.0.3
 
-  postcss@8.5.15:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -4201,7 +4201,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.23
       rolldown: 1.0.3
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary

- update PostCSS from 8.5.15 to 8.5.23 in the desktop and web clipper lockfiles
- update electron-updater from 6.8.3 to 6.8.9
- replace the vulnerable builder-util-runtime 9.5.1 copy with 9.7.0 and deduplicate the desktop dependency tree

This addresses GHSA-r28c-9q8g-f849 in both JavaScript lockfiles and GHSA-p2f4-r6v6-j797 in the desktop application.

## Validation

- `npm ci`
- `npm test` — 2,185 passed, 2 todo
- `npm run build`
- `pnpm install --frozen-lockfile`
- `pnpm run check` — TypeScript compile, 25 tests, Chrome build, and Firefox build
- targeted audit verification confirms no PostCSS or builder-util-runtime advisories remain