### PR TITLE
Fix markdown location breadcrumb overflow

### DIFF
--- a/apps/desktop/src/features/editor/Editor.tsx
+++ b/apps/desktop/src/features/editor/Editor.tsx
@@ -3999,7 +3999,7 @@ export function Editor({
 
     const activeLocation = activeTabInfo
         ? getNoteLocation(activeTabInfo.noteId)
-        : { parent: "" };
+        : { parentSegments: [] };
     const addWordToSpellcheckDictionary = async (word: string) => {
         await useSpellcheckStore
             .getState()
@@ -4257,7 +4257,7 @@ export function Editor({
                         onTitleChange={applyTitleChange}
                         titleInputRef={titleInputRef}
                         onTitleContextMenu={handleTitleContextMenu}
-                        locationParent={activeLocation.parent}
+                        locationSegments={activeLocation.parentSegments}
                         frontmatterRaw={activeFrontmatter}
                         onFrontmatterChange={applyFrontmatterChange}
                         propertiesExpanded={propertiesExpanded}

--- a/apps/desktop/src/features/editor/EditorHeader.tsx
+++ b/apps/desktop/src/features/editor/EditorHeader.tsx
@@ -12,6 +12,7 @@ export function MetaBadge({
     leading,
     onClick,
     title,
+    truncate = false,
 }: {
     label: string;
     tone?: "muted" | "accent" | "success" | "warning";
@@ -20,6 +21,8 @@ export function MetaBadge({
     /** When provided, the badge renders as a button. */
     onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
     title?: string;
+    /** Keeps a long label on one line and truncates it with an ellipsis. */
+    truncate?: boolean;
 }) {
     const palette =
         tone === "accent"
@@ -53,7 +56,20 @@ export function MetaBadge({
     const content = (
         <>
             {leading}
-            {label}
+            {truncate ? (
+                <span
+                    style={{
+                        minWidth: 0,
+                        overflow: "hidden",
+                        textOverflow: "ellipsis",
+                        whiteSpace: "nowrap",
+                    }}
+                >
+                    {label}
+                </span>
+            ) : (
+                label
+            )}
         </>
     );
 
@@ -68,6 +84,8 @@ export function MetaBadge({
                     alignItems: "center",
                     gap: 6,
                     maxWidth: "100%",
+                    minWidth: 0,
+                    overflow: truncate ? "hidden" : undefined,
                     height: 24,
                     padding: "0 8px",
                     borderRadius: 2,
@@ -93,6 +111,8 @@ export function MetaBadge({
                 alignItems: "center",
                 gap: 6,
                 maxWidth: "100%",
+                minWidth: 0,
+                overflow: truncate ? "hidden" : undefined,
                 height: 24,
                 padding: "0 8px",
                 borderRadius: 2,

--- a/apps/desktop/src/features/editor/LocationBreadcrumb.test.tsx
+++ b/apps/desktop/src/features/editor/LocationBreadcrumb.test.tsx
@@ -51,7 +51,7 @@ describe("LocationBreadcrumb", () => {
         });
     });
 
-    it("collapses intermediate folders when the available width is too small", () => {
+    it("collapses intermediate folders within the space left by sibling badges", () => {
         let resizeCallback: ResizeObserverCallback | null = null;
         const originalResizeObserver = globalThis.ResizeObserver;
 
@@ -81,16 +81,22 @@ describe("LocationBreadcrumb", () => {
                             "Semana 2026-08-03 a 2026-08-09",
                         ]}
                     />
+                    <span>Published</span>
                 </div>,
             );
 
             const parent = container.querySelector(
                 '[data-breadcrumb-container="true"]',
             )!;
+            const root = parent.firstElementChild!;
             const measurement = container.querySelector(
                 '[aria-hidden="true"]',
             )!;
             Object.defineProperty(parent, "clientWidth", {
+                configurable: true,
+                value: 800,
+            });
+            Object.defineProperty(root, "clientWidth", {
                 configurable: true,
                 value: 200,
             });

--- a/apps/desktop/src/features/editor/LocationBreadcrumb.test.tsx
+++ b/apps/desktop/src/features/editor/LocationBreadcrumb.test.tsx
@@ -1,0 +1,118 @@
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LocationBreadcrumb } from "./LocationBreadcrumb";
+import { getCompactLocationSegments } from "./locationBreadcrumbUtils";
+
+describe("getCompactLocationSegments", () => {
+    it("keeps short routes intact", () => {
+        expect(getCompactLocationSegments(["Notes", "Daily"])).toEqual([
+            "Notes",
+            "Daily",
+        ]);
+    });
+
+    it("preserves the root and immediate parent when compacting a deep route", () => {
+        expect(
+            getCompactLocationSegments([
+                "Análisis",
+                "Agosto 2026",
+                "Ficha diaria",
+                "Semana 2026-08-03 a 2026-08-09",
+            ]),
+        ).toEqual(["Análisis", "…", "Semana 2026-08-03 a 2026-08-09"]);
+    });
+});
+
+describe("LocationBreadcrumb", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("keeps the full path in a native tooltip and truncates to one line", () => {
+        const fullPath =
+            "Análisis / Agosto 2026 / Ficha diaria / Semana 2026-08-03 a 2026-08-09";
+
+        render(
+            <LocationBreadcrumb
+                segments={[
+                    "Análisis",
+                    "Agosto 2026",
+                    "Ficha diaria",
+                    "Semana 2026-08-03 a 2026-08-09",
+                ]}
+            />,
+        );
+
+        const breadcrumb = screen.getByTitle(fullPath);
+        expect(breadcrumb).toHaveStyle({ overflow: "hidden" });
+        expect(breadcrumb.firstElementChild).toHaveStyle({
+            textOverflow: "ellipsis",
+            whiteSpace: "nowrap",
+        });
+    });
+
+    it("collapses intermediate folders when the available width is too small", () => {
+        let resizeCallback: ResizeObserverCallback | null = null;
+        const originalResizeObserver = globalThis.ResizeObserver;
+
+        class MockResizeObserver {
+            constructor(callback: ResizeObserverCallback) {
+                resizeCallback = callback;
+            }
+
+            observe() {}
+
+            disconnect() {}
+        }
+
+        Object.defineProperty(globalThis, "ResizeObserver", {
+            configurable: true,
+            value: MockResizeObserver,
+        });
+
+        try {
+            const { container } = render(
+                <div data-breadcrumb-container="true">
+                    <LocationBreadcrumb
+                        segments={[
+                            "Análisis",
+                            "Agosto 2026",
+                            "Ficha diaria",
+                            "Semana 2026-08-03 a 2026-08-09",
+                        ]}
+                    />
+                </div>,
+            );
+
+            const parent = container.querySelector(
+                '[data-breadcrumb-container="true"]',
+            )!;
+            const measurement = container.querySelector(
+                '[aria-hidden="true"]',
+            )!;
+            Object.defineProperty(parent, "clientWidth", {
+                configurable: true,
+                value: 200,
+            });
+            Object.defineProperty(measurement, "offsetWidth", {
+                configurable: true,
+                value: 600,
+            });
+
+            act(() => {
+                resizeCallback?.([], {} as ResizeObserver);
+            });
+
+            expect(
+                screen.getByText(
+                    "Análisis / … / Semana 2026-08-03 a 2026-08-09",
+                ),
+            ).toBeInTheDocument();
+        } finally {
+            Object.defineProperty(globalThis, "ResizeObserver", {
+                configurable: true,
+                value: originalResizeObserver,
+            });
+        }
+    });
+});

--- a/apps/desktop/src/features/editor/LocationBreadcrumb.tsx
+++ b/apps/desktop/src/features/editor/LocationBreadcrumb.tsx
@@ -1,0 +1,71 @@
+import { useLayoutEffect, useRef, useState } from "react";
+import { MetaBadge } from "./EditorHeader";
+import { getCompactLocationSegments } from "./locationBreadcrumbUtils";
+
+type LocationBreadcrumbProps = {
+    segments: string[];
+};
+
+export function LocationBreadcrumb({ segments }: LocationBreadcrumbProps) {
+    const rootRef = useRef<HTMLSpanElement | null>(null);
+    const measurementRef = useRef<HTMLSpanElement | null>(null);
+    const [isCompact, setIsCompact] = useState(false);
+    const fullPath = segments.join(" / ");
+    const compactPath = getCompactLocationSegments(segments).join(" / ");
+
+    useLayoutEffect(() => {
+        const root = rootRef.current;
+        const measurement = measurementRef.current;
+        const parent = root?.parentElement;
+        if (!root || !measurement || !parent) return;
+
+        const updateLayout = () => {
+            const availableWidth = parent.clientWidth;
+            // JSDOM has no layout. Leave the complete label visible there so
+            // unit tests retain meaningful output while browsers measure it.
+            if (availableWidth === 0) return;
+            setIsCompact(measurement.offsetWidth > availableWidth);
+        };
+
+        updateLayout();
+
+        if (typeof ResizeObserver === "undefined") return;
+        const observer = new ResizeObserver(updateLayout);
+        observer.observe(parent);
+
+        return () => observer.disconnect();
+    }, [fullPath]);
+
+    return (
+        <span
+            ref={rootRef}
+            style={{
+                display: "inline-flex",
+                minWidth: 0,
+                maxWidth: "100%",
+            }}
+        >
+            <span
+                ref={measurementRef}
+                aria-hidden="true"
+                style={{
+                    position: "absolute",
+                    visibility: "hidden",
+                    whiteSpace: "nowrap",
+                    fontSize: 11,
+                    fontWeight: 600,
+                    letterSpacing: "0.04em",
+                    padding: "0 8px",
+                    border: "1px solid transparent",
+                }}
+            >
+                {fullPath}
+            </span>
+            <MetaBadge
+                label={isCompact ? compactPath : fullPath}
+                title={fullPath}
+                truncate
+            />
+        </span>
+    );
+}

--- a/apps/desktop/src/features/editor/LocationBreadcrumb.tsx
+++ b/apps/desktop/src/features/editor/LocationBreadcrumb.tsx
@@ -16,11 +16,10 @@ export function LocationBreadcrumb({ segments }: LocationBreadcrumbProps) {
     useLayoutEffect(() => {
         const root = rootRef.current;
         const measurement = measurementRef.current;
-        const parent = root?.parentElement;
-        if (!root || !measurement || !parent) return;
+        if (!root || !measurement) return;
 
         const updateLayout = () => {
-            const availableWidth = parent.clientWidth;
+            const availableWidth = root.clientWidth;
             // JSDOM has no layout. Leave the complete label visible there so
             // unit tests retain meaningful output while browsers measure it.
             if (availableWidth === 0) return;
@@ -31,7 +30,7 @@ export function LocationBreadcrumb({ segments }: LocationBreadcrumbProps) {
 
         if (typeof ResizeObserver === "undefined") return;
         const observer = new ResizeObserver(updateLayout);
-        observer.observe(parent);
+        observer.observe(root);
 
         return () => observer.disconnect();
     }, [fullPath]);
@@ -41,6 +40,7 @@ export function LocationBreadcrumb({ segments }: LocationBreadcrumbProps) {
             ref={rootRef}
             style={{
                 display: "inline-flex",
+                flex: "1 1 auto",
                 minWidth: 0,
                 maxWidth: "100%",
             }}

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.test.tsx
@@ -15,7 +15,7 @@ function renderWith(overrides: Partial<MarkdownNoteHeaderProps> = {}) {
         lineWrapping: true,
         onTitleChange: () => {},
         titleInputRef: { current: null },
-        locationParent: "Notes",
+        locationSegments: ["Notes"],
         frontmatterRaw: null,
         onFrontmatterChange: vi.fn(),
         propertiesExpanded: false,
@@ -34,7 +34,7 @@ function renderHeader(lineWrapping: boolean) {
             lineWrapping={lineWrapping}
             onTitleChange={() => {}}
             titleInputRef={{ current: null }}
-            locationParent="Notes"
+            locationSegments={["Notes"]}
             frontmatterRaw={null}
             onFrontmatterChange={() => {}}
             propertiesExpanded={false}
@@ -249,7 +249,7 @@ describe("MarkdownNoteHeader — OKF status", () => {
                     lineWrapping
                     onTitleChange={() => {}}
                     titleInputRef={{ current: null }}
-                    locationParent="Notes"
+                    locationSegments={["Notes"]}
                     frontmatterRaw={fm(`status: ${raw}`)}
                     onFrontmatterChange={vi.fn()}
                     propertiesExpanded={false}
@@ -499,7 +499,7 @@ describe("MarkdownNoteHeader — OKF status", () => {
                     lineWrapping
                     onTitleChange={() => {}}
                     titleInputRef={{ current: null }}
-                    locationParent="Notes"
+                    locationSegments={["Notes"]}
                     frontmatterRaw={raw}
                     onFrontmatterChange={(next) => {
                         changes.push(next);
@@ -574,7 +574,7 @@ describe("MarkdownNoteHeader — OKF status", () => {
             lineWrapping: true,
             onTitleChange: () => {},
             titleInputRef: { current: null },
-            locationParent: "Notes",
+            locationSegments: ["Notes"],
             frontmatterRaw: fm("status: draft\nstatus_by: simon"),
             onFrontmatterChange,
             propertiesExpanded: false,

--- a/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
+++ b/apps/desktop/src/features/editor/MarkdownNoteHeader.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useRef, useState, type RefObject } from "react";
 import { MetaBadge, EditableNoteTitle } from "./EditorHeader";
+import { LocationBreadcrumb } from "./LocationBreadcrumb";
 import {
     FrontmatterBody,
     parseFrontmatterRaw,
@@ -40,8 +41,8 @@ export interface MarkdownNoteHeaderProps {
     titleInputRef?: RefObject<HTMLTextAreaElement | null>;
     /** Context menu handler for the title textarea (spellcheck) */
     onTitleContextMenu?: (event: React.MouseEvent<HTMLTextAreaElement>) => void;
-    /** Location breadcrumb (e.g. "daily / notes") — empty string hides it */
-    locationParent: string;
+    /** Parent folders for the active note; empty for vault-root notes. */
+    locationSegments: string[];
     /** Raw frontmatter string (null if the note has no frontmatter) */
     frontmatterRaw: string | null;
     /** Callback when frontmatter is edited via Properties panel */
@@ -60,7 +61,7 @@ export function MarkdownNoteHeader({
     onTitleChange,
     titleInputRef,
     onTitleContextMenu,
-    locationParent,
+    locationSegments,
     frontmatterRaw,
     onFrontmatterChange,
     propertiesExpanded,
@@ -211,7 +212,9 @@ export function MarkdownNoteHeader({
                         marginBottom: 14,
                     }}
                 >
-                    {locationParent && <MetaBadge label={locationParent} />}
+                    {locationSegments.length > 0 && (
+                        <LocationBreadcrumb segments={locationSegments} />
+                    )}
                     {status ? (
                         <MetaBadge
                             label={statusLabel(status)}

--- a/apps/desktop/src/features/editor/locationBreadcrumbUtils.ts
+++ b/apps/desktop/src/features/editor/locationBreadcrumbUtils.ts
@@ -1,0 +1,4 @@
+export function getCompactLocationSegments(segments: string[]) {
+    if (segments.length <= 2) return segments;
+    return [segments[0], "…", segments.at(-1)!];
+}

--- a/apps/desktop/src/features/editor/noteTitleHelpers.ts
+++ b/apps/desktop/src/features/editor/noteTitleHelpers.ts
@@ -93,7 +93,7 @@ export function remapPositionPastLeadingContentCollapse(
 export function getNoteLocation(noteId: string) {
     const parts = noteId.split("/").filter(Boolean);
     return {
-        parent: parts.slice(0, -1).join(" / "),
+        parentSegments: parts.slice(0, -1),
     };
 }
 


### PR DESCRIPTION
## Summary
- preserve note locations as path segments until rendering
- collapse deep breadcrumbs to the root and immediate parent when space is limited
- keep the full path in a tooltip and prevent multiline wrapping

## Validation
- npm test -- src/features/editor/LocationBreadcrumb.test.tsx src/features/editor/MarkdownNoteHeader.test.tsx
- npx eslint src/features/editor/EditorHeader.tsx src/features/editor/LocationBreadcrumb.tsx src/features/editor/locationBreadcrumbUtils.ts src/features/editor/LocationBreadcrumb.test.tsx src/features/editor/MarkdownNoteHeader.tsx src/features/editor/MarkdownNoteHeader.test.tsx src/features/editor/noteTitleHelpers.ts src/features/editor/Editor.tsx
- npm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added location breadcrumbs to note headers.
  * Long paths compact automatically and show the full location on hover.
  * Breadcrumbs adapt to available space and window resizing.

* **Bug Fixes**
  * Improved header label handling so long location names truncate cleanly without disrupting layout.

* **Tests**
  * Added coverage for breadcrumb rendering, path compaction, tooltips, truncation, and responsive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->