### PR TITLE
Fix ACP recovery after idle runtime disconnects

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2011,7 +2011,13 @@ impl NativeAi {
             (prompt, handle)
         };
 
-        handle.prompt(&session_id, prompt)?;
+        if let Err(error) = handle.prompt(&session_id, prompt) {
+            if is_acp_transport_disconnect_error(&error) {
+                self.disconnect_runtime_session_after_send_failure(&session_id, handle.process_id)?;
+                return Err("The AI runtime disconnected while sending. Reconnect the chat and retry the message.".to_string());
+            }
+            return Err(error);
+        }
         self.load_session(&json!({ "sessionId": session_id }))
     }
 
@@ -2615,6 +2621,58 @@ impl NativeAi {
             .get(session_id)
             .map(|managed| managed.runtime_handle.clone())
             .ok_or_else(|| format!("AI session not found: {session_id}"))
+    }
+
+    fn disconnect_runtime_session_after_send_failure(
+        &self,
+        session_id: &str,
+        process_id: u64,
+    ) -> Result<(), String> {
+        let runtime_id = {
+            let mut state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            let managed = state
+                .sessions
+                .get(session_id)
+                .ok_or_else(|| format!("AI session not found: {session_id}"))?;
+            if managed
+                .runtime_handle
+                .as_ref()
+                .map(|handle| handle.process_id != process_id)
+                .unwrap_or(true)
+            {
+                return Ok(());
+            }
+            let runtime_id = managed.session.runtime_id.clone();
+            for managed in state.sessions.values_mut() {
+                if managed
+                    .runtime_handle
+                    .as_ref()
+                    .is_some_and(|handle| handle.process_id == process_id)
+                {
+                    managed.runtime_handle = None;
+                    managed.session.status = AiSessionStatus::Idle;
+                }
+            }
+            runtime_id
+        };
+
+        eprintln!(
+            "ACP runtime transport disconnected phase=send runtime_id={runtime_id} session_id={session_id} process_id={process_id}"
+        );
+        emit_event(
+            &self.event_tx,
+            AI_RUNTIME_CONNECTION_EVENT,
+            json!(AiRuntimeConnectionPayload {
+                runtime_id,
+                session_id: Some(session_id.to_string()),
+                status: "error".to_string(),
+                message: Some("The AI runtime disconnected while sending. Reconnect the chat and retry the message.".to_string()),
+            }),
+        );
+        Ok(())
     }
 
     fn cancel_user_input_waiters_for_session(&self, session_id: &str) {
@@ -4143,6 +4201,13 @@ fn remember_prompt_capabilities(
     }
 }
 
+fn is_acp_transport_disconnect_error(error: &str) -> bool {
+    let normalized = error.trim().to_lowercase();
+    normalized.contains("sending on a closed channel")
+        || normalized.contains("receiving on a closed channel")
+        || normalized.contains("channel closed")
+}
+
 fn neverwrite_acp12_client_capabilities(_runtime_id: &str) -> acp12::schema::ClientCapabilities {
     // ACP 0.12 does not expose the newer elicitation capability flags through the
     // umbrella `unstable` feature. Grok stays on the legacy surface.
@@ -4664,6 +4729,8 @@ async fn run_acp12_actor_inner(
     let transport = acp12::ByteStreams::new(stdin.compat_write(), stdout.compat());
     let session_created = Arc::new(AtomicBool::new(false));
     let session_created_for_connection = Arc::clone(&session_created);
+    let connected_session_id = Arc::new(Mutex::new(None::<String>));
+    let connected_session_id_for_connection = Arc::clone(&connected_session_id);
     let disconnect_runtime_id = spec.runtime_id.clone();
     let event_tx_for_connection = event_tx.clone();
     let prompt_capabilities = Arc::clone(&context.prompt_capabilities);
@@ -4734,6 +4801,7 @@ async fn run_acp12_actor_inner(
                         AI_RUNTIME_CONNECTION_EVENT,
                         json!(AiRuntimeConnectionPayload {
                             runtime_id: spec.runtime_id.clone(),
+                            session_id: None,
                             status: "ready".to_string(),
                             message: None,
                         }),
@@ -4767,6 +4835,9 @@ async fn run_acp12_actor_inner(
             client
                 .tool_diffs
                 .register_session_cwd(&session.session_id, spec.cwd.clone());
+            if let Ok(mut session_id) = connected_session_id_for_connection.lock() {
+                *session_id = Some(session.session_id.clone());
+            }
             session_created_for_connection.store(true, Ordering::Relaxed);
             let _ = created_tx.send(Ok(session));
             loop {
@@ -4806,6 +4877,10 @@ async fn run_acp12_actor_inner(
                 AI_RUNTIME_CONNECTION_EVENT,
                 json!(AiRuntimeConnectionPayload {
                     runtime_id: disconnect_runtime_id,
+                    session_id: connected_session_id
+                        .lock()
+                        .ok()
+                        .and_then(|session_id| session_id.clone()),
                     status: "error".to_string(),
                     message: Some(format!(
                         "The AI runtime process disconnected unexpectedly: {error}"
@@ -4871,6 +4946,8 @@ async fn run_acp_actor_inner(
     let transport = ByteStreams::new(stdin.compat_write(), stdout.compat());
     let session_created = Arc::new(AtomicBool::new(false));
     let session_created_for_connection = Arc::clone(&session_created);
+    let connected_session_id = Arc::new(Mutex::new(None::<String>));
+    let connected_session_id_for_connection = Arc::clone(&connected_session_id);
     let disconnect_runtime_id = spec.runtime_id.clone();
     let event_tx_for_connection = event_tx.clone();
     let prompt_capabilities = Arc::clone(&context.prompt_capabilities);
@@ -4978,6 +5055,7 @@ async fn run_acp_actor_inner(
                         AI_RUNTIME_CONNECTION_EVENT,
                         json!(AiRuntimeConnectionPayload {
                             runtime_id: spec.runtime_id.clone(),
+                            session_id: None,
                             status: "ready".to_string(),
                             message: None,
                         }),
@@ -5016,6 +5094,9 @@ async fn run_acp_actor_inner(
             client
                 .tool_diffs
                 .register_session_cwd(&session.session_id, spec.cwd.clone());
+            if let Ok(mut session_id) = connected_session_id_for_connection.lock() {
+                *session_id = Some(session.session_id.clone());
+            }
             session_created_for_connection.store(true, Ordering::Relaxed);
             let _ = created_tx.send(Ok(session));
             loop {
@@ -5055,6 +5136,10 @@ async fn run_acp_actor_inner(
                 AI_RUNTIME_CONNECTION_EVENT,
                 json!(AiRuntimeConnectionPayload {
                     runtime_id: disconnect_runtime_id,
+                    session_id: connected_session_id
+                        .lock()
+                        .ok()
+                        .and_then(|session_id| session_id.clone()),
                     status: "error".to_string(),
                     message: Some(format!(
                         "The AI runtime process disconnected unexpectedly: {error}"
@@ -11350,6 +11435,66 @@ mod tests {
 
         first_shutdown.join().unwrap();
         assert!(native_ai.inner.lock().unwrap().sessions.is_empty());
+    }
+
+    #[test]
+    fn send_transport_disconnect_invalidates_the_affected_session_family() {
+        let (event_tx, event_rx) = mpsc::channel();
+        let native_ai =
+            NativeAi::with_setup_store(event_tx, RuntimeSetupStore::in_memory_for_tests());
+        let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel();
+        drop(command_rx);
+        let handle = AcpSessionHandle {
+            process_id: 73,
+            command_tx,
+            prompt_capabilities: Arc::new(Mutex::new(AcpPromptCapabilities::default())),
+        };
+        let session_id = "disconnected-session";
+        let child_session_id = "disconnected-subagent";
+        let mut state = native_ai.inner.lock().unwrap();
+        for (id, session_handle) in [(session_id, handle.clone()), (child_session_id, handle)] {
+            state.sessions.insert(
+                id.to_string(),
+                ManagedAiSession {
+                    session: new_session_with_id(CODEX_RUNTIME_ID, id.to_string()).unwrap(),
+                    vault_root: None,
+                    additional_roots: vec![],
+                    runtime_handle: Some(session_handle),
+                    active_turn_id: None,
+                },
+            );
+        }
+        drop(state);
+
+        native_ai
+            .disconnect_runtime_session_after_send_failure(session_id, 73)
+            .unwrap();
+
+        let state = native_ai.inner.lock().unwrap();
+        assert!(state.sessions[session_id].runtime_handle.is_none());
+        assert!(state.sessions[child_session_id].runtime_handle.is_none());
+        assert_eq!(
+            state.sessions[session_id].session.status,
+            AiSessionStatus::Idle
+        );
+        drop(state);
+
+        let RpcOutput::Event {
+            event_name,
+            payload,
+        } = event_rx.recv().unwrap()
+        else {
+            panic!("expected runtime connection event");
+        };
+        assert_eq!(event_name, AI_RUNTIME_CONNECTION_EVENT);
+        assert_eq!(
+            payload.get("runtime_id").and_then(Value::as_str),
+            Some(CODEX_RUNTIME_ID)
+        );
+        assert_eq!(
+            payload.get("session_id").and_then(Value::as_str),
+            Some(session_id)
+        );
     }
 
     #[cfg(unix)]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2012,11 +2012,11 @@ impl NativeAi {
         };
 
         if let Err(error) = handle.prompt(&session_id, prompt) {
-            if is_acp_transport_disconnect_error(&error) {
+            if error.is_transport_disconnected() {
                 self.disconnect_runtime_session_after_send_failure(&session_id, handle.process_id)?;
                 return Err("The AI runtime disconnected while sending. Reconnect the chat and retry the message.".to_string());
             }
-            return Err(error);
+            return Err(error.into_message());
         }
         self.load_session(&json!({ "sessionId": session_id }))
     }
@@ -2810,16 +2810,43 @@ struct AcpSessionStartResponse {
     continuation_strategy: Option<AcpContinuationStrategy>,
 }
 
+#[derive(Debug)]
+enum AcpRequestError {
+    CommandChannelClosed,
+    ResponseChannelClosed,
+    Remote(String),
+}
+
+impl AcpRequestError {
+    fn is_transport_disconnected(&self) -> bool {
+        matches!(
+            self,
+            Self::CommandChannelClosed | Self::ResponseChannelClosed
+        )
+    }
+
+    fn into_message(self) -> String {
+        match self {
+            Self::CommandChannelClosed => "The AI runtime command channel is closed.".to_string(),
+            Self::ResponseChannelClosed => "The AI runtime response channel is closed.".to_string(),
+            Self::Remote(message) => message,
+        }
+    }
+}
+
 impl AcpSessionHandle {
     fn request<T>(
         &self,
         build: impl FnOnce(mpsc::Sender<Result<T, String>>) -> AcpCommand,
-    ) -> Result<T, String> {
+    ) -> Result<T, AcpRequestError> {
         let (response_tx, response_rx) = mpsc::channel();
         self.command_tx
             .send(build(response_tx))
-            .map_err(|error| error.to_string())?;
-        response_rx.recv().map_err(|error| error.to_string())?
+            .map_err(|_| AcpRequestError::CommandChannelClosed)?;
+        response_rx
+            .recv()
+            .map_err(|_| AcpRequestError::ResponseChannelClosed)?
+            .map_err(AcpRequestError::Remote)
     }
 
     fn prompt_capabilities(&self) -> AcpPromptCapabilities {
@@ -2829,7 +2856,7 @@ impl AcpSessionHandle {
             .unwrap_or_default()
     }
 
-    fn prompt(&self, session_id: &str, prompt: Vec<ContentBlock>) -> Result<(), String> {
+    fn prompt(&self, session_id: &str, prompt: Vec<ContentBlock>) -> Result<(), AcpRequestError> {
         self.request(|response_tx| AcpCommand::Prompt {
             session_id: session_id.to_string(),
             prompt,
@@ -2843,6 +2870,7 @@ impl AcpSessionHandle {
             mode_id: mode_id.to_string(),
             response_tx,
         })
+        .map_err(AcpRequestError::into_message)
     }
 
     fn set_model(&self, session_id: &str, model_id: &str) -> Result<(), String> {
@@ -2851,6 +2879,7 @@ impl AcpSessionHandle {
             model_id: model_id.to_string(),
             response_tx,
         })
+        .map_err(AcpRequestError::into_message)
     }
 
     fn set_config_option(
@@ -2865,6 +2894,7 @@ impl AcpSessionHandle {
             value: value.to_string(),
             response_tx,
         })
+        .map_err(AcpRequestError::into_message)
     }
 
     fn cancel(&self, session_id: &str) -> Result<(), String> {
@@ -2872,6 +2902,7 @@ impl AcpSessionHandle {
             session_id: session_id.to_string(),
             response_tx,
         })
+        .map_err(AcpRequestError::into_message)
     }
 
     fn respond_permission(&self, request_id: &str, option_id: Option<&str>) -> Result<(), String> {
@@ -2880,10 +2911,12 @@ impl AcpSessionHandle {
             option_id: option_id.map(ToString::to_string),
             response_tx,
         })
+        .map_err(AcpRequestError::into_message)
     }
 
     fn shutdown(&self) -> Result<(), String> {
         self.request(|response_tx| AcpCommand::Shutdown { response_tx })
+            .map_err(AcpRequestError::into_message)
     }
 }
 
@@ -4199,13 +4232,6 @@ fn remember_prompt_capabilities(
     if let Ok(mut target) = target.lock() {
         *target = capabilities;
     }
-}
-
-fn is_acp_transport_disconnect_error(error: &str) -> bool {
-    let normalized = error.trim().to_lowercase();
-    normalized.contains("sending on a closed channel")
-        || normalized.contains("receiving on a closed channel")
-        || normalized.contains("channel closed")
 }
 
 fn neverwrite_acp12_client_capabilities(_runtime_id: &str) -> acp12::schema::ClientCapabilities {
@@ -11495,6 +11521,42 @@ mod tests {
             payload.get("session_id").and_then(Value::as_str),
             Some(session_id)
         );
+    }
+
+    #[test]
+    fn acp_request_classifies_a_closed_command_channel() {
+        let (command_tx, command_rx) = tokio::sync::mpsc::unbounded_channel();
+        drop(command_rx);
+        let handle = AcpSessionHandle {
+            process_id: 1,
+            command_tx,
+            prompt_capabilities: Arc::new(Mutex::new(AcpPromptCapabilities::default())),
+        };
+
+        assert!(matches!(
+            handle.prompt("session", vec![]),
+            Err(AcpRequestError::CommandChannelClosed)
+        ));
+    }
+
+    #[test]
+    fn acp_request_classifies_a_closed_response_channel() {
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = AcpSessionHandle {
+            process_id: 1,
+            command_tx,
+            prompt_capabilities: Arc::new(Mutex::new(AcpPromptCapabilities::default())),
+        };
+        let responder = thread::spawn(move || match command_rx.blocking_recv() {
+            Some(AcpCommand::Prompt { response_tx, .. }) => drop(response_tx),
+            _ => panic!("expected prompt command"),
+        });
+
+        assert!(matches!(
+            handle.prompt("session", vec![]),
+            Err(AcpRequestError::ResponseChannelClosed)
+        ));
+        responder.join().unwrap();
     }
 
     #[cfg(unix)]

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7714,6 +7714,45 @@ describe("chatStore", () => {
         expect(sendAttempts).toBe(2);
     });
 
+    it("preserves a failed idle ACP send for reconnection and explicit retry", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        let sendAttempts = 0;
+        invokeMock.mockImplementation(async (command) => {
+            if (command === "ai_send_message") {
+                sendAttempts += 1;
+                if (sendAttempts === 1) {
+                    throw new Error("sending on a closed channel");
+                }
+                return { ...sessionPayload, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command);
+        });
+
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        useChatStore.getState().setComposerParts([
+            { id: "text-idle-retry", type: "text", text: "Continue this chat" },
+        ]);
+
+        await useChatStore.getState().sendMessage(activeSessionId);
+
+        expect(useChatStore.getState().sessionsById[activeSessionId]).toMatchObject({
+            runtimeState: "detached",
+            status: "error",
+            resumeContextPending: true,
+        });
+        expect(
+            serializeComposerParts(
+                useChatStore.getState().composerPartsBySessionId[activeSessionId] ?? [],
+            ),
+        ).toContain("Continue this chat");
+
+        await useChatStore.getState().sendMessage(activeSessionId);
+
+        expect(sendAttempts).toBe(2);
+    });
+
     it("interrupts the current turn and sends the queued message immediately when sending it now", async () => {
         invokeMock.mockImplementation(async (command, args) => {
             if (command === "ai_list_runtimes") return runtimePayload;
@@ -17778,7 +17817,7 @@ describe("chatStore", () => {
         ).toEqual([parent.sessionId]);
     });
 
-    it("marks live parent and child sessions as errored when their ACP runtime disconnects", () => {
+    it("marks only the affected live ACP session family as errored when its runtime disconnects", () => {
         const parent = {
             ...createSessionWithTrackedFiles("session-parent", []),
             runtimeId: "codex-acp",
@@ -17798,22 +17837,31 @@ describe("chatStore", () => {
             runtimeState: "live" as const,
             status: "streaming" as const,
         };
+        const otherCodexSession = {
+            ...createSessionWithTrackedFiles("session-other-codex", []),
+            runtimeId: "codex-acp",
+            runtimeState: "live" as const,
+            status: "streaming" as const,
+        };
 
         useChatStore.setState({
             sessionsById: {
                 [parent.sessionId]: parent,
                 [child.sessionId]: child,
                 [otherRuntime.sessionId]: otherRuntime,
+                [otherCodexSession.sessionId]: otherCodexSession,
             },
             sessionOrder: [
                 parent.sessionId,
                 child.sessionId,
                 otherRuntime.sessionId,
+                otherCodexSession.sessionId,
             ],
         });
 
         useChatStore.getState().applyRuntimeConnection({
             runtime_id: "codex-acp",
+            session_id: parent.sessionId,
             status: "error",
             message: "The ACP process exited.",
         });
@@ -17854,6 +17902,9 @@ describe("chatStore", () => {
         expect(
             useChatStore.getState().sessionsById[otherRuntime.sessionId],
         ).toBe(otherRuntime);
+        expect(
+            useChatStore.getState().sessionsById[otherCodexSession.sessionId],
+        ).toBe(otherCodexSession);
     });
 
     it("clears virtualized row UI state when deleting a session", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -7714,18 +7714,58 @@ describe("chatStore", () => {
         expect(sendAttempts).toBe(2);
     });
 
-    it("preserves a failed idle ACP send for reconnection and explicit retry", async () => {
+    it("retries a failed idle ACP send without reinjecting the unsent prompt", async () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
         let sendAttempts = 0;
-        invokeMock.mockImplementation(async (command) => {
+        let persistedMessages: Array<{ content: string }> = [];
+        const sentPrompts: string[] = [];
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_save_session_history") {
+                const history = (args as { history?: { messages?: unknown } })
+                    .history;
+                persistedMessages = Array.isArray(history?.messages)
+                    ? history.messages.map((message) => ({
+                          content:
+                              typeof message === "object" &&
+                              message !== null &&
+                              "content" in message &&
+                              typeof message.content === "string"
+                                  ? message.content
+                                  : "",
+                      }))
+                    : [];
+                return;
+            }
+            if (command === "ai_load_session_history_page") {
+                const requestedSessionId = (args as { sessionId?: string })
+                    .sessionId;
+                return {
+                    session_id: requestedSessionId ?? "codex-session-1",
+                    total_messages: persistedMessages.length,
+                    start_index: 0,
+                    end_index: persistedMessages.length,
+                    messages: persistedMessages.map((message, index) => ({
+                        id: `persisted-${index}`,
+                        role: "assistant",
+                        kind: "error",
+                        content: message.content,
+                        timestamp: index,
+                    })),
+                };
+            }
             if (command === "ai_send_message") {
                 sendAttempts += 1;
+                sentPrompts.push(
+                    (args as { content?: string }).content ?? "",
+                );
                 if (sendAttempts === 1) {
-                    throw new Error("sending on a closed channel");
+                    throw new Error(
+                        "The AI runtime disconnected while sending. Reconnect the chat and retry the message.",
+                    );
                 }
                 return { ...sessionPayload, status: "streaming" };
             }
-            return defaultInvokeImplementation(command);
+            return defaultInvokeImplementation(command, args);
         });
 
         await useChatStore.getState().initialize();
@@ -7740,17 +7780,36 @@ describe("chatStore", () => {
         expect(useChatStore.getState().sessionsById[activeSessionId]).toMatchObject({
             runtimeState: "detached",
             status: "error",
-            resumeContextPending: true,
+            resumeContextPending: false,
         });
         expect(
             serializeComposerParts(
                 useChatStore.getState().composerPartsBySessionId[activeSessionId] ?? [],
             ),
         ).toContain("Continue this chat");
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById[activeSessionId]?.messages.some(
+                    (message) =>
+                        message.role === "user" &&
+                        message.content === "Continue this chat",
+                ),
+        ).toBe(false);
+
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(
+            persistedMessages.some(
+                (message) => message.content === "Continue this chat",
+            ),
+        ).toBe(false);
 
         await useChatStore.getState().sendMessage(activeSessionId);
 
         expect(sendAttempts).toBe(2);
+        expect(
+            sentPrompts[1]?.match(/Continue this chat/g),
+        ).toHaveLength(1);
     });
 
     it("interrupts the current turn and sends the queued message immediately when sending it now", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -692,6 +692,23 @@ function isClosedSubagentSession(session: AIChatSession) {
     return Boolean(session.parentSessionId && session.closedAt);
 }
 
+function getRuntimeConnectionRootSessionId(
+    sessionsById: Record<string, AIChatSession>,
+    sessionId: string,
+) {
+    let currentSessionId = sessionId;
+    const visitedSessionIds = new Set<string>();
+    while (!visitedSessionIds.has(currentSessionId)) {
+        visitedSessionIds.add(currentSessionId);
+        const parentSessionId = sessionsById[currentSessionId]?.parentSessionId;
+        if (!parentSessionId || !sessionsById[parentSessionId]) {
+            return currentSessionId;
+        }
+        currentSessionId = parentSessionId;
+    }
+    return sessionId;
+}
+
 function isRemovedGeminiAcpSession(session: Pick<AIChatSession, "runtimeId">) {
     return session.runtimeId === "gemini-acp";
 }
@@ -1911,6 +1928,10 @@ function isProviderQuotaErrorMessage(message: string) {
 function isRuntimeSessionDisconnectedErrorMessage(message: string) {
     const normalized = message.trim().toLowerCase();
     return (
+        normalized.includes("runtime disconnected while sending") ||
+        normalized.includes("sending on a closed channel") ||
+        normalized.includes("receiving on a closed channel") ||
+        normalized.includes("channel closed") ||
         normalized.includes("runtime session is not connected") ||
         normalized.includes("resource_not_found") ||
         normalized.includes("ai session not found")
@@ -7875,6 +7896,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         let activeSessionId = sessionId;
         let currentItem = queuedItem;
         let optimisticMessageInserted = false;
+        let shouldRecoverPromptForRetry = false;
         let preflightOwnership = options?.preflightOwnership ?? null;
         let session = get().sessionsById[activeSessionId];
         try {
@@ -8138,6 +8160,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 "Failed to send the message.",
                 session.runtimeId,
             );
+            shouldRecoverPromptForRetry =
+                source === "immediate" &&
+                isRuntimeSessionDisconnectedErrorMessage(message);
             if (source === "queue") {
                 restoreActiveQueuedMessage(activeSessionId, (item) => ({
                     ...item,
@@ -8159,11 +8184,14 @@ export const useChatStore = create<ChatStore>((set, get) => {
                       preflightOwnership.token,
                   )
                 : null;
-            const preflightFailureRecovery = !optimisticMessageInserted
+            const preflightFailureRecovery =
+                (!optimisticMessageInserted || shouldRecoverPromptForRetry)
                 ? (options?.preflightFailureRecovery ??
                   (releasedPreflightOwnership
                       ? ({ kind: "composer" } as const)
-                      : undefined))
+                      : shouldRecoverPromptForRetry
+                        ? ({ kind: "composer" } as const)
+                        : undefined))
                 : undefined;
             if (source === "immediate" && preflightFailureRecovery) {
                 set((state) => {
@@ -9458,7 +9486,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
             });
         },
 
-        applyRuntimeConnection: ({ runtime_id, status, message }) => {
+        applyRuntimeConnection: ({ runtime_id, session_id, status, message }) => {
             const affectedSessionIds: string[] = [];
             set((state) => {
                 const runtimeConnectionByRuntimeId = setRuntimeConnectionState(
@@ -9476,6 +9504,13 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
                 const nextSessionsById = { ...state.sessionsById };
                 const failedAt = Date.now();
+                const affectedConnectionRootSessionId =
+                    session_id != null
+                        ? getRuntimeConnectionRootSessionId(
+                              state.sessionsById,
+                              session_id,
+                          )
+                        : null;
                 let changed = false;
 
                 for (const [sessionId, session] of Object.entries(
@@ -9483,6 +9518,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 )) {
                     if (
                         session.runtimeId !== runtime_id ||
+                        (affectedConnectionRootSessionId != null &&
+                            getRuntimeConnectionRootSessionId(
+                                state.sessionsById,
+                                sessionId,
+                            ) !== affectedConnectionRootSessionId) ||
                         !isLiveRuntimeSession(session)
                     ) {
                         continue;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -7896,6 +7896,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
         let activeSessionId = sessionId;
         let currentItem = queuedItem;
         let optimisticMessageInserted = false;
+        let optimisticMessageId: string | null = null;
         let shouldRecoverPromptForRetry = false;
         let preflightOwnership = options?.preflightOwnership ?? null;
         let session = get().sessionsById[activeSessionId];
@@ -8030,6 +8031,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
 
             const userMessageId =
                 currentItem.optimisticMessageId ?? crypto.randomUUID();
+            optimisticMessageId = userMessageId;
             if (
                 source === "queue" &&
                 currentItem.optimisticMessageId !== userMessageId
@@ -8163,6 +8165,24 @@ export const useChatStore = create<ChatStore>((set, get) => {
             shouldRecoverPromptForRetry =
                 source === "immediate" &&
                 isRuntimeSessionDisconnectedErrorMessage(message);
+            const failedOptimisticMessageId = shouldRecoverPromptForRetry
+                ? optimisticMessageId
+                : null;
+            if (failedOptimisticMessageId) {
+                set((state) => {
+                    const targetSession = state.sessionsById[activeSessionId];
+                    if (!targetSession) return state;
+                    return {
+                        sessionsById: {
+                            ...state.sessionsById,
+                            [activeSessionId]: removeSessionMessage(
+                                targetSession,
+                                failedOptimisticMessageId,
+                            ),
+                        },
+                    };
+                });
+            }
             if (source === "queue") {
                 restoreActiveQueuedMessage(activeSessionId, (item) => ({
                     ...item,
@@ -8173,6 +8193,9 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 session_id: activeSessionId,
                 message,
             });
+            if (shouldRecoverPromptForRetry) {
+                persistCurrentSession(activeSessionId);
+            }
             if (isAuthenticationErrorMessage(message, session.runtimeId)) {
                 await get().refreshSetupStatus(session.runtimeId);
             }

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -56,6 +56,7 @@ export interface AIRuntimeConnectionState {
 
 export interface AIRuntimeConnectionPayload extends AIRuntimeConnectionState {
     runtime_id: string;
+    session_id?: string | null;
 }
 
 export interface AITokenUsageCost {

--- a/crates/ai/src/events.rs
+++ b/crates/ai/src/events.rs
@@ -34,6 +34,7 @@ pub struct AiSessionErrorPayload {
 #[derive(Debug, Clone, Serialize)]
 pub struct AiRuntimeConnectionPayload {
     pub runtime_id: String,
+    pub session_id: Option<String>,
     pub status: String,
     pub message: Option<String>,
 }


### PR DESCRIPTION
## Summary

- detect unexpected ACP runtime disconnects after idle periods
- invalidate disconnected runtime session handles so later requests can reconnect
- restore the interrupted prompt for retry and expose the connection state to the renderer

## Validation

- Existing ACP recovery tests included in the change set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted AI connections and closed transport channels.
  * Affected conversations now enter an appropriate error or idle state without disrupting unrelated active sessions.
  * Failed messages preserve their content for reconnection and retry.
  * Reconnection errors now identify the affected conversation and provide clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->