### PR TITLE
Add configurable AI chat content width

### DIFF
--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -71,6 +71,10 @@ describe("settingsStore", () => {
         useSettingsStore.getState().setSetting("aiChatContentWidth", 1_600);
 
         expect(useSettingsStore.getState().aiChatContentWidth).toBe(1_200);
+
+        useSettingsStore.getState().setSetting("aiChatContentWidth", 601);
+
+        expect(useSettingsStore.getState().aiChatContentWidth).toBe(600);
     });
 
     it("persists vim settings globally across vaults", () => {

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -43,6 +43,7 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().pdfFilter).toBe("none");
         expect(useSettingsStore.getState().pdfDefaultZoom).toBe("fit-width");
         expect(useSettingsStore.getState().editorSpellcheck).toBe(false);
+        expect(useSettingsStore.getState().aiChatContentWidth).toBe(600);
         expect(useSettingsStore.getState().fileTreeScale).toBe(114);
         expect(useSettingsStore.getState().agentsSidebarScale).toBe(100);
         expect(useSettingsStore.getState().fileTreeStickyFolders).toBe(true);
@@ -64,6 +65,12 @@ describe("settingsStore", () => {
 
         useSettingsStore.getState().setSetting("pdfDefaultZoom", "fit-width");
         expect(resolvePdfInitialZoom()).toEqual({ zoom: 1, fitWidth: true });
+    });
+
+    it("normalizes the AI chat content width", () => {
+        useSettingsStore.getState().setSetting("aiChatContentWidth", 1_600);
+
+        expect(useSettingsStore.getState().aiChatContentWidth).toBe(1_200);
     });
 
     it("persists vim settings globally across vaults", () => {

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -18,6 +18,7 @@ export interface Settings {
     editorLineHeight: number; // 120–220 (percentage)
     editorAutosaveDelayMs: number; // 50–5000
     editorContentWidth: number; // 600–1200
+    aiChatContentWidth: number; // 480–1200
     lineWrapping: boolean;
     editorActiveLineHighlight: boolean;
     justifyText: boolean;
@@ -192,6 +193,7 @@ const defaults: Settings = {
     editorLineHeight: 175,
     editorAutosaveDelayMs: 300,
     editorContentWidth: 940,
+    aiChatContentWidth: 600,
     lineWrapping: true,
     editorActiveLineHighlight: true,
     justifyText: false,
@@ -478,6 +480,12 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
                 600,
                 1200,
             ),
+            aiChatContentWidth: normalizeIntInRange(
+                parsed.state.aiChatContentWidth,
+                defaults.aiChatContentWidth,
+                480,
+                1200,
+            ),
             lineWrapping: parsed.state.lineWrapping ?? defaults.lineWrapping,
             editorActiveLineHighlight:
                 parsed.state.editorActiveLineHighlight ??
@@ -621,6 +629,7 @@ function pickSettings(state: SettingsStore): Settings {
         editorLineHeight: state.editorLineHeight,
         editorAutosaveDelayMs: state.editorAutosaveDelayMs,
         editorContentWidth: state.editorContentWidth,
+        aiChatContentWidth: state.aiChatContentWidth,
         lineWrapping: state.lineWrapping,
         editorActiveLineHighlight: state.editorActiveLineHighlight,
         justifyText: state.justifyText,

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -273,6 +273,17 @@ function normalizeIntInRange(
     return Math.min(max, Math.max(min, Math.round(parsed)));
 }
 
+function normalizeAiChatContentWidth(value: unknown): number {
+    const width = normalizeIntInRange(
+        value,
+        defaults.aiChatContentWidth,
+        480,
+        1200,
+    );
+
+    return Math.round(width / 20) * 20;
+}
+
 function normalizeTabSize(value: unknown): 2 | 4 {
     const normalized = normalizeIntInRange(value, defaults.tabSize, 2, 4);
     return normalized <= 2 ? 2 : 4;
@@ -480,11 +491,8 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
                 600,
                 1200,
             ),
-            aiChatContentWidth: normalizeIntInRange(
+            aiChatContentWidth: normalizeAiChatContentWidth(
                 parsed.state.aiChatContentWidth,
-                defaults.aiChatContentWidth,
-                480,
-                1200,
             ),
             lineWrapping: parsed.state.lineWrapping ?? defaults.lineWrapping,
             editorActiveLineHighlight:
@@ -880,6 +888,12 @@ export const useSettingsStore = create<SettingsStore>()((set) => ({
                 return {
                     fileTreeExtensionFilter:
                         normalizeFileTreeExtensionFilter(value),
+                };
+            }
+
+            if (key === "aiChatContentWidth") {
+                return {
+                    aiChatContentWidth: normalizeAiChatContentWidth(value),
                 };
             }
 

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -64,7 +64,7 @@ import {
     shouldIncludeVaultEntryInFileScope,
     isTextLikeVaultEntry,
 } from "../../../app/utils/vaultEntries";
-import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import { getAiChatContentColumnStyle } from "./chatContentLayout";
 import { getComposerPrimaryAction } from "./chatComposerPrimaryAction";
 import {
     type ImageAttachmentValidationFailure,
@@ -984,6 +984,7 @@ export function AIChatComposer({
     onSubmit,
     onStop,
 }: AIChatComposerProps) {
+    const aiChatContentWidth = useSettingsStore((s) => s.aiChatContentWidth);
     const fileTreeContentMode = useSettingsStore((s) => s.fileTreeContentMode);
     const fileTreeShowExtensions = useSettingsStore(
         (s) => s.fileTreeShowExtensions,
@@ -1698,7 +1699,7 @@ export function AIChatComposer({
                 <div className={expanded ? "px-2 pb-1.5" : "px-3 pb-1.5"}>
                     <div
                         className="min-w-0"
-                        style={AI_CHAT_CONTENT_COLUMN_STYLE}
+                        style={getAiChatContentColumnStyle(aiChatContentWidth)}
                     >
                         {contextBar}
                     </div>
@@ -1729,7 +1730,7 @@ export function AIChatComposer({
                     ref={bindContentColumnRef}
                     className={contentColumnClassName}
                     data-testid="chat-composer-content-column"
-                    style={AI_CHAT_CONTENT_COLUMN_STYLE}
+                    style={getAiChatContentColumnStyle(aiChatContentWidth)}
                 >
                     {!expanded && (
                         <div

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -14,7 +14,10 @@ import {
     ContextMenu,
     type ContextMenuState,
 } from "../../../components/context-menu/ContextMenu";
-import type { EditorFontFamily } from "../../../app/store/settingsStore";
+import {
+    useSettingsStore,
+    type EditorFontFamily,
+} from "../../../app/store/settingsStore";
 import type {
     AIChatMessage,
     AIChatSessionStatus,
@@ -39,7 +42,7 @@ import {
 import { useChatStore } from "../store/chatStore";
 import type { ActivityDisplayMode } from "../activityDisplayMode";
 import { isTurnStartedStatusMessage } from "../transcriptModel";
-import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import { getAiChatContentColumnStyle } from "./chatContentLayout";
 import { ChatFindBar } from "./find/ChatFindBar";
 import { useChatFind } from "./find/useChatFind";
 import {
@@ -389,6 +392,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     onUrlElicitationOpen,
     onUrlElicitationResponse,
 }: AIChatMessageListProps) {
+    const aiChatContentWidth = useSettingsStore((s) => s.aiChatContentWidth);
     const containerRef = useRef<HTMLDivElement>(null);
     const findHighlightOwnerId = useId();
     const [findQuery, setFindQuery] = useState("");
@@ -842,7 +846,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                     <div
                         className="min-w-0"
                         data-testid="chat-pinned-plan-column"
-                        style={AI_CHAT_CONTENT_COLUMN_STYLE}
+                        style={getAiChatContentColumnStyle(aiChatContentWidth)}
                     >
                         <PlanMessage
                             sessionId={sessionId}
@@ -872,7 +876,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                     className="min-w-0"
                     data-selectable="true"
                     style={{
-                        ...AI_CHAT_CONTENT_COLUMN_STYLE,
+                        ...getAiChatContentColumnStyle(aiChatContentWidth),
                         fontSize: chatFontSize,
                         fontFamily: getEditorFontFamily(chatFontFamily),
                     }}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -57,7 +57,7 @@ import { formatShortcutAction } from "../../../app/shortcuts/format";
 import { getDesktopPlatform } from "../../../app/utils/platform";
 import { AIDiscardedRootsBanner } from "./AIDiscardedRootsBanner";
 import { useInlineRename } from "./useInlineRename";
-import { AI_CHAT_CONTENT_COLUMN_STYLE } from "./chatContentLayout";
+import { getAiChatContentColumnStyle } from "./chatContentLayout";
 import { useChatFindShortcut } from "./find/useChatFindShortcut";
 import {
     appendFileAttachmentPart,
@@ -190,11 +190,13 @@ function ChatContentColumn({
 }: {
     children: ReactNode;
 }) {
+    const aiChatContentWidth = useSettingsStore((s) => s.aiChatContentWidth);
+
     return (
         <div
             className="min-w-0"
             data-testid="chat-content-column"
-            style={AI_CHAT_CONTENT_COLUMN_STYLE}
+            style={getAiChatContentColumnStyle(aiChatContentWidth)}
         >
             {children}
         </div>

--- a/apps/desktop/src/features/ai/components/chatContentLayout.ts
+++ b/apps/desktop/src/features/ai/components/chatContentLayout.ts
@@ -2,8 +2,14 @@ import type { CSSProperties } from "react";
 
 export const AI_CHAT_CONTENT_MAX_WIDTH_PX = 600;
 
-export const AI_CHAT_CONTENT_COLUMN_STYLE = {
-    width: "100%",
-    maxWidth: AI_CHAT_CONTENT_MAX_WIDTH_PX,
-    marginInline: "auto",
-} satisfies CSSProperties;
+export function getAiChatContentColumnStyle(
+    maxWidth = AI_CHAT_CONTENT_MAX_WIDTH_PX,
+) {
+    return {
+        width: "100%",
+        maxWidth,
+        marginInline: "auto",
+    } satisfies CSSProperties;
+}
+
+export const AI_CHAT_CONTENT_COLUMN_STYLE = getAiChatContentColumnStyle();

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -306,6 +306,22 @@ describe("SettingsPanel", () => {
         expect(screen.getByDisplayValue("125")).toBeInTheDocument();
     });
 
+    it("sets the AI chat content width from Appearance", () => {
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Appearance" }));
+
+        const label = screen.getByText("Chat content width");
+        const row = label.parentElement?.parentElement;
+        expect(row).not.toBeNull();
+
+        fireEvent.change(within(row as HTMLElement).getByDisplayValue("600"), {
+            target: { value: "800" },
+        });
+
+        expect(useSettingsStore.getState().aiChatContentWidth).toBe(800);
+    });
+
     it("filters recent vaults in a scrollable list", () => {
         localStorage.setItem(
             "neverwrite:recentVaults",

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -949,6 +949,7 @@ function AppearanceSettings({
         fileTreeScale,
         agentsSidebarScale,
         fileTreeStickyFolders,
+        aiChatContentWidth,
         setSetting,
     } = useSettingsStore();
     const [appZoomPercent, setAppZoomPercent] = useAppZoomPercent();
@@ -999,8 +1000,14 @@ function AppearanceSettings({
             appZoomShortcut,
         ],
     ]);
+    const showChat = sectionHasSettingsSearchMatches(searchQuery, "Chat", [
+        [
+            "Chat content width",
+            "Maximum width of AI chat messages, composer, and related panels, in pixels.",
+        ],
+    ]);
 
-    if (!showMode && !showTheme && !showNavigation && !showZoom) {
+    if (!showMode && !showTheme && !showNavigation && !showZoom && !showChat) {
         return <EmptyPanelSearchResult />;
     }
 
@@ -1073,6 +1080,24 @@ function AppearanceSettings({
                         onChange={(v) =>
                             setSetting("fileTreeStickyFolders", v)
                         }
+                    />
+                }
+            />
+
+            {showChat ? <SectionLabel>Chat</SectionLabel> : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Chat"
+                label="Chat content width"
+                description="Maximum width of AI chat messages, composer, and related panels, in pixels."
+                control={
+                    <SliderField
+                        value={aiChatContentWidth}
+                        min={480}
+                        max={1200}
+                        step={20}
+                        onChange={(v) => setSetting("aiChatContentWidth", v)}
+                        formatValue={(value) => `${value}px`}
                     />
                 }
             />

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -67,7 +67,7 @@ the same Settings stores.
 | Appearance / Navigation | `fileTreeScale` | Per-vault | `114` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `agentsSidebarScale` | Per-vault | `100` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `fileTreeStickyFolders` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Controls sticky parent folders in the file tree. |
-| Appearance / Chat | `aiChatContentWidth` | Per-vault | `600` | `neverwrite:settings:<vault-path>` | Maximum width of AI chat messages, composer, and related panels; clamped to `480..1200`. |
+| Appearance / Chat | `aiChatContentWidth` | Per-vault | `600` | `neverwrite:settings:<vault-path>` | Maximum width of AI chat messages, composer, and related panels; clamped to `480..1200` in 20 px increments. |
 | Appearance / Zoom | `appZoom` | Global | `1` | `neverwrite:appZoom` | Stored outside `settingsStore`; normalized by `appZoom.ts`. |
 | Editor / Typography | `editorFontSize` | Per-vault | `14` | `neverwrite:settings:<vault-path>` | Clamped to `10..24`. |
 | Editor / Typography | `editorFontFamily` | Per-vault | `system` | `neverwrite:settings:<vault-path>` | Validated against `EDITOR_FONT_FAMILY_OPTIONS`. |

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -67,6 +67,7 @@ the same Settings stores.
 | Appearance / Navigation | `fileTreeScale` | Per-vault | `114` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `agentsSidebarScale` | Per-vault | `100` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `fileTreeStickyFolders` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Controls sticky parent folders in the file tree. |
+| Appearance / Chat | `aiChatContentWidth` | Per-vault | `600` | `neverwrite:settings:<vault-path>` | Maximum width of AI chat messages, composer, and related panels; clamped to `480..1200`. |
 | Appearance / Zoom | `appZoom` | Global | `1` | `neverwrite:appZoom` | Stored outside `settingsStore`; normalized by `appZoom.ts`. |
 | Editor / Typography | `editorFontSize` | Per-vault | `14` | `neverwrite:settings:<vault-path>` | Clamped to `10..24`. |
 | Editor / Typography | `editorFontFamily` | Per-vault | `system` | `neverwrite:settings:<vault-path>` | Validated against `EDITOR_FONT_FAMILY_OPTIONS`. |


### PR DESCRIPTION
## Summary
- add an Appearance setting for the maximum AI chat content width
- persist the per-vault preference with a 480–1200 px range in 20 px steps
- apply the selected width consistently to the transcript, composer, and pinned plan

## Testing
- npm run build
- npm test -- --run src/app/store/settingsStore.test.ts src/features/settings/SettingsPanel.test.tsx src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatMessageList.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Appearance setting to adjust AI chat content width from 480–1200px.
  * Choose widths in 20px increments using the new slider in the Chat settings.
  * Chat layout updates dynamically across messages, composer, and related content.
  * The preference defaults to 600px and is saved separately for each vault.

* **Bug Fixes**
  * Width values are automatically constrained to the supported range and normalized to valid increments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->