### PR TITLE
Prepare 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.7.0] - 2026-08-08
+
+### Added
+
+- Added customizable global keyboard shortcuts under Settings > Shortcuts, with shortcut recording, conflict-aware reassignment, per-action reset, and platform-specific preferences shared across vaults.
+- Added a configurable AI chat content width under Settings > Appearance, covering messages, the composer, and related panels.
+
+### Changed
+
+- Refined AI chat presentation with translucent composer surfaces, clearer plan progress in expanded and collapsed states, and formatted code fences while responses are still streaming.
+- Updated the embedded Claude ACP runtime to `0.66.0`, including visibility into active Claude permission scopes.
+
+### Fixed
+
+- Fixed ACP chats failing after idle runtime disconnects by automatically recovering the session, excluding unsent prompts from recovery context, and surfacing sanitized startup diagnostics when reconnection fails.
+- Fixed chat scroll behavior so the jump-to-bottom control appears reliably and newly opened or previously unvisited chats start at the end of the transcript.
+- Fixed long Markdown location breadcrumbs overflowing the editor header by compacting them while preserving the full path on hover.
+
+### Security
+
+- Patched dependency vulnerabilities affecting HTTP handling, URI parsing, HTML sanitization, YAML parsing, and Nano ID generation.
+
 ## [0.6.0] - 2026-07-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.6.0",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.6.0",
+            "version": "0.7.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.6.0",
+    "version": "0.7.0",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.6.0",
+    "version": "0.7.0",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- add the 0.7.0 user-facing changelog
- align desktop, native backend, Cargo lockfile, and Web Clipper versions at 0.7.0

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.7.0`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable keyboard shortcuts.
  * Added settings to adjust AI chat width.

* **Improvements**
  * Improved presentation, runtime behavior, and chat usability.
  * Added better breadcrumb overflow handling.
  * Improved reconnection behavior.

* **Bug Fixes**
  * Addressed dependency security vulnerabilities.

* **Chores**
  * Updated the application version to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->