### PR TITLE
Fix chat scroll-to-bottom visibility

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -597,6 +597,70 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(secondScrollContainer.scrollTop).toBe(4_320);
     });
 
+    it("does not carry the scroll-to-bottom control into a new short chat", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-scrolled"
+                messages={createLongTranscript(140)}
+                status="idle"
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer);
+
+        act(() => {
+            scrollContainer.scrollTop = 1_000;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        expect(
+            screen.getByRole("button", { name: "Scroll to bottom" }),
+        ).toBeInTheDocument();
+
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-new"
+                messages={createMessages()}
+                status="idle"
+            />,
+        );
+
+        expect(
+            screen.queryByRole("button", { name: "Scroll to bottom" }),
+        ).not.toBeInTheDocument();
+    });
+
+    it("hides the restored scroll-to-bottom control when the transcript no longer overflows", () => {
+        const messages = createLongTranscript(140);
+        const firstMount = renderComponent(
+            <AIChatMessageList
+                sessionId="session-restored-short"
+                messages={messages}
+                status="idle"
+            />,
+        );
+        const firstScrollContainer = getScrollContainer(firstMount.container);
+        configureScrollableViewport(firstScrollContainer);
+
+        act(() => {
+            firstScrollContainer.scrollTop = 0;
+            firstScrollContainer.dispatchEvent(new Event("scroll"));
+        });
+        firstMount.unmount();
+
+        renderComponent(
+            <AIChatMessageList
+                sessionId="session-restored-short"
+                messages={createMessages()}
+                status="idle"
+            />,
+        );
+
+        expect(
+            screen.queryByRole("button", { name: "Scroll to bottom" }),
+        ).not.toBeInTheDocument();
+    });
+
     it("keeps non-visible diff work cycles as rich cards", () => {
         const messages: AIChatMessage[] = [
             {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -598,6 +598,7 @@ describe("AIChatMessageList streaming run indicator", () => {
     });
 
     it("does not carry the scroll-to-bottom control into a new short chat", () => {
+        let isShortTranscript = false;
         const view = renderComponent(
             <AIChatMessageList
                 sessionId="session-scrolled"
@@ -606,7 +607,9 @@ describe("AIChatMessageList streaming run indicator", () => {
             />,
         );
         const scrollContainer = getScrollContainer(view.container);
-        configureScrollableViewport(scrollContainer);
+        configureScrollableViewport(scrollContainer, 320, {
+            getScrollHeight: () => (isShortTranscript ? 320 : 12_000),
+        });
 
         act(() => {
             scrollContainer.scrollTop = 1_000;
@@ -617,6 +620,8 @@ describe("AIChatMessageList streaming run indicator", () => {
             screen.getByRole("button", { name: "Scroll to bottom" }),
         ).toBeInTheDocument();
 
+        isShortTranscript = true;
+        scrollContainer.scrollTop = 0;
         view.rerender(
             <AIChatMessageList
                 sessionId="session-new"

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -635,6 +635,36 @@ describe("AIChatMessageList streaming run indicator", () => {
         ).not.toBeInTheDocument();
     });
 
+    it("starts an unvisited long chat at the bottom after switching sessions", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-scrolled"
+                messages={createLongTranscript(140)}
+                status="idle"
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer);
+
+        act(() => {
+            scrollContainer.scrollTop = 1_000;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-unvisited-long"
+                messages={createLongTranscript(140)}
+                status="idle"
+            />,
+        );
+
+        expect(scrollContainer.scrollTop).toBe(12_000);
+        expect(
+            screen.queryByRole("button", { name: "Scroll to bottom" }),
+        ).not.toBeInTheDocument();
+    });
+
     it("hides the restored scroll-to-bottom control when the transcript no longer overflows", () => {
         const messages = createLongTranscript(140);
         const firstMount = renderComponent(

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -655,7 +655,15 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         previousStatusRef.current = status;
         pendingPrependAdjustmentRef.current = null;
         setShowScrollButton(false);
-    }, [messages, status, viewStateScope]);
+
+        if (!pendingRestoreRef.current) {
+            const container = containerRef.current;
+            if (container) {
+                container.scrollTop = container.scrollHeight;
+                queueMicrotask(syncScrollButton);
+            }
+        }
+    }, [messages, status, syncScrollButton, viewStateScope]);
 
     useLayoutEffect(() => {
         const container = containerRef.current;

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -102,9 +102,18 @@ const NEAR_BOTTOM_THRESHOLD = 80;
 const LOAD_OLDER_THRESHOLD = 120;
 const DETACHED_TIMELINE_SCOPE = "__detached_timeline__";
 
+function getRemainingScrollDistance(el: HTMLElement) {
+    return Math.max(0, el.scrollHeight - el.scrollTop - el.clientHeight);
+}
+
 function isNearBottom(el: HTMLElement) {
+    return getRemainingScrollDistance(el) < NEAR_BOTTOM_THRESHOLD;
+}
+
+function shouldShowScrollToBottomButton(el: HTMLElement) {
     return (
-        el.scrollHeight - el.scrollTop - el.clientHeight < NEAR_BOTTOM_THRESHOLD
+        el.scrollHeight > el.clientHeight &&
+        getRemainingScrollDistance(el) >= NEAR_BOTTOM_THRESHOLD
     );
 }
 
@@ -394,6 +403,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 }: AIChatMessageListProps) {
     const aiChatContentWidth = useSettingsStore((s) => s.aiChatContentWidth);
     const containerRef = useRef<HTMLDivElement>(null);
+    const contentRef = useRef<HTMLDivElement>(null);
     const findHighlightOwnerId = useId();
     const [findQuery, setFindQuery] = useState("");
     const [findCaseSensitive, setFindCaseSensitive] = useState(false);
@@ -447,17 +457,23 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         setShowScrollButton(false);
     }, []);
 
+    const syncScrollButton = useCallback(() => {
+        const container = containerRef.current;
+        if (!container) {
+            setShowScrollButton(false);
+            return;
+        }
+
+        setShowScrollButton(shouldShowScrollToBottomButton(container));
+    }, []);
+
     const handleScroll = useCallback(() => {
         const container = containerRef.current;
         if (!container) return;
 
         const nearBottom = isNearBottom(container);
         wasNearBottomRef.current = nearBottom;
-        if (nearBottom) {
-            setShowScrollButton(false);
-        } else {
-            setShowScrollButton(true);
-        }
+        setShowScrollButton(shouldShowScrollToBottomButton(container));
 
         persistChatMessageListViewState(
             viewStateScope,
@@ -638,6 +654,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         previousMessagesRef.current = messages;
         previousStatusRef.current = status;
         pendingPrependAdjustmentRef.current = null;
+        setShowScrollButton(false);
     }, [messages, status, viewStateScope]);
 
     useLayoutEffect(() => {
@@ -661,8 +678,8 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         pendingRestoreRef.current = null;
         wasNearBottomRef.current = pendingState.nearBottom;
-        setShowScrollButton(!pendingState.nearBottom);
-    }, [timelineRows, viewStateScope]);
+        syncScrollButton();
+    }, [syncScrollButton, timelineRows, viewStateScope]);
 
     useLayoutEffect(() => {
         const container = containerRef.current;
@@ -694,13 +711,13 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 container.scrollHeight -
                 previousScrollHeight +
                 previousScrollTop;
-            queueMicrotask(() => setShowScrollButton(true));
+            queueMicrotask(syncScrollButton);
         } else if (wasNearBottomRef.current) {
             container.scrollTop = container.scrollHeight;
-            queueMicrotask(() => setShowScrollButton(false));
+            queueMicrotask(syncScrollButton);
         } else {
             const frameId = window.requestAnimationFrame(() => {
-                setShowScrollButton(true);
+                syncScrollButton();
             });
 
             previousMessagesRef.current = messages;
@@ -713,7 +730,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         previousMessagesRef.current = messages;
         previousStatusRef.current = status;
-    }, [messages, status]);
+    }, [messages, status, syncScrollButton]);
 
     useEffect(() => {
         if (isLoadingOlderMessages || !pendingPrependAdjustmentRef.current) {
@@ -762,32 +779,40 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         const ro = new ResizeObserver(() => {
             const newWidth = scrollContainer.clientWidth;
-            if (newWidth === prevWidth) return;
-            prevWidth = newWidth;
+            if (newWidth !== prevWidth) {
+                prevWidth = newWidth;
 
-            if (anchorSnapshot.nearBottom) {
-                scrollContainer.scrollTop = scrollContainer.scrollHeight;
-            } else if (anchorSnapshot.rowKey) {
-                const anchorNode = findChatRowByKey(
-                    scrollContainer,
-                    anchorSnapshot.rowKey,
-                );
-                if (!anchorNode) {
-                    return;
+                if (anchorSnapshot.nearBottom) {
+                    scrollContainer.scrollTop = scrollContainer.scrollHeight;
+                } else if (anchorSnapshot.rowKey) {
+                    const anchorNode = findChatRowByKey(
+                        scrollContainer,
+                        anchorSnapshot.rowKey,
+                    );
+                    if (!anchorNode) {
+                        syncScrollButton();
+                        return;
+                    }
+                    const containerRect =
+                        scrollContainer.getBoundingClientRect();
+                    const rect = anchorNode.getBoundingClientRect();
+                    scrollContainer.scrollTop +=
+                        rect.top - containerRect.top - anchorSnapshot.offset;
                 }
-                const containerRect = scrollContainer.getBoundingClientRect();
-                const rect = anchorNode.getBoundingClientRect();
-                scrollContainer.scrollTop +=
-                    rect.top - containerRect.top - anchorSnapshot.offset;
             }
+
+            syncScrollButton();
         });
 
         ro.observe(scrollContainer);
+        if (contentRef.current) {
+            ro.observe(contentRef.current);
+        }
         return () => {
             scrollContainer.removeEventListener("scroll", captureAnchor);
             ro.disconnect();
         };
-    }, []);
+    }, [syncScrollButton]);
 
     useLayoutEffect(() => {
         if (!scrollToMessageId) return;
@@ -873,6 +898,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 data-scrollbar-active="true"
             >
                 <div
+                    ref={contentRef}
                     className="min-w-0"
                     data-selectable="true"
                     style={{


### PR DESCRIPTION
## Summary
- show the jump-to-bottom control only when the transcript has real overflow and at least 80 px remain
- reset and recalculate its visibility when switching chats, restoring scroll state, streaming, or resizing activity rails
- cover new-chat and restored-short-transcript regressions
- this is a regression since the introduction of activity rails 

## Verification
- npm test -- --run src/features/ai/components/AIChatMessageList.test.tsx
- npx eslint src/features/ai/components/AIChatMessageList.tsx src/features/ai/components/AIChatMessageList.test.tsx
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat scroll behavior when switching between sessions.
  * The scroll-to-bottom button is now hidden when chat content does not overflow or is already near the bottom.
  * Preserved scroll position more reliably when messages are added, restored, resized, or reflowed.
  * Fixed stale scroll-button visibility after remounting a chat session.

* **Tests**
  * Added regression coverage for session switching and non-overflowing transcripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->