### PR TITLE
Add translucent chat composer surfaces

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -357,6 +357,9 @@ describe("AIChatComposer mention picker", () => {
     it("keeps the capped composer content flexible while expanded", () => {
         renderComposer({ expanded: true });
 
+        expect(
+            screen.getByTestId("chat-composer-shell").getAttribute("style"),
+        ).toContain("background-color: transparent");
         const contentColumn = screen.getByTestId(
             "chat-composer-content-column",
         );

--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { getCurrentWebview, invoke } from "@neverwrite/runtime";
+import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import type { EditorFontFamily } from "../../../app/store/settingsStore";
@@ -51,6 +52,7 @@ function renderComposer({
     isStopping = false,
     hasPendingSubmitAfterStop = false,
     expanded = false,
+    contextBar,
     onMentionAttach = vi.fn(),
     onFolderAttach = vi.fn(),
     onToggleExpanded = vi.fn(),
@@ -69,6 +71,7 @@ function renderComposer({
     isStopping?: boolean;
     hasPendingSubmitAfterStop?: boolean;
     expanded?: boolean;
+    contextBar?: ReactNode;
     onMentionAttach?: (note: {
         id: string;
         title: string;
@@ -103,6 +106,7 @@ function renderComposer({
             isStopping={isStopping}
             hasPendingSubmitAfterStop={hasPendingSubmitAfterStop}
             expanded={expanded}
+            contextBar={contextBar}
             onToggleExpanded={onToggleExpanded}
             onChange={onChange}
             onMentionAttach={onMentionAttach}
@@ -328,6 +332,8 @@ describe("AIChatComposer mention picker", () => {
         );
 
         expect(shell).toContainElement(contentColumn);
+        expect(shell).toHaveClass("min-h-0", "max-h-full");
+        expect(shell).toHaveStyle({ maxHeight: "100%" });
         expect(shell).not.toHaveStyle({
             maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
         });
@@ -336,6 +342,16 @@ describe("AIChatComposer mention picker", () => {
             maxWidth: `${AI_CHAT_CONTENT_MAX_WIDTH_PX}px`,
             marginInline: "auto",
         });
+    });
+
+    it("reserves top spacing only when the context bar is present", () => {
+        renderComposer({
+            contextBar: <div data-testid="test-context-bar">Context</div>,
+        });
+
+        expect(
+            screen.getByTestId("test-context-bar").closest(".pt-2"),
+        ).not.toBeNull();
     });
 
     it("keeps the capped composer content flexible while expanded", () => {

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -1698,7 +1698,9 @@ export function AIChatComposer({
             {contextBar ? (
                 <div
                     className={
-                        expanded ? "px-2 pb-1.5" : "px-3 pb-1.5 pt-2"
+                        expanded
+                            ? "px-2 pb-1.5 pt-1.5"
+                            : "px-3 pb-1.5 pt-2"
                     }
                 >
                     <div
@@ -1720,9 +1722,7 @@ export function AIChatComposer({
                     border: "none",
                     borderTop: "1px solid var(--border)",
                     borderRadius: 0,
-                    backgroundColor: expanded
-                        ? "var(--bg-tertiary)"
-                        : "transparent",
+                    backgroundColor: "transparent",
                     boxShadow: externalDragActive
                         ? "0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent)"
                         : "none",

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -1682,7 +1682,7 @@ export function AIChatComposer({
     const contentColumnClassName =
         expanded || customHeight != null
             ? "relative flex h-full min-h-0 min-w-0 flex-1 flex-col"
-            : "relative flex min-w-0 flex-col";
+            : "relative flex min-h-0 max-h-full min-w-0 flex-col";
 
     return (
         <div
@@ -1692,11 +1692,15 @@ export function AIChatComposer({
             className={
                 expanded
                     ? "flex h-full min-h-0 flex-1 flex-col"
-                    : "flex flex-col"
+                    : "flex min-h-0 max-h-full flex-col"
             }
         >
             {contextBar ? (
-                <div className={expanded ? "px-2 pb-1.5" : "px-3 pb-1.5"}>
+                <div
+                    className={
+                        expanded ? "px-2 pb-1.5" : "px-3 pb-1.5 pt-2"
+                    }
+                >
                     <div
                         className="min-w-0"
                         style={getAiChatContentColumnStyle(aiChatContentWidth)}
@@ -1710,17 +1714,20 @@ export function AIChatComposer({
                 className={
                     expanded
                         ? "relative flex h-full min-h-0 flex-1 flex-col"
-                        : "relative flex flex-col"
+                        : "relative flex min-h-0 max-h-full flex-col"
                 }
                 style={{
                     border: "none",
                     borderTop: "1px solid var(--border)",
                     borderRadius: 0,
-                    backgroundColor: "var(--bg-tertiary)",
+                    backgroundColor: expanded
+                        ? "var(--bg-tertiary)"
+                        : "transparent",
                     boxShadow: externalDragActive
                         ? "0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent)"
                         : "none",
                     transition: "box-shadow 0.15s ease",
+                    maxHeight: "100%",
                     ...(expanded || customHeight == null
                         ? {}
                         : { height: customHeight }),

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -319,6 +319,180 @@ describe("AIChatMessageList streaming run indicator", () => {
         expectSharedChatContentColumn(messageColumn);
     });
 
+    it("reserves the translucent dock inset inside the transcript scroller", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-dock-inset"
+                messages={createMessages()}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+
+        expect(getScrollContainer(view.container)).toHaveStyle({
+            paddingBottom: "192px",
+            scrollPaddingBottom: "192px",
+        });
+    });
+
+    it("keeps a bottom-anchored transcript pinned when the dock height changes", () => {
+        let scrollHeight = 1_000;
+        const messages = createMessages();
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-dock-bottom-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={0}
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer, 320, {
+            getScrollHeight: () => scrollHeight,
+        });
+
+        act(() => {
+            scrollContainer.scrollTop = 680;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        scrollHeight = 1_180;
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-dock-bottom-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+
+        expect(scrollContainer.scrollTop).toBe(scrollHeight);
+    });
+
+    it("does not move a transcript being read when the dock height changes", () => {
+        let scrollHeight = 1_000;
+        const messages = createMessages();
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-dock-reading-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={0}
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer, 320, {
+            getScrollHeight: () => scrollHeight,
+        });
+
+        act(() => {
+            scrollContainer.scrollTop = 200;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        scrollHeight = 1_180;
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-dock-reading-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+
+        expect(scrollContainer.scrollTop).toBe(200);
+    });
+
+    it("retains a shrinking dock inset until the reader returns to the bottom", () => {
+        let scrollHeight = 1_180;
+        const messages = createMessages();
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-dock-shrink-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer, 320, {
+            getScrollHeight: () => scrollHeight,
+        });
+
+        act(() => {
+            scrollContainer.scrollTop = 760;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-dock-shrink-anchor"
+                messages={messages}
+                status="idle"
+                bottomInset={0}
+            />,
+        );
+
+        expect(scrollContainer).toHaveStyle({ paddingBottom: "192px" });
+        expect(scrollContainer.scrollTop).toBe(760);
+        expect(
+            screen.getByRole("button", { name: "Scroll to bottom" }),
+        ).toHaveStyle({ bottom: "12px" });
+
+        scrollHeight = 1_000;
+        act(() => {
+            scrollContainer.scrollTop = 680;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        expect(scrollContainer).toHaveStyle({ paddingBottom: "12px" });
+        expect(scrollContainer.scrollTop).toBe(scrollHeight);
+    });
+
+    it("resets a retained dock inset when switching session scopes", () => {
+        const messages = createMessages();
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-scope-low"
+                messages={messages}
+                status="idle"
+                bottomInset={0}
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer);
+
+        act(() => {
+            scrollContainer.scrollTop = 1_000;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-scope-high"
+                messages={messages}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+        act(() => {
+            scrollContainer.scrollTop = 1_000;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+        expect(scrollContainer).toHaveStyle({ paddingBottom: "192px" });
+
+        view.rerender(
+            <AIChatMessageList
+                sessionId="session-scope-low"
+                messages={messages}
+                status="idle"
+                bottomInset={0}
+            />,
+        );
+
+        expect(scrollContainer).toHaveStyle({ paddingBottom: "12px" });
+    });
+
     it.each([
         ["narrow", 320],
         ["wide", 1200],
@@ -633,6 +807,30 @@ describe("AIChatMessageList streaming run indicator", () => {
         expect(
             screen.queryByRole("button", { name: "Scroll to bottom" }),
         ).not.toBeInTheDocument();
+    });
+
+    it("keeps the scroll-to-bottom control clear of the dock stacking context", () => {
+        const view = renderComponent(
+            <AIChatMessageList
+                sessionId="session-scroll-control-dock"
+                messages={createLongTranscript(140)}
+                status="idle"
+                bottomInset={180}
+            />,
+        );
+        const scrollContainer = getScrollContainer(view.container);
+        configureScrollableViewport(scrollContainer);
+
+        act(() => {
+            scrollContainer.scrollTop = 1_000;
+            scrollContainer.dispatchEvent(new Event("scroll"));
+        });
+
+        const button = screen.getByRole("button", {
+            name: "Scroll to bottom",
+        });
+        expect(button).not.toHaveClass("z-30");
+        expect(button).toHaveStyle({ bottom: "192px" });
     });
 
     it("starts an unvisited long chat at the bottom after switching sessions", () => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -55,6 +55,7 @@ interface AIChatMessageListProps {
     sessionId?: string | null;
     messages: AIChatMessage[];
     status: AIChatSessionStatus;
+    bottomInset?: number;
     readOnly?: boolean;
     hasOlderMessages?: boolean;
     isLoadingOlderMessages?: boolean;
@@ -100,6 +101,9 @@ type TimelineRow =
 
 const NEAR_BOTTOM_THRESHOLD = 80;
 const LOAD_OLDER_THRESHOLD = 120;
+// Keep a small visual gap without raising the button above the dock's stacking
+// context, where it could cover non-portaled composer dropdowns.
+const SCROLL_TO_BOTTOM_DOCK_GAP_PX = 12;
 const DETACHED_TIMELINE_SCOPE = "__detached_timeline__";
 
 function getRemainingScrollDistance(el: HTMLElement) {
@@ -385,6 +389,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     sessionId = null,
     messages,
     status,
+    bottomInset = 0,
     readOnly = false,
     hasOlderMessages = false,
     isLoadingOlderMessages = false,
@@ -420,6 +425,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         enabled: findOpen,
     });
     const wasNearBottomRef = useRef(true);
+    // Do not shrink the spacer while someone is reading above the bottom.
+    // Chromium would clamp scrollTop immediately and move the visible rows.
+    const [reservedBottomInset, setReservedBottomInset] =
+        useState(bottomInset);
+    const previousReservedBottomInsetRef = useRef(reservedBottomInset);
     const pendingPrependAdjustmentRef = useRef<{
         previousScrollHeight: number;
         previousScrollTop: number;
@@ -453,9 +463,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     const scrollToBottom = useCallback(() => {
         const container = containerRef.current;
         if (!container) return;
+        wasNearBottomRef.current = true;
+        setReservedBottomInset(bottomInset);
         container.scrollTop = container.scrollHeight;
         setShowScrollButton(false);
-    }, []);
+    }, [bottomInset]);
 
     const syncScrollButton = useCallback(() => {
         const container = containerRef.current;
@@ -473,6 +485,9 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         const nearBottom = isNearBottom(container);
         wasNearBottomRef.current = nearBottom;
+        if (nearBottom && reservedBottomInset !== bottomInset) {
+            setReservedBottomInset(bottomInset);
+        }
         setShowScrollButton(shouldShowScrollToBottomButton(container));
 
         persistChatMessageListViewState(
@@ -498,6 +513,8 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         hasOlderMessages,
         isLoadingOlderMessages,
         onLoadOlderMessages,
+        bottomInset,
+        reservedBottomInset,
         viewStateScope,
     ]);
 
@@ -647,6 +664,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         }
 
         restoredScopeRef.current = viewStateScope;
+        setReservedBottomInset(bottomInset);
         pendingRestoreRef.current =
             readPersistedChatMessageListViewState(viewStateScope);
         wasNearBottomRef.current =
@@ -663,7 +681,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 queueMicrotask(syncScrollButton);
             }
         }
-    }, [messages, status, syncScrollButton, viewStateScope]);
+    }, [bottomInset, messages, status, syncScrollButton, viewStateScope]);
 
     useLayoutEffect(() => {
         const container = containerRef.current;
@@ -758,6 +776,32 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             pendingPrependAdjustmentRef.current = null;
         }
     }, [isLoadingOlderMessages, messages.length]);
+
+    useLayoutEffect(() => {
+        if (
+            bottomInset > reservedBottomInset ||
+            (wasNearBottomRef.current && bottomInset !== reservedBottomInset)
+        ) {
+            setReservedBottomInset(bottomInset);
+        }
+    }, [bottomInset, reservedBottomInset]);
+
+    useLayoutEffect(() => {
+        if (
+            previousReservedBottomInsetRef.current === reservedBottomInset
+        ) {
+            return;
+        }
+
+        previousReservedBottomInsetRef.current = reservedBottomInset;
+        const container = containerRef.current;
+        if (!container) return;
+
+        if (wasNearBottomRef.current) {
+            container.scrollTop = container.scrollHeight;
+        }
+        queueMicrotask(syncScrollButton);
+    }, [reservedBottomInset, syncScrollButton]);
 
     // Anchor scroll position when container width changes (e.g. sidebar resize).
     // Tracks the topmost visible chat row and its viewport offset on every scroll,
@@ -904,6 +948,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 onContextMenu={handleContextMenu}
                 className="min-h-0 min-w-0 flex-1 flex flex-col overflow-y-auto px-3 py-3"
                 data-scrollbar-active="true"
+                style={{
+                    paddingBottom: Math.max(0, reservedBottomInset) + 12,
+                    scrollPaddingBottom:
+                        Math.max(0, reservedBottomInset) + 12,
+                }}
             >
                 <div
                     ref={contentRef}
@@ -972,8 +1021,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
                 <button
                     type="button"
                     onClick={scrollToBottom}
-                    className="absolute bottom-3 left-1/2 flex h-7 w-7 -translate-x-1/2 items-center justify-center rounded-full"
+                    className="absolute left-1/2 flex h-7 w-7 -translate-x-1/2 items-center justify-center rounded-full"
                     style={{
+                        bottom:
+                            Math.max(0, bottomInset) +
+                            SCROLL_TO_BOTTOM_DOCK_GAP_PX,
                         backgroundColor: "var(--bg-tertiary)",
                         border: "1px solid var(--border)",
                         color: "var(--text-secondary)",

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -23,6 +23,8 @@ const composerMockState = vi.hoisted(() => ({
 }));
 const messageListMockState = vi.hoisted(() => ({
     props: [] as Array<{
+        bottomInset?: number;
+        sessionId?: string | null;
         scrollToMessageId?: string | null;
         onScrollToMessageComplete?: () => void;
     }>,
@@ -32,6 +34,8 @@ const invokeMock = vi.mocked(invoke);
 
 vi.mock("./AIChatMessageList", () => ({
     AIChatMessageList: (props: {
+        bottomInset?: number;
+        sessionId?: string | null;
         scrollToMessageId?: string | null;
         onScrollToMessageComplete?: () => void;
     }) => {
@@ -49,6 +53,7 @@ vi.mock("./AIChatComposer", () => ({
     AIChatComposer: ({
         disabled,
         expanded,
+        contextBar,
         footer,
         onToggleExpanded,
         onPasteImage,
@@ -56,6 +61,7 @@ vi.mock("./AIChatComposer", () => ({
     }: {
         disabled?: boolean;
         expanded?: boolean;
+        contextBar?: ReactNode;
         footer?: ReactNode;
         onToggleExpanded?: () => void;
         onPasteImage?: (file: File) => void;
@@ -71,6 +77,7 @@ vi.mock("./AIChatComposer", () => ({
             >
                 {placeholderText}
             </button>
+            {contextBar}
             <div data-testid="chat-composer-footer">{footer}</div>
             <button
                 type="button"
@@ -350,6 +357,173 @@ describe("AIChatSessionView", () => {
         ).toBeNull();
     });
 
+    it("overlays one shared bottom dock above the transcript", () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        const dock = screen.getByTestId("chat-bottom-dock");
+        expect(dock).toHaveClass(
+            "nw-chat-bottom-dock",
+            "absolute",
+            "bottom-0",
+        );
+        expect(dock).toContainElement(
+            screen.getByTestId("queued-messages-panel"),
+        );
+        expect(dock).toContainElement(
+            screen.getByTestId("edited-files-panel"),
+        );
+        expect(dock).toContainElement(screen.getByTestId("chat-composer"));
+        expect(dock).not.toContainElement(
+            screen.getByTestId("chat-message-list"),
+        );
+
+        const auxiliaryRegion = screen.getByTestId(
+            "chat-bottom-dock-auxiliary-region",
+        );
+        expect(auxiliaryRegion).toHaveClass(
+            "min-h-0",
+            "overflow-y-auto",
+        );
+        expect(auxiliaryRegion).toHaveStyle({ flexShrink: "999" });
+        const composerRegion = screen.getByTestId(
+            "chat-bottom-dock-composer-region",
+        );
+        expect(composerRegion).toHaveClass(
+            "flex",
+            "min-h-16",
+            "shrink",
+            "flex-col",
+        );
+        expect(composerRegion).not.toHaveClass("pt-2");
+    });
+
+    it("does not reserve an empty context strip above the composer", () => {
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        expect(screen.queryByTestId("chat-context-bar")).toBeNull();
+    });
+
+    it("renders the context strip when the session has attachments", () => {
+        setupWorkspaceSession();
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                ...state.sessionsById,
+                "session-a": {
+                    ...state.sessionsById["session-a"]!,
+                    attachments: [
+                        {
+                            id: "attachment-1",
+                            type: "note",
+                            noteId: "notes/context.md",
+                            label: "Context",
+                            path: "/vault/notes/context.md",
+                            status: "ready",
+                        },
+                    ],
+                },
+            },
+        }));
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        expect(screen.getByTestId("chat-context-bar")).toBeInTheDocument();
+    });
+
+    it("passes the measured bottom dock height to the transcript", async () => {
+        const rectSpy = vi
+            .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+            .mockImplementation(function (this: HTMLElement) {
+                const height =
+                    this.dataset.testid === "chat-bottom-dock"
+                        ? 184
+                        : 0;
+                return {
+                    bottom: height,
+                    height,
+                    left: 0,
+                    right: 600,
+                    top: 0,
+                    width: 600,
+                    x: 0,
+                    y: 0,
+                    toJSON: () => ({}),
+                };
+            });
+        setupWorkspaceSession();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        await waitFor(() => {
+            expect(messageListMockState.props.at(-1)?.bottomInset).toBe(184);
+        });
+        rectSpy.mockRestore();
+    });
+
+    it("does not pass a previous session dock measurement into a new chat", async () => {
+        let measuredHeight = 180;
+        const rectSpy = vi
+            .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+            .mockImplementation(function (this: HTMLElement) {
+                const height =
+                    this.dataset.testid === "chat-bottom-dock"
+                        ? measuredHeight
+                        : 0;
+                return {
+                    bottom: height,
+                    height,
+                    left: 0,
+                    right: 600,
+                    top: 0,
+                    width: 600,
+                    x: 0,
+                    y: 0,
+                    toJSON: () => ({}),
+                };
+            });
+        setupWorkspaceSession("session-a");
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        await waitFor(() => {
+            expect(messageListMockState.props.at(-1)?.bottomInset).toBe(180);
+        });
+
+        act(() => {
+            useChatStore.setState((state) => ({
+                ...state,
+                sessionsById: {
+                    ...state.sessionsById,
+                    "session-b": createSession("session-b", "Second chat"),
+                },
+            }));
+        });
+        const propsBeforeSwitch = messageListMockState.props.length;
+        measuredHeight = 48;
+
+        act(() => {
+            useEditorStore.getState().openChat("session-b", {
+                title: "Second chat",
+                paneId: "primary",
+            });
+        });
+
+        await waitFor(() => {
+            expect(messageListMockState.props.at(-1)?.sessionId).toBe(
+                "session-b",
+            );
+            expect(messageListMockState.props.at(-1)?.bottomInset).toBe(48);
+        });
+        const newSessionProps = messageListMockState.props
+            .slice(propsBeforeSwitch)
+            .filter((props) => props.sessionId === "session-b");
+        expect(newSessionProps[0]?.bottomInset).toBe(0);
+        rectSpy.mockRestore();
+    });
+
     it("hides the Edited files panel when AI change review is disabled", () => {
         useSettingsStore.getState().setSetting("aiReviewEnabled", false);
         setupWorkspaceSession();
@@ -372,6 +546,10 @@ describe("AIChatSessionView", () => {
             "data-expanded",
             "true",
         );
+        expect(screen.queryByTestId("chat-bottom-dock")).toBeNull();
+        expect(
+            screen.getByTestId("chat-expanded-composer-region"),
+        ).toBeInTheDocument();
     });
 
     it("closes and disables chat find while the composer is expanded", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -547,9 +547,25 @@ describe("AIChatSessionView", () => {
             "true",
         );
         expect(screen.queryByTestId("chat-bottom-dock")).toBeNull();
+        const expandedRegion = screen.getByTestId(
+            "chat-expanded-composer-region",
+        );
+        expect(expandedRegion).toHaveClass(
+            "nw-chat-translucent-surface",
+            "absolute",
+            "inset-0",
+        );
+        expect(screen.getByTestId("chat-message-list")).toBeInTheDocument();
+        expect(screen.getByTestId("chat-transcript-region")).toHaveAttribute(
+            "aria-hidden",
+            "true",
+        );
+        expect(screen.getByTestId("chat-transcript-region")).toHaveAttribute(
+            "inert",
+        );
         expect(
-            screen.getByTestId("chat-expanded-composer-region"),
-        ).toBeInTheDocument();
+            screen.getByTestId("chat-bottom-dock-composer-region"),
+        ).not.toHaveClass("pt-1.5");
     });
 
     it("closes and disables chat find while the composer is expanded", async () => {
@@ -569,9 +585,10 @@ describe("AIChatSessionView", () => {
             expect(findButton).toBeDisabled();
             expect(findButton).toHaveAttribute("aria-pressed", "false");
         });
-        expect(
-            screen.queryByTestId("chat-message-list"),
-        ).not.toBeInTheDocument();
+        expect(screen.getByTestId("chat-message-list")).toBeInTheDocument();
+        expect(screen.getByTestId("chat-transcript-region")).toHaveAttribute(
+            "inert",
+        );
 
         fireEvent.click(findButton);
         expect(findButton).toHaveAttribute("aria-pressed", "false");

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -699,8 +699,8 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         setScrollToMessageId(null);
     }, [sessionId]);
 
-    // The message list owns the finder UI and is unmounted while the composer is
-    // expanded, so keep local message-list overlays aligned with that boundary.
+    // Keep local message-list overlays closed while the expanded composer makes
+    // the transcript visual-only beneath its translucent surface.
     useEffect(() => {
         if (composerExpanded) {
             setFindOpen(false);
@@ -1026,7 +1026,12 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             ) : null}
 
             <div className="relative flex min-h-0 flex-1 flex-col">
-                {!composerExpanded && (
+                <div
+                    data-testid="chat-transcript-region"
+                    className="flex min-h-0 flex-1 flex-col"
+                    aria-hidden={composerExpanded || undefined}
+                    inert={composerExpanded || undefined}
+                >
                     <AIChatMessageList
                         sessionId={sessionId}
                         messages={session?.messages ?? []}
@@ -1082,7 +1087,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                             );
                         }}
                     />
-                )}
+                </div>
 
                 <div
                     ref={composerExpanded ? undefined : bottomDockRef}
@@ -1093,8 +1098,8 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                     }
                     className={
                         composerExpanded
-                            ? "flex min-h-0 flex-1 flex-col"
-                            : "nw-chat-bottom-dock absolute inset-x-0 bottom-0 z-20 flex max-h-full flex-col"
+                            ? "nw-chat-translucent-surface absolute inset-0 z-20 flex min-h-0 flex-col"
+                            : "nw-chat-translucent-surface nw-chat-bottom-dock absolute inset-x-0 bottom-0 z-20 flex max-h-full flex-col"
                     }
                 >
                     {/* Queue and Edits yield their height before Composer,
@@ -1149,7 +1154,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                         data-testid="chat-bottom-dock-composer-region"
                         className={
                             composerExpanded
-                                ? "flex min-h-0 flex-1 flex-col pt-1.5"
+                                ? "flex min-h-0 flex-1 flex-col"
                                 : "flex min-h-16 shrink flex-col"
                         }
                     >

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -12,6 +12,7 @@
 import {
     useCallback,
     useEffect,
+    useLayoutEffect,
     useMemo,
     useRef,
     useState,
@@ -210,6 +211,11 @@ interface AIChatSessionViewProps {
 
 export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     const [composerExpanded, setComposerExpanded] = useState(false);
+    const bottomDockRef = useRef<HTMLDivElement>(null);
+    const [bottomDockMeasurement, setBottomDockMeasurement] = useState<{
+        sessionId: string | null;
+        height: number;
+    }>({ sessionId: null, height: 0 });
     const [imageAttachmentNotice, setImageAttachmentNotice] = useState<
         string | null
     >(null);
@@ -229,6 +235,10 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             : selectEditorPaneActiveTab(state, paneId);
         return tab && isChatTab(tab) ? tab.sessionId : null;
     });
+    const bottomDockHeight =
+        bottomDockMeasurement.sessionId === sessionId
+            ? bottomDockMeasurement.height
+            : 0;
 
     // Actions ref — avoids subscribing to every action
     const chatActions = useRef(useChatStore.getState()).current;
@@ -358,6 +368,35 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                     mimeType: e.mime_type,
                 })),
         [entries],
+    );
+    const contextBarAttachments = useMemo(
+        () =>
+            (session?.attachments ?? [])
+                .filter(
+                    (attachment) =>
+                        !composerParts.some(
+                            (part) =>
+                                (part.type === "mention" &&
+                                    part.noteId === attachment.noteId) ||
+                                (part.type === "file_mention" &&
+                                    attachment.type === "file" &&
+                                    attachment.path === part.path) ||
+                                (part.type === "folder_mention" &&
+                                    attachment.type === "folder" &&
+                                    part.folderPath === attachment.noteId),
+                        ),
+                )
+                .map((attachment) => ({
+                    id: attachment.id,
+                    noteId: attachment.noteId,
+                    label: attachment.label,
+                    path: attachment.path,
+                    removable: true,
+                    type: attachment.type,
+                    status: attachment.status,
+                    errorMessage: attachment.errorMessage,
+                })),
+        [composerParts, session?.attachments],
     );
 
     const runtimeLabel =
@@ -702,6 +741,35 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         return () => window.removeEventListener("keydown", handleEscape, true);
     }, [findOpen, paneId]);
 
+    useLayoutEffect(() => {
+        if (composerExpanded) {
+            setBottomDockMeasurement({ sessionId, height: 0 });
+            return;
+        }
+
+        const dock = bottomDockRef.current;
+        if (!dock) return;
+
+        const updateHeight = () => {
+            const nextHeight = Math.max(
+                0,
+                Math.ceil(dock.getBoundingClientRect().height),
+            );
+            setBottomDockMeasurement((currentMeasurement) =>
+                currentMeasurement.sessionId === sessionId &&
+                currentMeasurement.height === nextHeight
+                    ? currentMeasurement
+                    : { sessionId, height: nextHeight },
+            );
+        };
+
+        updateHeight();
+        const observer = new ResizeObserver(updateHeight);
+        observer.observe(dock);
+
+        return () => observer.disconnect();
+    }, [composerExpanded, sessionId]);
+
     const isSubagent = Boolean(session?.parentSessionId?.trim());
     const parentTitle = parentSession ? getSessionTitle(parentSession) : null;
     const findDisabled = composerExpanded;
@@ -957,276 +1025,283 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                 />
             ) : null}
 
-            {!composerExpanded && (
-                <AIChatMessageList
-                    sessionId={sessionId}
-                    messages={session?.messages ?? []}
-                    status={session?.status ?? "idle"}
-                    hasOlderMessages={
-                        (session?.loadedPersistedMessageStart ?? 0) > 0
-                    }
-                    isLoadingOlderMessages={
-                        session?.isLoadingPersistedMessages ?? false
-                    }
-                    visibleWorkCycleId={session?.visibleWorkCycleId ?? null}
-                    findOpen={findOpen}
-                    scrollToMessageId={scrollToMessageId}
-                    onScrollToMessageComplete={() => {
-                        setScrollToMessageId(null);
-                    }}
-                    onCloseFind={() => {
-                        setFindOpen(false);
-                        rootRef.current?.focus();
-                    }}
-                    chatFontSize={chatFontSize}
-                    chatFontFamily={chatFontFamily}
-                    onLoadOlderMessages={() => {
-                        void chatActions.loadOlderMessages(sessionId);
-                    }}
-                    onPermissionResponse={(requestId, optionId) => {
-                        void chatActions.respondPermissionForSession(
-                            sessionId,
-                            requestId,
-                            optionId,
-                        );
-                    }}
-                    onUserInputResponse={(requestId, answers, action) => {
-                        void chatActions.respondUserInput(
-                            requestId,
-                            answers,
-                            sessionId,
-                            action,
-                        );
-                    }}
-                    onUrlElicitationOpen={(requestId) => {
-                        void chatActions.openUrlElicitation(
-                            requestId,
-                            sessionId,
-                        );
-                    }}
-                    onUrlElicitationResponse={(requestId, action) => {
-                        void chatActions.respondUrlElicitation(
-                            requestId,
-                            action,
-                            sessionId,
-                        );
-                    }}
-                />
-            )}
+            <div className="relative flex min-h-0 flex-1 flex-col">
+                {!composerExpanded && (
+                    <AIChatMessageList
+                        sessionId={sessionId}
+                        messages={session?.messages ?? []}
+                        status={session?.status ?? "idle"}
+                        bottomInset={bottomDockHeight}
+                        hasOlderMessages={
+                            (session?.loadedPersistedMessageStart ?? 0) > 0
+                        }
+                        isLoadingOlderMessages={
+                            session?.isLoadingPersistedMessages ?? false
+                        }
+                        visibleWorkCycleId={session?.visibleWorkCycleId ?? null}
+                        findOpen={findOpen}
+                        scrollToMessageId={scrollToMessageId}
+                        onScrollToMessageComplete={() => {
+                            setScrollToMessageId(null);
+                        }}
+                        onCloseFind={() => {
+                            setFindOpen(false);
+                            rootRef.current?.focus();
+                        }}
+                        chatFontSize={chatFontSize}
+                        chatFontFamily={chatFontFamily}
+                        onLoadOlderMessages={() => {
+                            void chatActions.loadOlderMessages(sessionId);
+                        }}
+                        onPermissionResponse={(requestId, optionId) => {
+                            void chatActions.respondPermissionForSession(
+                                sessionId,
+                                requestId,
+                                optionId,
+                            );
+                        }}
+                        onUserInputResponse={(requestId, answers, action) => {
+                            void chatActions.respondUserInput(
+                                requestId,
+                                answers,
+                                sessionId,
+                                action,
+                            );
+                        }}
+                        onUrlElicitationOpen={(requestId) => {
+                            void chatActions.openUrlElicitation(
+                                requestId,
+                                sessionId,
+                            );
+                        }}
+                        onUrlElicitationResponse={(requestId, action) => {
+                            void chatActions.respondUrlElicitation(
+                                requestId,
+                                action,
+                                sessionId,
+                            );
+                        }}
+                    />
+                )}
 
-            <ChatContentColumn>
-                <QueuedMessagesPanel
-                    items={queuedMessages}
-                    editingItem={queuedMessageEdit?.item ?? null}
-                    onCancel={(messageId) => {
-                        chatActions.removeQueuedMessage(sessionId, messageId);
-                    }}
-                    onClearAll={() => {
-                        chatActions.clearSessionQueue(sessionId);
-                    }}
-                    onEdit={(messageId) => {
-                        chatActions.editQueuedMessage(sessionId, messageId);
-                    }}
-                    onSendNow={(messageId) => {
-                        void chatActions.sendQueuedMessageNow(
-                            sessionId,
-                            messageId,
-                        );
-                    }}
-                    onCancelEdit={() => {
-                        chatActions.cancelQueuedMessageEdit(sessionId);
-                    }}
-                />
-            </ChatContentColumn>
-
-            {aiReviewEnabled ? (
-                <ChatContentColumn>
-                    <EditedFilesBufferPanel sessionId={sessionId} />
-                </ChatContentColumn>
-            ) : null}
-
-            <div
-                className={
-                    composerExpanded
-                        ? "flex min-h-0 flex-1 flex-col pt-1.5"
-                        : "pt-2"
-                }
-            >
-                <AIChatComposer
-                    key={sessionId}
-                    sessionId={sessionId}
-                    parts={composerParts}
-                    notes={noteOptions}
-                    files={fileOptions}
-                    status={session?.status ?? "idle"}
-                    runtimeName={runtimeLabel}
-                    runtimeId={session?.runtimeId}
-                    requireCmdEnterToSend={requireCmdEnterToSend}
-                    composerFontSize={composerFontSize}
-                    composerFontFamily={composerFontFamily}
-                    availableCommands={session?.availableCommands}
-                    isStopping={Boolean(interruptedTurnState?.isStopping)}
-                    hasPendingSubmitAfterStop={Boolean(
-                        interruptedTurnState?.pendingManualSend,
-                    )}
-                    expanded={composerExpanded}
-                    onToggleExpanded={() => setComposerExpanded((v) => !v)}
-                    disabled={
-                        !session ||
-                        isClosedSubagent ||
-                        isRemovedGeminiAcpSession ||
-                        isPendingSessionCreation ||
-                        activeConnection.status === "loading" ||
-                        Boolean(session.isResumingSession)
+                <div
+                    ref={composerExpanded ? undefined : bottomDockRef}
+                    data-testid={
+                        composerExpanded
+                            ? "chat-expanded-composer-region"
+                            : "chat-bottom-dock"
                     }
-                    placeholderText={
-                        isClosedSubagent
-                            ? "This subagent was closed by its parent thread."
-                            : isRemovedGeminiAcpSession
-                              ? REMOVED_GEMINI_ACP_COMPOSER_MESSAGE
-                            : isPendingSessionCreation
-                              ? pendingSessionError
-                                  ? "Agent unavailable"
-                                  : "Loading agent"
-                              : undefined
+                    className={
+                        composerExpanded
+                            ? "flex min-h-0 flex-1 flex-col"
+                            : "nw-chat-bottom-dock absolute inset-x-0 bottom-0 z-20 flex max-h-full flex-col"
                     }
-                    contextBar={
-                        <AIChatContextBar
-                            attachments={[
-                                ...(session?.attachments ?? [])
-                                    .filter(
-                                        (a) =>
-                                            !composerParts.some(
-                                                (p) =>
-                                                    (p.type === "mention" &&
-                                                        p.noteId ===
-                                                            a.noteId) ||
-                                                    (p.type ===
-                                                        "file_mention" &&
-                                                        a.type === "file" &&
-                                                        a.path === p.path) ||
-                                                    (p.type ===
-                                                        "folder_mention" &&
-                                                        a.type === "folder" &&
-                                                        p.folderPath ===
-                                                            a.noteId),
-                                            ),
-                                    )
-                                    .map((attachment) => ({
-                                        id: attachment.id,
-                                        noteId: attachment.noteId,
-                                        label: attachment.label,
-                                        path: attachment.path,
-                                        removable: true,
-                                        type: attachment.type,
-                                        status: attachment.status,
-                                        errorMessage: attachment.errorMessage,
-                                    })),
-                            ]}
-                            onRemoveAttachment={handleRemoveAttachment}
-                            onClearAll={handleClearAttachments}
-                        />
-                    }
-                    bottomAccent={
-                        contextUsageBarEnabled ? (
-                            <AIChatContextUsageBar
-                                usage={tokenUsage}
-                                cornerRadius={composerExpanded ? 9 : 11}
+                >
+                    {/* Queue and Edits yield their height before Composer,
+                        then share a scrollable region in short panes. */}
+                    <div
+                        data-testid="chat-bottom-dock-auxiliary-region"
+                        data-scrollbar-active="true"
+                        className="min-h-0 overflow-y-auto"
+                        style={{ flexShrink: 999 }}
+                    >
+                        <ChatContentColumn>
+                            <QueuedMessagesPanel
+                                items={queuedMessages}
+                                editingItem={queuedMessageEdit?.item ?? null}
+                                onCancel={(messageId) => {
+                                    chatActions.removeQueuedMessage(
+                                        sessionId,
+                                        messageId,
+                                    );
+                                }}
+                                onClearAll={() => {
+                                    chatActions.clearSessionQueue(sessionId);
+                                }}
+                                onEdit={(messageId) => {
+                                    chatActions.editQueuedMessage(
+                                        sessionId,
+                                        messageId,
+                                    );
+                                }}
+                                onSendNow={(messageId) => {
+                                    void chatActions.sendQueuedMessageNow(
+                                        sessionId,
+                                        messageId,
+                                    );
+                                }}
+                                onCancelEdit={() => {
+                                    chatActions.cancelQueuedMessageEdit(
+                                        sessionId,
+                                    );
+                                }}
                             />
-                        ) : null
-                    }
-                    footer={
-                        <div className="flex min-w-0 flex-wrap items-center gap-1.5">
-                            {imageAttachmentNotice ? (
-                                <div
-                                    role="status"
-                                    aria-live="polite"
-                                    className="rounded-md px-2 py-1 text-xs font-medium"
-                                    style={{
-                                        color: "#f87171",
-                                        backgroundColor:
-                                            "color-mix(in srgb, #ef4444 8%, transparent)",
-                                        border: "1px solid color-mix(in srgb, #ef4444 24%, var(--border))",
-                                    }}
-                                >
-                                    {imageAttachmentNotice}
-                                </div>
-                            ) : null}
-                            {!isPendingSessionCreation && (
-                                <AIChatAgentControls
-                                    disabled={agentControlsDisabled}
-                                    runtimeId={session?.runtimeId}
-                                    lockIncompatibleModelSwitches={
-                                        lockIncompatibleModelSwitches
-                                    }
-                                    modelId={session?.modelId ?? ""}
-                                    modeId={session?.modeId ?? ""}
-                                    effortsByModel={
-                                        session?.effortsByModel ?? {}
-                                    }
-                                    models={agentCatalog.models}
-                                    modes={agentCatalog.modes}
-                                    configOptions={agentCatalog.configOptions}
-                                    onModelChange={(modelId) => {
-                                        void chatActions.setModel(
-                                            modelId,
-                                            sessionId,
-                                        );
-                                    }}
-                                    onModeChange={(modeId) => {
-                                        void chatActions.setMode(
-                                            modeId,
-                                            sessionId,
-                                        );
-                                    }}
-                                    onConfigOptionChange={(optionId, value) => {
-                                        void chatActions.setConfigOption(
-                                            optionId,
-                                            value,
-                                            sessionId,
-                                        );
-                                    }}
-                                />
+                        </ChatContentColumn>
+
+                        {aiReviewEnabled ? (
+                            <ChatContentColumn>
+                                <EditedFilesBufferPanel sessionId={sessionId} />
+                            </ChatContentColumn>
+                        ) : null}
+                    </div>
+
+                    <div
+                        data-testid="chat-bottom-dock-composer-region"
+                        className={
+                            composerExpanded
+                                ? "flex min-h-0 flex-1 flex-col pt-1.5"
+                                : "flex min-h-16 shrink flex-col"
+                        }
+                    >
+                        <AIChatComposer
+                            key={sessionId}
+                            sessionId={sessionId}
+                            parts={composerParts}
+                            notes={noteOptions}
+                            files={fileOptions}
+                            status={session?.status ?? "idle"}
+                            runtimeName={runtimeLabel}
+                            runtimeId={session?.runtimeId}
+                            requireCmdEnterToSend={requireCmdEnterToSend}
+                            composerFontSize={composerFontSize}
+                            composerFontFamily={composerFontFamily}
+                            availableCommands={session?.availableCommands}
+                            isStopping={Boolean(interruptedTurnState?.isStopping)}
+                            hasPendingSubmitAfterStop={Boolean(
+                                interruptedTurnState?.pendingManualSend,
                             )}
-                        </div>
-                    }
-                    onChange={(parts) => {
-                        cleanupRemovedScreenshotAttachments(
-                            sessionId,
-                            composerParts,
-                            parts,
-                        );
-                        chatActions.setComposerParts(parts, sessionId);
-                    }}
-                    onAttachFile={handleAttachFile}
-                    onPasteImage={handlePasteImage}
-                    onImageAttachmentValidationFailure={(reason) => {
-                        const runtimeId = session?.runtimeId ?? null;
-                        setImageAttachmentNotice(
-                            imageAttachmentValidationMessage(reason, runtimeId),
-                        );
-                    }}
-                    onFocus={() => {
-                        if (!sessionId) return;
-                        chatActions.markSessionFocused(sessionId);
-                    }}
-                    onMentionAttach={(note) => {
-                        chatActions.attachNote(note, sessionId);
-                    }}
-                    onFileMentionAttach={(file) => {
-                        chatActions.attachVaultFile(file, sessionId);
-                    }}
-                    onFolderAttach={(folderPath, name) => {
-                        chatActions.attachFolder(folderPath, name, sessionId);
-                    }}
-                    onSubmit={() => {
-                        setComposerExpanded(false);
-                        void chatActions.sendMessage(sessionId);
-                    }}
-                    onStop={() => {
-                        void chatActions.stopStreaming(sessionId);
-                    }}
-                />
+                            expanded={composerExpanded}
+                            onToggleExpanded={() => setComposerExpanded((v) => !v)}
+                            disabled={
+                                !session ||
+                                isClosedSubagent ||
+                                isRemovedGeminiAcpSession ||
+                                isPendingSessionCreation ||
+                                activeConnection.status === "loading" ||
+                                Boolean(session.isResumingSession)
+                            }
+                            placeholderText={
+                                isClosedSubagent
+                                    ? "This subagent was closed by its parent thread."
+                                    : isRemovedGeminiAcpSession
+                                      ? REMOVED_GEMINI_ACP_COMPOSER_MESSAGE
+                                    : isPendingSessionCreation
+                                      ? pendingSessionError
+                                          ? "Agent unavailable"
+                                          : "Loading agent"
+                                      : undefined
+                            }
+                            contextBar={
+                                contextBarAttachments.length > 0 ? (
+                                    <AIChatContextBar
+                                        attachments={contextBarAttachments}
+                                        onRemoveAttachment={handleRemoveAttachment}
+                                        onClearAll={handleClearAttachments}
+                                    />
+                                ) : null
+                            }
+                            bottomAccent={
+                                contextUsageBarEnabled ? (
+                                    <AIChatContextUsageBar
+                                        usage={tokenUsage}
+                                        cornerRadius={composerExpanded ? 9 : 11}
+                                    />
+                                ) : null
+                            }
+                            footer={
+                                <div className="flex min-w-0 flex-wrap items-center gap-1.5">
+                                    {imageAttachmentNotice ? (
+                                        <div
+                                            role="status"
+                                            aria-live="polite"
+                                            className="rounded-md px-2 py-1 text-xs font-medium"
+                                            style={{
+                                                color: "#f87171",
+                                                backgroundColor:
+                                                    "color-mix(in srgb, #ef4444 8%, transparent)",
+                                                border: "1px solid color-mix(in srgb, #ef4444 24%, var(--border))",
+                                            }}
+                                        >
+                                            {imageAttachmentNotice}
+                                        </div>
+                                    ) : null}
+                                    {!isPendingSessionCreation && (
+                                        <AIChatAgentControls
+                                            disabled={agentControlsDisabled}
+                                            runtimeId={session?.runtimeId}
+                                            lockIncompatibleModelSwitches={
+                                                lockIncompatibleModelSwitches
+                                            }
+                                            modelId={session?.modelId ?? ""}
+                                            modeId={session?.modeId ?? ""}
+                                            effortsByModel={
+                                                session?.effortsByModel ?? {}
+                                            }
+                                            models={agentCatalog.models}
+                                            modes={agentCatalog.modes}
+                                            configOptions={agentCatalog.configOptions}
+                                            onModelChange={(modelId) => {
+                                                void chatActions.setModel(
+                                                    modelId,
+                                                    sessionId,
+                                                );
+                                            }}
+                                            onModeChange={(modeId) => {
+                                                void chatActions.setMode(
+                                                    modeId,
+                                                    sessionId,
+                                                );
+                                            }}
+                                            onConfigOptionChange={(optionId, value) => {
+                                                void chatActions.setConfigOption(
+                                                    optionId,
+                                                    value,
+                                                    sessionId,
+                                                );
+                                            }}
+                                        />
+                                    )}
+                                </div>
+                            }
+                            onChange={(parts) => {
+                                cleanupRemovedScreenshotAttachments(
+                                    sessionId,
+                                    composerParts,
+                                    parts,
+                                );
+                                chatActions.setComposerParts(parts, sessionId);
+                            }}
+                            onAttachFile={handleAttachFile}
+                            onPasteImage={handlePasteImage}
+                            onImageAttachmentValidationFailure={(reason) => {
+                                const runtimeId = session?.runtimeId ?? null;
+                                setImageAttachmentNotice(
+                                    imageAttachmentValidationMessage(reason, runtimeId),
+                                );
+                            }}
+                            onFocus={() => {
+                                if (!sessionId) return;
+                                chatActions.markSessionFocused(sessionId);
+                            }}
+                            onMentionAttach={(note) => {
+                                chatActions.attachNote(note, sessionId);
+                            }}
+                            onFileMentionAttach={(file) => {
+                                chatActions.attachVaultFile(file, sessionId);
+                            }}
+                            onFolderAttach={(folderPath, name) => {
+                                chatActions.attachFolder(folderPath, name, sessionId);
+                            }}
+                            onSubmit={() => {
+                                setComposerExpanded(false);
+                                void chatActions.sendMessage(sessionId);
+                            }}
+                            onStop={() => {
+                                void chatActions.stopStreaming(sessionId);
+                            }}
+                        />
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
+++ b/apps/desktop/src/features/ai/components/EditedFilesBufferPanel.tsx
@@ -174,8 +174,7 @@ export function EditedFilesBufferPanel({
             <section
                 className="mb-1"
                 style={{
-                    backgroundColor:
-                        "color-mix(in srgb, var(--bg-secondary) 60%, transparent)",
+                    backgroundColor: "transparent",
                     borderTop:
                         "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
                     borderBottom:
@@ -228,8 +227,7 @@ export function EditedFilesBufferPanel({
         <section
             className="mb-1"
             style={{
-                backgroundColor:
-                    "color-mix(in srgb, var(--bg-secondary) 60%, transparent)",
+                backgroundColor: "transparent",
                 borderTop:
                     "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
                 borderBottom:

--- a/apps/desktop/src/features/ai/components/QueuedMessagesPanel.tsx
+++ b/apps/desktop/src/features/ai/components/QueuedMessagesPanel.tsx
@@ -69,11 +69,13 @@ function StripIconButton({
 }
 
 const STRIP_PANEL_STYLE: React.CSSProperties = {
-    backgroundColor: "color-mix(in srgb, var(--bg-secondary) 60%, transparent)",
+    backgroundColor: "transparent",
     borderTop: "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
     borderBottom:
         "1px solid color-mix(in srgb, var(--border) 50%, transparent)",
 };
+
+const QUEUE_MAX_LIST_HEIGHT_PX = 224;
 
 const STRIP_HEADER_LABEL_STYLE: React.CSSProperties = {
     fontSize: "0.68em",
@@ -206,7 +208,11 @@ export function QueuedMessagesPanel({
             )}
 
             {!effectiveCollapsed && (
-                <div className="flex flex-col">
+                <div
+                    className="flex flex-col overflow-y-auto"
+                    data-scrollbar-active="true"
+                    style={{ maxHeight: QUEUE_MAX_LIST_HEIGHT_PX }}
+                >
                     {items.map((item) => {
                         const sending = item.status === "sending";
                         const summary = summarizeContent(item.content);

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1617,6 +1617,37 @@ body.dragging-tab * {
     color: var(--text-primary);
 }
 
+/* The transcript scrolls beneath one shared frosted dock. Keeping the blur on
+   this wrapper avoids allocating separate backdrop surfaces for Queue, Edits,
+   and Composer while their internal borders remain independently legible. The
+   tight negative-spread shadow separates the dock without painting a false
+   panel above it. */
+.nw-chat-bottom-dock {
+    background-color: color-mix(
+        in srgb,
+        var(--bg-secondary) 82%,
+        transparent
+    );
+    backdrop-filter: blur(12px) saturate(120%);
+    -webkit-backdrop-filter: blur(12px) saturate(120%);
+    box-shadow: 0 -4px 10px -8px
+        color-mix(in srgb, black 36%, transparent);
+}
+
+@supports not (backdrop-filter: blur(1px)) {
+    .nw-chat-bottom-dock {
+        background-color: var(--bg-secondary);
+    }
+}
+
+@media (prefers-reduced-transparency: reduce) {
+    .nw-chat-bottom-dock {
+        background-color: var(--bg-secondary);
+        backdrop-filter: none;
+        -webkit-backdrop-filter: none;
+    }
+}
+
 /* Composer send/stop pill buttons. The press should feel like a physical
    button depressing: shrink slightly, dim, and gain an inset shadow that
    replaces the lifted drop shadow. */

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1623,7 +1623,7 @@ body.dragging-tab * {
 .nw-chat-translucent-surface {
     background-color: color-mix(
         in srgb,
-        var(--bg-secondary) 82%,
+        var(--bg-secondary) 80%,
         transparent
     );
     backdrop-filter: blur(12px) saturate(120%);

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1617,12 +1617,10 @@ body.dragging-tab * {
     color: var(--text-primary);
 }
 
-/* The transcript scrolls beneath one shared frosted dock. Keeping the blur on
-   this wrapper avoids allocating separate backdrop surfaces for Queue, Edits,
-   and Composer while their internal borders remain independently legible. The
-   tight negative-spread shadow separates the dock without painting a false
-   panel above it. */
-.nw-chat-bottom-dock {
+/* The transcript stays beneath one shared frosted surface in both compact and
+   expanded modes. Applying the blur only to this wrapper avoids allocating
+   separate backdrop surfaces for Queue, Edits, and Composer. */
+.nw-chat-translucent-surface {
     background-color: color-mix(
         in srgb,
         var(--bg-secondary) 82%,
@@ -1630,18 +1628,23 @@ body.dragging-tab * {
     );
     backdrop-filter: blur(12px) saturate(120%);
     -webkit-backdrop-filter: blur(12px) saturate(120%);
+}
+
+/* The tight negative-spread shadow separates the compact dock without painting
+   a false panel above it. The expanded surface already has pane edges. */
+.nw-chat-bottom-dock {
     box-shadow: 0 -4px 10px -8px
         color-mix(in srgb, black 36%, transparent);
 }
 
 @supports not (backdrop-filter: blur(1px)) {
-    .nw-chat-bottom-dock {
+    .nw-chat-translucent-surface {
         background-color: var(--bg-secondary);
     }
 }
 
 @media (prefers-reduced-transparency: reduce) {
-    .nw-chat-bottom-dock {
+    .nw-chat-translucent-surface {
         background-color: var(--bg-secondary);
         backdrop-filter: none;
         -webkit-backdrop-filter: none;


### PR DESCRIPTION
## Summary

- place Queue, Edited Files, and the Composer in one shared frosted dock while the transcript scrolls beneath it
- preserve transcript position as the dock changes size and keep auxiliary panels usable in short panes
- make the expanded Composer translucent over an inert transcript without adding separate blur layers
- include solid fallbacks for reduced-transparency preferences and unsupported backdrop filtering
- tune the shared surface to 20% transparency with a compact contrast shadow in normal mode

## Validation

- npm run test -- --run src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/AIChatMessageList.test.tsx src/features/ai/components/AIChatComposer.test.tsx src/features/ai/components/AIChatContextBar.test.tsx src/features/ai/components/EditedFilesBufferPanel.test.tsx
- targeted ESLint checks for the modified TypeScript and TSX files
- npx vite build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a shared, adaptive bottom dock for the AI chat composer, queued messages, and edited files.
  - Chat transcripts now preserve reading position and remain correctly aligned as the dock changes size.
  - Expanded composer mode provides a focused overlay experience.
  - Queued messages can scroll within a constrained panel.

- **UI Improvements**
  - Added frosted, translucent chat styling with browser and accessibility fallbacks.
  - Improved spacing, sizing, transparency, and scroll-to-bottom control placement around the chat dock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->