### PR TITLE
Update Undici security patch versions

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -9039,9 +9039,9 @@
             }
         },
         "node_modules/node-gyp/node_modules/undici": {
-            "version": "6.27.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-            "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+            "version": "6.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+            "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11000,9 +11000,9 @@
             "license": "MIT"
         },
         "node_modules/undici": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+            "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
             "dev": true,
             "license": "MIT",
             "optional": true,


### PR DESCRIPTION
## Summary

- update the Electron download path from `undici` 7.28.0 to 7.29.0
- update the nested `node-gyp` copy from `undici` 6.27.0 to 6.28.0
- resolve the five current Dependabot advisories affecting `undici`

## Security impact

The patched versions address:

- GHSA-4cwx-7wf7-3272
- GHSA-jr45-8vmc-qm54
- GHSA-v3r7-h72x-cjcm
- GHSA-8xcm-r25x-g524
- GHSA-m8rv-5g2x-5cg5

Both copies are transitive development dependencies. This keeps the change limited to the desktop lockfile without changing direct dependency ranges.

## Validation

- `npm ci`
- `npm ls undici --all`
- `npm test` — 188 test files passed, 2,251 tests passed
- `npm run build`
- `npm audit --json` — no remaining `undici` findings; unrelated existing findings remain
- `git diff --check`
