### PR TITLE
Surface ACP startup errors during chat reconnect

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -139,6 +139,8 @@ const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
 const ACP_STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 const MAX_ACP_STDERR_BYTES: usize = 16 * 1024;
+const ACP_RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC: &str =
+    "The AI runtime configuration is invalid.";
 const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
 const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
 const RUNTIME_SECRET_SERVICE_ENV: &str = "NEVERWRITE_AI_SECRET_SERVICE";
@@ -4735,46 +4737,16 @@ async fn capture_acp_stderr(mut stderr: tokio::process::ChildStderr) -> String {
     String::from_utf8_lossy(&captured).into_owned()
 }
 
-fn normalize_acp_stderr(stderr: &str) -> Option<String> {
-    let normalized = stderr
-        .chars()
-        .filter(|character| !character.is_control() || matches!(character, '\n' | '\r' | '\t'))
-        .collect::<String>();
-    let normalized = normalized
-        .lines()
-        .map(|line| {
-            let lower = line.to_ascii_lowercase();
-            if [
-                "api_key",
-                "api-key",
-                "apikey",
-                "authorization:",
-                "bearer ",
-                "token=",
-                "token:",
-                "secret=",
-                "secret:",
-                "password",
-            ]
-            .iter()
-            .any(|marker| lower.contains(marker))
-            {
-                "[redacted sensitive runtime stderr line]"
-            } else {
-                line
-            }
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-    let normalized = normalized.trim();
-    (!normalized.is_empty()).then(|| normalized.to_string())
-}
-
-// Keep the "Runtime stderr:" marker synchronized with RUNTIME_STDERR_MARKER in chatStore.ts.
-fn append_acp_stderr(message: String, stderr: &str) -> String {
-    match normalize_acp_stderr(stderr) {
-        Some(stderr) => format!("{message} Runtime stderr: {stderr}"),
-        None => message,
+fn append_acp_stderr_diagnostic(message: String, stderr: &str) -> String {
+    // ACP stderr can contain arbitrary runtime output, including credentials. Only expose a
+    // fixed diagnostic that NeverWrite recognizes; never propagate the original text.
+    if stderr
+        .to_ascii_lowercase()
+        .contains("error loading config:")
+    {
+        format!("{message} {ACP_RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC}")
+    } else {
+        message
     }
 }
 
@@ -4794,7 +4766,7 @@ async fn acp_child_exit_message_with_stderr(
         },
         None => String::new(),
     };
-    append_acp_stderr(message, &stderr)
+    append_acp_stderr_diagnostic(message, &stderr)
 }
 
 async fn acp_child_wait_message(
@@ -11686,48 +11658,50 @@ mod tests {
     }
 
     #[test]
-    fn acp_exit_errors_include_clean_runtime_stderr() {
-        let message = append_acp_stderr(
+    fn acp_exit_errors_expose_only_a_safe_configuration_diagnostic() {
+        let message = append_acp_stderr_diagnostic(
             "The AI runtime process exited with status exit status: 1.".to_string(),
-            "\nError: error loading config: /vault/.codex/config.toml\0\n",
+            "\nError: error loading config: /vault/.codex/config.toml\nAWS_SECRET_ACCESS_KEY=private-value\0\n",
         );
 
         assert_eq!(
             message,
-            "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: error loading config: /vault/.codex/config.toml"
+            "The AI runtime process exited with status exit status: 1. The AI runtime configuration is invalid."
         );
+        assert!(!message.contains("/vault/.codex/config.toml"));
+        assert!(!message.contains("private-value"));
     }
 
     #[test]
-    fn acp_exit_errors_omit_empty_runtime_stderr() {
+    fn acp_exit_errors_omit_unrecognized_runtime_stderr() {
         assert_eq!(
-            append_acp_stderr("The AI runtime process exited.".to_string(), " \n\t"),
+            append_acp_stderr_diagnostic(
+                "The AI runtime process exited.".to_string(),
+                "AWS_SECRET_ACCESS_KEY=private-value",
+            ),
             "The AI runtime process exited."
         );
     }
 
     #[test]
-    fn acp_exit_errors_redact_sensitive_runtime_stderr_lines() {
-        let message = append_acp_stderr(
+    fn acp_exit_errors_never_expose_runtime_stderr() {
+        let message = append_acp_stderr_diagnostic(
             "The AI runtime process exited.".to_string(),
             "Configuration failed\nAuthorization: Bearer private-value\nPASSWORD=database-value\nTry again",
         );
 
-        assert_eq!(
-            message,
-            "The AI runtime process exited. Runtime stderr: Configuration failed\n[redacted sensitive runtime stderr line]\n[redacted sensitive runtime stderr line]\nTry again"
-        );
+        assert_eq!(message, "The AI runtime process exited.");
         assert!(!message.contains("private-value"));
         assert!(!message.contains("database-value"));
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn acp_startup_errors_capture_stderr_after_a_protocol_failure() {
+    async fn acp_startup_errors_expose_only_safe_stderr_diagnostics() {
         let mut child = Command::new("sh")
             .args([
                 "-c",
-                "printf 'Error: invalid runtime config\\n' >&2; exit 1",
+                "printf 'Error: error loading config: /vault/.codex/config.toml\\nAWS_SECRET_ACCESS_KEY=private-value\\n' >&2; exit 1",
             ])
             .stderr(std::process::Stdio::piped())
             .spawn()
@@ -11741,8 +11715,10 @@ mod tests {
 
         assert_eq!(
             message,
-            "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: invalid runtime config"
+            "The AI runtime process exited with status exit status: 1. The AI runtime configuration is invalid."
         );
+        assert!(!message.contains("/vault/.codex/config.toml"));
+        assert!(!message.contains("private-value"));
     }
 
     #[cfg(unix)]
@@ -11776,7 +11752,10 @@ mod tests {
         .await;
 
         assert!(capture_dropped.load(Ordering::SeqCst));
-        assert!(!message.contains("Runtime stderr:"));
+        assert_eq!(
+            message,
+            "The AI runtime process exited with status exit status: 1."
+        );
     }
 
     #[cfg(unix)]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4766,15 +4766,14 @@ async fn acp_child_exit_message_with_stderr(
     config_invalid: &AtomicBool,
 ) -> String {
     let message = acp_child_exit_message(status);
-    match stderr_task.take() {
-        Some(mut task) => match tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, &mut task).await {
+    if let Some(mut task) = stderr_task.take() {
+        match tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, &mut task).await {
             Ok(_) => {}
             Err(_) => {
                 task.abort();
                 let _ = task.await;
             }
-        },
-        None => {}
+        }
     }
     append_acp_stderr_diagnostic(message, config_invalid.load(Ordering::Relaxed))
 }

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4754,6 +4754,7 @@ fn normalize_acp_stderr(stderr: &str) -> Option<String> {
                 "token:",
                 "secret=",
                 "secret:",
+                "password",
             ]
             .iter()
             .any(|marker| lower.contains(marker))
@@ -11677,14 +11678,15 @@ mod tests {
     fn acp_exit_errors_redact_sensitive_runtime_stderr_lines() {
         let message = append_acp_stderr(
             "The AI runtime process exited.".to_string(),
-            "Configuration failed\nAuthorization: Bearer private-value\nTry again",
+            "Configuration failed\nAuthorization: Bearer private-value\nPASSWORD=database-value\nTry again",
         );
 
         assert_eq!(
             message,
-            "The AI runtime process exited. Runtime stderr: Configuration failed\n[redacted sensitive runtime stderr line]\nTry again"
+            "The AI runtime process exited. Runtime stderr: Configuration failed\n[redacted sensitive runtime stderr line]\n[redacted sensitive runtime stderr line]\nTry again"
         );
         assert!(!message.contains("private-value"));
+        assert!(!message.contains("database-value"));
     }
 
     #[cfg(unix)]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -138,7 +138,7 @@ const AUTH_TERMINAL_MONITOR_INTERVAL: Duration = Duration::from_millis(120);
 const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
 const ACP_STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
-const MAX_ACP_STDERR_BYTES: usize = 16 * 1024;
+const ACP_RUNTIME_CONFIGURATION_ERROR_MARKER: &[u8] = b"error loading config:";
 const ACP_RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC: &str =
     "The AI runtime configuration is invalid.";
 const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
@@ -4711,8 +4711,34 @@ async fn shutdown_acp_child(child: &mut tokio::process::Child) -> Result<(), Str
     Ok(())
 }
 
-async fn capture_acp_stderr(mut stderr: tokio::process::ChildStderr) -> String {
-    let mut captured = Vec::with_capacity(MAX_ACP_STDERR_BYTES);
+fn observe_acp_stderr_chunk(
+    config_invalid: &AtomicBool,
+    matched_marker_bytes: &mut usize,
+    chunk: &[u8],
+) {
+    if config_invalid.load(Ordering::Relaxed) {
+        return;
+    }
+
+    for byte in chunk {
+        let byte = byte.to_ascii_lowercase();
+        if byte == ACP_RUNTIME_CONFIGURATION_ERROR_MARKER[*matched_marker_bytes] {
+            *matched_marker_bytes += 1;
+            if *matched_marker_bytes == ACP_RUNTIME_CONFIGURATION_ERROR_MARKER.len() {
+                config_invalid.store(true, Ordering::Relaxed);
+                return;
+            }
+        } else {
+            *matched_marker_bytes = usize::from(byte == ACP_RUNTIME_CONFIGURATION_ERROR_MARKER[0]);
+        }
+    }
+}
+
+async fn capture_acp_stderr(
+    mut stderr: tokio::process::ChildStderr,
+    config_invalid: Arc<AtomicBool>,
+) {
+    let mut matched_marker_bytes = 0;
     let mut chunk = [0_u8; 4096];
     loop {
         let read = match stderr.read(&mut chunk).await {
@@ -4720,30 +4746,14 @@ async fn capture_acp_stderr(mut stderr: tokio::process::ChildStderr) -> String {
             Ok(read) => read,
             Err(_) => break,
         };
-        if read >= MAX_ACP_STDERR_BYTES {
-            captured.clear();
-            captured.extend_from_slice(&chunk[read - MAX_ACP_STDERR_BYTES..read]);
-            continue;
-        }
-        let overflow = captured
-            .len()
-            .saturating_add(read)
-            .saturating_sub(MAX_ACP_STDERR_BYTES);
-        if overflow > 0 {
-            captured.drain(..overflow);
-        }
-        captured.extend_from_slice(&chunk[..read]);
+        observe_acp_stderr_chunk(&config_invalid, &mut matched_marker_bytes, &chunk[..read]);
     }
-    String::from_utf8_lossy(&captured).into_owned()
 }
 
-fn append_acp_stderr_diagnostic(message: String, stderr: &str) -> String {
+fn append_acp_stderr_diagnostic(message: String, config_invalid: bool) -> String {
     // ACP stderr can contain arbitrary runtime output, including credentials. Only expose a
     // fixed diagnostic that NeverWrite recognizes; never propagate the original text.
-    if stderr
-        .to_ascii_lowercase()
-        .contains("error loading config:")
-    {
+    if config_invalid {
         format!("{message} {ACP_RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC}")
     } else {
         message
@@ -4752,36 +4762,38 @@ fn append_acp_stderr_diagnostic(message: String, stderr: &str) -> String {
 
 async fn acp_child_exit_message_with_stderr(
     status: std::process::ExitStatus,
-    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+    stderr_task: &mut Option<tokio::task::JoinHandle<()>>,
+    config_invalid: &AtomicBool,
 ) -> String {
     let message = acp_child_exit_message(status);
-    let stderr = match stderr_task.take() {
+    match stderr_task.take() {
         Some(mut task) => match tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, &mut task).await {
-            Ok(result) => result.unwrap_or_default(),
+            Ok(_) => {}
             Err(_) => {
                 task.abort();
                 let _ = task.await;
-                String::new()
             }
         },
-        None => String::new(),
-    };
-    append_acp_stderr_diagnostic(message, &stderr)
+        None => {}
+    }
+    append_acp_stderr_diagnostic(message, config_invalid.load(Ordering::Relaxed))
 }
 
 async fn acp_child_wait_message(
     wait_result: std::io::Result<std::process::ExitStatus>,
-    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+    stderr_task: &mut Option<tokio::task::JoinHandle<()>>,
+    config_invalid: &AtomicBool,
 ) -> String {
     match wait_result {
-        Ok(status) => acp_child_exit_message_with_stderr(status, stderr_task).await,
+        Ok(status) => acp_child_exit_message_with_stderr(status, stderr_task, config_invalid).await,
         Err(error) => format!("Failed to wait for AI runtime process: {error}"),
     }
 }
 
 async fn acp_startup_exit_message(
     child: &mut tokio::process::Child,
-    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+    stderr_task: &mut Option<tokio::task::JoinHandle<()>>,
+    config_invalid: &AtomicBool,
 ) -> Option<String> {
     let wait_result = match child.try_wait() {
         Ok(Some(status)) => Ok(status),
@@ -4791,7 +4803,7 @@ async fn acp_startup_exit_message(
         },
         Err(_) => return None,
     };
-    Some(acp_child_wait_message(wait_result, stderr_task).await)
+    Some(acp_child_wait_message(wait_result, stderr_task, config_invalid).await)
 }
 
 async fn run_acp12_actor_inner(
@@ -4817,7 +4829,11 @@ async fn run_acp12_actor_inner(
         .stderr
         .take()
         .ok_or_else(|| "Failed to acquire ACP stderr".to_string())?;
-    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
+    let config_invalid = Arc::new(AtomicBool::new(false));
+    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(
+        stderr,
+        Arc::clone(&config_invalid),
+    )));
     let stdin = child
         .stdin
         .take()
@@ -4936,14 +4952,25 @@ async fn run_acp12_actor_inner(
                 } => match response {
                     Ok(response) => response,
                     Err(error) => {
-                        if let Some(message) = acp_startup_exit_message(&mut child, &mut stderr_task).await {
+                        if let Some(message) = acp_startup_exit_message(
+                            &mut child,
+                            &mut stderr_task,
+                            &config_invalid,
+                        )
+                        .await
+                        {
                             return Err(acp12::Error::internal_error().data(message));
                         }
                         return Err(error);
                     }
                 },
                 wait_result = child.wait() => {
-                    let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
+                    let message = acp_child_wait_message(
+                        wait_result,
+                        &mut stderr_task,
+                        &config_invalid,
+                    )
+                    .await;
                     return Err(acp12::Error::internal_error().data(message));
                 }
             };
@@ -4978,7 +5005,12 @@ async fn run_acp12_actor_inner(
                         handle_acp12_command(command, &connection, &client, &permission_waiters).await;
                     }
                     wait_result = child.wait() => {
-                        let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
+                        let message = acp_child_wait_message(
+                            wait_result,
+                            &mut stderr_task,
+                            &config_invalid,
+                        )
+                        .await;
                         return Err(acp12::Error::internal_error().data(message));
                     }
                 }
@@ -5035,7 +5067,11 @@ async fn run_acp_actor_inner(
         .stderr
         .take()
         .ok_or_else(|| "Failed to acquire ACP stderr".to_string())?;
-    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
+    let config_invalid = Arc::new(AtomicBool::new(false));
+    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(
+        stderr,
+        Arc::clone(&config_invalid),
+    )));
     let stdin = child
         .stdin
         .take()
@@ -5196,14 +5232,25 @@ async fn run_acp_actor_inner(
                 } => match response {
                     Ok(response) => response,
                     Err(error) => {
-                        if let Some(message) = acp_startup_exit_message(&mut child, &mut stderr_task).await {
+                        if let Some(message) = acp_startup_exit_message(
+                            &mut child,
+                            &mut stderr_task,
+                            &config_invalid,
+                        )
+                        .await
+                        {
                             return Err(agent_client_protocol::Error::internal_error().data(message));
                         }
                         return Err(error);
                     }
                 },
                 wait_result = child.wait() => {
-                    let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
+                    let message = acp_child_wait_message(
+                        wait_result,
+                        &mut stderr_task,
+                        &config_invalid,
+                    )
+                    .await;
                     return Err(agent_client_protocol::Error::internal_error().data(message));
                 }
             };
@@ -5242,7 +5289,12 @@ async fn run_acp_actor_inner(
                         handle_acp_command(command, &connection, &client, &permission_waiters).await;
                     }
                     wait_result = child.wait() => {
-                        let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
+                        let message = acp_child_wait_message(
+                            wait_result,
+                            &mut stderr_task,
+                            &config_invalid,
+                        )
+                        .await;
                         return Err(agent_client_protocol::Error::internal_error().data(message));
                     }
                 }
@@ -11661,7 +11713,7 @@ mod tests {
     fn acp_exit_errors_expose_only_a_safe_configuration_diagnostic() {
         let message = append_acp_stderr_diagnostic(
             "The AI runtime process exited with status exit status: 1.".to_string(),
-            "\nError: error loading config: /vault/.codex/config.toml\nAWS_SECRET_ACCESS_KEY=private-value\0\n",
+            true,
         );
 
         assert_eq!(
@@ -11675,24 +11727,24 @@ mod tests {
     #[test]
     fn acp_exit_errors_omit_unrecognized_runtime_stderr() {
         assert_eq!(
-            append_acp_stderr_diagnostic(
-                "The AI runtime process exited.".to_string(),
-                "AWS_SECRET_ACCESS_KEY=private-value",
-            ),
+            append_acp_stderr_diagnostic("The AI runtime process exited.".to_string(), false,),
             "The AI runtime process exited."
         );
     }
 
     #[test]
-    fn acp_exit_errors_never_expose_runtime_stderr() {
-        let message = append_acp_stderr_diagnostic(
-            "The AI runtime process exited.".to_string(),
-            "Configuration failed\nAuthorization: Bearer private-value\nPASSWORD=database-value\nTry again",
-        );
+    fn acp_stderr_detection_is_case_insensitive_across_chunks() {
+        let config_invalid = AtomicBool::new(false);
+        let mut matched_marker_bytes = 0;
 
-        assert_eq!(message, "The AI runtime process exited.");
-        assert!(!message.contains("private-value"));
-        assert!(!message.contains("database-value"));
+        observe_acp_stderr_chunk(
+            &config_invalid,
+            &mut matched_marker_bytes,
+            b"Error: ERROR LOAD",
+        );
+        observe_acp_stderr_chunk(&config_invalid, &mut matched_marker_bytes, b"ING CONFIG: ");
+
+        assert!(config_invalid.load(Ordering::Relaxed));
     }
 
     #[cfg(unix)]
@@ -11707,9 +11759,13 @@ mod tests {
             .spawn()
             .unwrap();
         let stderr = child.stderr.take().unwrap();
-        let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
+        let config_invalid = Arc::new(AtomicBool::new(false));
+        let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(
+            stderr,
+            Arc::clone(&config_invalid),
+        )));
 
-        let message = acp_startup_exit_message(&mut child, &mut stderr_task)
+        let message = acp_startup_exit_message(&mut child, &mut stderr_task, &config_invalid)
             .await
             .unwrap();
 
@@ -11719,6 +11775,34 @@ mod tests {
         );
         assert!(!message.contains("/vault/.codex/config.toml"));
         assert!(!message.contains("private-value"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acp_startup_errors_keep_configuration_diagnostic_when_stderr_stays_open() {
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                "printf 'Error: error loading config: /vault/.codex/config.toml\\n' >&2; sleep 1 >&2 & exit 1",
+            ])
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stderr = child.stderr.take().unwrap();
+        let config_invalid = Arc::new(AtomicBool::new(false));
+        let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(
+            stderr,
+            Arc::clone(&config_invalid),
+        )));
+
+        let message = acp_startup_exit_message(&mut child, &mut stderr_task, &config_invalid)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            message,
+            "The AI runtime process exited with status exit status: 1. The AI runtime configuration is invalid."
+        );
     }
 
     #[cfg(unix)]
@@ -11741,13 +11825,14 @@ mod tests {
         let mut stderr_task = Some(tokio::spawn(async move {
             let _drop_signal = DropSignal(capture_dropped_for_task);
             let _ = started_tx.send(());
-            std::future::pending::<String>().await
+            std::future::pending::<()>().await
         }));
         started_rx.await.unwrap();
 
         let message = acp_child_exit_message_with_stderr(
             std::process::ExitStatus::from_raw(1 << 8),
             &mut stderr_task,
+            &AtomicBool::new(false),
         )
         .await;
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -57,6 +57,7 @@ use portable_pty::{
 };
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use tokio::io::AsyncReadExt as TokioAsyncReadExt;
 use tokio::{process::Command, runtime::Builder, sync::oneshot};
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
@@ -136,6 +137,8 @@ const AUTH_TERMINAL_DEFAULT_ROWS: u16 = 28;
 const AUTH_TERMINAL_MONITOR_INTERVAL: Duration = Duration::from_millis(120);
 const AUTH_TERMINAL_OUTPUT_CHUNK_SIZE: usize = 4096;
 const ACP_SESSION_START_TIMEOUT: Duration = Duration::from_secs(15);
+const ACP_STDERR_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const MAX_ACP_STDERR_BYTES: usize = 16 * 1024;
 const RUNTIME_SETUP_STORE_VERSION: u32 = 2;
 const RUNTIME_SECRET_SERVICE: &str = "NeverWrite AI Provider Secrets";
 const RUNTIME_SECRET_SERVICE_ENV: &str = "NEVERWRITE_AI_SECRET_SERVICE";
@@ -4706,6 +4709,99 @@ async fn shutdown_acp_child(child: &mut tokio::process::Child) -> Result<(), Str
     Ok(())
 }
 
+async fn capture_acp_stderr(mut stderr: tokio::process::ChildStderr) -> String {
+    let mut captured = Vec::with_capacity(MAX_ACP_STDERR_BYTES);
+    let mut chunk = [0_u8; 4096];
+    loop {
+        let read = match stderr.read(&mut chunk).await {
+            Ok(0) => break,
+            Ok(read) => read,
+            Err(_) => break,
+        };
+        if read >= MAX_ACP_STDERR_BYTES {
+            captured.clear();
+            captured.extend_from_slice(&chunk[read - MAX_ACP_STDERR_BYTES..read]);
+            continue;
+        }
+        let overflow = captured
+            .len()
+            .saturating_add(read)
+            .saturating_sub(MAX_ACP_STDERR_BYTES);
+        if overflow > 0 {
+            captured.drain(..overflow);
+        }
+        captured.extend_from_slice(&chunk[..read]);
+    }
+    String::from_utf8_lossy(&captured).into_owned()
+}
+
+fn normalize_acp_stderr(stderr: &str) -> Option<String> {
+    let normalized = stderr
+        .chars()
+        .filter(|character| !character.is_control() || matches!(character, '\n' | '\r' | '\t'))
+        .collect::<String>();
+    let normalized = normalized
+        .lines()
+        .map(|line| {
+            let lower = line.to_ascii_lowercase();
+            if [
+                "api_key",
+                "api-key",
+                "apikey",
+                "authorization:",
+                "bearer ",
+                "token=",
+                "token:",
+                "secret=",
+                "secret:",
+            ]
+            .iter()
+            .any(|marker| lower.contains(marker))
+            {
+                "[redacted sensitive runtime stderr line]"
+            } else {
+                line
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let normalized = normalized.trim();
+    (!normalized.is_empty()).then(|| normalized.to_string())
+}
+
+fn append_acp_stderr(message: String, stderr: &str) -> String {
+    match normalize_acp_stderr(stderr) {
+        Some(stderr) => format!("{message} Runtime stderr: {stderr}"),
+        None => message,
+    }
+}
+
+async fn acp_child_exit_message_with_stderr(
+    status: std::process::ExitStatus,
+    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+) -> String {
+    let message = acp_child_exit_message(status);
+    let stderr = match stderr_task.take() {
+        Some(task) => tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, task)
+            .await
+            .ok()
+            .and_then(Result::ok)
+            .unwrap_or_default(),
+        None => String::new(),
+    };
+    append_acp_stderr(message, &stderr)
+}
+
+async fn acp_child_wait_message(
+    wait_result: std::io::Result<std::process::ExitStatus>,
+    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+) -> String {
+    match wait_result {
+        Ok(status) => acp_child_exit_message_with_stderr(status, stderr_task).await,
+        Err(error) => format!("Failed to wait for AI runtime process: {error}"),
+    }
+}
+
 async fn run_acp12_actor_inner(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
@@ -4725,6 +4821,11 @@ async fn run_acp12_actor_inner(
         command.process_group(0);
     }
     let mut child = command.spawn().map_err(|error| error.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to acquire ACP stderr".to_string())?;
+    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
     let stdin = child
         .stdin
         .take()
@@ -4842,11 +4943,7 @@ async fn run_acp12_actor_inner(
                     .await
                 } => response?,
                 wait_result = child.wait() => {
-                    let message = wait_result
-                        .map(acp_child_exit_message)
-                        .unwrap_or_else(|error| {
-                            format!("Failed to wait for AI runtime process: {error}")
-                        });
+                    let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                     return Err(acp12::Error::internal_error().data(message));
                 }
             };
@@ -4881,11 +4978,7 @@ async fn run_acp12_actor_inner(
                         handle_acp12_command(command, &connection, &client, &permission_waiters).await;
                     }
                     wait_result = child.wait() => {
-                        let message = wait_result
-                            .map(acp_child_exit_message)
-                            .unwrap_or_else(|error| {
-                                format!("Failed to wait for AI runtime process: {error}")
-                            });
+                        let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                         return Err(acp12::Error::internal_error().data(message));
                     }
                 }
@@ -4938,6 +5031,11 @@ async fn run_acp_actor_inner(
         command.process_group(0);
     }
     let mut child = command.spawn().map_err(|error| error.to_string())?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to acquire ACP stderr".to_string())?;
+    let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
     let stdin = child
         .stdin
         .take()
@@ -5097,11 +5195,7 @@ async fn run_acp_actor_inner(
                     .await
                 } => response?,
                 wait_result = child.wait() => {
-                    let message = wait_result
-                        .map(acp_child_exit_message)
-                        .unwrap_or_else(|error| {
-                            format!("Failed to wait for AI runtime process: {error}")
-                        });
+                    let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                     return Err(agent_client_protocol::Error::internal_error().data(message));
                 }
             };
@@ -5140,11 +5234,7 @@ async fn run_acp_actor_inner(
                         handle_acp_command(command, &connection, &client, &permission_waiters).await;
                     }
                     wait_result = child.wait() => {
-                        let message = wait_result
-                            .map(acp_child_exit_message)
-                            .unwrap_or_else(|error| {
-                                format!("Failed to wait for AI runtime process: {error}")
-                            });
+                        let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                         return Err(agent_client_protocol::Error::internal_error().data(message));
                     }
                 }
@@ -11557,6 +11647,41 @@ mod tests {
             Err(AcpRequestError::ResponseChannelClosed)
         ));
         responder.join().unwrap();
+    }
+
+    #[test]
+    fn acp_exit_errors_include_clean_runtime_stderr() {
+        let message = append_acp_stderr(
+            "The AI runtime process exited with status exit status: 1.".to_string(),
+            "\nError: error loading config: /vault/.codex/config.toml\0\n",
+        );
+
+        assert_eq!(
+            message,
+            "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: error loading config: /vault/.codex/config.toml"
+        );
+    }
+
+    #[test]
+    fn acp_exit_errors_omit_empty_runtime_stderr() {
+        assert_eq!(
+            append_acp_stderr("The AI runtime process exited.".to_string(), " \n\t"),
+            "The AI runtime process exited."
+        );
+    }
+
+    #[test]
+    fn acp_exit_errors_redact_sensitive_runtime_stderr_lines() {
+        let message = append_acp_stderr(
+            "The AI runtime process exited.".to_string(),
+            "Configuration failed\nAuthorization: Bearer private-value\nTry again",
+        );
+
+        assert_eq!(
+            message,
+            "The AI runtime process exited. Runtime stderr: Configuration failed\n[redacted sensitive runtime stderr line]\nTry again"
+        );
+        assert!(!message.contains("private-value"));
     }
 
     #[cfg(unix)]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4807,6 +4807,21 @@ async fn acp_child_wait_message(
     }
 }
 
+async fn acp_startup_exit_message(
+    child: &mut tokio::process::Child,
+    stderr_task: &mut Option<tokio::task::JoinHandle<String>>,
+) -> Option<String> {
+    let wait_result = match child.try_wait() {
+        Ok(Some(status)) => Ok(status),
+        Ok(None) => match tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, child.wait()).await {
+            Ok(wait_result) => wait_result,
+            Err(_) => return None,
+        },
+        Err(_) => return None,
+    };
+    Some(acp_child_wait_message(wait_result, stderr_task).await)
+}
+
 async fn run_acp12_actor_inner(
     spec: AcpProcessSpec,
     start_mode: AcpSessionStartMode,
@@ -4946,7 +4961,15 @@ async fn run_acp12_actor_inner(
                         initialize_model_state,
                     )
                     .await
-                } => response?,
+                } => match response {
+                    Ok(response) => response,
+                    Err(error) => {
+                        if let Some(message) = acp_startup_exit_message(&mut child, &mut stderr_task).await {
+                            return Err(acp12::Error::internal_error().data(message));
+                        }
+                        return Err(error);
+                    }
+                },
                 wait_result = child.wait() => {
                     let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                     return Err(acp12::Error::internal_error().data(message));
@@ -5198,7 +5221,15 @@ async fn run_acp_actor_inner(
                         &suppress_replayed_session_events,
                     )
                     .await
-                } => response?,
+                } => match response {
+                    Ok(response) => response,
+                    Err(error) => {
+                        if let Some(message) = acp_startup_exit_message(&mut child, &mut stderr_task).await {
+                            return Err(agent_client_protocol::Error::internal_error().data(message));
+                        }
+                        return Err(error);
+                    }
+                },
                 wait_result = child.wait() => {
                     let message = acp_child_wait_message(wait_result, &mut stderr_task).await;
                     return Err(agent_client_protocol::Error::internal_error().data(message));
@@ -11688,6 +11719,30 @@ mod tests {
         );
         assert!(!message.contains("private-value"));
         assert!(!message.contains("database-value"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acp_startup_errors_capture_stderr_after_a_protocol_failure() {
+        let mut child = Command::new("sh")
+            .args([
+                "-c",
+                "printf 'Error: invalid runtime config\\n' >&2; exit 1",
+            ])
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stderr = child.stderr.take().unwrap();
+        let mut stderr_task = Some(tokio::spawn(capture_acp_stderr(stderr)));
+
+        let message = acp_startup_exit_message(&mut child, &mut stderr_task)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            message,
+            "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: invalid runtime config"
+        );
     }
 
     #[cfg(unix)]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4770,6 +4770,7 @@ fn normalize_acp_stderr(stderr: &str) -> Option<String> {
     (!normalized.is_empty()).then(|| normalized.to_string())
 }
 
+// Keep the "Runtime stderr:" marker synchronized with RUNTIME_STDERR_MARKER in chatStore.ts.
 fn append_acp_stderr(message: String, stderr: &str) -> String {
     match normalize_acp_stderr(stderr) {
         Some(stderr) => format!("{message} Runtime stderr: {stderr}"),

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4782,11 +4782,14 @@ async fn acp_child_exit_message_with_stderr(
 ) -> String {
     let message = acp_child_exit_message(status);
     let stderr = match stderr_task.take() {
-        Some(task) => tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, task)
-            .await
-            .ok()
-            .and_then(Result::ok)
-            .unwrap_or_default(),
+        Some(mut task) => match tokio::time::timeout(ACP_STDERR_DRAIN_TIMEOUT, &mut task).await {
+            Ok(result) => result.unwrap_or_default(),
+            Err(_) => {
+                task.abort();
+                let _ = task.await;
+                String::new()
+            }
+        },
         None => String::new(),
     };
     append_acp_stderr(message, &stderr)
@@ -11682,6 +11685,40 @@ mod tests {
             "The AI runtime process exited. Runtime stderr: Configuration failed\n[redacted sensitive runtime stderr line]\nTry again"
         );
         assert!(!message.contains("private-value"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn acp_exit_errors_abort_stderr_capture_after_drain_timeout() {
+        use std::os::unix::process::ExitStatusExt;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct DropSignal(Arc<AtomicBool>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let capture_dropped = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel();
+        let capture_dropped_for_task = Arc::clone(&capture_dropped);
+        let mut stderr_task = Some(tokio::spawn(async move {
+            let _drop_signal = DropSignal(capture_dropped_for_task);
+            let _ = started_tx.send(());
+            std::future::pending::<String>().await
+        }));
+        started_rx.await.unwrap();
+
+        let message = acp_child_exit_message_with_stderr(
+            std::process::ExitStatus::from_raw(1 << 8),
+            &mut stderr_task,
+        )
+        .await;
+
+        assert!(capture_dropped.load(Ordering::SeqCst));
+        assert!(!message.contains("Runtime stderr:"));
     }
 
     #[cfg(unix)]

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14631,6 +14631,89 @@ describe("chatStore", () => {
         ).toBe(true);
     });
 
+    it("surfaces runtime configuration errors when a saved chat cannot reconnect", async () => {
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [],
+        });
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                {
+                    runtime: runtimePayload[0].runtime,
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                "persisted:history-1": {
+                    sessionId: "persisted:history-1",
+                    historySessionId: "history-1",
+                    status: "idle",
+                    runtimeId: "codex-acp",
+                    modelId: "test-model",
+                    modeId: "default",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    messages: [],
+                    attachments: [],
+                    runtimeState: "persisted_only",
+                    isPersistedSession: true,
+                    persistedMessageCount: 2,
+                    loadedPersistedMessageStart: null,
+                    resumeContextPending: false,
+                },
+            },
+            sessionOrder: ["persisted:history-1"],
+            activeSessionId: "persisted:history-1",
+            selectedRuntimeId: "codex-acp",
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                throw new Error(
+                    'Internal error: "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: error loading config: /vault/.codex/config.toml:1:1: invalid type: integer `3`, expected struct AgentRoleToml"',
+                );
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        const nextSessionId = await useChatStore
+            .getState()
+            .resumeSession("persisted:history-1");
+
+        expect(nextSessionId).toBeNull();
+        expect(
+            useChatStore
+                .getState()
+                .sessionsById["persisted:history-1"]?.messages.at(-1),
+        ).toMatchObject({
+            kind: "error",
+            content:
+                "Could not reconnect this chat because the AI runtime configuration is invalid. Error: error loading config: /vault/.codex/config.toml:1:1: invalid type: integer `3`, expected struct AgentRoleToml",
+        });
+        expect(
+            useChatStore.getState().sessionsById["persisted:history-1"]
+                ?.resumeReconnectFailed,
+        ).toBe(true);
+
+        await useChatStore.getState().resumeSession("persisted:history-1");
+        const configurationErrors =
+            useChatStore
+                .getState()
+                .sessionsById["persisted:history-1"]?.messages.filter(
+                    (message) =>
+                        message.kind === "error" &&
+                        message.content.startsWith(
+                            "Could not reconnect this chat because the AI runtime configuration is invalid.",
+                        ),
+                ) ?? [];
+        expect(configurationErrors).toHaveLength(1);
+    });
+
     it("blocks removed Gemini ACP saved chats instead of reconnecting them", async () => {
         useVaultStore.setState({
             vaultPath: "/vault",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14675,7 +14675,7 @@ describe("chatStore", () => {
         invokeMock.mockImplementation(async (command, args) => {
             if (command === "ai_create_session") {
                 throw new Error(
-                    'Internal error: "The AI runtime process exited with status exit status: 1. Runtime stderr: Error: error loading config: /vault/.codex/config.toml:1:1: invalid type: integer `3`, expected struct AgentRoleToml"',
+                    'Internal error: "The AI runtime process exited with status exit status: 1. The AI runtime configuration is invalid. AWS_SECRET_ACCESS_KEY=private-value"',
                 );
             }
             return defaultInvokeImplementation(command, args);
@@ -14693,7 +14693,7 @@ describe("chatStore", () => {
         ).toMatchObject({
             kind: "error",
             content:
-                "Could not reconnect this chat because the AI runtime configuration is invalid. Error: error loading config: /vault/.codex/config.toml:1:1: invalid type: integer `3`, expected struct AgentRoleToml",
+                "Could not reconnect this chat because the AI runtime configuration is invalid. Review its configuration and try again.",
         });
         expect(
             useChatStore.getState().sessionsById["persisted:history-1"]

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -216,8 +216,8 @@ const SAVED_CHAT_RECONNECT_FAILED_MESSAGE =
     "Could not reconnect this chat. Start a new session with saved transcript context?";
 const SAVED_CHAT_RECONNECT_FAILURE_PREFIX =
     "Could not reconnect this chat because the AI runtime ";
-// Keep this marker synchronized with append_acp_stderr in native-backend/src/ai.rs.
-const RUNTIME_STDERR_MARKER = "Runtime stderr:";
+const RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC =
+    "The AI runtime configuration is invalid.";
 const CUSTOM_RUNTIME_CONTINUATION_STATUS_EVENT_ID =
     "neverwrite:recovery:custom-runtime-continuation";
 const CUSTOM_RUNTIME_UNAVAILABLE_MESSAGE =
@@ -718,24 +718,11 @@ function isRemovedGeminiAcpSession(session: Pick<AIChatSession, "runtimeId">) {
 }
 
 function getSavedChatReconnectFailureMessage(runtimeError: string) {
-    const markerIndex = runtimeError.lastIndexOf(RUNTIME_STDERR_MARKER);
-    if (markerIndex < 0) {
-        return SAVED_CHAT_RECONNECT_FAILED_MESSAGE;
+    if (runtimeError.includes(RUNTIME_CONFIGURATION_INVALID_DIAGNOSTIC)) {
+        return `${SAVED_CHAT_RECONNECT_FAILURE_PREFIX}configuration is invalid. Review its configuration and try again.`;
     }
 
-    const runtimeDetail = runtimeError
-        .slice(markerIndex + RUNTIME_STDERR_MARKER.length)
-        .trim()
-        .replace(/\\?"$/, "");
-    if (!runtimeDetail) {
-        return SAVED_CHAT_RECONNECT_FAILED_MESSAGE;
-    }
-
-    if (runtimeDetail.toLowerCase().includes("error loading config:")) {
-        return `${SAVED_CHAT_RECONNECT_FAILURE_PREFIX}configuration is invalid. ${runtimeDetail}`;
-    }
-
-    return `${SAVED_CHAT_RECONNECT_FAILURE_PREFIX}failed to start. ${runtimeDetail}`;
+    return SAVED_CHAT_RECONNECT_FAILED_MESSAGE;
 }
 
 function isSavedChatReconnectFailureMessage(message: string) {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -216,6 +216,7 @@ const SAVED_CHAT_RECONNECT_FAILED_MESSAGE =
     "Could not reconnect this chat. Start a new session with saved transcript context?";
 const SAVED_CHAT_RECONNECT_FAILURE_PREFIX =
     "Could not reconnect this chat because the AI runtime ";
+// Keep this marker synchronized with append_acp_stderr in native-backend/src/ai.rs.
 const RUNTIME_STDERR_MARKER = "Runtime stderr:";
 const CUSTOM_RUNTIME_CONTINUATION_STATUS_EVENT_ID =
     "neverwrite:recovery:custom-runtime-continuation";

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -214,6 +214,8 @@ const CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_TITLE =
     "Queued messages were cancelled because this subagent was closed by its parent thread.";
 const SAVED_CHAT_RECONNECT_FAILED_MESSAGE =
     "Could not reconnect this chat. Start a new session with saved transcript context?";
+const SAVED_CHAT_RECONNECT_FAILURE_PREFIX =
+    "Could not reconnect this chat because the AI runtime ";
 const RUNTIME_STDERR_MARKER = "Runtime stderr:";
 const CUSTOM_RUNTIME_CONTINUATION_STATUS_EVENT_ID =
     "neverwrite:recovery:custom-runtime-continuation";
@@ -729,18 +731,16 @@ function getSavedChatReconnectFailureMessage(runtimeError: string) {
     }
 
     if (runtimeDetail.toLowerCase().includes("error loading config:")) {
-        return `Could not reconnect this chat because the AI runtime configuration is invalid. ${runtimeDetail}`;
+        return `${SAVED_CHAT_RECONNECT_FAILURE_PREFIX}configuration is invalid. ${runtimeDetail}`;
     }
 
-    return `Could not reconnect this chat because the AI runtime failed to start. ${runtimeDetail}`;
+    return `${SAVED_CHAT_RECONNECT_FAILURE_PREFIX}failed to start. ${runtimeDetail}`;
 }
 
 function isSavedChatReconnectFailureMessage(message: string) {
     return (
         message === SAVED_CHAT_RECONNECT_FAILED_MESSAGE ||
-        message.startsWith(
-            "Could not reconnect this chat because the AI runtime ",
-        )
+        message.startsWith(SAVED_CHAT_RECONNECT_FAILURE_PREFIX)
     );
 }
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -214,6 +214,7 @@ const CLOSED_SUBAGENT_QUEUE_CANCELLED_STATUS_TITLE =
     "Queued messages were cancelled because this subagent was closed by its parent thread.";
 const SAVED_CHAT_RECONNECT_FAILED_MESSAGE =
     "Could not reconnect this chat. Start a new session with saved transcript context?";
+const RUNTIME_STDERR_MARKER = "Runtime stderr:";
 const CUSTOM_RUNTIME_CONTINUATION_STATUS_EVENT_ID =
     "neverwrite:recovery:custom-runtime-continuation";
 const CUSTOM_RUNTIME_UNAVAILABLE_MESSAGE =
@@ -711,6 +712,36 @@ function getRuntimeConnectionRootSessionId(
 
 function isRemovedGeminiAcpSession(session: Pick<AIChatSession, "runtimeId">) {
     return session.runtimeId === "gemini-acp";
+}
+
+function getSavedChatReconnectFailureMessage(runtimeError: string) {
+    const markerIndex = runtimeError.lastIndexOf(RUNTIME_STDERR_MARKER);
+    if (markerIndex < 0) {
+        return SAVED_CHAT_RECONNECT_FAILED_MESSAGE;
+    }
+
+    const runtimeDetail = runtimeError
+        .slice(markerIndex + RUNTIME_STDERR_MARKER.length)
+        .trim()
+        .replace(/\\?"$/, "");
+    if (!runtimeDetail) {
+        return SAVED_CHAT_RECONNECT_FAILED_MESSAGE;
+    }
+
+    if (runtimeDetail.toLowerCase().includes("error loading config:")) {
+        return `Could not reconnect this chat because the AI runtime configuration is invalid. ${runtimeDetail}`;
+    }
+
+    return `Could not reconnect this chat because the AI runtime failed to start. ${runtimeDetail}`;
+}
+
+function isSavedChatReconnectFailureMessage(message: string) {
+    return (
+        message === SAVED_CHAT_RECONNECT_FAILED_MESSAGE ||
+        message.startsWith(
+            "Could not reconnect this chat because the AI runtime ",
+        )
+    );
 }
 
 function getWorkspaceHistorySessionIdForSession(sessionId: string) {
@@ -9472,7 +9503,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                     ...removeSessionMessage(session, messageId),
                     resumeReconnectFailed:
                         message.kind === "error" &&
-                        message.content === SAVED_CHAT_RECONNECT_FAILED_MESSAGE
+                        isSavedChatReconnectFailureMessage(message.content)
                             ? false
                             : session.resumeReconnectFailed,
                 };
@@ -11192,7 +11223,7 @@ export const useChatStore = create<ChatStore>((set, get) => {
                 });
                 get().applySessionError({
                     session_id: sessionId,
-                    message: SAVED_CHAT_RECONNECT_FAILED_MESSAGE,
+                    message: getSavedChatReconnectFailureMessage(message),
                 });
                 if (
                     isAuthenticationErrorMessage(


### PR DESCRIPTION
## Summary

- drain bounded stderr output from current and legacy ACP child processes and attach it to process exit errors
- redact potentially sensitive stderr lines and cap drain time to avoid blocking runtime shutdown
- surface runtime configuration and startup failures during saved-chat reconnects instead of replacing them with the generic reconnect fallback
- keep repeated reconnect failures deduplicated and dismissible

## Root cause

NeverWrite piped ACP stderr without consuming it, so an invalid project runtime configuration appeared only as exit status 1. The renderer then discarded that backend error and displayed a generic reconnect message.

## Validation

- cargo test -p neverwrite-native-backend (338 passed)
- npm test -- src/features/ai/store/chatStore.test.ts (318 passed)
- npx eslint src/features/ai/store/chatStore.ts src/features/ai/store/chatStore.test.ts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error messages when AI runtime startup or configuration fails.
  - Saved chats now clearly report reconnection failures without duplicating errors on repeated attempts.
  - Sensitive or unrecognized diagnostic details are no longer exposed in process failure messages.
  - Empty diagnostic output is no longer appended to errors.

- **Reliability**
  - Improved handling of runtime failure output during startup and shutdown.
  - Added safeguards to prevent stalled diagnostics from affecting runtime recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->