### PR TITLE
Prepare 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.7.1] - 2026-08-09
+
+### Fixed
+
+- Fixed the translucent AI chat composer backdrop blur being omitted from packaged desktop builds, so release builds now match the frosted appearance shown during development.
+
 ## [0.7.0] - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.7.0",
+            "version": "0.7.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.7.0",
+    "version": "0.7.1",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.7.0",
+    "version": "0.7.1",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- bump the desktop app, native backend, lockfiles, and Web Clipper to `0.7.1`
- add the `0.7.1` changelog entry for the packaged chat backdrop blur fix
- align all release metadata for the `v0.7.1` tag

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.7.1`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the backdrop blur effect in packaged desktop AI chat composers.

* **Release**
  * Updated the application and web clipper to version 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->