### PR TITLE
Fix chat backdrop blur in release builds

### DIFF
--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1619,7 +1619,9 @@ body.dragging-tab * {
 
 /* The transcript stays beneath one shared frosted surface in both compact and
    expanded modes. Applying the blur only to this wrapper avoids allocating
-   separate backdrop surfaces for Queue, Edits, and Composer. */
+   separate backdrop surfaces for Queue, Edits, and Composer. Keep the standard
+   property only: the production CSS pipeline adds compatible prefixes, while
+   declaring both can make minification retain only the unsupported prefix. */
 .nw-chat-translucent-surface {
     background-color: color-mix(
         in srgb,
@@ -1627,7 +1629,6 @@ body.dragging-tab * {
         transparent
     );
     backdrop-filter: blur(12px) saturate(120%);
-    -webkit-backdrop-filter: blur(12px) saturate(120%);
 }
 
 /* The tight negative-spread shadow separates the compact dock without painting
@@ -1647,7 +1648,6 @@ body.dragging-tab * {
     .nw-chat-translucent-surface {
         background-color: var(--bg-secondary);
         backdrop-filter: none;
-        -webkit-backdrop-filter: none;
     }
 }
 


### PR DESCRIPTION
## Summary

- remove manually prefixed backdrop-filter declarations from the chat translucent surface
- let the production CSS pipeline emit compatible prefixes without dropping the standard Chromium property
- preserve the reduced-transparency fallback

## Verification

- built the production Electron renderer successfully
- confirmed the generated CSS retains the standard `backdrop-filter` declaration
- verified the blur works in the release build

Fixes #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the translucent chat surface styling to rely on the standard backdrop-filter behavior.
  * Improved consistency for reduced-transparency display settings by simplifying the related styling rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->