### PR TITLE
Prepare 0.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,25 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.6.0] - 2026-07-29
+
+### Added
+
+- Added configurable custom ACP runtimes under Settings > AI Providers, with executable verification, isolated launch environments, capability-driven chat integration, and safe reconnection when a runtime definition changes.
+- Added device-local AI chat history as the default for new vaults, plus a per-vault setting to move history and managed screenshot attachments between device and vault storage with transactional recovery controls.
+
+### Changed
+
+- Updated the embedded Claude ACP runtime to `0.63.0` and Claude Agent SDK to `0.3.220`.
+
+### Fixed
+
+- Fixed Claude tool activity attribution for progress heartbeats, Bash terminal metadata, and denied tool calls.
+
+### Security
+
+- Patched dependency vulnerabilities in the desktop updater, PostCSS, Nano ID, and QUIC protocol stack.
+
 ## [0.5.2] - 2026-07-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.5.2"
+version = "0.6.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.5.2",
+    "version": "0.6.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.5.2",
+            "version": "0.6.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.5.2",
+    "version": "0.6.0",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.5.2",
+    "version": "0.6.0",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- add the 0.6.0 user-facing changelog entry
- align desktop, native backend, Cargo lockfile, and Web Clipper versions at 0.6.0

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.6.0`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`