### PR TITLE
Establish canonical conversation lifecycle 

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     mpsc::{self, Sender},
-    Arc, Mutex,
+    Arc, Mutex, OnceLock,
 };
 use std::thread;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -78,6 +78,10 @@ const GROK_LOGIN_INVALIDATED_MESSAGE: &str =
     "Grok login looks invalid or expired. Run Grok login again to reconnect.";
 const CLAUDE_LOGIN_INVALIDATED_MESSAGE: &str =
     "Claude login looks invalid or expired. Run Claude subscription login again to reconnect.";
+const CLAUDE_AUTH_STATUS_TIMEOUT: Duration = Duration::from_secs(3);
+const CLAUDE_AUTH_STATUS_CACHE_TTL: Duration = Duration::from_secs(5);
+const CLAUDE_AUTH_STATUS_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const CLAUDE_AUTH_STATUS_MAX_OUTPUT_BYTES: u64 = 64 * 1024;
 const GROK_STORED_XAI_API_KEY_INVALID_MESSAGE: &str =
     "Stored xAI API key looks invalid. Add a new xAI API key to reconnect Grok.";
 const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
@@ -8547,6 +8551,7 @@ fn inherited_auth_method_for_setup(runtime_id: &str, setup: &RuntimeSetupState) 
         runtime_id,
         !setup.suppress_persisted_auth,
         setup.auth_invalidated_at_ms,
+        setup,
     )
 }
 
@@ -8554,6 +8559,7 @@ fn inherited_auth_method(
     runtime_id: &str,
     include_persisted: bool,
     auth_invalidated_at_ms: Option<u64>,
+    setup: &RuntimeSetupState,
 ) -> Option<String> {
     match runtime_id {
         CODEX_RUNTIME_ID => env_secret_present("CODEX_API_KEY")
@@ -8564,6 +8570,7 @@ fn inherited_auth_method(
                     runtime_id,
                     include_persisted,
                     auth_invalidated_at_ms,
+                    setup,
                 )
             }),
         CLAUDE_RUNTIME_ID => env_secret_present("ANTHROPIC_AUTH_TOKEN")
@@ -8581,6 +8588,7 @@ fn inherited_auth_method(
                     runtime_id,
                     include_persisted,
                     auth_invalidated_at_ms,
+                    setup,
                 )
             }),
         GROK_RUNTIME_ID => env_secret_present("XAI_API_KEY")
@@ -8590,6 +8598,7 @@ fn inherited_auth_method(
                     runtime_id,
                     include_persisted,
                     auth_invalidated_at_ms,
+                    setup,
                 )
             }),
         KILO_RUNTIME_ID => env_secret_present("KILO_API_KEY")
@@ -8599,6 +8608,7 @@ fn inherited_auth_method(
                     runtime_id,
                     include_persisted,
                     auth_invalidated_at_ms,
+                    setup,
                 )
             }),
         OPENCODE_RUNTIME_ID => opencode_env_auth_present()
@@ -8608,6 +8618,7 @@ fn inherited_auth_method(
                     runtime_id,
                     include_persisted,
                     auth_invalidated_at_ms,
+                    setup,
                 )
             }),
         _ => None,
@@ -8618,15 +8629,19 @@ fn inherited_persisted_auth_method(
     runtime_id: &str,
     include_persisted: bool,
     auth_invalidated_at_ms: Option<u64>,
+    setup: &RuntimeSetupState,
 ) -> Option<String> {
     include_persisted
-        .then(|| persisted_cli_auth_method_with_invalidated_at(runtime_id, auth_invalidated_at_ms))
+        .then(|| {
+            persisted_cli_auth_method_with_invalidated_at(runtime_id, auth_invalidated_at_ms, setup)
+        })
         .flatten()
 }
 
 fn persisted_cli_auth_method_with_invalidated_at(
     runtime_id: &str,
     auth_invalidated_at_ms: Option<u64>,
+    setup: &RuntimeSetupState,
 ) -> Option<String> {
     let home = home_dir()?;
     let method = persisted_cli_auth_method_for_home_with_invalidated_at(
@@ -8639,7 +8654,7 @@ fn persisted_cli_auth_method_with_invalidated_at(
         return method;
     }
 
-    match claude_cli_auth_ready() {
+    match claude_cli_auth_ready(setup) {
         Some(true) => method,
         Some(false) => None,
         None if auth_invalidated_at_ms.is_some() => None,
@@ -8654,19 +8669,165 @@ fn parse_claude_auth_status(raw: &[u8]) -> Option<bool> {
         .as_bool()
 }
 
-fn claude_cli_auth_ready() -> Option<bool> {
-    let mut resolved = resolve_base_acp_command(CLAUDE_RUNTIME_ID, &RuntimeSetupState::default());
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct ClaudeAuthProbeKey {
+    program: PathBuf,
+    args: Vec<String>,
+    env: Vec<(String, String)>,
+    auth_invalidated_at_ms: Option<u64>,
+}
+
+#[derive(Clone, Debug)]
+struct ClaudeAuthProbe {
+    key: ClaudeAuthProbeKey,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct ClaudeAuthProbeCacheEntry {
+    checked_at: Instant,
+    result: Option<bool>,
+}
+
+#[derive(Default)]
+struct ClaudeAuthProbeCache {
+    entries: HashMap<ClaudeAuthProbeKey, ClaudeAuthProbeCacheEntry>,
+}
+
+impl ClaudeAuthProbeCache {
+    fn get(&mut self, key: &ClaudeAuthProbeKey, ttl: Duration) -> Option<Option<bool>> {
+        self.entries
+            .retain(|_, entry| entry.checked_at.elapsed() < ttl);
+        self.entries.get(key).map(|entry| entry.result)
+    }
+
+    fn insert(&mut self, key: ClaudeAuthProbeKey, result: Option<bool>) {
+        self.entries.insert(
+            key,
+            ClaudeAuthProbeCacheEntry {
+                checked_at: Instant::now(),
+                result,
+            },
+        );
+    }
+}
+
+fn claude_auth_probe_cache() -> &'static Mutex<ClaudeAuthProbeCache> {
+    static CACHE: OnceLock<Mutex<ClaudeAuthProbeCache>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(ClaudeAuthProbeCache::default()))
+}
+
+fn resolve_claude_auth_probe(setup: &RuntimeSetupState) -> Option<ClaudeAuthProbe> {
+    let mut resolved = resolve_base_acp_command(CLAUDE_RUNTIME_ID, setup);
     let program = resolved.program.take()?;
     resolved.args.extend([
         "--cli".to_string(),
         "auth".to_string(),
         "status".to_string(),
     ]);
-    let output = std::process::Command::new(program)
-        .args(resolved.args)
-        .output()
-        .ok()?;
-    parse_claude_auth_status(&output.stdout).or_else(|| parse_claude_auth_status(&output.stderr))
+    let mut env = setup
+        .env
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<Vec<_>>();
+    env.sort_unstable();
+    Some(ClaudeAuthProbe {
+        key: ClaudeAuthProbeKey {
+            program,
+            args: resolved.args,
+            env,
+            auth_invalidated_at_ms: setup.auth_invalidated_at_ms,
+        },
+    })
+}
+
+fn capture_child_output<R: Read + Send + 'static>(mut reader: R) -> thread::JoinHandle<Vec<u8>> {
+    thread::spawn(move || {
+        let mut output = Vec::new();
+        let _ = reader
+            .by_ref()
+            .take(CLAUDE_AUTH_STATUS_MAX_OUTPUT_BYTES)
+            .read_to_end(&mut output);
+        output
+    })
+}
+
+fn terminate_auth_probe(child: &mut std::process::Child) {
+    #[cfg(unix)]
+    {
+        let process_group = -(child.id() as i32);
+        // The child starts in its own process group, so the negative PID cannot
+        // target NeverWrite or another unrelated group.
+        unsafe {
+            libc::kill(process_group, libc::SIGKILL);
+        }
+        let _ = child.kill();
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = child.kill();
+    }
+    let _ = child.wait();
+}
+
+fn execute_claude_auth_probe(probe: &ClaudeAuthProbe, timeout: Duration) -> Option<bool> {
+    let mut command = std::process::Command::new(&probe.key.program);
+    command
+        .args(&probe.key.args)
+        .envs(probe.key.env.iter().map(|(key, value)| (key, value)))
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        command.process_group(0);
+    }
+
+    let mut child = command.spawn().ok()?;
+    let stdout = child.stdout.take().map(capture_child_output);
+    let stderr = child.stderr.take().map(capture_child_output);
+    let started_at = Instant::now();
+
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if started_at.elapsed() < timeout => {
+                let remaining = timeout.saturating_sub(started_at.elapsed());
+                thread::sleep(CLAUDE_AUTH_STATUS_POLL_INTERVAL.min(remaining));
+            }
+            Ok(None) | Err(_) => {
+                terminate_auth_probe(&mut child);
+                // Dropping the handles detaches the readers so an inherited
+                // pipe held by a misbehaving descendant cannot extend the
+                // synchronous timeout seen by the caller.
+                drop(stdout);
+                drop(stderr);
+                return None;
+            }
+        }
+    }
+
+    let stdout = stdout
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr
+        .and_then(|reader| reader.join().ok())
+        .unwrap_or_default();
+    parse_claude_auth_status(&stdout).or_else(|| parse_claude_auth_status(&stderr))
+}
+
+fn claude_cli_auth_ready(setup: &RuntimeSetupState) -> Option<bool> {
+    let probe = resolve_claude_auth_probe(setup)?;
+    if let Ok(mut cache) = claude_auth_probe_cache().lock() {
+        if let Some(result) = cache.get(&probe.key, CLAUDE_AUTH_STATUS_CACHE_TTL) {
+            return result;
+        }
+    }
+
+    let result = execute_claude_auth_probe(&probe, CLAUDE_AUTH_STATUS_TIMEOUT);
+    if let Ok(mut cache) = claude_auth_probe_cache().lock() {
+        cache.insert(probe.key, result);
+    }
+    result
 }
 
 #[cfg(test)]
@@ -18624,6 +18785,71 @@ mod tests {
         assert_eq!(parse_claude_auth_status(b"not-json"), None);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn claude_auth_probe_uses_the_effective_binary_and_caches_its_result() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("custom-claude-acp");
+        let marker = temp.path().join("probe-count");
+        fs::write(
+            &executable,
+            "#!/bin/sh\nprintf x >> \"$NEVERWRITE_AUTH_PROBE_MARKER\"\nprintf '{\"loggedIn\":%s}' \"$NEVERWRITE_AUTH_PROBE_RESULT\"\n",
+        )
+        .unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let mut setup = RuntimeSetupState {
+            custom_binary_path: Some(executable.display().to_string()),
+            env: HashMap::from([
+                (
+                    "NEVERWRITE_AUTH_PROBE_MARKER".to_string(),
+                    marker.display().to_string(),
+                ),
+                (
+                    "NEVERWRITE_AUTH_PROBE_RESULT".to_string(),
+                    "true".to_string(),
+                ),
+            ]),
+            ..RuntimeSetupState::default()
+        };
+
+        assert_eq!(claude_cli_auth_ready(&setup), Some(true));
+        assert_eq!(claude_cli_auth_ready(&setup), Some(true));
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "x");
+
+        setup.env.insert(
+            "NEVERWRITE_AUTH_PROBE_RESULT".to_string(),
+            "false".to_string(),
+        );
+        assert_eq!(claude_cli_auth_ready(&setup), Some(false));
+        assert_eq!(claude_cli_auth_ready(&setup), Some(false));
+        assert_eq!(fs::read_to_string(&marker).unwrap(), "xx");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn claude_auth_probe_terminates_a_hung_process_group() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = tempfile::tempdir().unwrap();
+        let executable = temp.path().join("hanging-claude-acp");
+        fs::write(&executable, "#!/bin/sh\nsleep 30\n").unwrap();
+        fs::set_permissions(&executable, fs::Permissions::from_mode(0o755)).unwrap();
+        let setup = RuntimeSetupState {
+            custom_binary_path: Some(executable.display().to_string()),
+            ..RuntimeSetupState::default()
+        };
+        let probe = resolve_claude_auth_probe(&setup).expect("custom probe should resolve");
+        let started_at = Instant::now();
+
+        assert_eq!(
+            execute_claude_auth_probe(&probe, Duration::from_millis(50)),
+            None
+        );
+        assert!(started_at.elapsed() < Duration::from_secs(2));
+    }
+
     #[test]
     fn claude_auth_error_detector_matches_expired_oauth() {
         for error in [
@@ -19749,7 +19975,7 @@ mod tests {
             .expect("Grok ACP process spec should resolve");
 
         assert_eq!(
-            inherited_auth_method(GROK_RUNTIME_ID, true, None),
+            inherited_auth_method(GROK_RUNTIME_ID, true, None, &setup),
             Some("xai-api-key".to_string())
         );
         assert_eq!(spec.env.get("XAI_API_KEY"), None);

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -307,6 +307,24 @@ struct AiCreateSessionInput {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+struct AiConversationTurnSelectionInput {
+    runtime_id: String,
+    model_id: String,
+    mode_id: String,
+    #[serde(default)]
+    options: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct AiStartConversationTurnInput {
+    conversation_id: String,
+    binding_id: String,
+    runtime_id: String,
+    session_id: String,
+    selection: AiConversationTurnSelectionInput,
+}
+
+#[derive(Debug, Clone, Deserialize)]
 struct AiCustomRuntimeContinuationInput {
     runtime_id: String,
     runtime_session_id: String,
@@ -1536,6 +1554,54 @@ impl NativeAi {
         drop(state);
         self.emit_session("ai://session-updated", &session);
         Ok(json!(session))
+    }
+
+    pub(crate) fn start_conversation_turn(&self, args: &Value) -> Result<Value, String> {
+        let input: AiStartConversationTurnInput = input_from_args(args)?;
+        if input.conversation_id.trim().is_empty() || input.binding_id.trim().is_empty() {
+            return Err("Conversation and binding ids are required to start a turn.".to_string());
+        }
+        if input.selection.runtime_id != input.runtime_id {
+            return Err(
+                "Conversation turn selection does not match the target runtime.".to_string(),
+            );
+        }
+
+        let state = self
+            .inner
+            .lock()
+            .map_err(|error| format!("Internal AI state error: {error}"))?;
+        let session = state
+            .sessions
+            .get(&input.session_id)
+            .map(|managed| &managed.session)
+            .ok_or_else(|| format!("AI session not found: {}", input.session_id))?;
+        if session.runtime_id != input.runtime_id {
+            return Err(
+                "Refusing to start a conversation turn on another provider's session.".to_string(),
+            );
+        }
+        if session.model_id != input.selection.model_id
+            || session.mode_id != input.selection.mode_id
+        {
+            return Err(
+                "Conversation turn selection was not applied to the target session.".to_string(),
+            );
+        }
+        for (option_id, expected_value) in &input.selection.options {
+            if let Some(option) = session
+                .config_options
+                .iter()
+                .find(|option| option.id == *option_id)
+            {
+                if option.value != *expected_value {
+                    return Err(format!(
+                        "Conversation turn option was not applied: {option_id}"
+                    ));
+                }
+            }
+        }
+        Ok(json!(null))
     }
 
     pub(crate) fn create_session(
@@ -10783,6 +10849,30 @@ mod tests {
         let empty = normalize_additional_roots(Some(vec![]));
         assert!(empty.kept.is_empty());
         assert!(empty.discarded.is_empty());
+    }
+
+    #[test]
+    fn conversation_turn_rejects_a_selection_for_another_runtime() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let ai = NativeAi::new(event_tx);
+        let error = ai
+            .start_conversation_turn(&json!({
+                "input": {
+                    "conversation_id": "conversation-1",
+                    "binding_id": "binding-b",
+                    "runtime_id": "provider-b",
+                    "session_id": "local-b",
+                    "selection": {
+                        "runtime_id": "provider-a",
+                        "model_id": "model-a",
+                        "mode_id": "default",
+                        "options": {}
+                    }
+                }
+            }))
+            .expect_err("cross-runtime selections must be rejected");
+
+        assert!(error.contains("does not match the target runtime"));
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -5692,6 +5692,7 @@ async fn start_acp12_runtime_session(
                 session_id: response.session_id.0.to_string(),
                 modes: acp12_to_current(response.modes).map_err(acp12_internal_error)?,
                 config_options: acp12_session_config_options(
+                    &spec.runtime_id,
                     response.config_options,
                     response.models.or_else(|| initialize_model_state.clone()),
                 )
@@ -5723,6 +5724,7 @@ async fn start_acp12_runtime_session(
                 session_id: session_id.clone(),
                 modes: acp12_to_current(response.modes).map_err(acp12_internal_error)?,
                 config_options: acp12_session_config_options(
+                    &spec.runtime_id,
                     response.config_options,
                     response.models.or_else(|| initialize_model_state.clone()),
                 )
@@ -5744,6 +5746,7 @@ fn acp12_initialize_model_state(
 }
 
 fn acp12_session_config_options(
+    runtime_id: &str,
     legacy_options: Option<Vec<acp12::schema::SessionConfigOption>>,
     legacy_models: Option<acp12::schema::SessionModelState>,
 ) -> Result<Option<Vec<SessionConfigOption>>, String> {
@@ -5755,7 +5758,7 @@ fn acp12_session_config_options(
     let options = options.get_or_insert_with(Vec::new);
     if !options.iter().any(|option| {
         matches!(
-            map_config_option_category(&option.id.0, option.category.as_ref()),
+            map_config_option_category(runtime_id, &option.id.0, option.category.as_ref()),
             AiConfigOptionCategory::Model
         )
     }) {
@@ -6301,7 +6304,11 @@ fn map_session_config_options(
             Some(AiConfigOption {
                 id: option.id.0.to_string(),
                 runtime_id: runtime_id.to_string(),
-                category: map_config_option_category(&option.id.0, option.category.as_ref()),
+                category: map_config_option_category(
+                    runtime_id,
+                    &option.id.0,
+                    option.category.as_ref(),
+                ),
                 label: option.name,
                 description: option.description,
                 kind: "select".to_string(),
@@ -6338,6 +6345,7 @@ fn align_synthesized_config_options_to_acp_state(
 }
 
 fn map_config_option_category(
+    runtime_id: &str,
     option_id: &str,
     category: Option<&SessionConfigOptionCategory>,
 ) -> AiConfigOptionCategory {
@@ -6357,6 +6365,11 @@ fn map_config_option_category(
     ) {
         return AiConfigOptionCategory::Reasoning;
     }
+    if matches!(normalized_id.as_str(), "servicetier" | "fastmode")
+        || (runtime_id == CLAUDE_RUNTIME_ID && normalized_id == "fast")
+    {
+        return AiConfigOptionCategory::ServiceTier;
+    }
 
     match category {
         Some(SessionConfigOptionCategory::Mode) => AiConfigOptionCategory::Mode,
@@ -6369,6 +6382,14 @@ fn map_config_option_category(
             ) =>
         {
             AiConfigOptionCategory::Reasoning
+        }
+        Some(SessionConfigOptionCategory::Other(value))
+            if matches!(
+                normalize_config_option_key(value).as_str(),
+                "servicetier" | "fastmode"
+            ) =>
+        {
+            AiConfigOptionCategory::ServiceTier
         }
         _ => AiConfigOptionCategory::Other,
     }
@@ -15075,6 +15096,15 @@ mod tests {
                     "high",
                     vec![SessionConfigSelectOption::new("high", "High")],
                 ),
+                SessionConfigOption::select(
+                    "service_tier",
+                    "Fast Mode",
+                    "off",
+                    vec![
+                        SessionConfigSelectOption::new("off", "Off"),
+                        SessionConfigSelectOption::new("fast", "Fast"),
+                    ],
+                ),
             ],
         );
 
@@ -15083,6 +15113,10 @@ mod tests {
         assert!(matches!(
             options[2].category,
             AiConfigOptionCategory::Reasoning
+        ));
+        assert!(matches!(
+            options[3].category,
+            AiConfigOptionCategory::ServiceTier
         ));
     }
 
@@ -15117,6 +15151,7 @@ mod tests {
     #[test]
     fn acp12_model_state_is_exposed_as_model_config_option() {
         let config_options = acp12_session_config_options(
+            GROK_RUNTIME_ID,
             None,
             Some(acp12::schema::SessionModelState::new(
                 "grok-build",
@@ -16076,6 +16111,46 @@ mod tests {
         assert!(matches!(
             mapped[0].category,
             AiConfigOptionCategory::Reasoning
+        ));
+    }
+
+    #[test]
+    fn acp_config_mapping_classifies_only_known_fast_options_as_service_tiers() {
+        let claude = map_session_config_options(
+            CLAUDE_RUNTIME_ID,
+            vec![SessionConfigOption::select(
+                "fast",
+                "Fast mode",
+                "off",
+                vec![
+                    SessionConfigSelectOption::new("off", "Off"),
+                    SessionConfigSelectOption::new("on", "On"),
+                ],
+            )
+            .category(SessionConfigOptionCategory::Other(
+                "model_config".to_string(),
+            ))],
+        );
+        let unrelated = map_session_config_options(
+            "custom:example",
+            vec![SessionConfigOption::select(
+                "fast",
+                "Fast mode",
+                "off",
+                vec![
+                    SessionConfigSelectOption::new("off", "Off"),
+                    SessionConfigSelectOption::new("on", "On"),
+                ],
+            )],
+        );
+
+        assert!(matches!(
+            claude[0].category,
+            AiConfigOptionCategory::ServiceTier
+        ));
+        assert!(matches!(
+            unrelated[0].category,
+            AiConfigOptionCategory::Other
         ));
     }
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -76,6 +76,8 @@ static ACP_PROCESS_COUNTER: AtomicU64 = AtomicU64::new(1);
 const ELECTRON_AI_INTERACTIVE_AUTH_UNAVAILABLE: &str = "Interactive AI authentication is not available in Electron yet. Use an existing CLI login, an environment/API key, or a custom gateway.";
 const GROK_LOGIN_INVALIDATED_MESSAGE: &str =
     "Grok login looks invalid or expired. Run Grok login again to reconnect.";
+const CLAUDE_LOGIN_INVALIDATED_MESSAGE: &str =
+    "Claude login looks invalid or expired. Run Claude subscription login again to reconnect.";
 const GROK_STORED_XAI_API_KEY_INVALID_MESSAGE: &str =
     "Stored xAI API key looks invalid. Add a new xAI API key to reconnect Grok.";
 const GROK_INHERITED_XAI_API_KEY_INVALID_MESSAGE: &str =
@@ -1650,13 +1652,13 @@ impl NativeAi {
         ) {
             Ok(created) => created,
             Err(error) => {
-                if let Err(update_error) = self.invalidate_grok_auth_after_session_start_error(
+                if let Err(update_error) = self.invalidate_auth_after_session_start_error(
                     &input.runtime_id,
                     &setup,
                     error.message(),
                 ) {
                     return Err(format!(
-                        "{error}\n\nFailed to update Grok auth state: {update_error}"
+                        "{error}\n\nFailed to update runtime auth state: {update_error}"
                     ));
                 }
                 return Err(error.to_string());
@@ -1763,13 +1765,13 @@ impl NativeAi {
         ) {
             Ok(created) => created,
             Err(error) => {
-                if let Err(update_error) = self.invalidate_grok_auth_after_session_start_error(
+                if let Err(update_error) = self.invalidate_auth_after_session_start_error(
                     &input.runtime_id,
                     &setup,
                     error.message(),
                 ) {
                     return Err(format!(
-                        "{error}\n\nFailed to update Grok auth state: {update_error}"
+                        "{error}\n\nFailed to update runtime auth state: {update_error}"
                     ));
                 }
                 return Err(error.to_string());
@@ -2363,19 +2365,22 @@ impl NativeAi {
         Ok(())
     }
 
-    fn invalidate_grok_auth_after_session_start_error(
+    fn invalidate_auth_after_session_start_error(
         &self,
         runtime_id: &str,
         setup_at_start: &RuntimeSetupState,
         error: &str,
     ) -> Result<(), String> {
-        if runtime_id != GROK_RUNTIME_ID || !is_grok_auth_error(error) {
+        let claude_method = (runtime_id == CLAUDE_RUNTIME_ID && is_claude_auth_error(error))
+            .then(|| effective_auth_method_for_acp_process_spec(runtime_id, setup_at_start))
+            .flatten()
+            .filter(|method| matches!(method.as_str(), "claude-ai-login" | "claude-login"));
+        let grok_source = (runtime_id == GROK_RUNTIME_ID && is_grok_auth_error(error))
+            .then(|| grok_auth_failure_source(setup_at_start))
+            .flatten();
+        if claude_method.is_none() && grok_source.is_none() {
             return Ok(());
         }
-
-        let Some(source) = grok_auth_failure_source(setup_at_start) else {
-            return Ok(());
-        };
 
         let (mut pending_setup, setup_load_error) = {
             let state = self
@@ -2389,7 +2394,11 @@ impl NativeAi {
         }
 
         let setup = pending_setup.entry(runtime_id.to_string()).or_default();
-        apply_grok_auth_failure(setup, source);
+        if let Some(method) = claude_method {
+            apply_claude_auth_failure(setup, method);
+        } else if let Some(source) = grok_source {
+            apply_grok_auth_failure(setup, source);
+        }
         self.setup_store.save(&pending_setup)?;
 
         let mut state = self
@@ -8114,7 +8123,7 @@ fn resolve_base_acp_command(runtime_id: &str, setup: &RuntimeSetupState) -> Reso
 
     if runtime_id == CLAUDE_RUNTIME_ID {
         let vendor = claude_vendor_entry_path();
-        if vendor.is_file() {
+        if vendor.is_file() && claude_runtime_dependencies_ready(&vendor) {
             return ResolvedAcpCommand {
                 display: Some(vendor.display().to_string()),
                 program: Some(PathBuf::from("node")),
@@ -8178,7 +8187,7 @@ fn resolve_packaged_acp_command(runtime_id: &str) -> Option<ResolvedAcpCommand> 
                 .join("claude-agent-acp")
                 .join("dist")
                 .join("index.js");
-            if node.is_file() && entry.is_file() {
+            if node.is_file() && entry.is_file() && claude_runtime_dependencies_ready(&entry) {
                 return Some(ResolvedAcpCommand {
                     display: Some(entry.display().to_string()),
                     program: Some(node),
@@ -8560,12 +8569,44 @@ fn persisted_cli_auth_method_with_invalidated_at(
     auth_invalidated_at_ms: Option<u64>,
 ) -> Option<String> {
     let home = home_dir()?;
-    persisted_cli_auth_method_for_home_with_invalidated_at(
+    let method = persisted_cli_auth_method_for_home_with_invalidated_at(
         runtime_id,
         &home,
         is_claude_remote_environment(),
         auth_invalidated_at_ms,
-    )
+    );
+    if runtime_id != CLAUDE_RUNTIME_ID || method.is_none() {
+        return method;
+    }
+
+    match claude_cli_auth_ready() {
+        Some(true) => method,
+        Some(false) => None,
+        None if auth_invalidated_at_ms.is_some() => None,
+        None => method,
+    }
+}
+
+fn parse_claude_auth_status(raw: &[u8]) -> Option<bool> {
+    serde_json::from_slice::<Value>(raw)
+        .ok()?
+        .get("loggedIn")?
+        .as_bool()
+}
+
+fn claude_cli_auth_ready() -> Option<bool> {
+    let mut resolved = resolve_base_acp_command(CLAUDE_RUNTIME_ID, &RuntimeSetupState::default());
+    let program = resolved.program.take()?;
+    resolved.args.extend([
+        "--cli".to_string(),
+        "auth".to_string(),
+        "status".to_string(),
+    ]);
+    let output = std::process::Command::new(program)
+        .args(resolved.args)
+        .output()
+        .ok()?;
+    parse_claude_auth_status(&output.stdout).or_else(|| parse_claude_auth_status(&output.stderr))
 }
 
 #[cfg(test)]
@@ -8809,12 +8850,17 @@ fn should_persist_auth_method(
 fn is_persistable_external_auth_method(runtime_id: &str, method_id: &str) -> bool {
     matches!(
         (runtime_id, method_id),
-        (GROK_RUNTIME_ID, "grok-login") | (OPENCODE_RUNTIME_ID, "opencode-login")
+        (CLAUDE_RUNTIME_ID, "claude-ai-login" | "claude-login")
+            | (GROK_RUNTIME_ID, "grok-login")
+            | (OPENCODE_RUNTIME_ID, "opencode-login")
     )
 }
 
 fn is_invalidation_tracked_external_auth_runtime(runtime_id: &str) -> bool {
-    matches!(runtime_id, GROK_RUNTIME_ID | OPENCODE_RUNTIME_ID)
+    matches!(
+        runtime_id,
+        CLAUDE_RUNTIME_ID | GROK_RUNTIME_ID | OPENCODE_RUNTIME_ID
+    )
 }
 
 fn is_local_auth_method(method_id: &str) -> bool {
@@ -8950,6 +8996,29 @@ enum GrokAuthFailureSource {
     InheritedXaiApiKey,
 }
 
+fn is_claude_auth_error(error: &str) -> bool {
+    let normalized = error.to_lowercase();
+    [
+        "oauth session expired",
+        "failed to authenticate",
+        "authentication_failed",
+        "authentication required",
+        "auth_required",
+        "not logged in",
+    ]
+    .into_iter()
+    .any(|needle| normalized.contains(needle))
+}
+
+fn apply_claude_auth_failure(setup: &mut RuntimeSetupState, method: String) {
+    setup.auth_method = Some(method);
+    setup.auth_ready = false;
+    setup.suppress_persisted_auth = false;
+    setup.auth_invalidated_at_ms = Some(current_epoch_ms());
+    setup.message = Some(CLAUDE_LOGIN_INVALIDATED_MESSAGE.to_string());
+    refresh_runtime_setup_flags(CLAUDE_RUNTIME_ID, setup);
+}
+
 fn is_grok_auth_error(error: &str) -> bool {
     let normalized = error.to_lowercase();
     [
@@ -9056,6 +9125,25 @@ fn codex_vendor_binary_path() -> PathBuf {
 fn claude_vendor_entry_path() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
         .join("../../../vendor/Claude-agent-acp-upstream/dist/index.js")
+}
+
+fn claude_runtime_dependencies_ready(entry: &Path) -> bool {
+    let Some(runtime_root) = entry.parent().and_then(Path::parent) else {
+        return false;
+    };
+    [
+        ["@agentclientprotocol", "sdk"],
+        ["@anthropic-ai", "claude-agent-sdk"],
+        ["zod", ""],
+    ]
+    .iter()
+    .all(|components| {
+        let mut package = runtime_root.join("node_modules").join(components[0]);
+        if !components[1].is_empty() {
+            package = package.join(components[1]);
+        }
+        package.join("package.json").is_file()
+    })
 }
 
 fn auth_methods(runtime_id: &str) -> Vec<AiAuthMethod> {
@@ -10849,6 +10937,39 @@ mod tests {
         let empty = normalize_additional_roots(Some(vec![]));
         assert!(empty.kept.is_empty());
         assert!(empty.discarded.is_empty());
+    }
+
+    #[test]
+    fn claude_runtime_requires_its_production_dependencies() {
+        let temp = tempfile::tempdir().unwrap();
+        let entry = temp.path().join("dist/index.js");
+        fs::create_dir_all(entry.parent().unwrap()).unwrap();
+        fs::write(&entry, b"").unwrap();
+
+        assert!(!claude_runtime_dependencies_ready(&entry));
+    }
+
+    #[test]
+    fn claude_runtime_accepts_a_complete_production_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let entry = temp.path().join("dist/index.js");
+        fs::create_dir_all(entry.parent().unwrap()).unwrap();
+        fs::write(&entry, b"").unwrap();
+        for package in [
+            "@agentclientprotocol/sdk",
+            "@anthropic-ai/claude-agent-sdk",
+            "zod",
+        ] {
+            let package_json = temp
+                .path()
+                .join("node_modules")
+                .join(package)
+                .join("package.json");
+            fs::create_dir_all(package_json.parent().unwrap()).unwrap();
+            fs::write(package_json, b"{}").unwrap();
+        }
+
+        assert!(claude_runtime_dependencies_ready(&entry));
     }
 
     #[test]
@@ -18165,6 +18286,91 @@ mod tests {
     }
 
     #[test]
+    fn claude_auth_status_parser_uses_the_cli_logged_in_flag() {
+        assert_eq!(
+            parse_claude_auth_status(br#"{"loggedIn":true,"authMethod":"claude.ai"}"#),
+            Some(true)
+        );
+        assert_eq!(
+            parse_claude_auth_status(br#"{"loggedIn":false,"authMethod":"none"}"#),
+            Some(false)
+        );
+        assert_eq!(parse_claude_auth_status(b"not-json"), None);
+    }
+
+    #[test]
+    fn claude_auth_error_detector_matches_expired_oauth() {
+        for error in [
+            "Failed to authenticate: OAuth session expired and could not be refreshed",
+            "authentication_failed",
+            "authentication required",
+            "auth_required",
+            "Claude is not logged in",
+        ] {
+            assert!(is_claude_auth_error(error), "{error:?} should be detected");
+        }
+
+        assert!(!is_claude_auth_error("model does not support that option"));
+    }
+
+    #[test]
+    fn claude_oauth_error_marks_subscription_login_invalidated() {
+        let temp = tempfile::tempdir().unwrap();
+        let store_path = temp.path().join("runtime-setup.json");
+        let native_ai = test_native_ai_with_secret_store(
+            store_path,
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let setup_at_start = RuntimeSetupState {
+            auth_method: Some("claude-ai-login".to_string()),
+            auth_ready: true,
+            ..RuntimeSetupState::default()
+        };
+        native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .insert(CLAUDE_RUNTIME_ID.to_string(), setup_at_start.clone());
+
+        native_ai
+            .invalidate_auth_after_session_start_error(
+                CLAUDE_RUNTIME_ID,
+                &setup_at_start,
+                "Failed to authenticate: OAuth session expired and could not be refreshed",
+            )
+            .unwrap();
+
+        let setup = native_ai
+            .inner
+            .lock()
+            .unwrap()
+            .setup
+            .get(CLAUDE_RUNTIME_ID)
+            .cloned()
+            .expect("Claude setup should remain");
+        assert_eq!(setup.auth_method.as_deref(), Some("claude-ai-login"));
+        assert!(!setup.auth_ready);
+        assert!(setup.auth_invalidated_at_ms.is_some());
+        assert_eq!(
+            setup.message.as_deref(),
+            Some(CLAUDE_LOGIN_INVALIDATED_MESSAGE)
+        );
+
+        let persisted_setup = native_ai
+            .setup_store
+            .load()
+            .unwrap()
+            .remove(CLAUDE_RUNTIME_ID)
+            .expect("Claude setup should persist invalidated login");
+        assert_eq!(
+            persisted_setup.auth_method.as_deref(),
+            Some("claude-ai-login")
+        );
+        assert!(persisted_setup.auth_invalidated_at_ms.is_some());
+    }
+
+    #[test]
     fn grok_login_auth_error_marks_external_auth_invalidated() {
         let _guard = ENV_TEST_LOCK.lock().unwrap();
         let previous = std::env::var_os("XAI_API_KEY");
@@ -18189,7 +18395,7 @@ mod tests {
             .insert(GROK_RUNTIME_ID.to_string(), setup_at_start.clone());
 
         native_ai
-            .invalidate_grok_auth_after_session_start_error(
+            .invalidate_auth_after_session_start_error(
                 GROK_RUNTIME_ID,
                 &setup_at_start,
                 "cached_token unauthorized",
@@ -18265,7 +18471,7 @@ mod tests {
             .cloned()
             .expect("Grok setup should exist");
         native_ai
-            .invalidate_grok_auth_after_session_start_error(
+            .invalidate_auth_after_session_start_error(
                 GROK_RUNTIME_ID,
                 &setup_at_start,
                 "401 invalid api key",
@@ -18328,7 +18534,7 @@ mod tests {
             .cloned()
             .expect("Grok setup should exist");
         native_ai
-            .invalidate_grok_auth_after_session_start_error(
+            .invalidate_auth_after_session_start_error(
                 GROK_RUNTIME_ID,
                 &setup_at_start,
                 "unauthorized",

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -941,10 +941,18 @@ struct ManagedAiSession {
     active_turn_id: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ConversationTurnBindingOwner {
+    conversation_id: String,
+    runtime_id: String,
+    session_id: String,
+}
+
 #[derive(Default)]
 struct NativeAiInner {
     sessions: HashMap<String, ManagedAiSession>,
     session_order: Vec<String>,
+    conversation_turn_bindings: HashMap<String, ConversationTurnBindingOwner>,
     setup: HashMap<String, RuntimeSetupState>,
     setup_load_error: Option<String>,
 }
@@ -1576,33 +1584,38 @@ impl NativeAi {
             );
         }
 
-        let state = self
+        let mut state = self
             .inner
             .lock()
             .map_err(|error| format!("Internal AI state error: {error}"))?;
-        let session = state
-            .sessions
-            .get(&input.session_id)
-            .map(|managed| &managed.session)
-            .ok_or_else(|| format!("AI session not found: {}", input.session_id))?;
-        if session.runtime_id != input.runtime_id {
-            return Err(
-                "Refusing to start a conversation turn on another provider's session.".to_string(),
-            );
-        }
-        if session.model_id != input.selection.model_id
-            || session.mode_id != input.selection.mode_id
         {
-            return Err(
-                "Conversation turn selection was not applied to the target session.".to_string(),
-            );
-        }
-        for (option_id, expected_value) in &input.selection.options {
-            if let Some(option) = session
-                .config_options
-                .iter()
-                .find(|option| option.id == *option_id)
+            let session = state
+                .sessions
+                .get(&input.session_id)
+                .map(|managed| &managed.session)
+                .ok_or_else(|| format!("AI session not found: {}", input.session_id))?;
+            if session.runtime_id != input.runtime_id {
+                return Err(
+                    "Refusing to start a conversation turn on another provider's session."
+                        .to_string(),
+                );
+            }
+            if session.model_id != input.selection.model_id
+                || session.mode_id != input.selection.mode_id
             {
+                return Err(
+                    "Conversation turn selection was not applied to the target session."
+                        .to_string(),
+                );
+            }
+            for (option_id, expected_value) in &input.selection.options {
+                let option = session
+                    .config_options
+                    .iter()
+                    .find(|option| option.id == *option_id)
+                    .ok_or_else(|| {
+                        format!("Conversation turn option is unavailable: {option_id}")
+                    })?;
                 if option.value != *expected_value {
                     return Err(format!(
                         "Conversation turn option was not applied: {option_id}"
@@ -1610,6 +1623,45 @@ impl NativeAi {
                 }
             }
         }
+
+        if let Some(owner) = state.conversation_turn_bindings.get(&input.binding_id) {
+            if owner.conversation_id != input.conversation_id
+                || owner.runtime_id != input.runtime_id
+                || owner.session_id != input.session_id
+            {
+                return Err(
+                    "Conversation binding is already associated with another conversation or session."
+                        .to_string(),
+                );
+            }
+            return Ok(json!(null));
+        }
+        if state
+            .conversation_turn_bindings
+            .iter()
+            .any(|(binding_id, owner)| {
+                binding_id != &input.binding_id && owner.conversation_id == input.conversation_id
+            })
+        {
+            return Err("Conversation is already associated with another binding.".to_string());
+        }
+        if state
+            .conversation_turn_bindings
+            .iter()
+            .any(|(binding_id, owner)| {
+                binding_id != &input.binding_id && owner.session_id == input.session_id
+            })
+        {
+            return Err("Runtime session is already associated with another binding.".to_string());
+        }
+        state.conversation_turn_bindings.insert(
+            input.binding_id,
+            ConversationTurnBindingOwner {
+                conversation_id: input.conversation_id,
+                runtime_id: input.runtime_id,
+                session_id: input.session_id,
+            },
+        );
         Ok(json!(null))
     }
 
@@ -2226,6 +2278,9 @@ impl NativeAi {
             .remove(&session_id)
             .ok_or_else(|| format!("AI session not found: {session_id}"))?;
         state.session_order.retain(|id| id != &session_id);
+        state
+            .conversation_turn_bindings
+            .retain(|_, owner| owner.session_id != session_id);
         let shutdown_handle = removed.runtime_handle.filter(|handle| {
             !state.sessions.values().any(|managed| {
                 managed
@@ -2266,6 +2321,9 @@ impl NativeAi {
                 }
             }
             state.session_order.retain(|id| id != &session_id);
+            state
+                .conversation_turn_bindings
+                .retain(|_, owner| owner.session_id != session_id);
             self.tool_diffs.clear_session(&session_id);
         }
         drop(state);
@@ -11218,6 +11276,49 @@ mod tests {
     }
 
     #[test]
+    fn conversation_turn_rejects_unknown_requested_options() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let ai = NativeAi::new(event_tx);
+        insert_test_managed_session(&ai.inner, CODEX_RUNTIME_ID, "session-1");
+        let mut input =
+            test_conversation_turn_input(&ai, "conversation-1", "binding-1", "session-1");
+        input["input"]["selection"]["options"]["unknown-option"] = json!("value");
+
+        let error = ai
+            .start_conversation_turn(&input)
+            .expect_err("unknown requested options must be rejected");
+
+        assert!(error.contains("option is unavailable: unknown-option"));
+    }
+
+    #[test]
+    fn conversation_turn_binds_canonical_identity_to_one_runtime_session() {
+        let (event_tx, _event_rx) = mpsc::channel();
+        let ai = NativeAi::new(event_tx);
+        insert_test_managed_session(&ai.inner, CODEX_RUNTIME_ID, "session-1");
+        let input = test_conversation_turn_input(&ai, "conversation-1", "binding-1", "session-1");
+
+        ai.start_conversation_turn(&input)
+            .expect("the initial canonical association should succeed");
+        ai.start_conversation_turn(&input)
+            .expect("reusing the same canonical association should succeed");
+
+        let conflicting =
+            test_conversation_turn_input(&ai, "conversation-2", "binding-1", "session-1");
+        let error = ai
+            .start_conversation_turn(&conflicting)
+            .expect_err("a binding cannot move to another conversation");
+        assert!(error.contains("already associated with another conversation or session"));
+
+        let conflicting =
+            test_conversation_turn_input(&ai, "conversation-2", "binding-2", "session-1");
+        let error = ai
+            .start_conversation_turn(&conflicting)
+            .expect_err("a runtime session cannot belong to another binding");
+        assert!(error.contains("Runtime session is already associated"));
+    }
+
+    #[test]
     fn normalize_additional_roots_keeps_existing_directory() {
         let temp = tempfile::tempdir().unwrap();
         let raw = temp.path().to_string_lossy().to_string();
@@ -11862,6 +11963,39 @@ mod tests {
                 active_turn_id: None,
             },
         );
+    }
+
+    fn test_conversation_turn_input(
+        ai: &NativeAi,
+        conversation_id: &str,
+        binding_id: &str,
+        session_id: &str,
+    ) -> Value {
+        let state = ai.inner.lock().unwrap();
+        let session = &state
+            .sessions
+            .get(session_id)
+            .expect("test session should exist")
+            .session;
+        let options = session
+            .config_options
+            .iter()
+            .map(|option| (option.id.clone(), option.value.clone()))
+            .collect::<HashMap<_, _>>();
+        json!({
+            "input": {
+                "conversation_id": conversation_id,
+                "binding_id": binding_id,
+                "runtime_id": session.runtime_id,
+                "session_id": session_id,
+                "selection": {
+                    "runtime_id": session.runtime_id,
+                    "model_id": session.model_id,
+                    "mode_id": session.mode_id,
+                    "options": options,
+                }
+            }
+        })
     }
 
     fn mark_test_session_as_child(

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -13980,11 +13980,13 @@ mod tests {
     fn setup_accepts_local_http_claude_gateway_urls() {
         let (event_tx, _event_rx) = mpsc::channel();
         let ai = NativeAi::new(event_tx);
+        let runtime = std::env::current_exe().expect("test executable should resolve");
 
         let status = ai
             .update_setup(&json!({
                 "runtimeId": CLAUDE_RUNTIME_ID,
                 "input": {
+                    "custom_binary_path": runtime,
                     "anthropic_base_url": "http://localhost:3000",
                     "anthropic_auth_token": { "action": "set", "value": "test-token" }
                 }
@@ -14076,11 +14078,13 @@ mod tests {
     fn setup_accepts_anthropic_api_key_auth() {
         let (event_tx, _event_rx) = mpsc::channel();
         let ai = NativeAi::new(event_tx);
+        let runtime = std::env::current_exe().expect("test executable should resolve");
 
         let status = ai
             .update_setup(&json!({
                 "runtimeId": CLAUDE_RUNTIME_ID,
                 "input": {
+                    "custom_binary_path": runtime,
                     "anthropic_api_key": { "action": "set", "value": "test-key" }
                 }
             }))
@@ -14223,10 +14227,12 @@ mod tests {
     fn claude_provider_routing_validates_and_normalizes_explicit_setup() {
         let (event_tx, _event_rx) = mpsc::channel();
         let ai = NativeAi::new(event_tx);
+        let runtime = std::env::current_exe().expect("test executable should resolve");
 
         ai.update_setup(&json!({
             "runtimeId": CLAUDE_RUNTIME_ID,
             "input": {
+                "custom_binary_path": runtime,
                 "anthropic_api_key": {
                     "action": "set",
                     "value": "existing-anthropic-secret"

--- a/apps/desktop/native-backend/src/ai_history/migration.rs
+++ b/apps/desktop/native-backend/src/ai_history/migration.rs
@@ -4,7 +4,8 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use neverwrite_ai::persistence::{
-    self, InspectedHistory, PersistedSessionHistory, StorageInventory,
+    self, InspectedHistory, PersistedSessionHistory, PersistedSessionHistoryEnvelope,
+    StorageInventory,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -710,11 +711,11 @@ fn build_stage(
     let destination_histories = load_histories_strict(destination)?;
     let mut by_source = source_histories
         .into_iter()
-        .map(|history| (history.session_id.clone(), history))
+        .map(|envelope| (envelope.history.session_id.clone(), envelope))
         .collect::<BTreeMap<_, _>>();
     let mut by_destination = destination_histories
         .into_iter()
-        .map(|history| (history.session_id.clone(), history))
+        .map(|envelope| (envelope.history.session_id.clone(), envelope))
         .collect::<BTreeMap<_, _>>();
     let mut converted_sessions = BTreeSet::new();
     let mut legacy_files = BTreeMap::new();
@@ -723,10 +724,10 @@ fn build_stage(
             MergeSource::Source(_) => (by_source.remove(session_id), source),
             MergeSource::Destination(_) => (by_destination.remove(session_id), destination),
         };
-        let mut history =
+        let mut envelope =
             history.ok_or_else(|| format!("Could not load inspected session {session_id}."))?;
         if convert_legacy_attachments(
-            &mut history,
+            &mut envelope.history,
             owner_root,
             managed_stage,
             attachments_by_id,
@@ -734,15 +735,19 @@ fn build_stage(
         )? {
             converted_sessions.insert(session_id.clone());
         }
-        persistence::save_session_history(stage, &history)?;
+        persistence::save_session_history_with_bindings(
+            stage,
+            &envelope.history,
+            Some(envelope.conversation_bindings),
+        )?;
     }
     sync_tree(stage)?;
     sync_directory(stage)?;
     Ok((converted_sessions, legacy_files))
 }
 
-fn load_histories_strict(root: &Path) -> Result<Vec<PersistedSessionHistory>, String> {
-    let histories = persistence::load_all_session_histories(root, true)?;
+fn load_histories_strict(root: &Path) -> Result<Vec<PersistedSessionHistoryEnvelope>, String> {
+    let histories = persistence::load_all_session_histories_with_bindings(root, true)?;
     let inventory = persistence::inspect_history_storage(root);
     if histories.len() != inventory.histories.sessions.len() {
         return Err("Strict inventory and loaded history count differ.".into());
@@ -2005,6 +2010,7 @@ mod tests {
                 plan_entries: None,
                 plan_detail: None,
                 tool_action: None,
+                turn_provenance: None,
             }],
         }
     }

--- a/apps/desktop/native-backend/src/ai_history/mod.rs
+++ b/apps/desktop/native-backend/src/ai_history/mod.rs
@@ -4,7 +4,7 @@ use std::sync::{mpsc::Sender, Mutex};
 
 use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
 use base64::Engine;
-use neverwrite_ai::persistence::{self, PersistedSessionHistory};
+use neverwrite_ai::persistence::{self, PersistedConversationBindings, PersistedSessionHistory};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
@@ -1043,12 +1043,18 @@ impl AiHistoryStorageService {
                     .ok_or_else(|| "Missing argument: history".to_string())?;
                 let managed_attachment_ids =
                     validate_managed_attachment_shapes(attachment_owner, &history_value)?;
+                let bindings = history_value
+                    .get("conversation_bindings")
+                    .cloned()
+                    .map(serde_json::from_value::<PersistedConversationBindings>)
+                    .transpose()
+                    .map_err(|error| error.to_string())?;
                 let history: PersistedSessionHistory =
                     serde_json::from_value(history_value).map_err(|error| error.to_string())?;
                 // Validate and promote blobs before publishing the transcript;
                 // mark them committed only after the durable history reference
                 // exists, so cleanup can protect interrupted promotions.
-                persistence::save_session_history(&storage_root, &history)?;
+                persistence::save_session_history_with_bindings(&storage_root, &history, bindings)?;
                 for attachment_id in managed_attachment_ids {
                     attachments::mark_committed(attachment_owner, &attachment_id)?;
                 }
@@ -1058,10 +1064,12 @@ impl AiHistoryStorageService {
                 let include_messages = bool_arg(&args, "includeMessages")
                     .or_else(|| bool_arg(&args, "include_messages"))
                     .unwrap_or(true);
-                Ok(json!(persistence::load_all_session_histories(
-                    &storage_root,
-                    include_messages
-                )?))
+                Ok(json!(
+                    persistence::load_all_session_histories_with_bindings(
+                        &storage_root,
+                        include_messages
+                    )?
+                ))
             }
             "ai_load_session_history_page" => {
                 let session_id = required_string(&args, &["sessionId", "session_id"])?;
@@ -2134,6 +2142,81 @@ mod tests {
             persistence::load_all_session_histories(&layout.device.histories, true).unwrap();
         assert_eq!(histories.len(), 2);
         assert!(!layout.vault.histories.exists());
+    }
+
+    #[test]
+    fn storage_moves_preserve_canonical_provider_bindings() {
+        let app_data = tempfile::tempdir().unwrap();
+        let vault = tempfile::tempdir().unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        let history = json!({
+            "version": 1,
+            "session_id": "canonical-session",
+            "runtime_id": "codex-acp",
+            "model_id": "test-model",
+            "mode_id": "default",
+            "created_at": 1,
+            "updated_at": 2,
+            "messages": [{
+                "id": "message-canonical",
+                "role": "user",
+                "kind": "text",
+                "content": "Preserve bindings",
+                "timestamp": 2
+            }],
+            "conversation_bindings": {
+                "version": 1,
+                "revision": 0,
+                "conversation_id": "canonical-session",
+                "preferred_selection": {
+                    "runtime_id": "codex-acp",
+                    "model_id": "test-model",
+                    "mode_id": "default",
+                    "options": {}
+                },
+                "active_binding_id": "binding-codex",
+                "provider_bindings": [{
+                    "binding_id": "binding-codex",
+                    "conversation_id": "canonical-session",
+                    "runtime_id": "codex-acp",
+                    "model_id": "test-model",
+                    "mode_id": "default",
+                    "options": {},
+                    "runtime_state": "live",
+                    "context_generation": 0
+                }],
+                "context_summary": null,
+                "transcript_observation": {
+                    "message_count": 1,
+                    "updated_at": 2,
+                    "transcript_fingerprint": null
+                }
+            }
+        });
+        service
+            .invoke(
+                "ai_save_session_history",
+                vault.path(),
+                json!({ "history": history }),
+            )
+            .unwrap();
+
+        for target_scope in ["vault", "device"] {
+            service
+                .invoke(
+                    "reconcile_ai_history_storage",
+                    vault.path(),
+                    json!({ "targetScope": target_scope }),
+                )
+                .unwrap();
+            let loaded = service
+                .invoke("ai_load_session_histories", vault.path(), json!({}))
+                .unwrap();
+            assert_eq!(
+                loaded[0]["conversation_bindings"]["provider_bindings"][0]["binding_id"],
+                "binding-codex"
+            );
+        }
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -890,6 +890,7 @@ impl NativeBackend {
             "ai_set_model" => self.ai.set_model(&args),
             "ai_set_mode" => self.ai.set_mode(&args),
             "ai_set_config_option" => self.ai.set_config_option(&args),
+            "ai_start_conversation_turn" => self.ai.start_conversation_turn(&args),
             "ai_send_message" => self.ai.send_message(&args, &self.ai_history),
             "ai_cancel_turn" => self.ai.cancel_turn(&args),
             "ai_respond_permission" => self.ai.respond_permission(&args),

--- a/apps/desktop/native-backend/src/runtime_catalog.rs
+++ b/apps/desktop/native-backend/src/runtime_catalog.rs
@@ -188,7 +188,7 @@ const BUILT_IN_RUNTIME_DEFINITIONS: &[BuiltInRuntimeDefinition] = &[
         id: CODEX_RUNTIME_ID,
         name: "Codex",
         description: "OpenAI Codex-compatible agent runtime.",
-        default_executable: "codex",
+        default_executable: "codex-acp",
         bin_env_var: "NEVERWRITE_CODEX_ACP_BIN",
         acp_args: NO_ACP_ARGS,
         acp_protocol: AcpProtocolFlavor::Current,
@@ -311,7 +311,7 @@ mod tests {
         let expected = vec![
             (
                 CODEX_RUNTIME_ID,
-                "codex",
+                "codex-acp",
                 Some("NEVERWRITE_CODEX_ACP_BIN"),
                 Vec::<String>::new(),
             ),

--- a/apps/desktop/native-backend/src/runtime_catalog.rs
+++ b/apps/desktop/native-backend/src/runtime_catalog.rs
@@ -198,7 +198,7 @@ const BUILT_IN_RUNTIME_DEFINITIONS: &[BuiltInRuntimeDefinition] = &[
         id: CLAUDE_RUNTIME_ID,
         name: "Claude",
         description: "Claude ACP-compatible agent runtime.",
-        default_executable: "claude",
+        default_executable: "claude-agent-acp",
         bin_env_var: "NEVERWRITE_CLAUDE_ACP_BIN",
         acp_args: NO_ACP_ARGS,
         acp_protocol: AcpProtocolFlavor::Current,
@@ -317,7 +317,7 @@ mod tests {
             ),
             (
                 CLAUDE_RUNTIME_ID,
-                "claude",
+                "claude-agent-acp",
                 Some("NEVERWRITE_CLAUDE_ACP_BIN"),
                 Vec::new(),
             ),

--- a/apps/desktop/scripts/build-electron-release.mjs
+++ b/apps/desktop/scripts/build-electron-release.mjs
@@ -1,5 +1,11 @@
 import { spawn } from "node:child_process";
 
+import {
+    createCommandExitError,
+    electronBuilderRetryAttempts,
+    runWithRetry,
+} from "./electron-release-retry.mjs";
+
 const DEFAULT_ELECTRON_OUTPUT_DIR = "dist-electron";
 
 function parseArgs(argv) {
@@ -126,40 +132,9 @@ function run(command, args, env = {}) {
                 resolve();
                 return;
             }
-            reject(
-                new Error(
-                    signal
-                        ? `${command} ${args.join(" ")} terminated with ${signal}`
-                        : `${command} ${args.join(" ")} exited with ${code}`,
-                ),
-            );
+            reject(createCommandExitError(command, args, code, signal));
         });
     });
-}
-
-function wait(milliseconds) {
-    return new Promise((resolve) => setTimeout(resolve, milliseconds));
-}
-
-async function runWithRetry(command, args, env = {}, options = {}) {
-    const attempts = options.attempts ?? 3;
-    const retryDelayMs = options.retryDelayMs ?? 5000;
-
-    for (let attempt = 1; attempt <= attempts; attempt += 1) {
-        try {
-            await run(command, args, env);
-            return;
-        } catch (error) {
-            if (attempt === attempts) {
-                throw error;
-            }
-
-            console.warn(
-                `Command failed on attempt ${attempt}/${attempts}; retrying in ${retryDelayMs}ms: ${command} ${args.join(" ")}`,
-            );
-            await wait(retryDelayMs);
-        }
-    }
 }
 
 function buildElectronBuilderArgs(args) {
@@ -214,15 +189,19 @@ await run("npm", [
     "--target",
     rustTarget,
 ]);
-await runWithRetry(
-    "npx",
-    buildElectronBuilderArgs({
-        ...args,
-        platform: normalizedPlatform,
-        arch: normalizedArch,
-    }),
-    builderEnv,
-);
+const electronBuilderArgs = buildElectronBuilderArgs({
+    ...args,
+    platform: normalizedPlatform,
+    arch: normalizedArch,
+});
+await runWithRetry(() => run("npx", electronBuilderArgs, builderEnv), {
+    attempts: electronBuilderRetryAttempts(args.publish),
+    onRetry: ({ attempt, attempts, retryDelayMs }) => {
+        console.warn(
+            `Command failed on attempt ${attempt}/${attempts}; retrying in ${retryDelayMs}ms: npx ${electronBuilderArgs.join(" ")}`,
+        );
+    },
+});
 
 if (normalizedPlatform === "mac" && !args.dir) {
     const postprocessArgs = [

--- a/apps/desktop/scripts/build-electron-release.mjs
+++ b/apps/desktop/scripts/build-electron-release.mjs
@@ -137,6 +137,31 @@ function run(command, args, env = {}) {
     });
 }
 
+function wait(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function runWithRetry(command, args, env = {}, options = {}) {
+    const attempts = options.attempts ?? 3;
+    const retryDelayMs = options.retryDelayMs ?? 5000;
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            await run(command, args, env);
+            return;
+        } catch (error) {
+            if (attempt === attempts) {
+                throw error;
+            }
+
+            console.warn(
+                `Command failed on attempt ${attempt}/${attempts}; retrying in ${retryDelayMs}ms: ${command} ${args.join(" ")}`,
+            );
+            await wait(retryDelayMs);
+        }
+    }
+}
+
 function buildElectronBuilderArgs(args) {
     const result = ["electron-builder", "--config", "electron-builder.config.mjs"];
 
@@ -189,7 +214,7 @@ await run("npm", [
     "--target",
     rustTarget,
 ]);
-await run(
+await runWithRetry(
     "npx",
     buildElectronBuilderArgs({
         ...args,

--- a/apps/desktop/scripts/codex-v8-artifacts.mjs
+++ b/apps/desktop/scripts/codex-v8-artifacts.mjs
@@ -76,6 +76,17 @@ export async function resolveV8Version(
     );
 }
 
+export function parseRustcHostTarget(versionOutput) {
+    const normalized = versionOutput.replace(/\r\n?/g, "\n");
+    const matches = [...normalized.matchAll(/^host:\s*(\S+)\s*$/gm)];
+    if (matches.length !== 1) {
+        throw new Error(
+            `Expected exactly one host target from rustc -vV, found ${matches.length}`,
+        );
+    }
+    return matches[0][1];
+}
+
 export function createV8ArtifactPlan({
     version,
     profile = CODEX_V8_ARTIFACT_PROFILE,

--- a/apps/desktop/scripts/codex-v8-artifacts.test.mjs
+++ b/apps/desktop/scripts/codex-v8-artifacts.test.mjs
@@ -29,6 +29,7 @@ import {
     CODEX_V8_ARTIFACT_PROFILE,
     createV8ArtifactPlan,
     fetchCodexV8Artifacts,
+    parseRustcHostTarget,
     parseV8ChecksumManifest,
     resolveCodexV8CargoEnvironment,
     resolveV8VersionFromLockfile,
@@ -113,6 +114,25 @@ function wrapperEnvironment(ambientEnv = process.env) {
 }
 
 describe("V8 artifact metadata", () => {
+    it("parses the host target from rustc verbose version output", () => {
+        expect(
+            parseRustcHostTarget(
+                "rustc 1.91.0\nbinary: rustc\nhost: aarch64-apple-darwin\nrelease: 1.91.0\n",
+            ),
+        ).toBe("aarch64-apple-darwin");
+    });
+
+    it("rejects missing or ambiguous rustc host targets", () => {
+        expect(() => parseRustcHostTarget("rustc 1.91.0\n")).toThrow(
+            /exactly one host target.*found 0/i,
+        );
+        expect(() =>
+            parseRustcHostTarget(
+                "host: aarch64-apple-darwin\nhost: x86_64-apple-darwin\n",
+            ),
+        ).toThrow(/exactly one host target.*found 2/i);
+    });
+
     it("resolves the exact v8 version from Cargo.lock", () => {
         expect(
             resolveV8VersionFromLockfile(`

--- a/apps/desktop/scripts/electron-release-retry.mjs
+++ b/apps/desktop/scripts/electron-release-retry.mjs
@@ -1,0 +1,45 @@
+const DEFAULT_ATTEMPTS = 3;
+const DEFAULT_RETRY_DELAY_MS = 5000;
+
+function wait(milliseconds) {
+    return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export function createCommandExitError(command, args, code, signal) {
+    const error = new Error(
+        signal
+            ? `${command} ${args.join(" ")} terminated with ${signal}`
+            : `${command} ${args.join(" ")} exited with ${code}`,
+    );
+    error.exitCode = code;
+    error.signal = signal;
+    return error;
+}
+
+export function electronBuilderRetryAttempts(publishMode) {
+    return publishMode === "never" ? DEFAULT_ATTEMPTS : 1;
+}
+
+export async function runWithRetry(
+    operation,
+    {
+        attempts = DEFAULT_ATTEMPTS,
+        retryDelayMs = DEFAULT_RETRY_DELAY_MS,
+        waitForRetry = wait,
+        onRetry = () => {},
+    } = {},
+) {
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+        try {
+            await operation();
+            return;
+        } catch (error) {
+            if (error?.signal || attempt === attempts) {
+                throw error;
+            }
+
+            onRetry({ attempt, attempts, retryDelayMs, error });
+            await waitForRetry(retryDelayMs);
+        }
+    }
+}

--- a/apps/desktop/scripts/electron-release-retry.test.mjs
+++ b/apps/desktop/scripts/electron-release-retry.test.mjs
@@ -1,0 +1,56 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+    createCommandExitError,
+    electronBuilderRetryAttempts,
+    runWithRetry,
+} from "./electron-release-retry.mjs";
+
+describe("Electron release retries", () => {
+    it("retries ordinary command failures", async () => {
+        const failure = createCommandExitError("npx", ["electron-builder"], 1);
+        const operation = vi
+            .fn()
+            .mockRejectedValueOnce(failure)
+            .mockResolvedValueOnce(undefined);
+        const waitForRetry = vi.fn().mockResolvedValue(undefined);
+        const onRetry = vi.fn();
+
+        await runWithRetry(operation, {
+            attempts: 3,
+            retryDelayMs: 25,
+            waitForRetry,
+            onRetry,
+        });
+
+        expect(operation).toHaveBeenCalledTimes(2);
+        expect(waitForRetry).toHaveBeenCalledWith(25);
+        expect(onRetry).toHaveBeenCalledWith(
+            expect.objectContaining({ attempt: 1, attempts: 3 }),
+        );
+    });
+
+    it("does not retry a signal-terminated command", async () => {
+        const failure = createCommandExitError(
+            "npx",
+            ["electron-builder"],
+            null,
+            "SIGTERM",
+        );
+        const operation = vi.fn().mockRejectedValue(failure);
+        const waitForRetry = vi.fn();
+
+        await expect(
+            runWithRetry(operation, { attempts: 3, waitForRetry }),
+        ).rejects.toBe(failure);
+
+        expect(operation).toHaveBeenCalledTimes(1);
+        expect(waitForRetry).not.toHaveBeenCalled();
+    });
+
+    it("retries builds but not publishing commands", () => {
+        expect(electronBuilderRetryAttempts("never")).toBe(3);
+        expect(electronBuilderRetryAttempts("always")).toBe(1);
+        expect(electronBuilderRetryAttempts("onTagOrDraft")).toBe(1);
+    });
+});

--- a/apps/desktop/scripts/packaged-sidecar-isolation.mjs
+++ b/apps/desktop/scripts/packaged-sidecar-isolation.mjs
@@ -1,5 +1,8 @@
 import fs from "node:fs/promises";
 
+const SMOKE_TEMP_CLEANUP_MAX_RETRIES = 20;
+const SMOKE_TEMP_CLEANUP_RETRY_DELAY_MS = 500;
+
 export async function isolateExecutableForSmoke(
     sourcePath,
     destinationPath,
@@ -20,4 +23,16 @@ export async function isolateExecutableForSmoke(
     }
 
     return isolationMethod;
+}
+
+export async function removeSmokeTempDirectory(
+    directoryPath,
+    { fileSystem = fs } = {},
+) {
+    await fileSystem.rm(directoryPath, {
+        recursive: true,
+        force: true,
+        maxRetries: SMOKE_TEMP_CLEANUP_MAX_RETRIES,
+        retryDelay: SMOKE_TEMP_CLEANUP_RETRY_DELAY_MS,
+    });
 }

--- a/apps/desktop/scripts/packaged-sidecar-isolation.test.mjs
+++ b/apps/desktop/scripts/packaged-sidecar-isolation.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { isolateExecutableForSmoke } from "./packaged-sidecar-isolation.mjs";
+import {
+    isolateExecutableForSmoke,
+    removeSmokeTempDirectory,
+} from "./packaged-sidecar-isolation.mjs";
 
 function fileSystemDouble() {
     return {
@@ -62,5 +65,20 @@ describe("packaged sidecar smoke isolation", () => {
 
         expect(fileSystem.copyFile).toHaveBeenCalled();
         expect(fileSystem.chmod).not.toHaveBeenCalled();
+    });
+
+    it("retries temporary directory cleanup for locked Windows files", async () => {
+        const fileSystem = {
+            rm: vi.fn().mockResolvedValue(undefined),
+        };
+
+        await removeSmokeTempDirectory("smoke-temp", { fileSystem });
+
+        expect(fileSystem.rm).toHaveBeenCalledWith("smoke-temp", {
+            recursive: true,
+            force: true,
+            maxRetries: 20,
+            retryDelay: 500,
+        });
     });
 });

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -95,6 +95,15 @@ process.on("unhandledRejection", (error) => {
 });
 
 async function main() {
+    await runOnce("cargo", [
+        "build",
+        "--locked",
+        "--manifest-path",
+        "../../vendor/codex-acp/Cargo.toml",
+        "--bin",
+        "codex-acp",
+    ]);
+
     await runOnce(
         "cargo",
         ["build", "-p", "neverwrite-native-backend"],

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -1,4 +1,6 @@
 import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -12,6 +14,12 @@ import {
 
 
 const rootDir = fileURLToPath(new URL("..", import.meta.url));
+const workspaceRoot = path.resolve(rootDir, "../..");
+const claudeRuntimeDir = path.join(
+    workspaceRoot,
+    "vendor",
+    "Claude-agent-acp-upstream",
+);
 const rendererUrl = "http://127.0.0.1:5174";
 
 let vite = null;
@@ -20,7 +28,7 @@ let shuttingDown = false;
 
 function run(command, args, options = {}) {
     const child = spawn(command, args, {
-        cwd: rootDir,
+        cwd: options.cwd ?? rootDir,
         env: { ...process.env, ...(options.env ?? {}) },
         stdio: options.stdio ?? "inherit",
         detached: !isWindows && options.detached === true,
@@ -45,9 +53,9 @@ function shutdown(exitCode = 0) {
     }, FORCED_EXIT_TIMEOUT_MS).unref();
 }
 
-function runOnce(command, args, env = {}) {
+function runOnce(command, args, env = {}, cwd = rootDir) {
     return new Promise((resolve, reject) => {
-        const child = run(command, args, { env });
+        const child = run(command, args, { cwd, env });
         child.on("error", reject);
         child.on("exit", (code) => {
             if (code === 0) {
@@ -57,6 +65,55 @@ function runOnce(command, args, env = {}) {
             reject(new Error(`${command} ${args.join(" ")} exited with ${code}`));
         });
     });
+}
+
+async function ensureClaudeRuntimeDependencies() {
+    const packageLockPath = path.join(claudeRuntimeDir, "package-lock.json");
+    const packageLock = await fs.readFile(packageLockPath);
+    const expectedStamp = createHash("sha256")
+        .update(packageLock)
+        .digest("hex");
+    const stampPath = path.join(
+        claudeRuntimeDir,
+        "node_modules",
+        ".neverwrite-production-lock",
+    );
+    const requiredPackages = [
+        "@agentclientprotocol/sdk",
+        "@anthropic-ai/claude-agent-sdk",
+        "zod",
+    ];
+    const installedStamp = await fs.readFile(stampPath, "utf8").catch(() => "");
+    const dependenciesPresent = await Promise.all(
+        requiredPackages.map((packageName) =>
+            fs
+                .access(
+                    path.join(
+                        claudeRuntimeDir,
+                        "node_modules",
+                        packageName,
+                        "package.json",
+                    ),
+                )
+                .then(() => true)
+                .catch(() => false),
+        ),
+    );
+    if (
+        installedStamp.trim() === expectedStamp &&
+        dependenciesPresent.every(Boolean)
+    ) {
+        return;
+    }
+
+    console.log("Installing Claude ACP production dependencies.");
+    await runOnce(
+        "npm",
+        ["ci", "--omit=dev", "--include=optional", "--no-audit", "--no-fund"],
+        {},
+        claudeRuntimeDir,
+    );
+    await fs.writeFile(stampPath, `${expectedStamp}\n`, "utf8");
 }
 
 function waitForRenderer() {
@@ -95,6 +152,8 @@ process.on("unhandledRejection", (error) => {
 });
 
 async function main() {
+    await ensureClaudeRuntimeDependencies();
+
     await runOnce("cargo", [
         "build",
         "--locked",

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -1,11 +1,16 @@
-import { spawn } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import http from "node:http";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
 
 import { isWindows } from "./common.mjs";
+import {
+    parseRustcHostTarget,
+    resolveCodexV8CargoEnvironment,
+} from "./codex-v8-artifacts.mjs";
 import {
     signalExitCode,
     terminateChild,
@@ -21,15 +26,20 @@ const claudeRuntimeDir = path.join(
     "Claude-agent-acp-upstream",
 );
 const rendererUrl = "http://127.0.0.1:5174";
+const execFileAsync = promisify(execFile);
 
 let vite = null;
 let electron = null;
 let shuttingDown = false;
 
 function run(command, args, options = {}) {
+    const env = { ...process.env, ...(options.env ?? {}) };
+    for (const key of options.unsetEnv ?? []) {
+        delete env[key];
+    }
     const child = spawn(command, args, {
         cwd: options.cwd ?? rootDir,
-        env: { ...process.env, ...(options.env ?? {}) },
+        env,
         stdio: options.stdio ?? "inherit",
         detached: !isWindows && options.detached === true,
         shell: isWindows,
@@ -154,14 +164,25 @@ process.on("unhandledRejection", (error) => {
 async function main() {
     await ensureClaudeRuntimeDependencies();
 
-    await runOnce("cargo", [
-        "build",
-        "--locked",
-        "--manifest-path",
-        "../../vendor/codex-acp/Cargo.toml",
-        "--bin",
-        "codex-acp",
-    ]);
+    const { stdout: rustcVersion } = await execFileAsync("rustc", ["-vV"], {
+        cwd: workspaceRoot,
+    });
+    const codexV8Environment = await resolveCodexV8CargoEnvironment({
+        targetTriple: parseRustcHostTarget(rustcVersion),
+    });
+
+    await runOnce(
+        "cargo",
+        [
+            "build",
+            "--locked",
+            "--manifest-path",
+            "../../vendor/codex-acp/Cargo.toml",
+            "--bin",
+            "codex-acp",
+        ],
+        codexV8Environment,
+    );
 
     await runOnce(
         "cargo",
@@ -206,6 +227,9 @@ async function main() {
         env: {
             ELECTRON_RENDERER_URL: rendererUrl,
         },
+        // Coding environments may use Electron as their Node runtime. The app
+        // process must start in normal Electron mode to expose the main API.
+        unsetEnv: ["ELECTRON_RUN_AS_NODE"],
         stdio: ["ignore", "inherit", "inherit"],
     });
 

--- a/apps/desktop/scripts/run-electron-dev.mjs
+++ b/apps/desktop/scripts/run-electron-dev.mjs
@@ -178,8 +178,7 @@ async function main() {
             "--locked",
             "--manifest-path",
             "../../vendor/codex-acp/Cargo.toml",
-            "--bin",
-            "codex-acp",
+            "--bins",
         ],
         codexV8Environment,
     );

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -6,7 +6,10 @@ import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
 
-import { isolateExecutableForSmoke } from "./packaged-sidecar-isolation.mjs";
+import {
+    isolateExecutableForSmoke,
+    removeSmokeTempDirectory,
+} from "./packaged-sidecar-isolation.mjs";
 
 const appRoot = fileURLToPath(new URL("..", import.meta.url));
 const executableName =
@@ -623,7 +626,7 @@ async function smokeMissingCodeModeHostFailsClosed(acpPath, packagedHostPath) {
             requireStandaloneHost: false,
         });
     } finally {
-        await fs.rm(isolatedRuntimeDir, { recursive: true, force: true });
+        await removeSmokeTempDirectory(isolatedRuntimeDir);
     }
 }
 

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -78,6 +78,7 @@ const SUPPORTED_COMMANDS = new Set([
     "ai_set_model",
     "ai_set_mode",
     "ai_set_config_option",
+    "ai_start_conversation_turn",
     "ai_send_message",
     "ai_cancel_turn",
     "ai_respond_permission",

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -13,10 +13,8 @@ import { LinksPanel } from "./features/notes/LinksPanel";
 import { OutlinePanel } from "./features/notes/OutlinePanel";
 import { AIChatWorkspaceHost } from "./features/ai/AIChatWorkspaceHost";
 import { AIChatDetachedWindowHost } from "./features/ai/AIChatDetachedWindowHost";
-import { createNewChatInWorkspace } from "./features/ai/chatPaneMovement";
 import { listChatWorkspaceHistoryReferences } from "./features/ai/chatWorkspaceRestoration";
-import { CLAUDE_TERMINAL_RUNTIME_ID } from "./features/ai/utils/runtimeMetadata";
-import { openClaudeCodeTerminalWithContext } from "./features/terminal/claudeCodeTerminal";
+import { createCanonicalAgent } from "./features/ai/newAgentCreation";
 import { WorkspaceTerminalHost } from "./features/terminal/WorkspaceTerminalHost";
 import { migrateLegacyTerminalTabsToWorkspace } from "./features/terminal/legacyTerminalMigration";
 import { UnifiedBar } from "./features/editor/UnifiedBar";
@@ -705,14 +703,7 @@ function useRegisterCommands(
             category: newAgentShortcut.category,
             when: hasVault,
             execute: () => {
-                if (
-                    useChatStore.getState().getDefaultNewChatRuntimeId() ===
-                    CLAUDE_TERMINAL_RUNTIME_ID
-                ) {
-                    void openClaudeCodeTerminalWithContext();
-                } else {
-                    void createNewChatInWorkspace();
-                }
+                void createCanonicalAgent();
             },
         });
 

--- a/apps/desktop/src/app/store/editorSession.ts
+++ b/apps/desktop/src/app/store/editorSession.ts
@@ -137,6 +137,7 @@ type PersistedGraphWorkspaceTab = {
 type PersistedChatWorkspaceTab = {
     id: string;
     kind: "ai-chat";
+    conversationId?: string;
     sessionId: string;
     historySessionId?: string;
     title: string;
@@ -400,6 +401,9 @@ function serializeWorkspaceTabForSession(
         return {
             id: normalized.id,
             kind: "ai-chat",
+            ...(normalized.conversationId
+                ? { conversationId: normalized.conversationId }
+                : {}),
             sessionId: normalized.sessionId,
             ...(normalized.historySessionId
                 ? { historySessionId: normalized.historySessionId }
@@ -744,6 +748,9 @@ async function restorePersistedWorkspaceTabsById(
             restoredTabsById[tab.id] = {
                 id: tab.id,
                 kind: "ai-chat",
+                ...(tab.conversationId
+                    ? { conversationId: tab.conversationId }
+                    : {}),
                 sessionId: tab.sessionId,
                 ...(tab.historySessionId
                     ? { historySessionId: tab.historySessionId }

--- a/apps/desktop/src/app/store/editorTabs.ts
+++ b/apps/desktop/src/app/store/editorTabs.ts
@@ -180,6 +180,8 @@ export interface ChatTab {
     id: string;
     kind: "ai-chat";
     sessionId: string;
+    /** Stable identity shared by every workspace presentation of this chat. */
+    conversationId?: string;
     historySessionId?: string;
     title: string;
     history?: ChatHistoryEntry[];
@@ -876,6 +878,11 @@ export function createChatTab(
     title: string,
     historySessionId?: string | null,
 ): ChatTab {
+    const conversationId =
+        historySessionId ??
+        (sessionId.startsWith("persisted:")
+            ? sessionId.slice("persisted:".length) || sessionId
+            : sessionId);
     const entry: ChatHistoryEntry = {
         sessionId,
         ...(historySessionId ? { historySessionId } : {}),
@@ -884,6 +891,7 @@ export function createChatTab(
     return {
         id: crypto.randomUUID(),
         kind: "ai-chat",
+        conversationId,
         ...entry,
         history: [entry],
         historyIndex: 0,
@@ -930,6 +938,7 @@ export function buildChatTabFromHistory(
     return {
         id,
         kind: "ai-chat",
+        conversationId: entry.historySessionId ?? entry.sessionId,
         ...entry,
         history,
         historyIndex: safeIndex,

--- a/apps/desktop/src/app/store/editorWorkspace.ts
+++ b/apps/desktop/src/app/store/editorWorkspace.ts
@@ -2623,14 +2623,20 @@ export function createEditorWorkspaceSlice<TState extends EditorWorkspaceStore>(
                     const nextTitle = options?.title ?? existing.title;
                     const nextHistorySessionId =
                         requestedHistorySessionId ?? existing.historySessionId;
+                    const nextConversationId =
+                        requestedHistorySessionId ??
+                        existing.conversationId ??
+                        sessionId;
                     const nextTab =
                         nextTitle === existing.title &&
                         existing.sessionId === sessionId &&
-                        existing.historySessionId === nextHistorySessionId
+                        existing.historySessionId === nextHistorySessionId &&
+                        existing.conversationId === nextConversationId
                             ? existing
                             : {
                                   ...existing,
                                   title: nextTitle,
+                                  conversationId: nextConversationId,
                                   sessionId,
                                   ...(nextHistorySessionId
                                       ? {

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -30,6 +30,7 @@ describe("settingsStore", () => {
     it("defaults app settings", () => {
         expect(useSettingsStore.getState().terminalFontFamily).toBe("");
         expect(useSettingsStore.getState().terminalFontSize).toBe(13);
+        expect(useSettingsStore.getState().claudeCodeEnabled).toBe(false);
         expect(useSettingsStore.getState().claudeCodeOptimized).toBe(false);
         expect(useSettingsStore.getState().claudeCodeSkipPermissions).toBe(
             false,
@@ -236,6 +237,7 @@ describe("settingsStore", () => {
             .getState()
             .setSetting("terminalFontFamily", "FiraCode Nerd Font");
         useSettingsStore.getState().setSetting("terminalFontSize", 16);
+        useSettingsStore.getState().setSetting("claudeCodeEnabled", true);
         useSettingsStore.getState().setSetting("claudeCodeOptimized", true);
         useSettingsStore
             .getState()
@@ -256,6 +258,7 @@ describe("settingsStore", () => {
             state: {
                 terminalFontFamily: "FiraCode Nerd Font",
                 terminalFontSize: 16,
+                claudeCodeEnabled: true,
                 claudeCodeOptimized: true,
                 claudeCodeSkipPermissions: true,
                 claudeCodeModel: "claude-sonnet-4-6",

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -47,6 +47,7 @@ export interface Settings {
     // Terminal
     terminalFontFamily: string;
     terminalFontSize: number; // 8–24
+    claudeCodeEnabled: boolean;
     claudeCodeOptimized: boolean;
     claudeCodeSkipPermissions: boolean;
     claudeCodeModel: string; // "" = Claude Code default
@@ -218,6 +219,7 @@ const defaults: Settings = {
     tabOpenBehavior: "history",
     terminalFontFamily: "",
     terminalFontSize: 13,
+    claudeCodeEnabled: false,
     claudeCodeOptimized: false,
     claudeCodeSkipPermissions: false,
     claudeCodeModel: "",
@@ -565,6 +567,8 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
                 8,
                 24,
             ),
+            claudeCodeEnabled:
+                parsed.state.claudeCodeEnabled ?? defaults.claudeCodeEnabled,
             claudeCodeOptimized:
                 parsed.state.claudeCodeOptimized ??
                 defaults.claudeCodeOptimized,
@@ -662,6 +666,7 @@ function pickSettings(state: SettingsStore): Settings {
         tabOpenBehavior: state.tabOpenBehavior,
         terminalFontFamily: state.terminalFontFamily,
         terminalFontSize: state.terminalFontSize,
+        claudeCodeEnabled: state.claudeCodeEnabled,
         claudeCodeOptimized: state.claudeCodeOptimized,
         claudeCodeSkipPermissions: state.claudeCodeSkipPermissions,
         claudeCodeModel: state.claudeCodeModel,

--- a/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
+++ b/apps/desktop/src/features/ai/AIChatWorkspaceHost.tsx
@@ -15,14 +15,12 @@ import {
 } from "./dragEvents";
 import type { AIChatSession } from "./types";
 import {
-    createNewChatInWorkspace,
     ensureWorkspaceChatSession,
     openChatSessionInWorkspace,
 } from "./chatPaneMovement";
 import { useChatStore } from "./store/chatStore";
 import { useAiChatEventBridge } from "./useAiChatEventBridge";
-import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
-import { openClaudeCodeTerminalWithContext } from "../terminal/claudeCodeTerminal";
+import { createCanonicalAgent } from "./newAgentCreation";
 
 function hasVisibleAiComposerDropZone(targetSessionId?: string) {
     const selector = targetSessionId
@@ -311,15 +309,7 @@ export function AIChatWorkspaceHost({
                 .detail;
             if (detail.phase !== "attach") return;
 
-            if (
-                useChatStore.getState().getDefaultNewChatRuntimeId() ===
-                CLAUDE_TERMINAL_RUNTIME_ID
-            ) {
-                void openClaudeCodeTerminalWithContext(detail);
-                return;
-            }
-
-            void createNewChatInWorkspace().then((sessionId) => {
+            void createCanonicalAgent().then((sessionId) => {
                 if (!sessionId) return;
                 replayAttachAfterComposerMount(detail, sessionId);
                 focusComposerAtEnd(sessionId);

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, screen, waitFor } from "@testing-library/react";
 import { confirm } from "@neverwrite/runtime";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../app/store/editorStore";
+import { useSettingsStore } from "../../app/store/settingsStore";
 import { useVaultStore } from "../../app/store/vaultStore";
 import { renderComponent } from "../../test/test-utils";
 import { AgentsSidebarPanel } from "./AgentsSidebarPanel";
@@ -108,6 +109,7 @@ describe("AgentsSidebarPanel", () => {
             collapsedFolderIds: [],
         });
         useEditorStore.getState().hydrateTabs([], null);
+        useSettingsStore.setState({ claudeCodeEnabled: false });
         vi.mocked(confirm).mockResolvedValue(true);
         useChatStore.setState({
             runtimes: [
@@ -161,18 +163,10 @@ describe("AgentsSidebarPanel", () => {
         });
     });
 
-    it("opens a provider menu from the plus button before creating a chat", async () => {
+    it("creates a canonical agent directly when Claude Code is disabled", async () => {
         renderComponent(<AgentsSidebarPanel />);
 
-        fireEvent.click(screen.getByRole("button", { name: "New chat" }));
-
-        expect(
-            chatPaneMovementMock.createNewChatInWorkspace,
-        ).not.toHaveBeenCalled();
-        expect(
-            await screen.findByRole("button", { name: "Codex" }),
-        ).toBeInTheDocument();
-        fireEvent.click(screen.getByRole("button", { name: "Claude" }));
+        fireEvent.click(screen.getByRole("button", { name: "New agent" }));
 
         await waitFor(() => {
             expect(
@@ -181,10 +175,8 @@ describe("AgentsSidebarPanel", () => {
         });
         expect(
             chatPaneMovementMock.createNewChatInWorkspace,
-        ).toHaveBeenCalledWith("claude-acp");
-        expect(
-            screen.queryByRole("button", { name: "Add providers" }),
-        ).toBeNull();
+        ).toHaveBeenCalledWith();
+        expect(screen.queryByRole("button", { name: "Claude" })).toBeNull();
     });
 
     it("keeps existing chats unfiled until the user explicitly moves one", async () => {
@@ -335,6 +327,7 @@ describe("AgentsSidebarPanel", () => {
     });
 
     it("opens Claude Code from the plus menu as a terminal runtime", async () => {
+        useSettingsStore.setState({ claudeCodeEnabled: true });
         useChatStore.setState({
             runtimes: [
                 {
@@ -361,11 +354,24 @@ describe("AgentsSidebarPanel", () => {
                 },
             ],
             selectedRuntimeId: "codex-acp",
+            setupStatusByRuntimeId: {
+                [CLAUDE_TERMINAL_RUNTIME_ID]: {
+                    runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                    binaryReady: true,
+                    binarySource: "env",
+                    authReady: true,
+                    onboardingRequired: false,
+                    authMethods: [],
+                },
+            },
         });
 
         renderComponent(<AgentsSidebarPanel />);
 
-        fireEvent.click(screen.getByRole("button", { name: "New chat" }));
+        fireEvent.click(screen.getByRole("button", { name: "New agent" }));
+        expect(
+            await screen.findByRole("button", { name: "New Agent" }),
+        ).toBeInTheDocument();
         fireEvent.click(
             await screen.findByRole("button", { name: "Claude Code" }),
         );
@@ -378,9 +384,7 @@ describe("AgentsSidebarPanel", () => {
         expect(
             chatPaneMovementMock.createNewChatInWorkspace,
         ).not.toHaveBeenCalled();
-        expect(useChatStore.getState().selectedRuntimeId).toBe(
-            CLAUDE_TERMINAL_RUNTIME_ID,
-        );
+        expect(useChatStore.getState().selectedRuntimeId).toBe("codex-acp");
     });
 
     it("keeps open working agents in the order they became busy", async () => {

--- a/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
+++ b/apps/desktop/src/features/ai/AgentsSidebarPanel.tsx
@@ -30,11 +30,13 @@ import {
     safeStorageSetItem,
 } from "../../app/utils/safeStorage";
 import {
-    createNewChatInWorkspace,
     openChatHistoryInWorkspace,
     openChatSessionInWorkspace,
 } from "./chatPaneMovement";
-import { openClaudeCodeTerminalWithContext } from "../terminal/claudeCodeTerminal";
+import {
+    createCanonicalAgent,
+    createClaudeCodeAgent,
+} from "./newAgentCreation";
 import { emitAgentSidebarDrag } from "./agentSidebarDragEvents";
 import {
     getSessionTitle,
@@ -147,10 +149,6 @@ function formatAgentTimestamp(timestamp: number): string {
         month: "short",
         day: "numeric",
     }).format(timestamp);
-}
-
-function getRuntimeMenuLabel(name: string) {
-    return name.trim().replace(/ ACP$/, "");
 }
 
 function isSessionWorking(session: AIChatSession) {
@@ -307,11 +305,15 @@ export function AgentsSidebarPanel() {
     const agentsSidebarScale = useSettingsStore(
         (state) => state.agentsSidebarScale,
     );
+    const claudeCodeEnabled = useSettingsStore(
+        (state) => state.claudeCodeEnabled,
+    );
     const activeSessionId = useChatStore((state) => state.activeSessionId);
     const sessionsById = useChatStore((state) => state.sessionsById);
     const sessionOrder = useChatStore((state) => state.sessionOrder);
-    const runtimes = useChatStore((state) => state.runtimes);
-    const selectedRuntimeId = useChatStore((state) => state.selectedRuntimeId);
+    const claudeCodeSetupStatus = useChatStore(
+        (state) => state.setupStatusByRuntimeId[CLAUDE_TERMINAL_RUNTIME_ID],
+    );
     const sessionInventoryLoaded = useChatStore(
         (state) => state.sessionInventoryLoaded,
     );
@@ -780,28 +782,26 @@ export function AgentsSidebarPanel() {
     );
 
     const newChatMenuEntries = useMemo<ContextMenuEntry[]>(() => {
-        const sortedRuntimes = [...runtimes].sort((left, right) => {
-            if (left.runtime.id === selectedRuntimeId) return -1;
-            if (right.runtime.id === selectedRuntimeId) return 1;
-            return left.runtime.name.localeCompare(right.runtime.name);
-        });
-
-        if (sortedRuntimes.length === 0) {
-            return [{ label: "No providers available", disabled: true }];
-        }
-
-        return sortedRuntimes.map((runtime) => ({
-            label: getRuntimeMenuLabel(runtime.runtime.name),
-            action: () => {
-                useChatStore.getState().setSelectedRuntime(runtime.runtime.id);
-                if (runtime.runtime.id === CLAUDE_TERMINAL_RUNTIME_ID) {
-                    void openClaudeCodeTerminalWithContext();
-                    return;
-                }
-                void createNewChatInWorkspace(runtime.runtime.id);
+        return [
+            {
+                label: "New Agent",
+                action: () => {
+                    void createCanonicalAgent();
+                },
             },
-        }));
-    }, [runtimes, selectedRuntimeId]);
+            {
+                label: "Claude Code",
+                action: () => {
+                    void createClaudeCodeAgent();
+                },
+            },
+        ];
+    }, []);
+
+    const showClaudeCodeCreation =
+        claudeCodeEnabled &&
+        claudeCodeSetupStatus?.authReady === true &&
+        !claudeCodeSetupStatus.onboardingRequired;
 
     const handleContextMenu = useCallback(
         (event: ReactMouseEvent<HTMLElement>, session: AIChatSession) => {
@@ -1276,6 +1276,10 @@ export function AgentsSidebarPanel() {
                         onClick={(event) => {
                             event.preventDefault();
                             event.stopPropagation();
+                            if (!showClaudeCodeCreation) {
+                                void createCanonicalAgent();
+                                return;
+                            }
                             const rect =
                                 event.currentTarget.getBoundingClientRect();
                             setContextMenu(null);
@@ -1285,8 +1289,8 @@ export function AgentsSidebarPanel() {
                                 payload: undefined,
                             });
                         }}
-                        title="New chat"
-                        aria-label="New chat"
+                        title="New agent"
+                        aria-label="New agent"
                         className="ub-chrome-btn flex h-5 w-5 cursor-pointer items-center justify-center rounded"
                         style={{
                             width: metrics.actionButtonSize,
@@ -1472,7 +1476,7 @@ export function AgentsSidebarPanel() {
                     ]}
                 />
             )}
-            {newChatMenu && (
+            {newChatMenu && showClaudeCodeCreation && (
                 <ContextMenu
                     menu={newChatMenu}
                     onClose={() => setNewChatMenu(null)}

--- a/apps/desktop/src/features/ai/api.test.ts
+++ b/apps/desktop/src/features/ai/api.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     aiCreateCustomRuntime,
     aiDeleteCustomRuntime,
+    aiGetSetupStatus,
     aiListCustomRuntimes,
     aiListDeletedCustomRuntimes,
     aiRestoreCustomRuntime,
@@ -11,6 +12,7 @@ import {
     normalizeBackendSession,
 } from "./api";
 import type {
+    AIBackendRuntimeSetupStatusPayload,
     AIBackendSessionPayload,
     AICustomAcpRuntimeDefinition,
     AICustomAcpRuntimeDefinitionInput,
@@ -43,6 +45,34 @@ describe("normalizeBackendSession", () => {
 
         expect(session.persistedTitle).toBe("Runtime generated title");
         expect(session.customTitle).toBeNull();
+    });
+});
+
+describe("runtime setup status", () => {
+    it("preserves Claude ACP subscription authentication", async () => {
+        const status: AIBackendRuntimeSetupStatusPayload = {
+            runtime_id: "claude-acp",
+            binary_ready: true,
+            binary_source: "vendor",
+            auth_ready: true,
+            auth_method: "claude-ai-login",
+            auth_methods: [
+                {
+                    id: "claude-ai-login",
+                    name: "Claude subscription",
+                    description: "Use a Claude subscription.",
+                },
+            ],
+            onboarding_required: false,
+        };
+        vi.mocked(invoke).mockResolvedValue(status);
+
+        await expect(aiGetSetupStatus("claude-acp")).resolves.toMatchObject({
+            runtimeId: "claude-acp",
+            authReady: true,
+            authMethod: "claude-ai-login",
+            authMethods: status.auth_methods,
+        });
     });
 });
 

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -44,7 +44,6 @@ import type {
     ConversationSelection,
 } from "./types";
 import { buildFallbackRuntimeDescriptors } from "./utils/runtimeMetadata";
-import { isClaudeTerminalAuthMethodId } from "./utils/authMethods";
 
 const FALLBACK_RUNTIMES: AIRuntimeDescriptor[] =
     buildFallbackRuntimeDescriptors();
@@ -253,36 +252,15 @@ function normalizeRuntimeDescriptor(
 function normalizeRuntimeSetupStatus(
     status: AIBackendRuntimeSetupStatusPayload,
 ): AIRuntimeSetupStatus {
-    let authMethods = status.auth_methods;
-    let authReady = status.auth_ready;
-    let authMethod = status.auth_method ?? undefined;
-
-    // Subscription-based auth (claude-ai-login, console-login, claude-login)
-    // only works with the Claude Code CLI, not the ACP sidecar. Strip these
-    // methods from claude-acp and mark as not-ready when the current auth is
-    // subscription-based so the provider shows as "Not configured" and the user
-    // is directed to use an API key instead.
-    if (status.runtime_id === "claude-acp") {
-        authMethods = authMethods.filter(
-            (m) => !isClaudeTerminalAuthMethodId(m.id),
-        );
-        if (isClaudeTerminalAuthMethodId(authMethod)) {
-            if (status.claude_provider_routing?.type !== "vertex") {
-                authReady = false;
-            }
-            authMethod = undefined;
-        }
-    }
-
     return {
         runtimeId: status.runtime_id,
         binaryReady: status.binary_ready,
         binaryPath: status.binary_path ?? undefined,
         binarySource: status.binary_source,
         hasCustomBinaryPath: status.has_custom_binary_path ?? false,
-        authReady,
-        authMethod,
-        authMethods,
+        authReady: status.auth_ready,
+        authMethod: status.auth_method ?? undefined,
+        authMethods: status.auth_methods,
         claudeProviderRouting: normalizeClaudeProviderRouting(
             status.claude_provider_routing,
         ),

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -41,6 +41,7 @@ import type {
     PersistedSessionHistory,
     PersistedSessionHistoryPage,
     CustomRuntimeContinuationResult,
+    ConversationSelection,
 } from "./types";
 import { buildFallbackRuntimeDescriptors } from "./utils/runtimeMetadata";
 import { isClaudeTerminalAuthMethodId } from "./utils/authMethods";
@@ -792,6 +793,30 @@ export async function aiSendMessage(
         attachments,
     });
     return normalizeBackendSession(session);
+}
+
+export async function aiStartConversationTurn(input: {
+    conversationId: string;
+    bindingId: string;
+    runtimeId: string;
+    sessionId: string;
+    selection: ConversationSelection;
+}) {
+    assertRuntimeSessionId(input.sessionId, "start a conversation turn");
+    await invoke("ai_start_conversation_turn", {
+        input: {
+            conversation_id: input.conversationId,
+            binding_id: input.bindingId,
+            runtime_id: input.runtimeId,
+            session_id: input.sessionId,
+            selection: {
+                runtime_id: input.selection.runtimeId,
+                model_id: input.selection.modelId,
+                mode_id: input.selection.modeId,
+                options: input.selection.options,
+            },
+        },
+    });
 }
 
 export async function aiCancelTurn(sessionId: string) {

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -176,7 +176,7 @@ export function normalizeBackendSession(
         sessionId: session.session_id,
         historySessionId: session.session_id,
         parentSessionId: session.parent_session_id ?? null,
-        runtimeSessionId: session.runtime_session_id ?? null,
+        runtimeSessionId: session.runtime_session_id ?? session.session_id,
         closedAt: session.closed_at ?? null,
         // Backend titles come from the runtime/persisted session state. Manual
         // renames live only in customTitle on the renderer side.

--- a/apps/desktop/src/features/ai/chatPaneMovement.test.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.test.ts
@@ -507,7 +507,7 @@ describe("createNewChatInWorkspace", () => {
         ).toBe("codex-acp");
     });
 
-    it("does not create an ACP chat when the selected runtime is Claude Code terminal", async () => {
+    it("falls back to an ACP runtime when the selected runtime is Claude Code", async () => {
         useChatStore.setState((state) => ({
             ...state,
             runtimes: [runtimeDescriptor, claudeTerminalRuntimeDescriptor],
@@ -525,12 +525,12 @@ describe("createNewChatInWorkspace", () => {
         const upsertSession = vi.spyOn(useChatStore.getState(), "upsertSession");
         const openChat = vi.spyOn(useEditorStore.getState(), "openChat");
 
-        await expect(createNewChatInWorkspace()).resolves.toBeNull();
+        const sessionId = await createNewChatInWorkspace();
 
-        expect(newSession).not.toHaveBeenCalled();
-        expect(upsertSession).not.toHaveBeenCalled();
-        expect(openChat).not.toHaveBeenCalled();
-        expect(selectEditorWorkspaceTabs(useEditorStore.getState())).toEqual([]);
+        expect(sessionId).toMatch(/^pending:/);
+        expect(newSession).toHaveBeenCalledWith("codex-acp", sessionId);
+        expect(upsertSession).toHaveBeenCalled();
+        expect(openChat).toHaveBeenCalled();
     });
 
     it("uses the selected native runtime over a stale Claude Code terminal preference", async () => {
@@ -563,7 +563,7 @@ describe("createNewChatInWorkspace", () => {
         expect(openChat).toHaveBeenCalled();
     });
 
-    it("does not create an ACP chat when Claude Code is the explicit default runtime", async () => {
+    it("ignores Claude Code when it remains in the explicit default field", async () => {
         useChatStore.setState((state) => ({
             ...state,
             defaultRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID,
@@ -582,11 +582,12 @@ describe("createNewChatInWorkspace", () => {
         const upsertSession = vi.spyOn(useChatStore.getState(), "upsertSession");
         const openChat = vi.spyOn(useEditorStore.getState(), "openChat");
 
-        await expect(createNewChatInWorkspace()).resolves.toBeNull();
+        const sessionId = await createNewChatInWorkspace();
 
-        expect(newSession).not.toHaveBeenCalled();
-        expect(upsertSession).not.toHaveBeenCalled();
-        expect(openChat).not.toHaveBeenCalled();
+        expect(sessionId).toMatch(/^pending:/);
+        expect(newSession).toHaveBeenCalledWith("codex-acp", sessionId);
+        expect(upsertSession).toHaveBeenCalled();
+        expect(openChat).toHaveBeenCalled();
     });
 
     it("does not create a pending chat when Claude Code terminal is the only ready runtime", async () => {
@@ -617,7 +618,7 @@ describe("createNewChatInWorkspace", () => {
         expect(openChat).not.toHaveBeenCalled();
     });
 
-    it("does not create an ACP chat when the active session uses Claude Code terminal", async () => {
+    it("falls back to an ACP runtime when the active session is Claude Code", async () => {
         const terminalSession = createStoredSession(
             "claude-terminal-session",
             "Claude Code terminal",
@@ -633,11 +634,12 @@ describe("createNewChatInWorkspace", () => {
         const upsertSession = vi.spyOn(useChatStore.getState(), "upsertSession");
         const openChat = vi.spyOn(useEditorStore.getState(), "openChat");
 
-        await expect(createNewChatInWorkspace()).resolves.toBeNull();
+        const sessionId = await createNewChatInWorkspace();
 
-        expect(newSession).not.toHaveBeenCalled();
-        expect(upsertSession).not.toHaveBeenCalled();
-        expect(openChat).not.toHaveBeenCalled();
+        expect(sessionId).toMatch(/^pending:/);
+        expect(newSession).toHaveBeenCalledWith("codex-acp", sessionId);
+        expect(upsertSession).toHaveBeenCalled();
+        expect(openChat).toHaveBeenCalled();
     });
 
     it("does not create an ACP chat when ensure is explicitly asked for Claude Code terminal", async () => {

--- a/apps/desktop/src/features/ai/chatPaneMovement.ts
+++ b/apps/desktop/src/features/ai/chatPaneMovement.ts
@@ -54,9 +54,6 @@ function resolvePendingRuntime(runtimeId?: string) {
     if (isClaudeTerminalRuntimeId(runtimeId)) {
         return null;
     }
-    if (!runtimeId && isClaudeTerminalRuntimeId(state.selectedRuntimeId)) {
-        return null;
-    }
 
     const getRuntime = (candidateRuntimeId?: string | null) =>
         candidateRuntimeId
@@ -116,18 +113,7 @@ function resolveStoreNewSessionRuntimeId(runtimeId?: string | null) {
     }
 
     const state = useChatStore.getState();
-    const firstReadyRuntimeId = state.runtimes.find((descriptor) =>
-        isRuntimeSetupReady(
-            state.setupStatusByRuntimeId[descriptor.runtime.id],
-        ),
-    )?.runtime.id;
-
-    return (
-        state.selectedRuntimeId ??
-        firstReadyRuntimeId ??
-        state.runtimes[0]?.runtime.id ??
-        null
-    );
+    return state.getDefaultNewChatRuntimeId();
 }
 
 function getSessionRuntimeId(sessionId?: string | null) {
@@ -140,7 +126,7 @@ function getSessionRuntimeId(sessionId?: string | null) {
 function getExplicitDefaultRuntimeId() {
     const state = useChatStore.getState();
     const runtimeId = state.defaultRuntimeId;
-    if (!runtimeId) {
+    if (!runtimeId || isClaudeTerminalRuntimeId(runtimeId)) {
         return null;
     }
     const runtime = state.runtimes.find(
@@ -166,22 +152,28 @@ function resolveWorkspaceNewChatRuntimeId(runtimeId?: string) {
 
     const chatState = useChatStore.getState();
     const defaultRuntimeId = chatState.getDefaultNewChatRuntimeId();
-    if (isClaudeTerminalRuntimeId(defaultRuntimeId)) {
-        return defaultRuntimeId;
-    }
-
     const focusedTab = selectFocusedEditorTab(useEditorStore.getState());
     const focusedChatRuntimeId =
         focusedTab && isChatTab(focusedTab)
             ? getSessionRuntimeId(focusedTab.sessionId)
             : null;
-    if (focusedChatRuntimeId) {
+    if (
+        focusedChatRuntimeId &&
+        !isClaudeTerminalRuntimeId(focusedChatRuntimeId)
+    ) {
         return focusedChatRuntimeId;
     }
 
+    const lastFocusedRuntimeId = getSessionRuntimeId(
+        chatState.lastFocusedSessionId,
+    );
+    const activeRuntimeId = getSessionRuntimeId(chatState.activeSessionId);
     return (
-        getSessionRuntimeId(chatState.lastFocusedSessionId) ??
-        getSessionRuntimeId(chatState.activeSessionId) ??
+        (!isClaudeTerminalRuntimeId(lastFocusedRuntimeId)
+            ? lastFocusedRuntimeId
+            : null) ??
+        (!isClaudeTerminalRuntimeId(activeRuntimeId) ? activeRuntimeId : null) ??
+        defaultRuntimeId ??
         undefined
     );
 }
@@ -378,17 +370,18 @@ export async function createNewChatInWorkspace(
     if (resolvedRuntimeId === CLAUDE_TERMINAL_RUNTIME_ID) return null;
     const pendingSession = createPendingWorkspaceSession(resolvedRuntimeId);
     if (!pendingSession) {
+        const fallbackRuntimeId =
+            resolveStoreNewSessionRuntimeId(resolvedRuntimeId);
         if (
-            isClaudeTerminalRuntimeId(
-                resolveStoreNewSessionRuntimeId(resolvedRuntimeId),
-            )
+            !fallbackRuntimeId ||
+            isClaudeTerminalRuntimeId(fallbackRuntimeId)
         ) {
             return null;
         }
 
         const createdSessionId = await useChatStore
             .getState()
-            .newSession(resolvedRuntimeId);
+            .newSession(fallbackRuntimeId);
         if (!createdSessionId) {
             return null;
         }

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -289,12 +289,13 @@ describe("AIChatAgentControls", () => {
             />,
         );
 
-        fireEvent.click(screen.getByTitle("Reasoning Effort"));
+        fireEvent.click(screen.getByTitle("Reasoning"));
 
         expect(screen.getAllByText("Medium")).toHaveLength(2);
         expect(screen.getByText("High")).toBeInTheDocument();
         expect(screen.queryByText("Low")).not.toBeInTheDocument();
         expect(screen.queryByText("Very High")).not.toBeInTheDocument();
+        expect(screen.queryByText("Service Tier")).not.toBeInTheDocument();
     });
 
     it("hides reasoning efforts when the selected model has none", () => {
@@ -404,7 +405,72 @@ describe("AIChatAgentControls", () => {
         expect(screen.queryByTitle("Thinking")).not.toBeInTheDocument();
     });
 
-    it("presents Claude fast mode as Off/Fast while preserving ACP values", () => {
+    it("groups Codex reasoning and service tier while preserving ACP values", () => {
+        const onConfigOptionChange = vi.fn();
+
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="codex-acp"
+                modelId="gpt-5.6"
+                modeId="default"
+                effortsByModel={{}}
+                models={[]}
+                modes={[]}
+                configOptions={[
+                    {
+                        id: "reasoning_effort",
+                        runtimeId: "codex-acp",
+                        category: "reasoning",
+                        label: "Reasoning Effort",
+                        type: "select",
+                        value: "medium",
+                        options: [
+                            { value: "low", label: "Low" },
+                            { value: "medium", label: "Medium" },
+                            { value: "high", label: "High" },
+                        ],
+                    },
+                    {
+                        id: "service_tier",
+                        runtimeId: "codex-acp",
+                        category: "service_tier",
+                        label: "Fast Mode",
+                        type: "select",
+                        value: "off",
+                        options: [
+                            { value: "off", label: "Off" },
+                            { value: "fast", label: "Fast" },
+                            { value: "flex", label: "Flex" },
+                        ],
+                    },
+                ]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={onConfigOptionChange}
+            />,
+        );
+
+        expect(screen.getByText("Medium")).toBeInTheDocument();
+        expect(screen.queryByTitle("Fast Mode")).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
+
+        expect(screen.getByText("Reasoning")).toBeInTheDocument();
+        expect(screen.getByText("Service Tier")).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Standard Default" }),
+        ).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: "Flex" })).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole("button", { name: "Fast" }));
+
+        expect(onConfigOptionChange).toHaveBeenCalledWith(
+            "service_tier",
+            "fast",
+        );
+    });
+
+    it("presents a legacy Claude fast option as a service tier", () => {
         const onConfigOptionChange = vi.fn();
 
         renderComponent(
@@ -435,14 +501,50 @@ describe("AIChatAgentControls", () => {
             />,
         );
 
-        fireEvent.click(screen.getByTitle("Fast Mode"));
+        fireEvent.click(screen.getByTitle("Service Tier"));
 
         expect(screen.getByRole("button", { name: "Fast" })).toBeInTheDocument();
         expect(screen.queryByRole("button", { name: "On" })).not.toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "Standard Default" }),
+        ).toBeInTheDocument();
 
         fireEvent.click(screen.getByRole("button", { name: "Fast" }));
 
         expect(onConfigOptionChange).toHaveBeenCalledWith("fast", "on");
+    });
+
+    it("does not reinterpret an unrelated fast option from another ACP", () => {
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="custom:example"
+                modelId="example-model"
+                modeId="default"
+                effortsByModel={{}}
+                models={[]}
+                modes={[]}
+                configOptions={[
+                    {
+                        id: "fast",
+                        runtimeId: "custom:example",
+                        category: "other",
+                        label: "Fast Mode",
+                        type: "select",
+                        value: "off",
+                        options: [
+                            { value: "on", label: "On" },
+                            { value: "off", label: "Off" },
+                        ],
+                    },
+                ]}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={() => {}}
+            />,
+        );
+
+        expect(screen.getByTitle("Fast Mode")).toBeInTheDocument();
+        expect(screen.queryByTitle("Service Tier")).not.toBeInTheDocument();
     });
 
     it("uses the ACP model config option as the source of truth", () => {

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -155,6 +155,66 @@ describe("AIChatAgentControls", () => {
     }
   });
 
+  it("loads a provider catalog when its rail item is activated", async () => {
+    const user = userEvent.setup();
+    let finishDiscovery!: () => void;
+    const onProviderActivate = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishDiscovery = resolve;
+        }),
+    );
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+          {
+            runtimeId: "claude-acp",
+            label: "Claude",
+            description: "Claude provider",
+            disabledReason: null,
+            defaultModelId: "",
+            models: [],
+          },
+        ]}
+        onProviderActivate={onProviderActivate}
+        onProviderModelChange={() => {}}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+    await user.click(screen.getByRole("button", { name: "Claude" }));
+
+    expect(onProviderActivate).toHaveBeenCalledWith("claude-acp");
+    expect(
+      screen.getByRole("button", { name: "Claude · Loading models…" }),
+    ).toBeDisabled();
+
+    finishDiscovery();
+  });
+
   it("keeps the original provider selected and explains the lock inline", async () => {
     const user = userEvent.setup();
     const onProviderChange = vi.fn();

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -1,10 +1,16 @@
 import { fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../../test/test-utils";
 import { AIChatAgentControls } from "./AIChatAgentControls";
 
 describe("AIChatAgentControls", () => {
+    beforeEach(() => {
+        localStorage.removeItem(
+            "neverwrite.ai.provider-model-picker-favorites",
+        );
+    });
+
     it("shows provider choices and exposes disabled reasons", async () => {
         const user = userEvent.setup();
         const onProviderChange = vi.fn();
@@ -55,6 +61,13 @@ describe("AIChatAgentControls", () => {
         );
 
         await user.click(screen.getByTitle("Provider and model"));
+        expect(
+            screen.getByLabelText("Provider and model search"),
+        ).toHaveFocus();
+        await user.type(
+            screen.getByLabelText("Provider and model search"),
+            "claude",
+        );
         const disabledClaude = screen.getByRole("button", {
             name: "Claude · Claude Sonnet",
         });
@@ -63,12 +76,78 @@ describe("AIChatAgentControls", () => {
             "title",
             "Finish the current turn before switching providers.",
         );
+        await user.clear(screen.getByLabelText("Provider and model search"));
         const codexOption = screen
             .getAllByRole("button", { name: "Codex · GPT 5" })
             .find((button) => button.getAttribute("title") === "Codex provider");
         expect(codexOption).toBeDefined();
         await user.click(codexOption!);
         expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
+    });
+
+    it("persists favorite models and opens the favorites rail first", async () => {
+        const user = userEvent.setup();
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="codex-acp"
+                modelId="gpt-5"
+                modeId="default"
+                models={[]}
+                modes={[]}
+                configOptions={[]}
+                providers={[
+                    {
+                        runtimeId: "codex-acp",
+                        label: "Codex",
+                        description: "Codex provider",
+                        disabledReason: null,
+                        defaultModelId: "gpt-5",
+                        models: [
+                            {
+                                modelId: "gpt-5",
+                                label: "GPT-5",
+                                disabledReason: null,
+                            },
+                            {
+                                modelId: "gpt-5-mini",
+                                label: "GPT-5 Mini",
+                                disabledReason: null,
+                            },
+                        ],
+                    },
+                ]}
+                onProviderModelChange={() => {}}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={() => {}}
+            />,
+        );
+
+        await user.click(screen.getByTitle("Provider and model"));
+        await user.click(
+            screen.getByRole("button", {
+                name: "Add GPT-5 Mini to favorites",
+            }),
+        );
+        await user.click(screen.getByTitle("Provider and model"));
+        await user.click(screen.getByTitle("Provider and model"));
+
+        expect(screen.getByRole("button", { name: "Favorites" })).toHaveStyle({
+            backgroundColor: "var(--bg-primary)",
+        });
+        expect(
+            screen.getByRole("button", { name: "Codex · GPT-5 Mini" }),
+        ).toBeInTheDocument();
+        expect(
+            JSON.parse(
+                localStorage.getItem(
+                    "neverwrite.ai.provider-model-picker-favorites",
+                ) ?? "[]",
+            ),
+        ).toContainEqual({
+            runtimeId: "codex-acp",
+            modelId: "gpt-5-mini",
+        });
     });
 
     it("shows contextual safety help only for Codex Full Access", () => {

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -86,6 +86,83 @@ describe("AIChatAgentControls", () => {
     expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
   });
 
+  it("keeps the original provider selected and explains the lock inline", async () => {
+    const user = userEvent.setup();
+    const onProviderChange = vi.fn();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        providerSwitchLocked
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+          {
+            runtimeId: "claude-acp",
+            label: "Claude",
+            description: "Claude provider",
+            disabledReason: null,
+            defaultModelId: "claude-sonnet",
+            models: [
+              {
+                modelId: "claude-sonnet",
+                label: "Claude Sonnet",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={onProviderChange}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+    const claudeRail = screen.getByRole("button", { name: "Claude" });
+    expect(claudeRail).toHaveAttribute("aria-disabled", "true");
+    await user.click(claudeRail);
+
+    expect(
+      screen.getByTestId("provider-switch-blocked-popover"),
+    ).toHaveTextContent(
+      "This chat is locked to Codex. Start a new chat to use Claude.",
+    );
+    expect(
+      screen.getByRole("button", { name: "Codex · GPT 5" }),
+    ).toBeInTheDocument();
+    expect(onProviderChange).not.toHaveBeenCalled();
+
+    await user.type(
+      screen.getByLabelText("Provider and model search"),
+      "claude",
+    );
+    await user.click(
+      screen.getByRole("button", { name: "Claude · Claude Sonnet" }),
+    );
+    expect(onProviderChange).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("dialog", { name: "Provider and model" }),
+    ).toBeInTheDocument();
+  });
+
   it("persists favorite models and opens the favorites rail first", async () => {
     const user = userEvent.setup();
     renderComponent(

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -87,11 +87,72 @@ describe("AIChatAgentControls", () => {
       .getAllByRole("button", { name: "Codex · GPT-5" })
       .find((button) => button.getAttribute("title") === "Codex provider");
     expect(codexOption).toBeDefined();
+    expect(codexOption).toHaveAttribute("aria-current", "true");
+    expect(screen.getByRole("button", { name: "Codex" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: "Claude" })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
     expect(
       screen.getByRole("button", { name: "Codex · Fallback model" }),
     ).toBeInTheDocument();
     await user.click(codexOption!);
     expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
+  });
+
+  it("leaves Escape available to the global agent shortcut", async () => {
+    const user = userEvent.setup();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={() => {}}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+    const searchInput = screen.getByLabelText("Provider and model search");
+    const escapeDefaultState = vi.fn((event: KeyboardEvent) =>
+      event.defaultPrevented,
+    );
+    window.addEventListener("keydown", escapeDefaultState);
+
+    try {
+      fireEvent.keyDown(searchInput, { key: "Escape" });
+
+      expect(escapeDefaultState).toHaveReturnedWith(false);
+      expect(
+        screen.getByRole("dialog", { name: "Provider and model" }),
+      ).toBeInTheDocument();
+    } finally {
+      window.removeEventListener("keydown", escapeDefaultState);
+    }
   });
 
   it("keeps the original provider selected and explains the lock inline", async () => {
@@ -218,6 +279,10 @@ describe("AIChatAgentControls", () => {
     expect(screen.getByRole("button", { name: "Favorites" })).toHaveStyle({
       backgroundColor: "var(--bg-primary)",
     });
+    expect(screen.getByRole("button", { name: "Favorites" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
     expect(
       screen.getByRole("button", { name: "Codex · GPT-5 Mini" }),
     ).toBeInTheDocument();

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -5,6 +5,72 @@ import { renderComponent } from "../../../test/test-utils";
 import { AIChatAgentControls } from "./AIChatAgentControls";
 
 describe("AIChatAgentControls", () => {
+    it("shows provider choices and exposes disabled reasons", async () => {
+        const user = userEvent.setup();
+        const onProviderChange = vi.fn();
+        renderComponent(
+            <AIChatAgentControls
+                runtimeId="codex-acp"
+                modelId="gpt-5"
+                modeId="default"
+                models={[]}
+                modes={[]}
+                configOptions={[]}
+                providers={[
+                    {
+                        runtimeId: "codex-acp",
+                        label: "Codex",
+                        description: "Codex provider",
+                        disabledReason: null,
+                        defaultModelId: "gpt-5",
+                        models: [
+                            {
+                                modelId: "gpt-5",
+                                label: "GPT-5",
+                                disabledReason: null,
+                            },
+                        ],
+                    },
+                    {
+                        runtimeId: "claude-acp",
+                        label: "Claude",
+                        description: "Claude provider",
+                        disabledReason:
+                            "Finish the current turn before switching providers.",
+                        defaultModelId: "claude-sonnet",
+                        models: [
+                            {
+                                modelId: "claude-sonnet",
+                                label: "Claude Sonnet",
+                                disabledReason: null,
+                            },
+                        ],
+                    },
+                ]}
+                onProviderModelChange={onProviderChange}
+                onModelChange={() => {}}
+                onModeChange={() => {}}
+                onConfigOptionChange={() => {}}
+            />,
+        );
+
+        await user.click(screen.getByTitle("Provider and model"));
+        const disabledClaude = screen.getByRole("button", {
+            name: "Claude · Claude Sonnet",
+        });
+        expect(disabledClaude).toBeDisabled();
+        expect(disabledClaude).toHaveAttribute(
+            "title",
+            "Finish the current turn before switching providers.",
+        );
+        const codexOption = screen
+            .getAllByRole("button", { name: "Codex · GPT 5" })
+            .find((button) => button.getAttribute("title") === "Codex provider");
+        expect(codexOption).toBeDefined();
+        await user.click(codexOption!);
+        expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
+    });
+
     it("shows contextual safety help only for Codex Full Access", () => {
         const fullAccessDescription =
             "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.";

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -5,1107 +5,1150 @@ import { renderComponent } from "../../../test/test-utils";
 import { AIChatAgentControls } from "./AIChatAgentControls";
 
 describe("AIChatAgentControls", () => {
-    beforeEach(() => {
-        localStorage.removeItem(
-            "neverwrite.ai.provider-model-picker-favorites",
-        );
-    });
+  beforeEach(() => {
+    localStorage.removeItem("neverwrite.ai.provider-model-picker-favorites");
+  });
 
-    it("shows provider choices and exposes disabled reasons", async () => {
-        const user = userEvent.setup();
-        const onProviderChange = vi.fn();
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="gpt-5"
-                modeId="default"
-                models={[]}
-                modes={[]}
-                configOptions={[]}
-                providers={[
-                    {
-                        runtimeId: "codex-acp",
-                        label: "Codex",
-                        description: "Codex provider",
-                        disabledReason: null,
-                        defaultModelId: "gpt-5",
-                        models: [
-                            {
-                                modelId: "gpt-5",
-                                label: "GPT-5",
-                                disabledReason: null,
-                            },
-                        ],
-                    },
-                    {
-                        runtimeId: "claude-acp",
-                        label: "Claude",
-                        description: "Claude provider",
-                        disabledReason:
-                            "Finish the current turn before switching providers.",
-                        defaultModelId: "claude-sonnet",
-                        models: [
-                            {
-                                modelId: "claude-sonnet",
-                                label: "Claude Sonnet",
-                                disabledReason: null,
-                            },
-                        ],
-                    },
-                ]}
-                onProviderModelChange={onProviderChange}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        await user.click(screen.getByTitle("Provider and model"));
-        expect(
-            screen.getByLabelText("Provider and model search"),
-        ).toHaveFocus();
-        await user.type(
-            screen.getByLabelText("Provider and model search"),
-            "claude",
-        );
-        const disabledClaude = screen.getByRole("button", {
-            name: "Claude · Claude Sonnet",
-        });
-        expect(disabledClaude).toBeDisabled();
-        expect(disabledClaude).toHaveAttribute(
-            "title",
-            "Finish the current turn before switching providers.",
-        );
-        await user.clear(screen.getByLabelText("Provider and model search"));
-        const codexOption = screen
-            .getAllByRole("button", { name: "Codex · GPT 5" })
-            .find((button) => button.getAttribute("title") === "Codex provider");
-        expect(codexOption).toBeDefined();
-        await user.click(codexOption!);
-        expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
-    });
-
-    it("persists favorite models and opens the favorites rail first", async () => {
-        const user = userEvent.setup();
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="gpt-5"
-                modeId="default"
-                models={[]}
-                modes={[]}
-                configOptions={[]}
-                providers={[
-                    {
-                        runtimeId: "codex-acp",
-                        label: "Codex",
-                        description: "Codex provider",
-                        disabledReason: null,
-                        defaultModelId: "gpt-5",
-                        models: [
-                            {
-                                modelId: "gpt-5",
-                                label: "GPT-5",
-                                disabledReason: null,
-                            },
-                            {
-                                modelId: "gpt-5-mini",
-                                label: "GPT-5 Mini",
-                                disabledReason: null,
-                            },
-                        ],
-                    },
-                ]}
-                onProviderModelChange={() => {}}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        await user.click(screen.getByTitle("Provider and model"));
-        await user.click(
-            screen.getByRole("button", {
-                name: "Add GPT-5 Mini to favorites",
-            }),
-        );
-        await user.click(screen.getByTitle("Provider and model"));
-        await user.click(screen.getByTitle("Provider and model"));
-
-        expect(screen.getByRole("button", { name: "Favorites" })).toHaveStyle({
-            backgroundColor: "var(--bg-primary)",
-        });
-        expect(
-            screen.getByRole("button", { name: "Codex · GPT-5 Mini" }),
-        ).toBeInTheDocument();
-        expect(
-            JSON.parse(
-                localStorage.getItem(
-                    "neverwrite.ai.provider-model-picker-favorites",
-                ) ?? "[]",
-            ),
-        ).toContainEqual({
+  it("shows provider choices and exposes disabled reasons", async () => {
+    const user = userEvent.setup();
+    const onProviderChange = vi.fn();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
             runtimeId: "codex-acp",
-            modelId: "gpt-5-mini",
-        });
-    });
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+          {
+            runtimeId: "claude-acp",
+            label: "Claude",
+            description: "Claude provider",
+            disabledReason:
+              "Finish the current turn before switching providers.",
+            defaultModelId: "claude-sonnet",
+            models: [
+              {
+                modelId: "claude-sonnet",
+                label: "Claude Sonnet",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={onProviderChange}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
 
-    it("shows contextual safety help only for Codex Full Access", () => {
-        const fullAccessDescription =
-            "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.";
-        const modes = [
+    await user.click(screen.getByTitle("Provider and model"));
+    expect(screen.getByLabelText("Provider and model search")).toHaveFocus();
+    await user.type(
+      screen.getByLabelText("Provider and model search"),
+      "claude",
+    );
+    const disabledClaude = screen.getByRole("button", {
+      name: "Claude · Claude Sonnet",
+    });
+    expect(disabledClaude).toBeDisabled();
+    expect(disabledClaude).toHaveAttribute(
+      "title",
+      "Finish the current turn before switching providers.",
+    );
+    await user.clear(screen.getByLabelText("Provider and model search"));
+    const codexOption = screen
+      .getAllByRole("button", { name: "Codex · GPT 5" })
+      .find((button) => button.getAttribute("title") === "Codex provider");
+    expect(codexOption).toBeDefined();
+    await user.click(codexOption!);
+    expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
+  });
+
+  it("persists favorite models and opens the favorites rail first", async () => {
+    const user = userEvent.setup();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+              {
+                modelId: "gpt-5-mini",
+                label: "GPT-5 Mini",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={() => {}}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+    await user.click(
+      screen.getByRole("button", {
+        name: "Add GPT-5 Mini to favorites",
+      }),
+    );
+    await user.click(screen.getByTitle("Provider and model"));
+    await user.click(screen.getByTitle("Provider and model"));
+
+    expect(screen.getByRole("button", { name: "Favorites" })).toHaveStyle({
+      backgroundColor: "var(--bg-primary)",
+    });
+    expect(
+      screen.getByRole("button", { name: "Codex · GPT-5 Mini" }),
+    ).toBeInTheDocument();
+    expect(
+      JSON.parse(
+        localStorage.getItem("neverwrite.ai.provider-model-picker-favorites") ??
+          "[]",
+      ),
+    ).toContainEqual({
+      runtimeId: "codex-acp",
+      modelId: "gpt-5-mini",
+    });
+  });
+
+  it("shows contextual safety help only for Codex Full Access", () => {
+    const fullAccessDescription =
+      "Codex can edit files outside this workspace and access the internet without asking for approval. Exercise caution when using.";
+    const modes = [
+      {
+        id: "auto",
+        runtimeId: "codex-acp",
+        name: "Default",
+        description: "Work inside the current workspace.",
+        disabled: false,
+      },
+      {
+        id: "full-access",
+        runtimeId: "codex-acp",
+        name: "Full Access",
+        description: fullAccessDescription,
+        disabled: false,
+      },
+    ];
+    const view = renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId=""
+        modeId="full-access"
+        effortsByModel={{}}
+        models={[]}
+        modes={modes}
+        configOptions={[]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    const help = screen.getByRole("button", {
+      name: "Full Access safety policy",
+    });
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.mouseEnter(help);
+    expect(screen.getByRole("tooltip")).toHaveTextContent(
+      "Some destructive command forms may still be blocked by Codex safety policy.",
+    );
+    fireEvent.mouseLeave(help);
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
+
+    fireEvent.focus(help);
+    expect(screen.getByRole("tooltip")).toBeInTheDocument();
+    fireEvent.blur(help);
+
+    fireEvent.click(screen.getByTitle("Approval Preset"));
+    const fullAccessOption = screen
+      .getAllByRole("button", { name: "Full Access" })
+      .find((option) => option.getAttribute("title") === fullAccessDescription);
+    expect(fullAccessOption).toHaveAttribute("title", fullAccessDescription);
+
+    view.unmount();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId=""
+        modeId="auto"
+        effortsByModel={{}}
+        models={[]}
+        modes={modes}
+        configOptions={[]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+    expect(
+      screen.queryByRole("button", {
+        name: "Full Access safety policy",
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters reasoning efforts to the selected model", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5.2-codex"
+        modeId="default"
+        effortsByModel={{
+          "gpt-5.2-codex": ["medium", "high"],
+          "gpt-5.3-codex": ["low", "medium", "high", "xhigh"],
+        }}
+        models={[
+          {
+            id: "gpt-5.2-codex",
+            runtimeId: "codex-acp",
+            name: "gpt-5.2-codex",
+            description: "",
+          },
+          {
+            id: "gpt-5.3-codex",
+            runtimeId: "codex-acp",
+            name: "gpt-5.3-codex",
+            description: "",
+          },
+        ]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "codex-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "reasoning_effort",
+            runtimeId: "codex-acp",
+            category: "reasoning",
+            label: "Reasoning Effort",
+            type: "select",
+            value: "medium",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "medium", label: "Medium" },
+              { value: "high", label: "High" },
+              { value: "xhigh", label: "Very High" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Reasoning"));
+
+    expect(screen.getAllByText("Medium")).toHaveLength(2);
+    expect(screen.getByText("High")).toBeInTheDocument();
+    expect(screen.getByText("Low")).toBeInTheDocument();
+    expect(screen.getByText("Very High")).toBeInTheDocument();
+    expect(screen.queryByText("Service Tier")).not.toBeInTheDocument();
+  });
+
+  it("keeps ACP reasoning options when discovery metadata is empty", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="claude-acp"
+        modelId="claude-haiku-4-5"
+        modeId="default"
+        effortsByModel={{
+          "claude-sonnet-4-5": ["low", "medium", "high"],
+          "claude-haiku-4-5": [],
+        }}
+        models={[
+          {
+            id: "claude-haiku-4-5",
+            runtimeId: "claude-acp",
+            name: "Claude Haiku 4.5",
+            description: "",
+          },
+        ]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "claude-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "effort",
+            runtimeId: "claude-acp",
+            category: "reasoning",
+            label: "Effort",
+            type: "select",
+            value: "medium",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "medium", label: "Medium" },
+              { value: "high", label: "High" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTitle("Reasoning and Service Tier")).toBeInTheDocument();
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+  });
+
+  it("hides a thought level config option duplicated by ACP modes", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="custom:pi"
+        modelId=""
+        modeId="low"
+        models={[]}
+        modes={[
+          {
+            id: "off",
+            runtimeId: "custom:pi",
+            name: "Thinking: off",
+            description: "",
+            disabled: false,
+          },
+          {
+            id: "low",
+            runtimeId: "custom:pi",
+            name: "Thinking: low",
+            description: "",
+            disabled: false,
+          },
+          {
+            id: "high",
+            runtimeId: "custom:pi",
+            name: "Thinking: high",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "thought_level",
+            runtimeId: "custom:pi",
+            category: "reasoning",
+            label: "Thinking",
+            type: "select",
+            value: "low",
+            options: [
+              { value: "off", label: "Thinking: off" },
+              { value: "low", label: "Thinking: low" },
+              { value: "high", label: "Thinking: high" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTitle("Approval Preset")).toBeInTheDocument();
+    expect(screen.queryByTitle("Thinking")).not.toBeInTheDocument();
+  });
+
+  it("groups Codex reasoning and service tier while preserving ACP values", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5.6"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "reasoning_effort",
+            runtimeId: "codex-acp",
+            category: "reasoning",
+            label: "Reasoning Effort",
+            type: "select",
+            value: "medium",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "medium", label: "Medium" },
+              { value: "high", label: "High" },
+            ],
+          },
+          {
+            id: "service_tier",
+            runtimeId: "codex-acp",
+            category: "service_tier",
+            label: "Fast Mode",
+            type: "select",
+            value: "off",
+            options: [
+              { value: "off", label: "Off" },
+              { value: "fast", label: "Fast" },
+              { value: "flex", label: "Flex" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    expect(screen.getByText("Medium")).toBeInTheDocument();
+    expect(screen.queryByTitle("Fast Mode")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
+
+    expect(screen.getByText("Reasoning")).toBeInTheDocument();
+    expect(screen.getByText("Service Tier")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Standard Default" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Flex" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fast" }));
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith("service_tier", "fast");
+  });
+
+  it("presents a legacy Claude fast option as a service tier", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="claude-acp"
+        modelId="claude-sonnet-5"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "fast",
+            runtimeId: "claude-acp",
+            category: "other",
+            label: "Fast mode",
+            type: "select",
+            value: "off",
+            options: [
+              { value: "on", label: "On" },
+              { value: "off", label: "Off" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Service Tier"));
+
+    expect(screen.getByRole("button", { name: "Fast" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "On" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Standard Default" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Fast" }));
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith("fast", "on");
+  });
+
+  it("shows Claude service tier and gates Fast by the selected model", () => {
+    const onConfigOptionChange = vi.fn();
+    const { rerender } = renderComponent(
+      <AIChatAgentControls
+        runtimeId="claude-acp"
+        modelId="default"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "effort",
+            runtimeId: "claude-acp",
+            category: "reasoning",
+            label: "Effort",
+            type: "select",
+            value: "high",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "high", label: "High" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
+    expect(screen.getByRole("button", { name: "Fast" })).toBeDisabled();
+    fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
+
+    rerender(
+      <AIChatAgentControls
+        runtimeId="claude-acp"
+        modelId="opus"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "effort",
+            runtimeId: "claude-acp",
+            category: "reasoning",
+            label: "Effort",
+            type: "select",
+            value: "high",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "high", label: "High" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
+    fireEvent.click(screen.getByRole("button", { name: "Fast" }));
+    expect(onConfigOptionChange).toHaveBeenCalledWith("fast", "on");
+  });
+
+  it("does not reinterpret an unrelated fast option from another ACP", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="custom:example"
+        modelId="example-model"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "fast",
+            runtimeId: "custom:example",
+            category: "other",
+            label: "Fast Mode",
+            type: "select",
+            value: "off",
+            options: [
+              { value: "on", label: "On" },
+              { value: "off", label: "Off" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTitle("Fast Mode")).toBeInTheDocument();
+    expect(screen.queryByTitle("Service Tier")).not.toBeInTheDocument();
+  });
+
+  it("uses the ACP model config option as the source of truth", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="fallback-model"
+        modeId="default"
+        effortsByModel={{
+          "gpt-5.2-codex": ["medium", "high"],
+        }}
+        models={[
+          {
+            id: "fallback-model",
+            runtimeId: "codex-acp",
+            name: "Fallback Model",
+            description: "",
+          },
+        ]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "codex-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "codex-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "gpt-5.2-codex",
+            options: [
+              {
+                value: "gpt-5.2-codex",
+                label: "GPT 5.2 Codex",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    expect(screen.getByText("GPT 5.2 Codex")).toBeInTheDocument();
+    expect(screen.queryByText("fallback-model")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle("Model"));
+    fireEvent.click(screen.getAllByText("GPT 5.2 Codex")[1]!);
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith("model", "gpt-5.2-codex");
+  });
+
+  it("disables Grok models that require a different agent after the chat starts", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="grok-acp"
+        lockIncompatibleModelSwitches
+        modelId=""
+        modeId="yolo"
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "grok-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "grok-build",
+            options: [
+              {
+                value: "grok-composer-2.5-fast",
+                label: "Composer 2.5",
+                agentType: "cursor",
+              },
+              {
+                value: "grok-build",
+                label: "Grok Build",
+                agentType: "grok-build-plan",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Model"));
+
+    const composer = screen.getByRole("button", {
+      name: "Composer 2.5",
+    });
+    expect(composer).toBeDisabled();
+    expect(composer).toHaveAttribute(
+      "title",
+      "Start a new Grok chat to switch to this model.",
+    );
+
+    fireEvent.click(composer);
+    expect(onConfigOptionChange).not.toHaveBeenCalled();
+  });
+
+  it("shows a model search field for Kilo and filters results", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="kilo-acp"
+        modelId="gpt-4o"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "kilo-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "kilo-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "gpt-4o",
+            options: [
+              {
+                value: "gpt-4o",
+                label: "Kilo Gateway/OpenAI: GPT-4o",
+              },
+              {
+                value: "claude-sonnet-4.6",
+                label: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
+              },
+              {
+                value: "gemini-2.5-pro",
+                label: "Kilo Gateway/Google: Gemini 2.5 Pro",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Model"));
+
+    const search = screen.getByLabelText("Model search");
+    expect(search).toBeInTheDocument();
+    expect(
+      screen.getAllByText("Kilo Gateway/OpenAI: GPT-4o").length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText("Kilo Gateway/Anthropic: Claude Sonnet 4.6"),
+    ).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "claude" } });
+
+    expect(
+      screen.getByText("Kilo Gateway/Anthropic: Claude Sonnet 4.6"),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("Kilo Gateway/OpenAI: GPT-4o")).toHaveLength(1);
+    expect(
+      screen.queryByText("Kilo Gateway/Google: Gemini 2.5 Pro"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows a model search field for OpenCode and filters Zen models", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="opencode-acp"
+        modelId="opencode/zen/qwen3.5-plus"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "opencode-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "opencode-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "opencode/zen/qwen3.5-plus",
+            options: [
+              {
+                value: "opencode/zen/qwen3.5-plus",
+                label: "OpenCode Zen/Qwen3.5 Plus",
+              },
+              {
+                value: "opencode/zen/gemini-3-flash",
+                label: "OpenCode Zen/Gemini 3 Flash",
+              },
+              {
+                value: "opencode/zen/claude-opus-4.7",
+                label: "OpenCode Zen/Claude Opus 4.7",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Model"));
+
+    const search = screen.getByLabelText("Model search");
+    expect(search).toBeInTheDocument();
+    expect(screen.getByText("OpenCode Zen/Gemini 3 Flash")).toBeInTheDocument();
+
+    fireEvent.change(search, { target: { value: "opus" } });
+
+    expect(
+      screen.getByText("OpenCode Zen/Claude Opus 4.7"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText("OpenCode Zen/Gemini 3 Flash"),
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "OpenCode Zen/Claude Opus 4.7",
+      }),
+    );
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith(
+      "model",
+      "opencode/zen/claude-opus-4.7",
+    );
+  });
+
+  it("shows Grok ACP models without a model search field", () => {
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="grok-acp"
+        modelId="grok-build"
+        modeId=""
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "grok-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "grok-build",
+            options: [
+              {
+                value: "grok-composer-2.5-fast",
+                label: "Composer 2.5",
+                description: "Cursor's latest coding model",
+              },
+              {
+                value: "grok-build",
+                label: "Grok Build",
+                description: "Best for advanced coding tasks",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={onConfigOptionChange}
+      />,
+    );
+
+    expect(screen.queryByTitle("Approval Preset")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle("Model"));
+
+    expect(screen.queryByLabelText("Model search")).not.toBeInTheDocument();
+    expect(screen.getByText("Composer 2.5")).toBeInTheDocument();
+    expect(screen.getAllByText("Grok Build").length).toBeGreaterThan(0);
+
+    const grokBuildOption = screen
+      .getAllByRole("button", { name: "Grok Build" })
+      .at(-1);
+    expect(grokBuildOption).toBeDefined();
+    fireEvent.click(grokBuildOption!);
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith("model", "grok-build");
+  });
+
+  it("shows the model label when model options exist but no value is selected", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="grok-acp"
+        modelId=""
+        modeId=""
+        effortsByModel={{}}
+        models={[]}
+        modes={[]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "grok-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "",
+            options: [
+              { value: "composer-2.5", label: "Composer 2.5" },
+              { value: "grok-build", label: "Grok Build" },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTitle("Model")).toHaveTextContent("Model");
+  });
+
+  it("hides the model selector when there are no real model options", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="grok-acp"
+        modelId=""
+        modeId="yolo"
+        effortsByModel={{}}
+        models={[]}
+        modes={[
+          {
+            id: "yolo",
+            runtimeId: "grok-acp",
+            name: "YOLO",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTitle("Model")).not.toBeInTheDocument();
+    expect(screen.getByTitle("Approval Preset")).toBeInTheDocument();
+  });
+
+  it("does not show the model search field for non-searchable runtimes", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5.2-codex"
+        modeId="default"
+        effortsByModel={{}}
+        models={[]}
+        modes={[
+          {
+            id: "default",
+            runtimeId: "codex-acp",
+            name: "Auto",
+            description: "",
+            disabled: false,
+          },
+        ]}
+        configOptions={[
+          {
+            id: "model",
+            runtimeId: "codex-acp",
+            category: "model",
+            label: "Model",
+            type: "select",
+            value: "gpt-5.2-codex",
+            options: [
+              {
+                value: "gpt-5.2-codex",
+                label: "GPT 5.2 Codex",
+              },
+              {
+                value: "gpt-5.4",
+                label: "GPT 5.4",
+              },
+            ],
+          },
+        ]}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTitle("Model"));
+
+    expect(screen.queryByLabelText("Model search")).not.toBeInTheDocument();
+  });
+
+  it("preserves the current focus when selecting a pointer-driven mode", async () => {
+    const user = userEvent.setup();
+    const onModeChange = vi.fn();
+
+    renderComponent(
+      <div>
+        <input aria-label="Composer focus target" />
+        <AIChatAgentControls
+          runtimeId="codex-acp"
+          modelId="gpt-5.2-codex"
+          modeId="default"
+          effortsByModel={{}}
+          models={[
             {
-                id: "auto",
-                runtimeId: "codex-acp",
-                name: "Default",
-                description: "Work inside the current workspace.",
-                disabled: false,
+              id: "gpt-5.2-codex",
+              runtimeId: "codex-acp",
+              name: "gpt-5.2-codex",
+              description: "",
+            },
+          ]}
+          modes={[
+            {
+              id: "default",
+              runtimeId: "codex-acp",
+              name: "Auto",
+              description: "",
+              disabled: false,
             },
             {
-                id: "full-access",
-                runtimeId: "codex-acp",
-                name: "Full Access",
-                description: fullAccessDescription,
-                disabled: false,
+              id: "review",
+              runtimeId: "codex-acp",
+              name: "Review mode",
+              description: "",
+              disabled: false,
             },
-        ];
-        const view = renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId=""
-                modeId="full-access"
-                effortsByModel={{}}
-                models={[]}
-                modes={modes}
-                configOptions={[]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        const help = screen.getByRole("button", {
-            name: "Full Access safety policy",
-        });
-        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-
-        fireEvent.mouseEnter(help);
-        expect(screen.getByRole("tooltip")).toHaveTextContent(
-            "Some destructive command forms may still be blocked by Codex safety policy.",
-        );
-        fireEvent.mouseLeave(help);
-        expect(screen.queryByRole("tooltip")).not.toBeInTheDocument();
-
-        fireEvent.focus(help);
-        expect(screen.getByRole("tooltip")).toBeInTheDocument();
-        fireEvent.blur(help);
-
-        fireEvent.click(screen.getByTitle("Approval Preset"));
-        const fullAccessOption = screen
-            .getAllByRole("button", { name: "Full Access" })
-            .find(
-                (option) =>
-                    option.getAttribute("title") === fullAccessDescription,
-            );
-        expect(fullAccessOption).toHaveAttribute(
-            "title",
-            fullAccessDescription,
-        );
-
-        view.unmount();
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId=""
-                modeId="auto"
-                effortsByModel={{}}
-                models={[]}
-                modes={modes}
-                configOptions={[]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-        expect(
-            screen.queryByRole("button", {
-                name: "Full Access safety policy",
-            }),
-        ).not.toBeInTheDocument();
-    });
-
-    it("filters reasoning efforts to the selected model", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="gpt-5.2-codex"
-                modeId="default"
-                effortsByModel={{
-                    "gpt-5.2-codex": ["medium", "high"],
-                    "gpt-5.3-codex": ["low", "medium", "high", "xhigh"],
-                }}
-                models={[
-                    {
-                        id: "gpt-5.2-codex",
-                        runtimeId: "codex-acp",
-                        name: "gpt-5.2-codex",
-                        description: "",
-                    },
-                    {
-                        id: "gpt-5.3-codex",
-                        runtimeId: "codex-acp",
-                        name: "gpt-5.3-codex",
-                        description: "",
-                    },
-                ]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "codex-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "reasoning_effort",
-                        runtimeId: "codex-acp",
-                        category: "reasoning",
-                        label: "Reasoning Effort",
-                        type: "select",
-                        value: "medium",
-                        options: [
-                            { value: "low", label: "Low" },
-                            { value: "medium", label: "Medium" },
-                            { value: "high", label: "High" },
-                            { value: "xhigh", label: "Very High" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Reasoning"));
-
-        expect(screen.getAllByText("Medium")).toHaveLength(2);
-        expect(screen.getByText("High")).toBeInTheDocument();
-        expect(screen.queryByText("Low")).not.toBeInTheDocument();
-        expect(screen.queryByText("Very High")).not.toBeInTheDocument();
-        expect(screen.queryByText("Service Tier")).not.toBeInTheDocument();
-    });
-
-    it("hides reasoning efforts when the selected model has none", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="claude-acp"
-                modelId="claude-haiku-4-5"
-                modeId="default"
-                effortsByModel={{
-                    "claude-sonnet-4-5": ["low", "medium", "high"],
-                    "claude-haiku-4-5": [],
-                }}
-                models={[
-                    {
-                        id: "claude-haiku-4-5",
-                        runtimeId: "claude-acp",
-                        name: "Claude Haiku 4.5",
-                        description: "",
-                    },
-                ]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "claude-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "effort",
-                        runtimeId: "claude-acp",
-                        category: "reasoning",
-                        label: "Effort",
-                        type: "select",
-                        value: "medium",
-                        options: [
-                            { value: "low", label: "Low" },
-                            { value: "medium", label: "Medium" },
-                            { value: "high", label: "High" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        expect(screen.queryByTitle("Effort")).not.toBeInTheDocument();
-        expect(screen.queryByText("Medium")).not.toBeInTheDocument();
-    });
-
-    it("hides a thought level config option duplicated by ACP modes", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="custom:pi"
-                modelId=""
-                modeId="low"
-                models={[]}
-                modes={[
-                    {
-                        id: "off",
-                        runtimeId: "custom:pi",
-                        name: "Thinking: off",
-                        description: "",
-                        disabled: false,
-                    },
-                    {
-                        id: "low",
-                        runtimeId: "custom:pi",
-                        name: "Thinking: low",
-                        description: "",
-                        disabled: false,
-                    },
-                    {
-                        id: "high",
-                        runtimeId: "custom:pi",
-                        name: "Thinking: high",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "thought_level",
-                        runtimeId: "custom:pi",
-                        category: "reasoning",
-                        label: "Thinking",
-                        type: "select",
-                        value: "low",
-                        options: [
-                            { value: "off", label: "Thinking: off" },
-                            { value: "low", label: "Thinking: low" },
-                            { value: "high", label: "Thinking: high" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        expect(screen.getByTitle("Approval Preset")).toBeInTheDocument();
-        expect(screen.queryByTitle("Thinking")).not.toBeInTheDocument();
-    });
-
-    it("groups Codex reasoning and service tier while preserving ACP values", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="gpt-5.6"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "reasoning_effort",
-                        runtimeId: "codex-acp",
-                        category: "reasoning",
-                        label: "Reasoning Effort",
-                        type: "select",
-                        value: "medium",
-                        options: [
-                            { value: "low", label: "Low" },
-                            { value: "medium", label: "Medium" },
-                            { value: "high", label: "High" },
-                        ],
-                    },
-                    {
-                        id: "service_tier",
-                        runtimeId: "codex-acp",
-                        category: "service_tier",
-                        label: "Fast Mode",
-                        type: "select",
-                        value: "off",
-                        options: [
-                            { value: "off", label: "Off" },
-                            { value: "fast", label: "Fast" },
-                            { value: "flex", label: "Flex" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        expect(screen.getByText("Medium")).toBeInTheDocument();
-        expect(screen.queryByTitle("Fast Mode")).not.toBeInTheDocument();
-
-        fireEvent.click(screen.getByTitle("Reasoning and Service Tier"));
-
-        expect(screen.getByText("Reasoning")).toBeInTheDocument();
-        expect(screen.getByText("Service Tier")).toBeInTheDocument();
-        expect(
-            screen.getByRole("button", { name: "Standard Default" }),
-        ).toBeInTheDocument();
-        expect(screen.getByRole("button", { name: "Flex" })).toBeInTheDocument();
-
-        fireEvent.click(screen.getByRole("button", { name: "Fast" }));
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith(
-            "service_tier",
-            "fast",
-        );
-    });
-
-    it("presents a legacy Claude fast option as a service tier", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="claude-acp"
-                modelId="claude-sonnet-5"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "fast",
-                        runtimeId: "claude-acp",
-                        category: "other",
-                        label: "Fast mode",
-                        type: "select",
-                        value: "off",
-                        options: [
-                            { value: "on", label: "On" },
-                            { value: "off", label: "Off" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Service Tier"));
-
-        expect(screen.getByRole("button", { name: "Fast" })).toBeInTheDocument();
-        expect(screen.queryByRole("button", { name: "On" })).not.toBeInTheDocument();
-        expect(
-            screen.getByRole("button", { name: "Standard Default" }),
-        ).toBeInTheDocument();
-
-        fireEvent.click(screen.getByRole("button", { name: "Fast" }));
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith("fast", "on");
-    });
-
-    it("does not reinterpret an unrelated fast option from another ACP", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="custom:example"
-                modelId="example-model"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "fast",
-                        runtimeId: "custom:example",
-                        category: "other",
-                        label: "Fast Mode",
-                        type: "select",
-                        value: "off",
-                        options: [
-                            { value: "on", label: "On" },
-                            { value: "off", label: "Off" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        expect(screen.getByTitle("Fast Mode")).toBeInTheDocument();
-        expect(screen.queryByTitle("Service Tier")).not.toBeInTheDocument();
-    });
-
-    it("uses the ACP model config option as the source of truth", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="fallback-model"
-                modeId="default"
-                effortsByModel={{
-                    "gpt-5.2-codex": ["medium", "high"],
-                }}
-                models={[
-                    {
-                        id: "fallback-model",
-                        runtimeId: "codex-acp",
-                        name: "Fallback Model",
-                        description: "",
-                    },
-                ]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "codex-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "codex-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "gpt-5.2-codex",
-                        options: [
-                            {
-                                value: "gpt-5.2-codex",
-                                label: "GPT 5.2 Codex",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        expect(screen.getByText("GPT 5.2 Codex")).toBeInTheDocument();
-        expect(screen.queryByText("fallback-model")).not.toBeInTheDocument();
-
-        fireEvent.click(screen.getByTitle("Model"));
-        fireEvent.click(screen.getAllByText("GPT 5.2 Codex")[1]!);
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith(
-            "model",
-            "gpt-5.2-codex",
-        );
-    });
-
-    it("disables Grok models that require a different agent after the chat starts", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="grok-acp"
-                lockIncompatibleModelSwitches
-                modelId=""
-                modeId="yolo"
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "grok-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "grok-build",
-                        options: [
-                            {
-                                value: "grok-composer-2.5-fast",
-                                label: "Composer 2.5",
-                                agentType: "cursor",
-                            },
-                            {
-                                value: "grok-build",
-                                label: "Grok Build",
-                                agentType: "grok-build-plan",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Model"));
-
-        const composer = screen.getByRole("button", {
-            name: "Composer 2.5",
-        });
-        expect(composer).toBeDisabled();
-        expect(composer).toHaveAttribute(
-            "title",
-            "Start a new Grok chat to switch to this model.",
-        );
-
-        fireEvent.click(composer);
-        expect(onConfigOptionChange).not.toHaveBeenCalled();
-    });
-
-    it("shows a model search field for Kilo and filters results", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="kilo-acp"
-                modelId="gpt-4o"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "kilo-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "kilo-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "gpt-4o",
-                        options: [
-                            {
-                                value: "gpt-4o",
-                                label: "Kilo Gateway/OpenAI: GPT-4o",
-                            },
-                            {
-                                value: "claude-sonnet-4.6",
-                                label: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
-                            },
-                            {
-                                value: "gemini-2.5-pro",
-                                label: "Kilo Gateway/Google: Gemini 2.5 Pro",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Model"));
-
-        const search = screen.getByLabelText("Model search");
-        expect(search).toBeInTheDocument();
-        expect(
-            screen.getAllByText("Kilo Gateway/OpenAI: GPT-4o").length,
-        ).toBeGreaterThan(0);
-        expect(
-            screen.getByText("Kilo Gateway/Anthropic: Claude Sonnet 4.6"),
-        ).toBeInTheDocument();
-
-        fireEvent.change(search, { target: { value: "claude" } });
-
-        expect(
-            screen.getByText("Kilo Gateway/Anthropic: Claude Sonnet 4.6"),
-        ).toBeInTheDocument();
-        expect(screen.getAllByText("Kilo Gateway/OpenAI: GPT-4o")).toHaveLength(
-            1,
-        );
-        expect(
-            screen.queryByText("Kilo Gateway/Google: Gemini 2.5 Pro"),
-        ).not.toBeInTheDocument();
-    });
-
-    it("shows a model search field for OpenCode and filters Zen models", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="opencode-acp"
-                modelId="opencode/zen/qwen3.5-plus"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "opencode-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "opencode-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "opencode/zen/qwen3.5-plus",
-                        options: [
-                            {
-                                value: "opencode/zen/qwen3.5-plus",
-                                label: "OpenCode Zen/Qwen3.5 Plus",
-                            },
-                            {
-                                value: "opencode/zen/gemini-3-flash",
-                                label: "OpenCode Zen/Gemini 3 Flash",
-                            },
-                            {
-                                value: "opencode/zen/claude-opus-4.7",
-                                label: "OpenCode Zen/Claude Opus 4.7",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Model"));
-
-        const search = screen.getByLabelText("Model search");
-        expect(search).toBeInTheDocument();
-        expect(
-            screen.getByText("OpenCode Zen/Gemini 3 Flash"),
-        ).toBeInTheDocument();
-
-        fireEvent.change(search, { target: { value: "opus" } });
-
-        expect(
-            screen.getByText("OpenCode Zen/Claude Opus 4.7"),
-        ).toBeInTheDocument();
-        expect(
-            screen.queryByText("OpenCode Zen/Gemini 3 Flash"),
-        ).not.toBeInTheDocument();
-
-        fireEvent.click(
-            screen.getByRole("button", {
-                name: "OpenCode Zen/Claude Opus 4.7",
-            }),
-        );
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith(
-            "model",
-            "opencode/zen/claude-opus-4.7",
-        );
-    });
-
-    it("shows Grok ACP models without a model search field", () => {
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="grok-acp"
-                modelId="grok-build"
-                modeId=""
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "grok-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "grok-build",
-                        options: [
-                            {
-                                value: "grok-composer-2.5-fast",
-                                label: "Composer 2.5",
-                                description: "Cursor's latest coding model",
-                            },
-                            {
-                                value: "grok-build",
-                                label: "Grok Build",
-                                description: "Best for advanced coding tasks",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={onConfigOptionChange}
-            />,
-        );
-
-        expect(screen.queryByTitle("Approval Preset")).not.toBeInTheDocument();
-
-        fireEvent.click(screen.getByTitle("Model"));
-
-        expect(screen.queryByLabelText("Model search")).not.toBeInTheDocument();
-        expect(screen.getByText("Composer 2.5")).toBeInTheDocument();
-        expect(screen.getAllByText("Grok Build").length).toBeGreaterThan(0);
-
-        const grokBuildOption = screen
-            .getAllByRole("button", { name: "Grok Build" })
-            .at(-1);
-        expect(grokBuildOption).toBeDefined();
-        fireEvent.click(grokBuildOption!);
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith(
-            "model",
-            "grok-build",
-        );
-    });
-
-    it("shows the model label when model options exist but no value is selected", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="grok-acp"
-                modelId=""
-                modeId=""
-                effortsByModel={{}}
-                models={[]}
-                modes={[]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "grok-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "",
-                        options: [
-                            { value: "composer-2.5", label: "Composer 2.5" },
-                            { value: "grok-build", label: "Grok Build" },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        expect(screen.getByTitle("Model")).toHaveTextContent("Model");
-    });
-
-    it("hides the model selector when there are no real model options", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="grok-acp"
-                modelId=""
-                modeId="yolo"
-                effortsByModel={{}}
-                models={[]}
-                modes={[
-                    {
-                        id: "yolo",
-                        runtimeId: "grok-acp",
-                        name: "YOLO",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        expect(screen.queryByTitle("Model")).not.toBeInTheDocument();
-        expect(screen.getByTitle("Approval Preset")).toBeInTheDocument();
-    });
-
-    it("does not show the model search field for non-searchable runtimes", () => {
-        renderComponent(
-            <AIChatAgentControls
-                runtimeId="codex-acp"
-                modelId="gpt-5.2-codex"
-                modeId="default"
-                effortsByModel={{}}
-                models={[]}
-                modes={[
-                    {
-                        id: "default",
-                        runtimeId: "codex-acp",
-                        name: "Auto",
-                        description: "",
-                        disabled: false,
-                    },
-                ]}
-                configOptions={[
-                    {
-                        id: "model",
-                        runtimeId: "codex-acp",
-                        category: "model",
-                        label: "Model",
-                        type: "select",
-                        value: "gpt-5.2-codex",
-                        options: [
-                            {
-                                value: "gpt-5.2-codex",
-                                label: "GPT 5.2 Codex",
-                            },
-                            {
-                                value: "gpt-5.4",
-                                label: "GPT 5.4",
-                            },
-                        ],
-                    },
-                ]}
-                onModelChange={() => {}}
-                onModeChange={() => {}}
-                onConfigOptionChange={() => {}}
-            />,
-        );
-
-        fireEvent.click(screen.getByTitle("Model"));
-
-        expect(screen.queryByLabelText("Model search")).not.toBeInTheDocument();
-    });
-
-    it("preserves the current focus when selecting a pointer-driven mode", async () => {
-        const user = userEvent.setup();
-        const onModeChange = vi.fn();
-
-        renderComponent(
-            <div>
-                <input aria-label="Composer focus target" />
-                <AIChatAgentControls
-                    runtimeId="codex-acp"
-                    modelId="gpt-5.2-codex"
-                    modeId="default"
-                    effortsByModel={{}}
-                    models={[
-                        {
-                            id: "gpt-5.2-codex",
-                            runtimeId: "codex-acp",
-                            name: "gpt-5.2-codex",
-                            description: "",
-                        },
-                    ]}
-                    modes={[
-                        {
-                            id: "default",
-                            runtimeId: "codex-acp",
-                            name: "Auto",
-                            description: "",
-                            disabled: false,
-                        },
-                        {
-                            id: "review",
-                            runtimeId: "codex-acp",
-                            name: "Review mode",
-                            description: "",
-                            disabled: false,
-                        },
-                    ]}
-                    configOptions={[]}
-                    onModelChange={() => {}}
-                    onModeChange={onModeChange}
-                    onConfigOptionChange={() => {}}
-                />
-            </div>,
-        );
-
-        const composer = screen.getByLabelText("Composer focus target");
-        composer.focus();
-        expect(composer).toHaveFocus();
-
-        await user.click(screen.getByTitle("Approval Preset"));
-        await user.click(screen.getByRole("button", { name: "Review mode" }));
-
-        expect(onModeChange).toHaveBeenCalledWith("review");
-        expect(composer).toHaveFocus();
-    });
-
-    it("restores the previous focus after choosing a searchable model", async () => {
-        const user = userEvent.setup();
-        const onConfigOptionChange = vi.fn();
-
-        renderComponent(
-            <div>
-                <input aria-label="Composer focus target" />
-                <AIChatAgentControls
-                    runtimeId="kilo-acp"
-                    modelId="gpt-4o"
-                    modeId="default"
-                    effortsByModel={{}}
-                    models={[]}
-                    modes={[
-                        {
-                            id: "default",
-                            runtimeId: "kilo-acp",
-                            name: "Auto",
-                            description: "",
-                            disabled: false,
-                        },
-                    ]}
-                    configOptions={[
-                        {
-                            id: "model",
-                            runtimeId: "kilo-acp",
-                            category: "model",
-                            label: "Model",
-                            type: "select",
-                            value: "gpt-4o",
-                            options: [
-                                {
-                                    value: "gpt-4o",
-                                    label: "Kilo Gateway/OpenAI: GPT-4o",
-                                },
-                                {
-                                    value: "claude-sonnet-4.6",
-                                    label: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
-                                },
-                            ],
-                        },
-                    ]}
-                    onModelChange={() => {}}
-                    onModeChange={() => {}}
-                    onConfigOptionChange={onConfigOptionChange}
-                />
-            </div>,
-        );
-
-        const composer = screen.getByLabelText("Composer focus target");
-        composer.focus();
-        expect(composer).toHaveFocus();
-
-        await user.click(screen.getByTitle("Model"));
-
-        const search = screen.getByLabelText("Model search");
-        expect(search).toHaveFocus();
-
-        await user.type(search, "claude");
-        await user.click(
-            screen.getByRole("button", {
-                name: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
-            }),
-        );
-
-        expect(onConfigOptionChange).toHaveBeenCalledWith(
-            "model",
-            "claude-sonnet-4.6",
-        );
-        expect(composer).toHaveFocus();
-    });
+          ]}
+          configOptions={[]}
+          onModelChange={() => {}}
+          onModeChange={onModeChange}
+          onConfigOptionChange={() => {}}
+        />
+      </div>,
+    );
+
+    const composer = screen.getByLabelText("Composer focus target");
+    composer.focus();
+    expect(composer).toHaveFocus();
+
+    await user.click(screen.getByTitle("Approval Preset"));
+    await user.click(screen.getByRole("button", { name: "Review mode" }));
+
+    expect(onModeChange).toHaveBeenCalledWith("review");
+    expect(composer).toHaveFocus();
+  });
+
+  it("restores the previous focus after choosing a searchable model", async () => {
+    const user = userEvent.setup();
+    const onConfigOptionChange = vi.fn();
+
+    renderComponent(
+      <div>
+        <input aria-label="Composer focus target" />
+        <AIChatAgentControls
+          runtimeId="kilo-acp"
+          modelId="gpt-4o"
+          modeId="default"
+          effortsByModel={{}}
+          models={[]}
+          modes={[
+            {
+              id: "default",
+              runtimeId: "kilo-acp",
+              name: "Auto",
+              description: "",
+              disabled: false,
+            },
+          ]}
+          configOptions={[
+            {
+              id: "model",
+              runtimeId: "kilo-acp",
+              category: "model",
+              label: "Model",
+              type: "select",
+              value: "gpt-4o",
+              options: [
+                {
+                  value: "gpt-4o",
+                  label: "Kilo Gateway/OpenAI: GPT-4o",
+                },
+                {
+                  value: "claude-sonnet-4.6",
+                  label: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
+                },
+              ],
+            },
+          ]}
+          onModelChange={() => {}}
+          onModeChange={() => {}}
+          onConfigOptionChange={onConfigOptionChange}
+        />
+      </div>,
+    );
+
+    const composer = screen.getByLabelText("Composer focus target");
+    composer.focus();
+    expect(composer).toHaveFocus();
+
+    await user.click(screen.getByTitle("Model"));
+
+    const search = screen.getByLabelText("Model search");
+    expect(search).toHaveFocus();
+
+    await user.type(search, "claude");
+    await user.click(
+      screen.getByRole("button", {
+        name: "Kilo Gateway/Anthropic: Claude Sonnet 4.6",
+      }),
+    );
+
+    expect(onConfigOptionChange).toHaveBeenCalledWith(
+      "model",
+      "claude-sonnet-4.6",
+    );
+    expect(composer).toHaveFocus();
+  });
 });

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -289,7 +289,7 @@ describe("AIChatAgentControls", () => {
     ).toBeInTheDocument();
   });
 
-  it("persists favorite models and opens the favorites rail first", async () => {
+  it("persists favorite models and opens favorites for a new conversation", async () => {
     const user = userEvent.setup();
     renderComponent(
       <AIChatAgentControls
@@ -355,6 +355,72 @@ describe("AIChatAgentControls", () => {
       runtimeId: "codex-acp",
       modelId: "gpt-5-mini",
     });
+  });
+
+  it("opens the active provider for a started conversation", async () => {
+    localStorage.setItem(
+      "neverwrite.ai.provider-model-picker-favorites",
+      JSON.stringify([{ runtimeId: "claude-acp", modelId: "claude-sonnet" }]),
+    );
+    const user = userEvent.setup();
+    renderComponent(
+      <AIChatAgentControls
+        conversationStarted
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+          {
+            runtimeId: "claude-acp",
+            label: "Claude",
+            description: "Claude provider",
+            disabledReason: null,
+            defaultModelId: "claude-sonnet",
+            models: [
+              {
+                modelId: "claude-sonnet",
+                label: "Claude Sonnet",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={() => {}}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+
+    expect(screen.getByRole("button", { name: "Codex" })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(
+      screen.getByRole("button", { name: "Codex · GPT-5" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Claude · Claude Sonnet" }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows contextual safety help only for Codex Full Access", () => {

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -269,7 +269,7 @@ describe("AIChatAgentControls", () => {
     await user.click(claudeRail);
 
     expect(
-      screen.getByTestId("provider-selection-blocked-popover"),
+      screen.getByTestId("provider-selection-blocked-notice"),
     ).toHaveTextContent("Start a new chat to use another provider.");
     expect(
       screen.getByRole("button", { name: "Codex · GPT-5" }),

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -59,6 +59,11 @@ describe("AIChatAgentControls", () => {
     );
 
     await user.click(screen.getByTitle("Provider and model"));
+    const modelMenu = screen.getByRole("dialog", {
+      name: "Provider and model",
+    });
+    expect(modelMenu).toHaveClass("nw-chat-glass-menu");
+    expect(modelMenu.parentElement).toBe(document.body);
     expect(screen.getByLabelText("Provider and model search")).toHaveFocus();
     await user.type(
       screen.getByLabelText("Provider and model search"),
@@ -450,6 +455,11 @@ describe("AIChatAgentControls", () => {
       screen.getByRole("button", { name: "Standard Default" }),
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Flex" })).toBeInTheDocument();
+    const traitMenu = screen
+      .getByRole("button", { name: "Fast" })
+      .closest(".nw-chat-glass-menu");
+    expect(traitMenu).not.toBeNull();
+    expect(traitMenu?.parentElement).toBe(document.body);
 
     fireEvent.click(screen.getByRole("button", { name: "Fast" }));
 

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -40,7 +40,7 @@ describe("AIChatAgentControls", () => {
             label: "Claude",
             description: "Claude provider",
             disabledReason:
-              "Finish the current turn before switching providers.",
+              "Finish the current turn before choosing another provider.",
             defaultModelId: "claude-sonnet",
             models: [
               {
@@ -72,10 +72,10 @@ describe("AIChatAgentControls", () => {
     const disabledClaude = screen.getByRole("button", {
       name: "Claude · Claude Sonnet",
     });
-    expect(disabledClaude).toBeDisabled();
+    expect(disabledClaude).toHaveAttribute("aria-disabled", "true");
     expect(disabledClaude).toHaveAttribute(
       "title",
-      "Finish the current turn before switching providers.",
+      "Finish the current turn before choosing another provider.",
     );
     await user.clear(screen.getByLabelText("Provider and model search"));
     const codexOption = screen
@@ -92,7 +92,6 @@ describe("AIChatAgentControls", () => {
     renderComponent(
       <AIChatAgentControls
         runtimeId="codex-acp"
-        providerSwitchLocked
         modelId="gpt-5"
         modeId="default"
         models={[]}
@@ -117,7 +116,7 @@ describe("AIChatAgentControls", () => {
             runtimeId: "claude-acp",
             label: "Claude",
             description: "Claude provider",
-            disabledReason: null,
+            disabledReason: "Start a new chat to use another provider.",
             defaultModelId: "claude-sonnet",
             models: [
               {
@@ -141,10 +140,8 @@ describe("AIChatAgentControls", () => {
     await user.click(claudeRail);
 
     expect(
-      screen.getByTestId("provider-switch-blocked-popover"),
-    ).toHaveTextContent(
-      "This chat is locked to Codex. Start a new chat to use Claude.",
-    );
+      screen.getByTestId("provider-selection-blocked-popover"),
+    ).toHaveTextContent("Start a new chat to use another provider.");
     expect(
       screen.getByRole("button", { name: "Codex · GPT 5" }),
     ).toBeInTheDocument();

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -33,6 +33,11 @@ describe("AIChatAgentControls", () => {
                 label: "GPT-5",
                 disabledReason: null,
               },
+              {
+                modelId: "fallback_model",
+                label: "",
+                disabledReason: null,
+              },
             ],
           },
           {
@@ -79,9 +84,12 @@ describe("AIChatAgentControls", () => {
     );
     await user.clear(screen.getByLabelText("Provider and model search"));
     const codexOption = screen
-      .getAllByRole("button", { name: "Codex · GPT 5" })
+      .getAllByRole("button", { name: "Codex · GPT-5" })
       .find((button) => button.getAttribute("title") === "Codex provider");
     expect(codexOption).toBeDefined();
+    expect(
+      screen.getByRole("button", { name: "Codex · Fallback model" }),
+    ).toBeInTheDocument();
     await user.click(codexOption!);
     expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
   });
@@ -143,7 +151,7 @@ describe("AIChatAgentControls", () => {
       screen.getByTestId("provider-selection-blocked-popover"),
     ).toHaveTextContent("Start a new chat to use another provider.");
     expect(
-      screen.getByRole("button", { name: "Codex · GPT 5" }),
+      screen.getByRole("button", { name: "Codex · GPT-5" }),
     ).toBeInTheDocument();
     expect(onProviderChange).not.toHaveBeenCalled();
 

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useId, useMemo, useRef, useState } from "react";
+import type { ConversationProviderPickerOption } from "../conversationPickerModel";
 import type { AIConfigOption, AIModeOption, AIModelOption } from "../types";
 
 interface AIChatAgentControlsProps {
@@ -11,6 +12,8 @@ interface AIChatAgentControlsProps {
     models: AIModelOption[];
     modes: AIModeOption[];
     configOptions: AIConfigOption[];
+    providers?: ConversationProviderPickerOption[];
+    onProviderModelChange?: (runtimeId: string, modelId: string) => void;
     onModelChange: (modelId: string) => void;
     onModeChange: (modeId: string) => void;
     onConfigOptionChange: (optionId: string, value: string) => void;
@@ -530,6 +533,8 @@ export function AIChatAgentControls({
     models,
     modes,
     configOptions,
+    providers = [],
+    onProviderModelChange,
     onModelChange,
     onModeChange,
     onConfigOptionChange,
@@ -565,6 +570,52 @@ export function AIChatAgentControls({
             runtimeId,
             selectedModelId,
         ],
+    );
+    const providerModelOptions = useMemo(
+        () =>
+            providers.flatMap((provider) => {
+                const models =
+                    provider.runtimeId === runtimeId &&
+                    lockedModelOptions.length > 0
+                        ? lockedModelOptions.map((model) => ({
+                              modelId: model.value,
+                              label: model.label,
+                              description: model.description,
+                              disabled: model.disabled,
+                          }))
+                        : provider.models.map((model) => ({
+                              modelId: model.modelId,
+                              label: formatFallbackLabel(model.label),
+                              description:
+                                  model.disabledReason ?? model.description,
+                              disabled: model.disabledReason != null,
+                          }));
+                const availableModels =
+                    models.length > 0
+                        ? models
+                        : [
+                              {
+                                  modelId: provider.defaultModelId,
+                                  label: "Default model",
+                                  description: provider.description,
+                                  disabled: false,
+                              },
+                          ];
+                return availableModels.map((model) => ({
+                    value: `${provider.runtimeId}\u0000${model.modelId}`,
+                    label:
+                        model.modelId || providers.length > 1
+                            ? `${provider.label} · ${model.label}`
+                            : provider.label,
+                    description:
+                        provider.disabledReason ??
+                        model.description ??
+                        provider.description,
+                    disabled:
+                        provider.disabledReason != null || model.disabled,
+                }));
+            }),
+        [lockedModelOptions, providers, runtimeId],
     );
     const extraConfigs = useMemo(
         () =>
@@ -605,6 +656,24 @@ export function AIChatAgentControls({
 
     return (
         <div className="flex min-w-0 flex-wrap items-center gap-1">
+            {providers.length > 0 && runtimeId && onProviderModelChange ? (
+                <DropdownField
+                    disabled={disabled}
+                    label="Provider and model"
+                    value={`${runtimeId}\u0000${selectedModelId}`}
+                    options={providerModelOptions}
+                    searchable={providerModelOptions.length > 10}
+                    searchPlaceholder="Search providers and models..."
+                    emptySearchMessage="No providers or models match that search."
+                    onChange={(value) => {
+                        const separator = value.indexOf("\u0000");
+                        onProviderModelChange(
+                            value.slice(0, separator),
+                            value.slice(separator + 1),
+                        );
+                    }}
+                />
+            ) : null}
             {modes.length > 0 ? (
                 <DropdownField
                     disabled={disabled}
@@ -620,7 +689,7 @@ export function AIChatAgentControls({
                 />
             ) : null}
             {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
-            {lockedModelOptions.length > 0 ? (
+            {providers.length === 0 && lockedModelOptions.length > 0 ? (
                 <DropdownField
                     disabled={disabled}
                     label="Model"

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -1,1016 +1,984 @@
 import {
-    useEffect,
-    useId,
-    useMemo,
-    useRef,
-    useState,
-    type ReactNode,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
 } from "react";
 import type { ConversationProviderPickerOption } from "../conversationPickerModel";
 import type { AIConfigOption, AIModeOption, AIModelOption } from "../types";
 import { AIProviderModelPicker } from "./AIProviderModelPicker";
 
 interface AIChatAgentControlsProps {
-    disabled?: boolean;
-    runtimeId?: string;
-    lockIncompatibleModelSwitches?: boolean;
-    modelId: string;
-    modeId: string;
-    effortsByModel?: Record<string, string[]>;
-    models: AIModelOption[];
-    modes: AIModeOption[];
-    configOptions: AIConfigOption[];
-    providers?: ConversationProviderPickerOption[];
-    onProviderModelChange?: (runtimeId: string, modelId: string) => void;
-    onModelChange: (modelId: string) => void;
-    onModeChange: (modeId: string) => void;
-    onConfigOptionChange: (optionId: string, value: string) => void;
+  disabled?: boolean;
+  runtimeId?: string;
+  lockIncompatibleModelSwitches?: boolean;
+  modelId: string;
+  modeId: string;
+  effortsByModel?: Record<string, string[]>;
+  models: AIModelOption[];
+  modes: AIModeOption[];
+  configOptions: AIConfigOption[];
+  providers?: ConversationProviderPickerOption[];
+  onProviderModelChange?: (runtimeId: string, modelId: string) => void;
+  onModelChange: (modelId: string) => void;
+  onModeChange: (modeId: string) => void;
+  onConfigOptionChange: (optionId: string, value: string) => void;
 }
 
 interface DropdownOption {
-    value: string;
-    label: string;
-    description?: string;
-    agentType?: string;
-    disabled?: boolean;
-    configOptionId?: string;
-    groupLabel?: string;
-    isDefault?: boolean;
-    selected?: boolean;
+  value: string;
+  label: string;
+  description?: string;
+  agentType?: string;
+  disabled?: boolean;
+  configOptionId?: string;
+  groupLabel?: string;
+  isDefault?: boolean;
+  selected?: boolean;
 }
 
 interface DropdownFieldProps {
-    disabled?: boolean;
-    label: string;
-    value: string;
-    options: DropdownOption[];
-    searchable?: boolean;
-    searchPlaceholder?: string;
-    emptySearchMessage?: string;
-    displayValue?: string;
-    menuMinWidth?: number;
-    leadingIcon?: ReactNode;
-    onChange?: (value: string) => void;
-    onOptionChange?: (value: string, option: DropdownOption) => void;
+  disabled?: boolean;
+  label: string;
+  value: string;
+  options: DropdownOption[];
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  emptySearchMessage?: string;
+  displayValue?: string;
+  menuMinWidth?: number;
+  leadingIcon?: ReactNode;
+  onChange?: (value: string) => void;
+  onOptionChange?: (value: string, option: DropdownOption) => void;
 }
 
 interface TraitMenuSection {
-    kind: "reasoning" | "service_tier";
-    optionId: string;
-    label: string;
-    value: string;
-    options: DropdownOption[];
-    defaultValues: string[];
+  kind: "reasoning" | "service_tier";
+  optionId: string;
+  label: string;
+  value: string;
+  options: DropdownOption[];
+  defaultValues: string[];
 }
 
-const SEARCHABLE_MODEL_RUNTIME_IDS = new Set([
-    "kilo-acp",
-    "opencode-acp",
-]);
+const SEARCHABLE_MODEL_RUNTIME_IDS = new Set(["kilo-acp", "opencode-acp"]);
 const GROK_RUNTIME_ID = "grok-acp";
 const CLAUDE_RUNTIME_ID = "claude-acp";
 const CLAUDE_FAST_OPTION_ID = "fast";
 const CODEX_RUNTIME_ID = "codex-acp";
 const CODEX_FULL_ACCESS_MODE_ID = "full-access";
 const CODEX_FULL_ACCESS_POLICY_HELP =
-    "Some destructive command forms may still be blocked by Codex safety policy.";
+  "Some destructive command forms may still be blocked by Codex safety policy.";
 
 function FullAccessPolicyHelp() {
-    const [open, setOpen] = useState(false);
-    const descriptionId = useId();
+  const [open, setOpen] = useState(false);
+  const descriptionId = useId();
 
-    return (
-        <div className="relative flex shrink-0 items-center">
-            <button
-                aria-describedby={open ? descriptionId : undefined}
-                aria-label="Full Access safety policy"
-                className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
-                onBlur={() => setOpen(false)}
-                onFocus={() => setOpen(true)}
-                onMouseEnter={() => setOpen(true)}
-                onMouseLeave={() => setOpen(false)}
-                style={{
-                    backgroundColor: "transparent",
-                    border: "1px solid var(--border)",
-                    color: "var(--text-secondary)",
-                }}
-                type="button"
-            >
-                ?
-            </button>
-            {open ? (
-                <div
-                    className="absolute bottom-full left-0 z-50 mb-1 w-72 rounded-lg px-3 py-2 text-xs"
-                    id={descriptionId}
-                    role="tooltip"
-                    style={{
-                        backgroundColor: "var(--bg-secondary)",
-                        border: "1px solid var(--border)",
-                        boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
-                        color: "var(--text-primary)",
-                        lineHeight: 1.4,
-                    }}
-                >
-                    {CODEX_FULL_ACCESS_POLICY_HELP}
-                </div>
-            ) : null}
+  return (
+    <div className="relative flex shrink-0 items-center">
+      <button
+        aria-describedby={open ? descriptionId : undefined}
+        aria-label="Full Access safety policy"
+        className="flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold"
+        onBlur={() => setOpen(false)}
+        onFocus={() => setOpen(true)}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        style={{
+          backgroundColor: "transparent",
+          border: "1px solid var(--border)",
+          color: "var(--text-secondary)",
+        }}
+        type="button"
+      >
+        ?
+      </button>
+      {open ? (
+        <div
+          className="absolute bottom-full left-0 z-50 mb-1 w-72 rounded-lg px-3 py-2 text-xs"
+          id={descriptionId}
+          role="tooltip"
+          style={{
+            backgroundColor: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            color: "var(--text-primary)",
+            lineHeight: 1.4,
+          }}
+        >
+          {CODEX_FULL_ACCESS_POLICY_HELP}
         </div>
-    );
+      ) : null}
+    </div>
+  );
 }
 
 function shouldUseSearchableModelMenu(runtimeId?: string) {
-    return (
-        runtimeId !== undefined && SEARCHABLE_MODEL_RUNTIME_IDS.has(runtimeId)
-    );
+  return runtimeId !== undefined && SEARCHABLE_MODEL_RUNTIME_IDS.has(runtimeId);
 }
 
 function formatFallbackLabel(value: string) {
-    if (value.trim().includes(" ")) {
-        return value;
-    }
+  if (value.trim().includes(" ")) {
+    return value;
+  }
 
-    return value
-        .replace(/_/g, " ")
-        .split("-")
-        .map((token) => {
-            if (!token) return token;
-            if (/^gpt$/i.test(token)) return "GPT";
-            if (/^claude$/i.test(token)) return "Claude";
-            if (/^\d+(\.\d+)?$/.test(token)) return token;
-            if (/^[a-z]\d+$/i.test(token)) return token.toUpperCase();
-            return token.charAt(0).toUpperCase() + token.slice(1);
-        })
-        .join(" ");
+  return value
+    .replace(/_/g, " ")
+    .split("-")
+    .map((token) => {
+      if (!token) return token;
+      if (/^gpt$/i.test(token)) return "GPT";
+      if (/^claude$/i.test(token)) return "Claude";
+      if (/^\d+(\.\d+)?$/.test(token)) return token;
+      if (/^[a-z]\d+$/i.test(token)) return token.toUpperCase();
+      return token.charAt(0).toUpperCase() + token.slice(1);
+    })
+    .join(" ");
 }
 
 function DropdownField({
-    disabled = false,
-    label,
-    value,
-    options,
-    searchable = false,
-    searchPlaceholder = "Search…",
-    emptySearchMessage = "No matches found.",
-    displayValue: displayValueOverride,
-    menuMinWidth,
-    leadingIcon,
-    onChange,
-    onOptionChange,
+  disabled = false,
+  label,
+  value,
+  options,
+  searchable = false,
+  searchPlaceholder = "Search…",
+  emptySearchMessage = "No matches found.",
+  displayValue: displayValueOverride,
+  menuMinWidth,
+  leadingIcon,
+  onChange,
+  onOptionChange,
 }: DropdownFieldProps) {
-    const [open, setOpen] = useState(false);
-    const [query, setQuery] = useState("");
-    const ref = useRef<HTMLDivElement>(null);
-    const searchInputRef = useRef<HTMLInputElement>(null);
-    const lastFocusedElementRef = useRef<HTMLElement | null>(null);
-    const selected = options.find(
-        (option) => option.selected ?? option.value === value,
-    );
-    const displayValue =
-        displayValueOverride ??
-        selected?.label ??
-        (value.trim() ? formatFallbackLabel(value) : label);
-    const isDisabled = disabled || options.length === 0;
-    const rememberFocusedElement = () => {
-        const activeElement = document.activeElement;
-        if (activeElement instanceof HTMLElement) {
-            lastFocusedElementRef.current = activeElement;
-        }
-    };
-    const restoreFocusedElement = () => {
-        const target = lastFocusedElementRef.current;
-        if (!target?.isConnected) {
-            return;
-        }
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const selected = options.find(
+    (option) => option.selected ?? option.value === value,
+  );
+  const displayValue =
+    displayValueOverride ??
+    selected?.label ??
+    (value.trim() ? formatFallbackLabel(value) : label);
+  const isDisabled = disabled || options.length === 0;
+  const rememberFocusedElement = () => {
+    const activeElement = document.activeElement;
+    if (activeElement instanceof HTMLElement) {
+      lastFocusedElementRef.current = activeElement;
+    }
+  };
+  const restoreFocusedElement = () => {
+    const target = lastFocusedElementRef.current;
+    if (!target?.isConnected) {
+      return;
+    }
 
-        target.focus();
-    };
-    const closeDropdown = () => {
-        setOpen(false);
-        setQuery("");
-    };
-    const filteredOptions = useMemo(() => {
-        const normalizedQuery = query.trim().toLowerCase();
-        if (!searchable || !normalizedQuery) {
-            return options;
-        }
+    target.focus();
+  };
+  const closeDropdown = () => {
+    setOpen(false);
+    setQuery("");
+  };
+  const filteredOptions = useMemo(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!searchable || !normalizedQuery) {
+      return options;
+    }
 
-        return options.filter((option) => {
-            const label = option.label.toLowerCase();
-            const rawValue = option.value.toLowerCase();
-            const description = option.description?.toLowerCase() ?? "";
-            return (
-                label.includes(normalizedQuery) ||
-                rawValue.includes(normalizedQuery) ||
-                description.includes(normalizedQuery)
-            );
-        });
-    }, [options, query, searchable]);
+    return options.filter((option) => {
+      const label = option.label.toLowerCase();
+      const rawValue = option.value.toLowerCase();
+      const description = option.description?.toLowerCase() ?? "";
+      return (
+        label.includes(normalizedQuery) ||
+        rawValue.includes(normalizedQuery) ||
+        description.includes(normalizedQuery)
+      );
+    });
+  }, [options, query, searchable]);
 
-    useEffect(() => {
-        if (!open) return;
-        const handleClick = (event: MouseEvent) => {
-            if (ref.current?.contains(event.target as Node)) return;
+  useEffect(() => {
+    if (!open) return;
+    const handleClick = (event: MouseEvent) => {
+      if (ref.current?.contains(event.target as Node)) return;
+      closeDropdown();
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+
+    if (searchable) {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    }
+  }, [open, searchable]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onMouseDown={(event) => {
+          if (isDisabled) return;
+          rememberFocusedElement();
+          // Keep the composer focused during pointer interactions so
+          // Cmd+Enter continues to submit immediately after a change.
+          event.preventDefault();
+        }}
+        onClick={() => {
+          if (isDisabled) return;
+          if (open) {
             closeDropdown();
-        };
-        document.addEventListener("mousedown", handleClick);
-        return () => document.removeEventListener("mousedown", handleClick);
-    }, [open]);
-
-    useEffect(() => {
-        if (!open) return;
-
-        if (searchable) {
-            searchInputRef.current?.focus();
-            searchInputRef.current?.select();
-        }
-    }, [open, searchable]);
-
-    return (
-        <div ref={ref} className="relative">
-            <button
-                type="button"
-                onMouseDown={(event) => {
-                    if (isDisabled) return;
-                    rememberFocusedElement();
-                    // Keep the composer focused during pointer interactions so
-                    // Cmd+Enter continues to submit immediately after a change.
-                    event.preventDefault();
-                }}
-                onClick={() => {
-                    if (isDisabled) return;
-                    if (open) {
-                        closeDropdown();
-                        return;
-                    }
-                    rememberFocusedElement();
-                    setOpen(true);
-                }}
-                className="nw-control-trigger flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs"
-                data-open={open ? "true" : undefined}
-                style={{
-                    color: "var(--text-secondary)",
-                    backgroundColor: "transparent",
-                    border: "none",
-                    opacity: isDisabled ? 0.45 : 1,
-                }}
-                title={label}
-                disabled={isDisabled}
+            return;
+          }
+          rememberFocusedElement();
+          setOpen(true);
+        }}
+        className="nw-control-trigger flex cursor-pointer items-center gap-1 rounded-md px-2 py-1 text-xs"
+        data-open={open ? "true" : undefined}
+        style={{
+          color: "var(--text-secondary)",
+          backgroundColor: "transparent",
+          border: "none",
+          opacity: isDisabled ? 0.45 : 1,
+        }}
+        title={label}
+        disabled={isDisabled}
+      >
+        {leadingIcon}
+        <span className="truncate">{displayValue}</span>
+        <svg
+          width="10"
+          height="10"
+          viewBox="0 0 10 10"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          style={{
+            opacity: 0.5,
+            transform: open ? "rotate(180deg)" : "none",
+            transition: "transform 0.1s ease",
+          }}
+        >
+          <path d="M2.5 4L5 6.5L7.5 4" />
+        </svg>
+      </button>
+      {open && options.length > 0 && (
+        <div
+          className="absolute bottom-full left-0 z-50 mb-1 min-w-35 overflow-hidden rounded-lg py-1"
+          style={{
+            backgroundColor: "var(--bg-secondary)",
+            border: "1px solid var(--border)",
+            boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            minWidth: menuMinWidth,
+            maxHeight: searchable ? 320 : undefined,
+            display: searchable ? "flex" : undefined,
+            flexDirection: searchable ? "column" : undefined,
+          }}
+        >
+          {searchable && (
+            <div
+              className="mx-1 mb-1 flex items-center gap-1.5 rounded-md"
+              style={{
+                backgroundColor: "var(--bg-primary)",
+                border: "1px solid var(--border)",
+                height: 24,
+                padding: "0 7px",
+              }}
             >
-                {leadingIcon}
-                <span className="truncate">{displayValue}</span>
-                <svg
-                    width="10"
-                    height="10"
-                    viewBox="0 0 10 10"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    style={{
-                        opacity: 0.5,
-                        transform: open ? "rotate(180deg)" : "none",
-                        transition: "transform 0.1s ease",
-                    }}
-                >
-                    <path d="M2.5 4L5 6.5L7.5 4" />
-                </svg>
-            </button>
-            {open && options.length > 0 && (
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 16 16"
+                fill="none"
+                style={{ opacity: 0.4, flexShrink: 0 }}
+                aria-hidden="true"
+              >
+                <circle
+                  cx="7"
+                  cy="7"
+                  r="5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                />
+                <path
+                  d="m13 13-2.5-2.5"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+              <input
+                ref={searchInputRef}
+                type="text"
+                value={query}
+                onChange={(event) => {
+                  setQuery(event.target.value);
+                }}
+                onKeyDown={(event) => {
+                  event.stopPropagation();
+                }}
+                placeholder={searchPlaceholder}
+                aria-label={`${label} search`}
+                className="min-w-0 flex-1 bg-transparent text-xs outline-none"
+                style={{
+                  color: "var(--text-primary)",
+                  border: "none",
+                  fontFamily: "inherit",
+                  // The global `input { font: inherit }` reset in
+                  // index.css lives outside Tailwind's cascade
+                  // layers, so it always wins over the `text-xs`
+                  // utility here regardless of specificity. Pin
+                  // the size/line-height inline to match the
+                  // option rows, which aren't affected (buttons
+                  // aren't targeted by that reset).
+                  fontSize: "0.75rem",
+                  lineHeight: "calc(1 / 0.75)",
+                }}
+              />
+              <span
+                className="shrink-0 font-mono text-[9px]"
+                style={{ color: "var(--text-secondary)" }}
+              >
+                {filteredOptions.length}/{options.length}
+              </span>
+            </div>
+          )}
+          <div
+            style={{
+              maxHeight: searchable ? 240 : undefined,
+              overflowY: searchable ? "auto" : undefined,
+              flex: searchable ? "1 1 auto" : undefined,
+            }}
+          >
+            {filteredOptions.length === 0 ? (
+              <div
+                className="px-3 py-2 text-xs"
+                style={{
+                  color: "var(--text-secondary)",
+                }}
+              >
+                {emptySearchMessage}
+              </div>
+            ) : (
+              filteredOptions.map((option, index) => (
                 <div
-                    className="absolute bottom-full left-0 z-50 mb-1 min-w-35 overflow-hidden rounded-lg py-1"
-                    style={{
-                        backgroundColor: "var(--bg-secondary)",
-                        border: "1px solid var(--border)",
-                        boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
-                        minWidth: menuMinWidth,
-                        maxHeight: searchable ? 320 : undefined,
-                        display: searchable ? "flex" : undefined,
-                        flexDirection: searchable ? "column" : undefined,
-                    }}
+                  key={`${option.groupLabel ?? ""}:${option.configOptionId ?? ""}:${option.value}`}
+                  style={{
+                    borderTop:
+                      option.groupLabel &&
+                      index > 0 &&
+                      filteredOptions[index - 1]?.groupLabel !==
+                        option.groupLabel
+                        ? "1px solid var(--border)"
+                        : undefined,
+                  }}
                 >
-                    {searchable && (
-                        <div
-                            className="mx-1 mb-1 flex items-center gap-1.5 rounded-md"
-                            style={{
-                                backgroundColor: "var(--bg-primary)",
-                                border: "1px solid var(--border)",
-                                height: 24,
-                                padding: "0 7px",
-                            }}
-                        >
-                            <svg
-                                width="10"
-                                height="10"
-                                viewBox="0 0 16 16"
-                                fill="none"
-                                style={{ opacity: 0.4, flexShrink: 0 }}
-                                aria-hidden="true"
-                            >
-                                <circle
-                                    cx="7"
-                                    cy="7"
-                                    r="5"
-                                    stroke="currentColor"
-                                    strokeWidth="1.5"
-                                />
-                                <path
-                                    d="m13 13-2.5-2.5"
-                                    stroke="currentColor"
-                                    strokeWidth="1.5"
-                                    strokeLinecap="round"
-                                />
-                            </svg>
-                            <input
-                                ref={searchInputRef}
-                                type="text"
-                                value={query}
-                                onChange={(event) => {
-                                    setQuery(event.target.value);
-                                }}
-                                onKeyDown={(event) => {
-                                    event.stopPropagation();
-                                }}
-                                placeholder={searchPlaceholder}
-                                aria-label={`${label} search`}
-                                className="min-w-0 flex-1 bg-transparent text-xs outline-none"
-                                style={{
-                                    color: "var(--text-primary)",
-                                    border: "none",
-                                    fontFamily: "inherit",
-                                    // The global `input { font: inherit }` reset in
-                                    // index.css lives outside Tailwind's cascade
-                                    // layers, so it always wins over the `text-xs`
-                                    // utility here regardless of specificity. Pin
-                                    // the size/line-height inline to match the
-                                    // option rows, which aren't affected (buttons
-                                    // aren't targeted by that reset).
-                                    fontSize: "0.75rem",
-                                    lineHeight: "calc(1 / 0.75)",
-                                }}
-                            />
-                            <span
-                                className="shrink-0 font-mono text-[9px]"
-                                style={{ color: "var(--text-secondary)" }}
-                            >
-                                {filteredOptions.length}/{options.length}
-                            </span>
-                        </div>
-                    )}
+                  {option.groupLabel &&
+                  (index === 0 ||
+                    filteredOptions[index - 1]?.groupLabel !==
+                      option.groupLabel) ? (
                     <div
-                        style={{
-                            maxHeight: searchable ? 240 : undefined,
-                            overflowY: searchable ? "auto" : undefined,
-                            flex: searchable ? "1 1 auto" : undefined,
-                        }}
+                      className="px-3 pb-1 pt-1.5 text-[10px] font-medium"
+                      style={{
+                        color: "var(--text-secondary)",
+                      }}
                     >
-                        {filteredOptions.length === 0 ? (
-                            <div
-                                className="px-3 py-2 text-xs"
-                                style={{
-                                    color: "var(--text-secondary)",
-                                }}
-                            >
-                                {emptySearchMessage}
-                            </div>
-                        ) : (
-                            filteredOptions.map((option, index) => (
-                                <div
-                                    key={`${option.groupLabel ?? ""}:${option.configOptionId ?? ""}:${option.value}`}
-                                    style={{
-                                        borderTop:
-                                            option.groupLabel &&
-                                            index > 0 &&
-                                            filteredOptions[index - 1]
-                                                ?.groupLabel !== option.groupLabel
-                                                ? "1px solid var(--border)"
-                                                : undefined,
-                                    }}
-                                >
-                                    {option.groupLabel &&
-                                    (index === 0 ||
-                                        filteredOptions[index - 1]
-                                            ?.groupLabel !==
-                                            option.groupLabel) ? (
-                                        <div
-                                            className="px-3 pb-1 pt-1.5 text-[10px] font-medium"
-                                            style={{
-                                                color: "var(--text-secondary)",
-                                            }}
-                                        >
-                                            {option.groupLabel}
-                                        </div>
-                                    ) : null}
-                                    <button
-                                        type="button"
-                                        disabled={option.disabled}
-                                        title={option.description}
-                                        onMouseDown={(event) => {
-                                            if (option.disabled) {
-                                                return;
-                                            }
-
-                                            event.preventDefault();
-                                        }}
-                                        onClick={() => {
-                                            if (onOptionChange) {
-                                                onOptionChange(
-                                                    option.value,
-                                                    option,
-                                                );
-                                            } else {
-                                                onChange?.(option.value);
-                                            }
-                                            closeDropdown();
-                                            restoreFocusedElement();
-                                        }}
-                                        className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-xs"
-                                        style={{
-                                            color:
-                                                option.selected === true
-                                                    ? "var(--text-primary)"
-                                                    : option.value === value
-                                                      ? "var(--accent)"
-                                                      : option.disabled
-                                                        ? "var(--text-secondary)"
-                                                        : "var(--text-primary)",
-                                            backgroundColor:
-                                                option.selected === true
-                                                    ? "var(--bg-tertiary)"
-                                                    : "transparent",
-                                            border: "none",
-                                            opacity: option.disabled ? 0.4 : 1,
-                                            transition:
-                                                "background-color 80ms ease",
-                                        }}
-                                        onMouseEnter={(event) => {
-                                            if (!option.disabled) {
-                                                event.currentTarget.style.backgroundColor =
-                                                    "var(--bg-tertiary)";
-                                            }
-                                        }}
-                                        onMouseLeave={(event) => {
-                                            event.currentTarget.style.backgroundColor =
-                                                option.selected === true
-                                                    ? "var(--bg-tertiary)"
-                                                    : "transparent";
-                                        }}
-                                    >
-                                        <span className="truncate">
-                                            {option.label}
-                                        </span>
-                                        {option.isDefault ? (
-                                            <span
-                                                className="ml-3 shrink-0 rounded px-1 py-0.5 font-mono text-[9px] font-semibold leading-none"
-                                                style={{
-                                                    backgroundColor:
-                                                        "var(--bg-primary)",
-                                                    color: "var(--text-secondary)",
-                                                }}
-                                            >
-                                                Default
-                                            </span>
-                                        ) : null}
-                                    </button>
-                                </div>
-                            ))
-                        )}
+                      {option.groupLabel}
                     </div>
+                  ) : null}
+                  <button
+                    type="button"
+                    disabled={option.disabled}
+                    title={option.description}
+                    onMouseDown={(event) => {
+                      if (option.disabled) {
+                        return;
+                      }
+
+                      event.preventDefault();
+                    }}
+                    onClick={() => {
+                      if (onOptionChange) {
+                        onOptionChange(option.value, option);
+                      } else {
+                        onChange?.(option.value);
+                      }
+                      closeDropdown();
+                      restoreFocusedElement();
+                    }}
+                    className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-xs"
+                    style={{
+                      color:
+                        option.selected === true
+                          ? "var(--text-primary)"
+                          : option.value === value
+                            ? "var(--accent)"
+                            : option.disabled
+                              ? "var(--text-secondary)"
+                              : "var(--text-primary)",
+                      backgroundColor:
+                        option.selected === true
+                          ? "var(--bg-tertiary)"
+                          : "transparent",
+                      border: "none",
+                      opacity: option.disabled ? 0.4 : 1,
+                      transition: "background-color 80ms ease",
+                    }}
+                    onMouseEnter={(event) => {
+                      if (!option.disabled) {
+                        event.currentTarget.style.backgroundColor =
+                          "var(--bg-tertiary)";
+                      }
+                    }}
+                    onMouseLeave={(event) => {
+                      event.currentTarget.style.backgroundColor =
+                        option.selected === true
+                          ? "var(--bg-tertiary)"
+                          : "transparent";
+                    }}
+                  >
+                    <span className="truncate">{option.label}</span>
+                    {option.isDefault ? (
+                      <span
+                        className="ml-3 shrink-0 rounded px-1 py-0.5 font-mono text-[9px] font-semibold leading-none"
+                        style={{
+                          backgroundColor: "var(--bg-primary)",
+                          color: "var(--text-secondary)",
+                        }}
+                      >
+                        Default
+                      </span>
+                    ) : null}
+                  </button>
                 </div>
+              ))
             )}
+          </div>
         </div>
-    );
+      )}
+    </div>
+  );
 }
 
 function isFastServiceTierValue(value: string) {
-    return ["fast", "on", "priority"].includes(
-        normalizeConfigOptionId(value),
-    );
+  return ["fast", "on", "priority"].includes(normalizeConfigOptionId(value));
 }
 
 function FastModeIcon() {
-    return (
-        <svg
-            aria-hidden="true"
-            className="shrink-0"
-            fill="currentColor"
-            height="11"
-            viewBox="0 0 16 16"
-            width="11"
-        >
-            <path d="M9.35 1.25 3.4 8.45h3.75l-.5 6.3 5.95-7.2H8.85l.5-6.3Z" />
-        </svg>
-    );
+  return (
+    <svg
+      aria-hidden="true"
+      className="shrink-0"
+      fill="currentColor"
+      height="11"
+      viewBox="0 0 16 16"
+      width="11"
+    >
+      <path d="M9.35 1.25 3.4 8.45h3.75l-.5 6.3 5.95-7.2H8.85l.5-6.3Z" />
+    </svg>
+  );
 }
 
 function PermissionModeIcon({ fullAccess }: { fullAccess: boolean }) {
-    return (
-        <svg
-            aria-hidden="true"
-            className="shrink-0 opacity-70"
-            fill="none"
-            height="13"
-            viewBox="0 0 16 16"
-            width="13"
-        >
-            <rect
-                height="8"
-                rx="1.5"
-                stroke="currentColor"
-                strokeWidth="1.35"
-                width="10"
-                x="3"
-                y="6.5"
-            />
-            <path
-                d={
-                    fullAccess
-                        ? "M5.25 6.5V5a2.75 2.75 0 0 1 5.05-1.51"
-                        : "M5.25 6.5V5a2.75 2.75 0 0 1 5.5 0v1.5"
-                }
-                stroke="currentColor"
-                strokeLinecap="round"
-                strokeWidth="1.35"
-            />
-        </svg>
-    );
+  return (
+    <svg
+      aria-hidden="true"
+      className="shrink-0 opacity-70"
+      fill="none"
+      height="13"
+      viewBox="0 0 16 16"
+      width="13"
+    >
+      <rect
+        height="8"
+        rx="1.5"
+        stroke="currentColor"
+        strokeWidth="1.35"
+        width="10"
+        x="3"
+        y="6.5"
+      />
+      <path
+        d={
+          fullAccess
+            ? "M5.25 6.5V5a2.75 2.75 0 0 1 5.05-1.51"
+            : "M5.25 6.5V5a2.75 2.75 0 0 1 5.5 0v1.5"
+        }
+        stroke="currentColor"
+        strokeLinecap="round"
+        strokeWidth="1.35"
+      />
+    </svg>
+  );
 }
 
 function ControlSeparator() {
-    return (
-        <span
-            aria-hidden="true"
-            className="mx-0.5 h-4 w-px"
-            style={{ backgroundColor: "var(--border)" }}
-        />
-    );
+  return (
+    <span
+      aria-hidden="true"
+      className="mx-0.5 h-4 w-px"
+      style={{ backgroundColor: "var(--border)" }}
+    />
+  );
 }
 
 function mapConfigOption(option: AIConfigOption): DropdownOption[] {
-    return option.options.map((item) => ({
-        value: item.value,
-        label: item.label,
-        description: item.description,
-        agentType: item.agentType,
-    }));
+  return option.options.map((item) => ({
+    value: item.value,
+    label: item.label,
+    description: item.description,
+    agentType: item.agentType,
+  }));
 }
 
 function applyGrokModelSwitchLock(
-    runtimeId: string | undefined,
-    selectedModelId: string,
-    options: DropdownOption[],
-    lockIncompatibleModelSwitches: boolean,
+  runtimeId: string | undefined,
+  selectedModelId: string,
+  options: DropdownOption[],
+  lockIncompatibleModelSwitches: boolean,
 ): DropdownOption[] {
+  if (
+    runtimeId !== GROK_RUNTIME_ID ||
+    !lockIncompatibleModelSwitches ||
+    !selectedModelId
+  ) {
+    return options;
+  }
+
+  const selectedAgentType = options.find(
+    (option) => option.value === selectedModelId,
+  )?.agentType;
+  if (!selectedAgentType) {
+    return options;
+  }
+
+  return options.map((option) => {
     if (
-        runtimeId !== GROK_RUNTIME_ID ||
-        !lockIncompatibleModelSwitches ||
-        !selectedModelId
+      option.value === selectedModelId ||
+      !option.agentType ||
+      option.agentType === selectedAgentType
     ) {
-        return options;
+      return option;
     }
 
-    const selectedAgentType = options.find(
-        (option) => option.value === selectedModelId,
-    )?.agentType;
-    if (!selectedAgentType) {
-        return options;
-    }
-
-    return options.map((option) => {
-        if (
-            option.value === selectedModelId ||
-            !option.agentType ||
-            option.agentType === selectedAgentType
-        ) {
-            return option;
-        }
-
-        return {
-            ...option,
-            disabled: true,
-            description: option.description
-                ? `${option.description} Start a new Grok chat to switch to this model.`
-                : "Start a new Grok chat to switch to this model.",
-        };
-    });
-}
-
-function filterConfigOptions(
-    option: AIConfigOption,
-    modelId: string,
-    effortsByModel?: Record<string, string[]>,
-) {
-    if (option.category !== "reasoning") {
-        return mapConfigOption(option);
-    }
-
-    const supportedEfforts = effortsByModel?.[modelId];
-    const hasModelEffortMetadata =
-        effortsByModel &&
-        Object.prototype.hasOwnProperty.call(effortsByModel, modelId);
-    const items = hasModelEffortMetadata
-        ? option.options.filter((item) =>
-              supportedEfforts?.includes(item.value),
-          )
-        : option.options;
-
-    return items.map((item) => ({
-        value: item.value,
-        label: item.label,
-        description: item.description,
-    }));
+    return {
+      ...option,
+      disabled: true,
+      description: option.description
+        ? `${option.description} Start a new Grok chat to switch to this model.`
+        : "Start a new Grok chat to switch to this model.",
+    };
+  });
 }
 
 function isDuplicateThoughtLevelMode(
-    option: AIConfigOption,
-    modes: AIModeOption[],
-    modeId: string,
+  option: AIConfigOption,
+  modes: AIModeOption[],
+  modeId: string,
 ) {
-    if (
-        option.category !== "reasoning" ||
-        option.id.replace(/[^a-z0-9]/gi, "").toLowerCase() !==
-            "thoughtlevel" ||
-        option.value !== modeId ||
-        modes.length === 0 ||
-        modes.some((mode) => mode.disabled)
-    ) {
-        return false;
-    }
+  if (
+    option.category !== "reasoning" ||
+    option.id.replace(/[^a-z0-9]/gi, "").toLowerCase() !== "thoughtlevel" ||
+    option.value !== modeId ||
+    modes.length === 0 ||
+    modes.some((mode) => mode.disabled)
+  ) {
+    return false;
+  }
 
-    const modeIds = new Set(modes.map((mode) => mode.id));
-    const optionValues = new Set(option.options.map((item) => item.value));
-    return (
-        modeIds.size === modes.length &&
-        optionValues.size === option.options.length &&
-        modeIds.size === optionValues.size &&
-        [...modeIds].every((modeId) => optionValues.has(modeId))
-    );
+  const modeIds = new Set(modes.map((mode) => mode.id));
+  const optionValues = new Set(option.options.map((item) => item.value));
+  return (
+    modeIds.size === modes.length &&
+    optionValues.size === option.options.length &&
+    modeIds.size === optionValues.size &&
+    [...modeIds].every((modeId) => optionValues.has(modeId))
+  );
 }
 
 function normalizeConfigOptionId(value: string) {
-    return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
 }
 
 function configPresentationCategory(
-    runtimeId: string | undefined,
-    option: AIConfigOption,
+  runtimeId: string | undefined,
+  option: AIConfigOption,
 ) {
-    if (option.category === "reasoning") {
-        return "reasoning" as const;
-    }
-    if (option.category === "service_tier") {
-        return "service_tier" as const;
-    }
+  if (option.category === "reasoning") {
+    return "reasoning" as const;
+  }
+  if (option.category === "service_tier") {
+    return "service_tier" as const;
+  }
 
-    const normalizedId = normalizeConfigOptionId(option.id);
-    if (
-        normalizedId === "servicetier" ||
-        normalizedId === "fastmode" ||
-        (runtimeId === CLAUDE_RUNTIME_ID &&
-            option.id === CLAUDE_FAST_OPTION_ID)
-    ) {
-        return "service_tier" as const;
-    }
+  const normalizedId = normalizeConfigOptionId(option.id);
+  if (
+    normalizedId === "servicetier" ||
+    normalizedId === "fastmode" ||
+    (runtimeId === CLAUDE_RUNTIME_ID && option.id === CLAUDE_FAST_OPTION_ID)
+  ) {
+    return "service_tier" as const;
+  }
 
-    return "other" as const;
+  return "other" as const;
 }
 
 function normalizeServiceTierOptions(
-    options: DropdownOption[],
-    description?: string,
+  options: DropdownOption[],
+  description?: string,
 ) {
-    return options.map((item) => {
-        const value = normalizeConfigOptionId(item.value);
-        if (["off", "default", "standard", "normal"].includes(value)) {
-            return { ...item, label: "Standard" };
-        }
-        if (["fast", "on", "priority"].includes(value)) {
-            return {
-                ...item,
-                label: "Fast",
-                description: item.description ?? description,
-            };
-        }
-        return item;
-    });
+  return options.map((item) => {
+    const value = normalizeConfigOptionId(item.value);
+    if (["off", "default", "standard", "normal"].includes(value)) {
+      return { ...item, label: "Standard" };
+    }
+    if (["fast", "on", "priority"].includes(value)) {
+      return {
+        ...item,
+        label: "Fast",
+        description: item.description ?? description,
+      };
+    }
+    return item;
+  });
 }
 
 function defaultServiceTierValues(options: DropdownOption[]) {
-    return options
-        .filter((item) =>
-            ["off", "default", "standard", "normal"].includes(
-                normalizeConfigOptionId(item.value),
-            ),
-        )
-        .map((item) => item.value);
+  return options
+    .filter((item) =>
+      ["off", "default", "standard", "normal"].includes(
+        normalizeConfigOptionId(item.value),
+      ),
+    )
+    .map((item) => item.value);
+}
+
+function claudeModelSupportsFastMode(modelId: string) {
+  const normalized = normalizeConfigOptionId(modelId);
+  return normalized === "opus" || normalized.includes("claudeopus");
 }
 
 export function AIChatAgentControls({
-    disabled = false,
-    runtimeId,
-    lockIncompatibleModelSwitches = false,
-    modelId,
-    modeId,
-    effortsByModel,
-    models,
-    modes,
-    configOptions,
-    providers = [],
-    onProviderModelChange,
-    onModelChange,
-    onModeChange,
-    onConfigOptionChange,
+  disabled = false,
+  runtimeId,
+  lockIncompatibleModelSwitches = false,
+  modelId,
+  modeId,
+  models,
+  modes,
+  configOptions,
+  providers = [],
+  onProviderModelChange,
+  onModelChange,
+  onModeChange,
+  onConfigOptionChange,
 }: AIChatAgentControlsProps) {
-    const modelConfig = useMemo(
-        () => configOptions.find((option) => option.category === "model"),
-        [configOptions],
-    );
-    const modelOptions = useMemo(
-        () =>
-            modelConfig
-                ? mapConfigOption(modelConfig)
-                : models.map((model) => ({
-                  value: model.id,
-                  label: formatFallbackLabel(model.name),
-                  description: model.description,
-                  agentType: model.agentType,
+  const modelConfig = useMemo(
+    () => configOptions.find((option) => option.category === "model"),
+    [configOptions],
+  );
+  const modelOptions = useMemo(
+    () =>
+      modelConfig
+        ? mapConfigOption(modelConfig)
+        : models.map((model) => ({
+            value: model.id,
+            label: formatFallbackLabel(model.name),
+            description: model.description,
+            agentType: model.agentType,
+          })),
+    [modelConfig, models],
+  );
+  const selectedModelId = modelConfig?.value ?? modelId;
+  const lockedModelOptions = useMemo(
+    () =>
+      applyGrokModelSwitchLock(
+        runtimeId,
+        selectedModelId,
+        modelOptions,
+        lockIncompatibleModelSwitches,
+      ),
+    [lockIncompatibleModelSwitches, modelOptions, runtimeId, selectedModelId],
+  );
+  const providerPickerOptions = useMemo(
+    () =>
+      providers.map((provider) => ({
+        ...provider,
+        models:
+          provider.runtimeId === runtimeId && lockedModelOptions.length > 0
+            ? lockedModelOptions.map((model) => ({
+                modelId: model.value,
+                label: model.label,
+                description: model.description,
+                disabledReason: model.disabled
+                  ? (model.description ?? "This model is unavailable.")
+                  : null,
+              }))
+            : provider.models.map((model) => ({
+                ...model,
+                label: formatFallbackLabel(model.label),
               })),
-        [modelConfig, models],
-    );
-    const selectedModelId = modelConfig?.value ?? modelId;
-    const lockedModelOptions = useMemo(
-        () =>
-            applyGrokModelSwitchLock(
-                runtimeId,
-                selectedModelId,
-                modelOptions,
-                lockIncompatibleModelSwitches,
-            ),
-        [
-            lockIncompatibleModelSwitches,
-            modelOptions,
-            runtimeId,
-            selectedModelId,
+      })),
+    [lockedModelOptions, providers, runtimeId],
+  );
+  const extraConfigs = useMemo(
+    () =>
+      [...configOptions]
+        .filter(
+          (option) =>
+            option.category !== "mode" &&
+            option.category !== "model" &&
+            !isDuplicateThoughtLevelMode(option, modes, modeId),
+        )
+        .sort((left, right) => {
+          const rank = (option: AIConfigOption) =>
+            option.category === "reasoning" ? 0 : 1;
+          return rank(left) - rank(right);
+        }),
+    [configOptions, modeId, modes],
+  );
+  const visibleConfigs = useMemo(
+    () =>
+      extraConfigs
+        .map((option) => ({
+          option,
+          presentationCategory: configPresentationCategory(runtimeId, option),
+          // Session config options are the ACP's authoritative view
+          // for the selected model. `effortsByModel` is discovery
+          // metadata and can be empty or stale during a handoff.
+          options: mapConfigOption(option),
+        }))
+        .filter(({ options }) => options.length > 0),
+    [extraConfigs, runtimeId],
+  );
+  const traitSections = useMemo<TraitMenuSection[]>(() => {
+    // Reasoning effort and service tier are separate ACP options, but they
+    // belong to one compact composer control. Keep their option ids intact so
+    // selecting an item still updates the provider-owned setting directly.
+    const sections = visibleConfigs
+      .filter(
+        ({ presentationCategory }) =>
+          presentationCategory === "reasoning" ||
+          presentationCategory === "service_tier",
+      )
+      .sort((left, right) =>
+        left.presentationCategory === right.presentationCategory
+          ? 0
+          : left.presentationCategory === "reasoning"
+            ? -1
+            : 1,
+      )
+      .map(({ option, options, presentationCategory }) => ({
+        kind: presentationCategory as "reasoning" | "service_tier",
+        optionId: option.id,
+        label:
+          presentationCategory === "reasoning" ? "Reasoning" : "Service Tier",
+        value: option.value,
+        options:
+          presentationCategory === "service_tier"
+            ? normalizeServiceTierOptions(options, option.description)
+            : options,
+        defaultValues:
+          presentationCategory === "service_tier"
+            ? defaultServiceTierValues(options)
+            : [],
+      }));
+
+    if (
+      runtimeId === CLAUDE_RUNTIME_ID &&
+      !sections.some((section) => section.kind === "service_tier")
+    ) {
+      // Claude only advertises `fast` after selecting a compatible model
+      // (currently Opus). Showing the stable Standard/Fast section avoids the
+      // control disappearing across model changes while still preventing an
+      // unsupported Fast selection.
+      const fastSupported = claudeModelSupportsFastMode(selectedModelId);
+      sections.push({
+        kind: "service_tier",
+        optionId: CLAUDE_FAST_OPTION_ID,
+        label: "Service Tier",
+        value: "off",
+        options: [
+          {
+            value: "off",
+            label: "Standard",
+          },
+          {
+            value: "on",
+            label: "Fast",
+            disabled: !fastSupported,
+            description: fastSupported
+              ? "Use Claude Fast mode."
+              : "Fast is unavailable for the selected Claude model.",
+          },
         ],
-    );
-    const providerPickerOptions = useMemo(
-        () =>
-            providers.map((provider) => ({
-                ...provider,
-                models:
-                    provider.runtimeId === runtimeId &&
-                    lockedModelOptions.length > 0
-                        ? lockedModelOptions.map((model) => ({
-                              modelId: model.value,
-                              label: model.label,
-                              description: model.description,
-                              disabledReason: model.disabled
-                                  ? (model.description ?? "This model is unavailable.")
-                                  : null,
-                          }))
-                        : provider.models.map((model) => ({
-                              ...model,
-                              label: formatFallbackLabel(model.label),
-                          })),
-            })),
-        [lockedModelOptions, providers, runtimeId],
-    );
-    const extraConfigs = useMemo(
-        () =>
-            [...configOptions]
-                .filter(
-                    (option) =>
-                        option.category !== "mode" &&
-                        option.category !== "model" &&
-                        !isDuplicateThoughtLevelMode(option, modes, modeId),
-                )
-                .sort((left, right) => {
-                    const rank = (option: AIConfigOption) =>
-                        option.category === "reasoning" ? 0 : 1;
-                    return rank(left) - rank(right);
-                }),
-        [configOptions, modeId, modes],
-    );
-    const visibleConfigs = useMemo(
-        () =>
-            extraConfigs
-                .map((option) => ({
-                    option,
-                    presentationCategory: configPresentationCategory(
-                        runtimeId,
-                        option,
-                    ),
-                    options: filterConfigOptions(
-                        option,
-                        selectedModelId,
-                        effortsByModel,
-                    ),
-                }))
-                .filter(({ options }) => options.length > 0),
-        [effortsByModel, extraConfigs, runtimeId, selectedModelId],
-    );
-    const traitSections = useMemo<TraitMenuSection[]>(
-        () =>
-            visibleConfigs
-                .filter(
-                    ({ presentationCategory }) =>
-                        presentationCategory === "reasoning" ||
-                        presentationCategory === "service_tier",
-                )
-                .sort((left, right) =>
-                    left.presentationCategory === right.presentationCategory
-                        ? 0
-                        : left.presentationCategory === "reasoning"
-                          ? -1
-                          : 1,
-                )
-                .map(({ option, options, presentationCategory }) => ({
-                    kind: presentationCategory as
-                        | "reasoning"
-                        | "service_tier",
-                    optionId: option.id,
-                    label:
-                        presentationCategory === "reasoning"
-                            ? "Reasoning"
-                            : "Service Tier",
-                    value: option.value,
-                    options:
-                        presentationCategory === "service_tier"
-                            ? normalizeServiceTierOptions(
-                                  options,
-                                  option.description,
-                              )
-                            : options,
-                    defaultValues:
-                        presentationCategory === "service_tier"
-                            ? defaultServiceTierValues(options)
-                            : [],
-                })),
-        [visibleConfigs],
-    );
-    const traitDropdown = useMemo(() => {
-        const reasoningSection = traitSections.find(
-            (section) => section.kind === "reasoning",
-        );
-        const serviceTierSection = traitSections.find(
-            (section) => section.kind === "service_tier",
-        );
-        const primarySection =
-            reasoningSection ?? serviceTierSection ?? traitSections[0];
-        if (!primarySection) {
-            return null;
-        }
+        defaultValues: ["off"],
+      });
+    }
 
-        const selected = primarySection.options.find(
-            (option) => option.value === primarySection.value,
-        );
-        return {
-            label: reasoningSection
-                ? serviceTierSection
-                    ? "Reasoning and Service Tier"
-                    : "Reasoning"
-                : "Service Tier",
-            value: primarySection.value,
-            displayValue:
-                selected?.label ??
-                (primarySection.value.trim()
-                    ? formatFallbackLabel(primarySection.value)
-                    : "Traits"),
-            fastModeEnabled: Boolean(
-                serviceTierSection &&
-                isFastServiceTierValue(serviceTierSection.value),
-            ),
-            options: traitSections.flatMap((section) =>
-                section.options.map((option) => ({
-                    ...option,
-                    configOptionId: section.optionId,
-                    groupLabel: section.label,
-                    isDefault: section.defaultValues.includes(option.value),
-                    selected: option.value === section.value,
-                })),
-            ),
-        };
-    }, [traitSections]);
-    const visibleExtraConfigs = useMemo(
-        () =>
-            visibleConfigs
-                .filter(
-                    ({ presentationCategory }) =>
-                        presentationCategory === "other",
-                )
-                .map(({ option, options }) => ({
-                    option,
-                    label: option.label,
-                    options,
-                })),
-        [visibleConfigs],
+    return sections;
+  }, [runtimeId, selectedModelId, visibleConfigs]);
+  const traitDropdown = useMemo(() => {
+    const reasoningSection = traitSections.find(
+      (section) => section.kind === "reasoning",
     );
-    const showFullAccessPolicyHelp =
-        runtimeId === CODEX_RUNTIME_ID && modeId === CODEX_FULL_ACCESS_MODE_ID;
-    const showProviderPicker =
-        providers.length > 0 && Boolean(runtimeId && onProviderModelChange);
-    const showLegacyModelPicker =
-        providers.length === 0 && lockedModelOptions.length > 0;
-    const hasControlBeforeExtras = showProviderPicker || showLegacyModelPicker;
+    const serviceTierSection = traitSections.find(
+      (section) => section.kind === "service_tier",
+    );
+    const primarySection =
+      reasoningSection ?? serviceTierSection ?? traitSections[0];
+    if (!primarySection) {
+      return null;
+    }
 
-    return (
-        <div className="flex min-w-0 flex-wrap items-center gap-1">
-            {showProviderPicker && runtimeId && onProviderModelChange ? (
-                <AIProviderModelPicker
-                    disabled={disabled}
-                    runtimeId={runtimeId}
-                    modelId={selectedModelId}
-                    providers={providerPickerOptions}
-                    onChange={onProviderModelChange}
-                />
-            ) : null}
-            {showLegacyModelPicker ? (
-                <DropdownField
-                    disabled={disabled}
-                    label="Model"
-                    value={selectedModelId}
-                    searchable={shouldUseSearchableModelMenu(runtimeId)}
-                    searchPlaceholder="Search models..."
-                    emptySearchMessage="No models match that search."
-                    options={lockedModelOptions}
-                    onChange={(value) =>
-                        modelConfig
-                            ? onConfigOptionChange(modelConfig.id, value)
-                            : onModelChange(value)
-                    }
-                />
-            ) : null}
-            {traitDropdown ? (
-                <>
-                    {hasControlBeforeExtras ? <ControlSeparator /> : null}
-                    <DropdownField
-                        disabled={disabled}
-                        displayValue={traitDropdown.displayValue}
-                        label={traitDropdown.label}
-                        leadingIcon={
-                            traitDropdown.fastModeEnabled ? (
-                                <FastModeIcon />
-                            ) : undefined
-                        }
-                        menuMinWidth={168}
-                        options={traitDropdown.options}
-                        value={traitDropdown.value}
-                        onOptionChange={(value, option) => {
-                            if (option.configOptionId) {
-                                onConfigOptionChange(
-                                    option.configOptionId,
-                                    value,
-                                );
-                            }
-                        }}
-                    />
-                </>
-            ) : null}
-            {visibleExtraConfigs.map(({ option, label, options }, index) => (
-                <div className="contents" key={option.id}>
-                    {hasControlBeforeExtras ||
-                    traitSections.length > 0 ||
-                    index > 0 ? (
-                        <ControlSeparator />
-                    ) : null}
-                    <DropdownField
-                        disabled={disabled}
-                        label={label}
-                        value={option.value}
-                        options={options}
-                        onChange={(value) =>
-                            onConfigOptionChange(option.id, value)
-                        }
-                    />
-                </div>
-            ))}
-            {modes.length > 0 ? (
-                <>
-                    {hasControlBeforeExtras ||
-                    traitSections.length > 0 ||
-                    visibleExtraConfigs.length > 0 ? (
-                        <ControlSeparator />
-                    ) : null}
-                    <DropdownField
-                        disabled={disabled}
-                        label="Approval Preset"
-                        leadingIcon={
-                            <PermissionModeIcon
-                                fullAccess={modeId === CODEX_FULL_ACCESS_MODE_ID}
-                            />
-                        }
-                        value={modeId}
-                        options={modes.map((mode) => ({
-                            value: mode.id,
-                            label: formatFallbackLabel(mode.name),
-                            description: mode.description,
-                            disabled: mode.disabled,
-                        }))}
-                        onChange={onModeChange}
-                    />
-                </>
-            ) : null}
-            {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
+    const selected = primarySection.options.find(
+      (option) => option.value === primarySection.value,
+    );
+    return {
+      // Reasoning remains the trigger's primary value. Service tier is exposed
+      // in the same menu and only changes the trigger icon when Fast is active.
+      label: reasoningSection
+        ? serviceTierSection
+          ? "Reasoning and Service Tier"
+          : "Reasoning"
+        : "Service Tier",
+      value: primarySection.value,
+      displayValue:
+        selected?.label ??
+        (primarySection.value.trim()
+          ? formatFallbackLabel(primarySection.value)
+          : "Traits"),
+      fastModeEnabled: Boolean(
+        serviceTierSection && isFastServiceTierValue(serviceTierSection.value),
+      ),
+      options: traitSections.flatMap((section) =>
+        section.options.map((option) => ({
+          ...option,
+          configOptionId: section.optionId,
+          groupLabel: section.label,
+          isDefault: section.defaultValues.includes(option.value),
+          selected: option.value === section.value,
+        })),
+      ),
+    };
+  }, [traitSections]);
+  const visibleExtraConfigs = useMemo(
+    () =>
+      visibleConfigs
+        .filter(({ presentationCategory }) => presentationCategory === "other")
+        .map(({ option, options }) => ({
+          option,
+          label: option.label,
+          options,
+        })),
+    [visibleConfigs],
+  );
+  const showFullAccessPolicyHelp =
+    runtimeId === CODEX_RUNTIME_ID && modeId === CODEX_FULL_ACCESS_MODE_ID;
+  const showProviderPicker =
+    providers.length > 0 && Boolean(runtimeId && onProviderModelChange);
+  const showLegacyModelPicker =
+    providers.length === 0 && lockedModelOptions.length > 0;
+  const hasControlBeforeExtras = showProviderPicker || showLegacyModelPicker;
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-1">
+      {showProviderPicker && runtimeId && onProviderModelChange ? (
+        <AIProviderModelPicker
+          disabled={disabled}
+          runtimeId={runtimeId}
+          modelId={selectedModelId}
+          providers={providerPickerOptions}
+          onChange={onProviderModelChange}
+        />
+      ) : null}
+      {showLegacyModelPicker ? (
+        <DropdownField
+          disabled={disabled}
+          label="Model"
+          value={selectedModelId}
+          searchable={shouldUseSearchableModelMenu(runtimeId)}
+          searchPlaceholder="Search models..."
+          emptySearchMessage="No models match that search."
+          options={lockedModelOptions}
+          onChange={(value) =>
+            modelConfig
+              ? onConfigOptionChange(modelConfig.id, value)
+              : onModelChange(value)
+          }
+        />
+      ) : null}
+      {traitDropdown ? (
+        <>
+          {hasControlBeforeExtras ? <ControlSeparator /> : null}
+          <DropdownField
+            disabled={disabled}
+            displayValue={traitDropdown.displayValue}
+            label={traitDropdown.label}
+            leadingIcon={
+              traitDropdown.fastModeEnabled ? <FastModeIcon /> : undefined
+            }
+            menuMinWidth={168}
+            options={traitDropdown.options}
+            value={traitDropdown.value}
+            onOptionChange={(value, option) => {
+              if (option.configOptionId) {
+                onConfigOptionChange(option.configOptionId, value);
+              }
+            }}
+          />
+        </>
+      ) : null}
+      {visibleExtraConfigs.map(({ option, label, options }, index) => (
+        <div className="contents" key={option.id}>
+          {hasControlBeforeExtras || traitSections.length > 0 || index > 0 ? (
+            <ControlSeparator />
+          ) : null}
+          <DropdownField
+            disabled={disabled}
+            label={label}
+            value={option.value}
+            options={options}
+            onChange={(value) => onConfigOptionChange(option.id, value)}
+          />
         </div>
-    );
+      ))}
+      {modes.length > 0 ? (
+        <>
+          {hasControlBeforeExtras ||
+          traitSections.length > 0 ||
+          visibleExtraConfigs.length > 0 ? (
+            <ControlSeparator />
+          ) : null}
+          <DropdownField
+            disabled={disabled}
+            label="Approval Preset"
+            leadingIcon={
+              <PermissionModeIcon
+                fullAccess={modeId === CODEX_FULL_ACCESS_MODE_ID}
+              />
+            }
+            value={modeId}
+            options={modes.map((mode) => ({
+              value: mode.id,
+              label: formatFallbackLabel(mode.name),
+              description: mode.description,
+              disabled: mode.disabled,
+            }))}
+            onChange={onModeChange}
+          />
+        </>
+      ) : null}
+      {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
+    </div>
+  );
 }

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -33,6 +33,10 @@ interface DropdownOption {
     description?: string;
     agentType?: string;
     disabled?: boolean;
+    configOptionId?: string;
+    groupLabel?: string;
+    isDefault?: boolean;
+    selected?: boolean;
 }
 
 interface DropdownFieldProps {
@@ -43,8 +47,20 @@ interface DropdownFieldProps {
     searchable?: boolean;
     searchPlaceholder?: string;
     emptySearchMessage?: string;
+    displayValue?: string;
+    menuMinWidth?: number;
     leadingIcon?: ReactNode;
-    onChange: (value: string) => void;
+    onChange?: (value: string) => void;
+    onOptionChange?: (value: string, option: DropdownOption) => void;
+}
+
+interface TraitMenuSection {
+    kind: "reasoning" | "service_tier";
+    optionId: string;
+    label: string;
+    value: string;
+    options: DropdownOption[];
+    defaultValues: string[];
 }
 
 const SEARCHABLE_MODEL_RUNTIME_IDS = new Set([
@@ -135,17 +151,24 @@ function DropdownField({
     searchable = false,
     searchPlaceholder = "Search…",
     emptySearchMessage = "No matches found.",
+    displayValue: displayValueOverride,
+    menuMinWidth,
     leadingIcon,
     onChange,
+    onOptionChange,
 }: DropdownFieldProps) {
     const [open, setOpen] = useState(false);
     const [query, setQuery] = useState("");
     const ref = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
     const lastFocusedElementRef = useRef<HTMLElement | null>(null);
-    const selected = options.find((option) => option.value === value);
+    const selected = options.find(
+        (option) => option.selected ?? option.value === value,
+    );
     const displayValue =
-        selected?.label ?? (value.trim() ? formatFallbackLabel(value) : label);
+        displayValueOverride ??
+        selected?.label ??
+        (value.trim() ? formatFallbackLabel(value) : label);
     const isDisabled = disabled || options.length === 0;
     const rememberFocusedElement = () => {
         const activeElement = document.activeElement;
@@ -260,6 +283,7 @@ function DropdownField({
                         backgroundColor: "var(--bg-secondary)",
                         border: "1px solid var(--border)",
                         boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+                        minWidth: menuMinWidth,
                         maxHeight: searchable ? 320 : undefined,
                         display: searchable ? "flex" : undefined,
                         flexDirection: searchable ? "column" : undefined,
@@ -350,57 +374,132 @@ function DropdownField({
                                 {emptySearchMessage}
                             </div>
                         ) : (
-                            filteredOptions.map((option) => (
-                                <button
-                                    key={option.value}
-                                    type="button"
-                                    disabled={option.disabled}
-                                    title={option.description}
-                                    onMouseDown={(event) => {
-                                        if (option.disabled) {
-                                            return;
-                                        }
-
-                                        event.preventDefault();
-                                    }}
-                                    onClick={() => {
-                                        onChange(option.value);
-                                        closeDropdown();
-                                        restoreFocusedElement();
-                                    }}
-                                    className="flex w-full items-center px-3 py-1.5 text-left text-xs"
+                            filteredOptions.map((option, index) => (
+                                <div
+                                    key={`${option.groupLabel ?? ""}:${option.configOptionId ?? ""}:${option.value}`}
                                     style={{
-                                        color:
-                                            option.value === value
-                                                ? "var(--accent)"
-                                                : option.disabled
-                                                  ? "var(--text-secondary)"
-                                                  : "var(--text-primary)",
-                                        backgroundColor: "transparent",
-                                        border: "none",
-                                        opacity: option.disabled ? 0.4 : 1,
-                                        transition:
-                                            "background-color 80ms ease",
-                                    }}
-                                    onMouseEnter={(event) => {
-                                        if (!option.disabled) {
-                                            event.currentTarget.style.backgroundColor =
-                                                "var(--bg-tertiary)";
-                                        }
-                                    }}
-                                    onMouseLeave={(event) => {
-                                        event.currentTarget.style.backgroundColor =
-                                            "transparent";
+                                        borderTop:
+                                            option.groupLabel &&
+                                            index > 0 &&
+                                            filteredOptions[index - 1]
+                                                ?.groupLabel !== option.groupLabel
+                                                ? "1px solid var(--border)"
+                                                : undefined,
                                     }}
                                 >
-                                    {option.label}
-                                </button>
+                                    {option.groupLabel &&
+                                    (index === 0 ||
+                                        filteredOptions[index - 1]
+                                            ?.groupLabel !==
+                                            option.groupLabel) ? (
+                                        <div
+                                            className="px-3 pb-1 pt-1.5 text-[10px] font-medium"
+                                            style={{
+                                                color: "var(--text-secondary)",
+                                            }}
+                                        >
+                                            {option.groupLabel}
+                                        </div>
+                                    ) : null}
+                                    <button
+                                        type="button"
+                                        disabled={option.disabled}
+                                        title={option.description}
+                                        onMouseDown={(event) => {
+                                            if (option.disabled) {
+                                                return;
+                                            }
+
+                                            event.preventDefault();
+                                        }}
+                                        onClick={() => {
+                                            if (onOptionChange) {
+                                                onOptionChange(
+                                                    option.value,
+                                                    option,
+                                                );
+                                            } else {
+                                                onChange?.(option.value);
+                                            }
+                                            closeDropdown();
+                                            restoreFocusedElement();
+                                        }}
+                                        className="flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-xs"
+                                        style={{
+                                            color:
+                                                option.selected === true
+                                                    ? "var(--text-primary)"
+                                                    : option.value === value
+                                                      ? "var(--accent)"
+                                                      : option.disabled
+                                                        ? "var(--text-secondary)"
+                                                        : "var(--text-primary)",
+                                            backgroundColor:
+                                                option.selected === true
+                                                    ? "var(--bg-tertiary)"
+                                                    : "transparent",
+                                            border: "none",
+                                            opacity: option.disabled ? 0.4 : 1,
+                                            transition:
+                                                "background-color 80ms ease",
+                                        }}
+                                        onMouseEnter={(event) => {
+                                            if (!option.disabled) {
+                                                event.currentTarget.style.backgroundColor =
+                                                    "var(--bg-tertiary)";
+                                            }
+                                        }}
+                                        onMouseLeave={(event) => {
+                                            event.currentTarget.style.backgroundColor =
+                                                option.selected === true
+                                                    ? "var(--bg-tertiary)"
+                                                    : "transparent";
+                                        }}
+                                    >
+                                        <span className="truncate">
+                                            {option.label}
+                                        </span>
+                                        {option.isDefault ? (
+                                            <span
+                                                className="ml-3 shrink-0 rounded px-1 py-0.5 font-mono text-[9px] font-semibold leading-none"
+                                                style={{
+                                                    backgroundColor:
+                                                        "var(--bg-primary)",
+                                                    color: "var(--text-secondary)",
+                                                }}
+                                            >
+                                                Default
+                                            </span>
+                                        ) : null}
+                                    </button>
+                                </div>
                             ))
                         )}
                     </div>
                 </div>
             )}
         </div>
+    );
+}
+
+function isFastServiceTierValue(value: string) {
+    return ["fast", "on", "priority"].includes(
+        normalizeConfigOptionId(value),
+    );
+}
+
+function FastModeIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="shrink-0"
+            fill="currentColor"
+            height="11"
+            viewBox="0 0 16 16"
+            width="11"
+        >
+            <path d="M9.35 1.25 3.4 8.45h3.75l-.5 6.3 5.95-7.2H8.85l.5-6.3Z" />
+        </svg>
     );
 }
 
@@ -548,33 +647,62 @@ function isDuplicateThoughtLevelMode(
     );
 }
 
-function normalizeExtraConfigPresentation(
+function normalizeConfigOptionId(value: string) {
+    return value.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+function configPresentationCategory(
     runtimeId: string | undefined,
     option: AIConfigOption,
-    options: DropdownOption[],
 ) {
-    if (
-        runtimeId !== CLAUDE_RUNTIME_ID ||
-        option.id !== CLAUDE_FAST_OPTION_ID
-    ) {
-        return {
-            label: option.label,
-            options,
-        };
+    if (option.category === "reasoning") {
+        return "reasoning" as const;
+    }
+    if (option.category === "service_tier") {
+        return "service_tier" as const;
     }
 
-    return {
-        label: "Fast Mode",
-        options: options.map((item) => {
-            if (item.value === "on") {
-                return { ...item, label: "Fast" };
-            }
-            if (item.value === "off") {
-                return { ...item, label: "Off" };
-            }
-            return item;
-        }),
-    };
+    const normalizedId = normalizeConfigOptionId(option.id);
+    if (
+        normalizedId === "servicetier" ||
+        normalizedId === "fastmode" ||
+        (runtimeId === CLAUDE_RUNTIME_ID &&
+            option.id === CLAUDE_FAST_OPTION_ID)
+    ) {
+        return "service_tier" as const;
+    }
+
+    return "other" as const;
+}
+
+function normalizeServiceTierOptions(
+    options: DropdownOption[],
+    description?: string,
+) {
+    return options.map((item) => {
+        const value = normalizeConfigOptionId(item.value);
+        if (["off", "default", "standard", "normal"].includes(value)) {
+            return { ...item, label: "Standard" };
+        }
+        if (["fast", "on", "priority"].includes(value)) {
+            return {
+                ...item,
+                label: "Fast",
+                description: item.description ?? description,
+            };
+        }
+        return item;
+    });
+}
+
+function defaultServiceTierValues(options: DropdownOption[]) {
+    return options
+        .filter((item) =>
+            ["off", "default", "standard", "normal"].includes(
+                normalizeConfigOptionId(item.value),
+            ),
+        )
+        .map((item) => item.value);
 }
 
 export function AIChatAgentControls({
@@ -663,23 +791,119 @@ export function AIChatAgentControls({
                 }),
         [configOptions, modeId, modes],
     );
-    const visibleExtraConfigs = useMemo(
+    const visibleConfigs = useMemo(
         () =>
             extraConfigs
                 .map((option) => ({
                     option,
-                    ...normalizeExtraConfigPresentation(
+                    presentationCategory: configPresentationCategory(
                         runtimeId,
                         option,
-                        filterConfigOptions(
-                            option,
-                            selectedModelId,
-                            effortsByModel,
-                        ),
+                    ),
+                    options: filterConfigOptions(
+                        option,
+                        selectedModelId,
+                        effortsByModel,
                     ),
                 }))
                 .filter(({ options }) => options.length > 0),
         [effortsByModel, extraConfigs, runtimeId, selectedModelId],
+    );
+    const traitSections = useMemo<TraitMenuSection[]>(
+        () =>
+            visibleConfigs
+                .filter(
+                    ({ presentationCategory }) =>
+                        presentationCategory === "reasoning" ||
+                        presentationCategory === "service_tier",
+                )
+                .sort((left, right) =>
+                    left.presentationCategory === right.presentationCategory
+                        ? 0
+                        : left.presentationCategory === "reasoning"
+                          ? -1
+                          : 1,
+                )
+                .map(({ option, options, presentationCategory }) => ({
+                    kind: presentationCategory as
+                        | "reasoning"
+                        | "service_tier",
+                    optionId: option.id,
+                    label:
+                        presentationCategory === "reasoning"
+                            ? "Reasoning"
+                            : "Service Tier",
+                    value: option.value,
+                    options:
+                        presentationCategory === "service_tier"
+                            ? normalizeServiceTierOptions(
+                                  options,
+                                  option.description,
+                              )
+                            : options,
+                    defaultValues:
+                        presentationCategory === "service_tier"
+                            ? defaultServiceTierValues(options)
+                            : [],
+                })),
+        [visibleConfigs],
+    );
+    const traitDropdown = useMemo(() => {
+        const reasoningSection = traitSections.find(
+            (section) => section.kind === "reasoning",
+        );
+        const serviceTierSection = traitSections.find(
+            (section) => section.kind === "service_tier",
+        );
+        const primarySection =
+            reasoningSection ?? serviceTierSection ?? traitSections[0];
+        if (!primarySection) {
+            return null;
+        }
+
+        const selected = primarySection.options.find(
+            (option) => option.value === primarySection.value,
+        );
+        return {
+            label: reasoningSection
+                ? serviceTierSection
+                    ? "Reasoning and Service Tier"
+                    : "Reasoning"
+                : "Service Tier",
+            value: primarySection.value,
+            displayValue:
+                selected?.label ??
+                (primarySection.value.trim()
+                    ? formatFallbackLabel(primarySection.value)
+                    : "Traits"),
+            fastModeEnabled: Boolean(
+                serviceTierSection &&
+                isFastServiceTierValue(serviceTierSection.value),
+            ),
+            options: traitSections.flatMap((section) =>
+                section.options.map((option) => ({
+                    ...option,
+                    configOptionId: section.optionId,
+                    groupLabel: section.label,
+                    isDefault: section.defaultValues.includes(option.value),
+                    selected: option.value === section.value,
+                })),
+            ),
+        };
+    }, [traitSections]);
+    const visibleExtraConfigs = useMemo(
+        () =>
+            visibleConfigs
+                .filter(
+                    ({ presentationCategory }) =>
+                        presentationCategory === "other",
+                )
+                .map(({ option, options }) => ({
+                    option,
+                    label: option.label,
+                    options,
+                })),
+        [visibleConfigs],
     );
     const showFullAccessPolicyHelp =
         runtimeId === CODEX_RUNTIME_ID && modeId === CODEX_FULL_ACCESS_MODE_ID;
@@ -716,9 +940,37 @@ export function AIChatAgentControls({
                     }
                 />
             ) : null}
+            {traitDropdown ? (
+                <>
+                    {hasControlBeforeExtras ? <ControlSeparator /> : null}
+                    <DropdownField
+                        disabled={disabled}
+                        displayValue={traitDropdown.displayValue}
+                        label={traitDropdown.label}
+                        leadingIcon={
+                            traitDropdown.fastModeEnabled ? (
+                                <FastModeIcon />
+                            ) : undefined
+                        }
+                        menuMinWidth={168}
+                        options={traitDropdown.options}
+                        value={traitDropdown.value}
+                        onOptionChange={(value, option) => {
+                            if (option.configOptionId) {
+                                onConfigOptionChange(
+                                    option.configOptionId,
+                                    value,
+                                );
+                            }
+                        }}
+                    />
+                </>
+            ) : null}
             {visibleExtraConfigs.map(({ option, label, options }, index) => (
                 <div className="contents" key={option.id}>
-                    {hasControlBeforeExtras || index > 0 ? (
+                    {hasControlBeforeExtras ||
+                    traitSections.length > 0 ||
+                    index > 0 ? (
                         <ControlSeparator />
                     ) : null}
                     <DropdownField
@@ -734,7 +986,9 @@ export function AIChatAgentControls({
             ))}
             {modes.length > 0 ? (
                 <>
-                    {hasControlBeforeExtras || visibleExtraConfigs.length > 0 ? (
+                    {hasControlBeforeExtras ||
+                    traitSections.length > 0 ||
+                    visibleExtraConfigs.length > 0 ? (
                         <ControlSeparator />
                     ) : null}
                     <DropdownField

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -24,6 +24,7 @@ interface AIChatAgentControlsProps {
   configOptions: AIConfigOption[];
   providers?: ConversationProviderPickerOption[];
   onProviderModelChange?: (runtimeId: string, modelId: string) => void;
+  onProviderActivate?: (runtimeId: string) => void | Promise<void>;
   onModelChange: (modelId: string) => void;
   onModeChange: (modeId: string) => void;
   onConfigOptionChange: (optionId: string, value: string) => void;
@@ -697,6 +698,7 @@ export function AIChatAgentControls({
   configOptions,
   providers = [],
   onProviderModelChange,
+  onProviderActivate,
   onModelChange,
   onModeChange,
   onConfigOptionChange,
@@ -918,6 +920,7 @@ export function AIChatAgentControls({
           modelId={selectedModelId}
           providers={providerPickerOptions}
           onChange={onProviderModelChange}
+          onProviderActivate={onProviderActivate}
         />
       ) : null}
       {showLegacyModelPicker ? (

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -15,7 +15,6 @@ import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 interface AIChatAgentControlsProps {
   disabled?: boolean;
   runtimeId?: string;
-  providerSwitchLocked?: boolean;
   lockIncompatibleModelSwitches?: boolean;
   modelId: string;
   modeId: string;
@@ -686,7 +685,6 @@ function claudeModelSupportsFastMode(modelId: string) {
 export function AIChatAgentControls({
   disabled = false,
   runtimeId,
-  providerSwitchLocked = false,
   lockIncompatibleModelSwitches = false,
   modelId,
   modeId,
@@ -914,7 +912,6 @@ export function AIChatAgentControls({
           disabled={disabled}
           runtimeId={runtimeId}
           modelId={selectedModelId}
-          providerSwitchLocked={providerSwitchLocked}
           providers={providerPickerOptions}
           onChange={onProviderModelChange}
         />

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -14,6 +14,7 @@ import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 
 interface AIChatAgentControlsProps {
   disabled?: boolean;
+  conversationStarted?: boolean;
   runtimeId?: string;
   lockIncompatibleModelSwitches?: boolean;
   modelId: string;
@@ -689,6 +690,7 @@ function claudeModelSupportsFastMode(modelId: string) {
 
 export function AIChatAgentControls({
   disabled = false,
+  conversationStarted = false,
   runtimeId,
   lockIncompatibleModelSwitches = false,
   modelId,
@@ -916,6 +918,7 @@ export function AIChatAgentControls({
       {showProviderPicker && runtimeId && onProviderModelChange ? (
         <AIProviderModelPicker
           disabled={disabled}
+          conversationStarted={conversationStarted}
           runtimeId={runtimeId}
           modelId={selectedModelId}
           providers={providerPickerOptions}

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -15,6 +15,7 @@ import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 interface AIChatAgentControlsProps {
   disabled?: boolean;
   runtimeId?: string;
+  providerSwitchLocked?: boolean;
   lockIncompatibleModelSwitches?: boolean;
   modelId: string;
   modeId: string;
@@ -685,6 +686,7 @@ function claudeModelSupportsFastMode(modelId: string) {
 export function AIChatAgentControls({
   disabled = false,
   runtimeId,
+  providerSwitchLocked = false,
   lockIncompatibleModelSwitches = false,
   modelId,
   modeId,
@@ -912,6 +914,7 @@ export function AIChatAgentControls({
           disabled={disabled}
           runtimeId={runtimeId}
           modelId={selectedModelId}
+          providerSwitchLocked={providerSwitchLocked}
           providers={providerPickerOptions}
           onChange={onProviderModelChange}
         />

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -6,9 +6,11 @@ import {
   useState,
   type ReactNode,
 } from "react";
+import { createPortal } from "react-dom";
 import type { ConversationProviderPickerOption } from "../conversationPickerModel";
 import type { AIConfigOption, AIModeOption, AIModelOption } from "../types";
 import { AIProviderModelPicker } from "./AIProviderModelPicker";
+import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 
 interface AIChatAgentControlsProps {
   disabled?: boolean;
@@ -155,6 +157,7 @@ function DropdownField({
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const ref = useRef<HTMLDivElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const selected = options.find(
@@ -200,11 +203,17 @@ function DropdownField({
       );
     });
   }, [options, query, searchable]);
+  const menuPosition = useAnchoredChatMenuPosition(ref, menuRef, open);
 
   useEffect(() => {
     if (!open) return;
     const handleClick = (event: MouseEvent) => {
-      if (ref.current?.contains(event.target as Node)) return;
+      if (
+        ref.current?.contains(event.target as Node) ||
+        menuRef.current?.contains(event.target as Node)
+      ) {
+        return;
+      }
       closeDropdown();
     };
     document.addEventListener("mousedown", handleClick);
@@ -271,13 +280,17 @@ function DropdownField({
           <path d="M2.5 4L5 6.5L7.5 4" />
         </svg>
       </button>
-      {open && options.length > 0 && (
+      {open && options.length > 0
+        ? createPortal(
         <div
-          className="absolute bottom-full left-0 z-50 mb-1 min-w-35 overflow-hidden rounded-lg py-1"
+          ref={menuRef}
+          className="nw-chat-glass-menu fixed z-50 min-w-35 overflow-hidden rounded-lg py-1"
           style={{
-            backgroundColor: "var(--bg-secondary)",
             border: "1px solid var(--border)",
             boxShadow: "0 4px 12px rgba(0,0,0,0.3)",
+            left: menuPosition?.left ?? 8,
+            top: menuPosition?.top ?? 8,
+            visibility: menuPosition ? "visible" : "hidden",
             minWidth: menuMinWidth,
             maxHeight: searchable ? 320 : undefined,
             display: searchable ? "flex" : undefined,
@@ -463,8 +476,10 @@ function DropdownField({
               ))
             )}
           </div>
-        </div>
-      )}
+        </div>,
+        document.body,
+        )
+        : null}
     </div>
   );
 }

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -140,6 +140,10 @@ function formatFallbackLabel(value: string) {
     .join(" ");
 }
 
+function modelDisplayLabel(label: string, modelId: string) {
+  return label.trim() || formatFallbackLabel(modelId);
+}
+
 function DropdownField({
   disabled = false,
   label,
@@ -707,7 +711,7 @@ export function AIChatAgentControls({
         ? mapConfigOption(modelConfig)
         : models.map((model) => ({
             value: model.id,
-            label: formatFallbackLabel(model.name),
+            label: modelDisplayLabel(model.name, model.id),
             description: model.description,
             agentType: model.agentType,
           })),
@@ -732,7 +736,7 @@ export function AIChatAgentControls({
           provider.runtimeId === runtimeId && lockedModelOptions.length > 0
             ? lockedModelOptions.map((model) => ({
                 modelId: model.value,
-                label: model.label,
+                label: modelDisplayLabel(model.label, model.value),
                 description: model.description,
                 disabledReason: model.disabled
                   ? (model.description ?? "This model is unavailable.")
@@ -740,7 +744,7 @@ export function AIChatAgentControls({
               }))
             : provider.models.map((model) => ({
                 ...model,
-                label: formatFallbackLabel(model.label),
+                label: modelDisplayLabel(model.label, model.modelId),
               })),
       })),
     [lockedModelOptions, providers, runtimeId],

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.tsx
@@ -1,6 +1,14 @@
-import { useEffect, useId, useMemo, useRef, useState } from "react";
+import {
+    useEffect,
+    useId,
+    useMemo,
+    useRef,
+    useState,
+    type ReactNode,
+} from "react";
 import type { ConversationProviderPickerOption } from "../conversationPickerModel";
 import type { AIConfigOption, AIModeOption, AIModelOption } from "../types";
+import { AIProviderModelPicker } from "./AIProviderModelPicker";
 
 interface AIChatAgentControlsProps {
     disabled?: boolean;
@@ -35,6 +43,7 @@ interface DropdownFieldProps {
     searchable?: boolean;
     searchPlaceholder?: string;
     emptySearchMessage?: string;
+    leadingIcon?: ReactNode;
     onChange: (value: string) => void;
 }
 
@@ -126,6 +135,7 @@ function DropdownField({
     searchable = false,
     searchPlaceholder = "Search…",
     emptySearchMessage = "No matches found.",
+    leadingIcon,
     onChange,
 }: DropdownFieldProps) {
     const [open, setOpen] = useState(false);
@@ -223,6 +233,7 @@ function DropdownField({
                 title={label}
                 disabled={isDisabled}
             >
+                {leadingIcon}
                 <span className="truncate">{displayValue}</span>
                 <svg
                     width="10"
@@ -390,6 +401,49 @@ function DropdownField({
                 </div>
             )}
         </div>
+    );
+}
+
+function PermissionModeIcon({ fullAccess }: { fullAccess: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            className="shrink-0 opacity-70"
+            fill="none"
+            height="13"
+            viewBox="0 0 16 16"
+            width="13"
+        >
+            <rect
+                height="8"
+                rx="1.5"
+                stroke="currentColor"
+                strokeWidth="1.35"
+                width="10"
+                x="3"
+                y="6.5"
+            />
+            <path
+                d={
+                    fullAccess
+                        ? "M5.25 6.5V5a2.75 2.75 0 0 1 5.05-1.51"
+                        : "M5.25 6.5V5a2.75 2.75 0 0 1 5.5 0v1.5"
+                }
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth="1.35"
+            />
+        </svg>
+    );
+}
+
+function ControlSeparator() {
+    return (
+        <span
+            aria-hidden="true"
+            className="mx-0.5 h-4 w-px"
+            style={{ backgroundColor: "var(--border)" }}
+        />
     );
 }
 
@@ -571,50 +625,26 @@ export function AIChatAgentControls({
             selectedModelId,
         ],
     );
-    const providerModelOptions = useMemo(
+    const providerPickerOptions = useMemo(
         () =>
-            providers.flatMap((provider) => {
-                const models =
+            providers.map((provider) => ({
+                ...provider,
+                models:
                     provider.runtimeId === runtimeId &&
                     lockedModelOptions.length > 0
                         ? lockedModelOptions.map((model) => ({
                               modelId: model.value,
                               label: model.label,
                               description: model.description,
-                              disabled: model.disabled,
+                              disabledReason: model.disabled
+                                  ? (model.description ?? "This model is unavailable.")
+                                  : null,
                           }))
                         : provider.models.map((model) => ({
-                              modelId: model.modelId,
+                              ...model,
                               label: formatFallbackLabel(model.label),
-                              description:
-                                  model.disabledReason ?? model.description,
-                              disabled: model.disabledReason != null,
-                          }));
-                const availableModels =
-                    models.length > 0
-                        ? models
-                        : [
-                              {
-                                  modelId: provider.defaultModelId,
-                                  label: "Default model",
-                                  description: provider.description,
-                                  disabled: false,
-                              },
-                          ];
-                return availableModels.map((model) => ({
-                    value: `${provider.runtimeId}\u0000${model.modelId}`,
-                    label:
-                        model.modelId || providers.length > 1
-                            ? `${provider.label} · ${model.label}`
-                            : provider.label,
-                    description:
-                        provider.disabledReason ??
-                        model.description ??
-                        provider.description,
-                    disabled:
-                        provider.disabledReason != null || model.disabled,
-                }));
-            }),
+                          })),
+            })),
         [lockedModelOptions, providers, runtimeId],
     );
     const extraConfigs = useMemo(
@@ -653,43 +683,24 @@ export function AIChatAgentControls({
     );
     const showFullAccessPolicyHelp =
         runtimeId === CODEX_RUNTIME_ID && modeId === CODEX_FULL_ACCESS_MODE_ID;
+    const showProviderPicker =
+        providers.length > 0 && Boolean(runtimeId && onProviderModelChange);
+    const showLegacyModelPicker =
+        providers.length === 0 && lockedModelOptions.length > 0;
+    const hasControlBeforeExtras = showProviderPicker || showLegacyModelPicker;
 
     return (
         <div className="flex min-w-0 flex-wrap items-center gap-1">
-            {providers.length > 0 && runtimeId && onProviderModelChange ? (
-                <DropdownField
+            {showProviderPicker && runtimeId && onProviderModelChange ? (
+                <AIProviderModelPicker
                     disabled={disabled}
-                    label="Provider and model"
-                    value={`${runtimeId}\u0000${selectedModelId}`}
-                    options={providerModelOptions}
-                    searchable={providerModelOptions.length > 10}
-                    searchPlaceholder="Search providers and models..."
-                    emptySearchMessage="No providers or models match that search."
-                    onChange={(value) => {
-                        const separator = value.indexOf("\u0000");
-                        onProviderModelChange(
-                            value.slice(0, separator),
-                            value.slice(separator + 1),
-                        );
-                    }}
+                    runtimeId={runtimeId}
+                    modelId={selectedModelId}
+                    providers={providerPickerOptions}
+                    onChange={onProviderModelChange}
                 />
             ) : null}
-            {modes.length > 0 ? (
-                <DropdownField
-                    disabled={disabled}
-                    label="Approval Preset"
-                    value={modeId}
-                    options={modes.map((mode) => ({
-                        value: mode.id,
-                        label: formatFallbackLabel(mode.name),
-                        description: mode.description,
-                        disabled: mode.disabled,
-                    }))}
-                    onChange={onModeChange}
-                />
-            ) : null}
-            {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
-            {providers.length === 0 && lockedModelOptions.length > 0 ? (
+            {showLegacyModelPicker ? (
                 <DropdownField
                     disabled={disabled}
                     label="Model"
@@ -705,16 +716,47 @@ export function AIChatAgentControls({
                     }
                 />
             ) : null}
-            {visibleExtraConfigs.map(({ option, label, options }) => (
-                <DropdownField
-                    key={option.id}
-                    disabled={disabled}
-                    label={label}
-                    value={option.value}
-                    options={options}
-                    onChange={(value) => onConfigOptionChange(option.id, value)}
-                />
+            {visibleExtraConfigs.map(({ option, label, options }, index) => (
+                <div className="contents" key={option.id}>
+                    {hasControlBeforeExtras || index > 0 ? (
+                        <ControlSeparator />
+                    ) : null}
+                    <DropdownField
+                        disabled={disabled}
+                        label={label}
+                        value={option.value}
+                        options={options}
+                        onChange={(value) =>
+                            onConfigOptionChange(option.id, value)
+                        }
+                    />
+                </div>
             ))}
+            {modes.length > 0 ? (
+                <>
+                    {hasControlBeforeExtras || visibleExtraConfigs.length > 0 ? (
+                        <ControlSeparator />
+                    ) : null}
+                    <DropdownField
+                        disabled={disabled}
+                        label="Approval Preset"
+                        leadingIcon={
+                            <PermissionModeIcon
+                                fullAccess={modeId === CODEX_FULL_ACCESS_MODE_ID}
+                            />
+                        }
+                        value={modeId}
+                        options={modes.map((mode) => ({
+                            value: mode.id,
+                            label: formatFallbackLabel(mode.name),
+                            description: mode.description,
+                            disabled: mode.disabled,
+                        }))}
+                        onChange={onModeChange}
+                    />
+                </>
+            ) : null}
+            {showFullAccessPolicyHelp ? <FullAccessPolicyHelp /> : null}
         </div>
     );
 }

--- a/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatCommandPicker.tsx
@@ -80,6 +80,7 @@ export function AIChatCommandPicker({
 
     return createPortal(
         <div
+            className="nw-chat-glass-menu"
             ref={ref}
             style={{
                 position: "fixed",
@@ -91,11 +92,8 @@ export function AIChatCommandPicker({
                 overflow: "hidden",
                 borderRadius: 10,
                 border: "1px solid color-mix(in srgb, var(--border) 86%, transparent)",
-                background:
-                    "color-mix(in srgb, var(--bg-elevated) 97%, transparent)",
                 boxShadow:
                     "0 12px 32px rgba(15, 23, 42, 0.16), 0 0 0 1px color-mix(in srgb, var(--border) 40%, transparent)",
-                backdropFilter: "blur(10px)",
             }}
         >
             <div

--- a/apps/desktop/src/features/ai/components/AIChatMentionPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMentionPicker.tsx
@@ -159,6 +159,7 @@ export function AIChatMentionPicker({
 
     return createPortal(
         <div
+            className="nw-chat-glass-menu"
             ref={ref}
             style={{
                 position: "fixed",
@@ -170,11 +171,8 @@ export function AIChatMentionPicker({
                 overflow: "hidden",
                 borderRadius: 10,
                 border: "1px solid color-mix(in srgb, var(--border) 86%, transparent)",
-                background:
-                    "color-mix(in srgb, var(--bg-elevated) 97%, transparent)",
                 boxShadow:
                     "0 12px 32px rgba(15, 23, 42, 0.16), 0 0 0 1px color-mix(in srgb, var(--border) 40%, transparent)",
-                backdropFilter: "blur(10px)",
             }}
         >
             <div

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -111,6 +111,57 @@ describe("AIChatMessageList streaming run indicator", () => {
         useChatStore.setState({ toolActivityDisplayMode: "collapsed" });
     });
 
+    it("marks provider boundaries and warns when handoff context was truncated", () => {
+        useChatStore.setState({
+            runtimes: [
+                {
+                    runtime: {
+                        id: "claude-acp",
+                        name: "Claude ACP",
+                        description: "Claude provider",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+        });
+        renderComponent(
+            <AIChatMessageList
+                messages={[
+                    {
+                        id: "user:switch",
+                        role: "user",
+                        kind: "text",
+                        content: "Continue here",
+                        timestamp: 1,
+                        turnProvenance: {
+                            bindingId: "binding-claude",
+                            runtimeId: "claude-acp",
+                            runtimeSessionId: "native-claude",
+                            modelId: "claude-sonnet",
+                            modeId: "default",
+                            options: {},
+                            startReason: "provider_switch",
+                            handoffTruncated: true,
+                            handoffOmittedTurnCount: 3,
+                        },
+                    },
+                ]}
+                status="idle"
+            />,
+        );
+
+        expect(screen.getByTestId("provider-boundary-marker")).toHaveTextContent(
+            "Continued with Claude",
+        );
+        expect(screen.getByTestId("provider-handoff-warning")).toHaveAttribute(
+            "title",
+            "3 earlier turns were omitted from the bounded handoff.",
+        );
+    });
+
     it("keeps reasoning, web, edit, and MCP activity in one chronological rail", () => {
         renderComponent(
             <AIChatMessageList

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -111,57 +111,6 @@ describe("AIChatMessageList streaming run indicator", () => {
         useChatStore.setState({ toolActivityDisplayMode: "collapsed" });
     });
 
-    it("marks provider boundaries and warns when handoff context was truncated", () => {
-        useChatStore.setState({
-            runtimes: [
-                {
-                    runtime: {
-                        id: "claude-acp",
-                        name: "Claude ACP",
-                        description: "Claude provider",
-                        capabilities: ["create_session"],
-                    },
-                    models: [],
-                    modes: [],
-                    configOptions: [],
-                },
-            ],
-        });
-        renderComponent(
-            <AIChatMessageList
-                messages={[
-                    {
-                        id: "user:switch",
-                        role: "user",
-                        kind: "text",
-                        content: "Continue here",
-                        timestamp: 1,
-                        turnProvenance: {
-                            bindingId: "binding-claude",
-                            runtimeId: "claude-acp",
-                            runtimeSessionId: "native-claude",
-                            modelId: "claude-sonnet",
-                            modeId: "default",
-                            options: {},
-                            startReason: "provider_switch",
-                            handoffTruncated: true,
-                            handoffOmittedTurnCount: 3,
-                        },
-                    },
-                ]}
-                status="idle"
-            />,
-        );
-
-        expect(screen.getByTestId("provider-boundary-marker")).toHaveTextContent(
-            "Continued with Claude",
-        );
-        expect(screen.getByTestId("provider-handoff-warning")).toHaveAttribute(
-            "title",
-            "3 earlier turns were omitted from the bounded handoff.",
-        );
-    });
-
     it("keeps reasoning, web, edit, and MCP activity in one chronological rail", () => {
         renderComponent(
             <AIChatMessageList

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -87,6 +87,13 @@ type TimelineRow =
           message: AIChatMessage;
       }
     | {
+          key: string;
+          kind: "provider-boundary";
+          runtimeId: string;
+          handoffTruncated: boolean;
+          omittedTurnCount: number;
+      }
+    | {
           isCurrentTurnTail: boolean;
           key: string;
           kind: "activity-segment";
@@ -215,6 +222,67 @@ function StreamingRunIndicator({
     );
 }
 
+function formatProviderFallback(runtimeId: string) {
+    return runtimeId
+        .replace(/^custom:/, "")
+        .replace(/-acp$/, "")
+        .replace(/[-_]+/g, " ")
+        .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function ProviderBoundaryMarker({
+    runtimeId,
+    runtimeName,
+    handoffTruncated,
+    omittedTurnCount,
+}: {
+    runtimeId: string;
+    runtimeName?: string;
+    handoffTruncated: boolean;
+    omittedTurnCount: number;
+}) {
+    const label = runtimeName?.replace(/ ACP$/, "") ||
+        formatProviderFallback(runtimeId);
+    return (
+        <div
+            className="flex items-center gap-2 py-1 text-[11px]"
+            data-testid="provider-boundary-marker"
+            data-runtime-id={runtimeId}
+            style={{ color: "var(--text-secondary)" }}
+        >
+            <span
+                aria-hidden="true"
+                className="h-px min-w-4 flex-1"
+                style={{ backgroundColor: "var(--border)" }}
+            />
+            <span className="shrink-0">Continued with {label}</span>
+            {handoffTruncated ? (
+                <span
+                    className="shrink-0 rounded px-1.5 py-0.5"
+                    data-testid="provider-handoff-warning"
+                    style={{
+                        backgroundColor:
+                            "color-mix(in srgb, #f59e0b 10%, transparent)",
+                        color: "#f59e0b",
+                    }}
+                    title={
+                        omittedTurnCount > 0
+                            ? `${omittedTurnCount} earlier ${omittedTurnCount === 1 ? "turn was" : "turns were"} omitted from the bounded handoff.`
+                            : "Part of the earlier context was omitted from the bounded handoff."
+                    }
+                >
+                    Context truncated
+                </span>
+            ) : null}
+            <span
+                aria-hidden="true"
+                className="h-px min-w-4 flex-1"
+                style={{ backgroundColor: "var(--border)" }}
+            />
+        </div>
+    );
+}
+
 function deriveMessageListDecorations(
     messages: AIChatMessage[],
     active: boolean,
@@ -302,6 +370,7 @@ function renderTimelineRow(
         forceExpandedMessageId?: string | null;
         forceExpandedForSearch?: boolean;
         activityDisplayMode: ActivityDisplayMode;
+        runtimeNamesById: Readonly<Record<string, string>>;
     },
 ) {
     if (row.kind === "run-indicator") {
@@ -327,6 +396,17 @@ function renderTimelineRow(
                 }
                 segment={row.segment}
                 sessionId={options.sessionId}
+            />
+        );
+    }
+
+    if (row.kind === "provider-boundary") {
+        return (
+            <ProviderBoundaryMarker
+                runtimeId={row.runtimeId}
+                runtimeName={options.runtimeNamesById[row.runtimeId]}
+                handoffTruncated={row.handoffTruncated}
+                omittedTurnCount={row.omittedTurnCount}
             />
         );
     }
@@ -451,6 +531,17 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     const dismissMessage = useChatStore((state) => state.dismissMessage);
     const activityDisplayMode = useChatStore(
         (state) => state.toolActivityDisplayMode,
+    );
+    const runtimes = useChatStore((state) => state.runtimes);
+    const runtimeNamesById = useMemo(
+        () =>
+            Object.fromEntries(
+                runtimes.map((runtime) => [
+                    runtime.runtime.id,
+                    runtime.runtime.name,
+                ]),
+            ),
+        [runtimes],
     );
     const handleDismissMessage = useCallback(
         (messageId: string) => {
@@ -582,6 +673,24 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         for (const presentationRow of presentationRows) {
             if (presentationRow.kind === "message") {
+                const provenance = presentationRow.message.turnProvenance;
+                if (
+                    presentationRow.message.role === "user" &&
+                    provenance?.startReason === "provider_switch"
+                ) {
+                    rows.push({
+                        key: scopeTimelineRowKey(
+                            sessionId,
+                            `provider-boundary:${presentationRow.id}`,
+                        ),
+                        kind: "provider-boundary",
+                        runtimeId: provenance.runtimeId,
+                        handoffTruncated:
+                            provenance.handoffTruncated === true,
+                        omittedTurnCount:
+                            provenance.handoffOmittedTurnCount ?? 0,
+                    });
+                }
                 rows.push({
                     key: scopeTimelineRowKey(sessionId, presentationRow.id),
                     kind: "message",
@@ -639,6 +748,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             forceExpandedForSearch: findOpen && findQuery.trim().length > 0,
             highlightedMessageId: outlineHighlightedMessageId,
             activityDisplayMode,
+            runtimeNamesById,
         }),
         [
             activityDisplayMode,
@@ -654,6 +764,7 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             onUrlElicitationResponse,
             pillMetrics,
             readOnly,
+            runtimeNamesById,
             sessionId,
             visibleWorkCycleId,
         ],

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -87,13 +87,6 @@ type TimelineRow =
           message: AIChatMessage;
       }
     | {
-          key: string;
-          kind: "provider-boundary";
-          runtimeId: string;
-          handoffTruncated: boolean;
-          omittedTurnCount: number;
-      }
-    | {
           isCurrentTurnTail: boolean;
           key: string;
           kind: "activity-segment";
@@ -222,67 +215,6 @@ function StreamingRunIndicator({
     );
 }
 
-function formatProviderFallback(runtimeId: string) {
-    return runtimeId
-        .replace(/^custom:/, "")
-        .replace(/-acp$/, "")
-        .replace(/[-_]+/g, " ")
-        .replace(/\b\w/g, (character) => character.toUpperCase());
-}
-
-function ProviderBoundaryMarker({
-    runtimeId,
-    runtimeName,
-    handoffTruncated,
-    omittedTurnCount,
-}: {
-    runtimeId: string;
-    runtimeName?: string;
-    handoffTruncated: boolean;
-    omittedTurnCount: number;
-}) {
-    const label = runtimeName?.replace(/ ACP$/, "") ||
-        formatProviderFallback(runtimeId);
-    return (
-        <div
-            className="flex items-center gap-2 py-1 text-[11px]"
-            data-testid="provider-boundary-marker"
-            data-runtime-id={runtimeId}
-            style={{ color: "var(--text-secondary)" }}
-        >
-            <span
-                aria-hidden="true"
-                className="h-px min-w-4 flex-1"
-                style={{ backgroundColor: "var(--border)" }}
-            />
-            <span className="shrink-0">Continued with {label}</span>
-            {handoffTruncated ? (
-                <span
-                    className="shrink-0 rounded px-1.5 py-0.5"
-                    data-testid="provider-handoff-warning"
-                    style={{
-                        backgroundColor:
-                            "color-mix(in srgb, #f59e0b 10%, transparent)",
-                        color: "#f59e0b",
-                    }}
-                    title={
-                        omittedTurnCount > 0
-                            ? `${omittedTurnCount} earlier ${omittedTurnCount === 1 ? "turn was" : "turns were"} omitted from the bounded handoff.`
-                            : "Part of the earlier context was omitted from the bounded handoff."
-                    }
-                >
-                    Context truncated
-                </span>
-            ) : null}
-            <span
-                aria-hidden="true"
-                className="h-px min-w-4 flex-1"
-                style={{ backgroundColor: "var(--border)" }}
-            />
-        </div>
-    );
-}
-
 function deriveMessageListDecorations(
     messages: AIChatMessage[],
     active: boolean,
@@ -370,7 +302,6 @@ function renderTimelineRow(
         forceExpandedMessageId?: string | null;
         forceExpandedForSearch?: boolean;
         activityDisplayMode: ActivityDisplayMode;
-        runtimeNamesById: Readonly<Record<string, string>>;
     },
 ) {
     if (row.kind === "run-indicator") {
@@ -396,17 +327,6 @@ function renderTimelineRow(
                 }
                 segment={row.segment}
                 sessionId={options.sessionId}
-            />
-        );
-    }
-
-    if (row.kind === "provider-boundary") {
-        return (
-            <ProviderBoundaryMarker
-                runtimeId={row.runtimeId}
-                runtimeName={options.runtimeNamesById[row.runtimeId]}
-                handoffTruncated={row.handoffTruncated}
-                omittedTurnCount={row.omittedTurnCount}
             />
         );
     }
@@ -531,17 +451,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
     const dismissMessage = useChatStore((state) => state.dismissMessage);
     const activityDisplayMode = useChatStore(
         (state) => state.toolActivityDisplayMode,
-    );
-    const runtimes = useChatStore((state) => state.runtimes);
-    const runtimeNamesById = useMemo(
-        () =>
-            Object.fromEntries(
-                runtimes.map((runtime) => [
-                    runtime.runtime.id,
-                    runtime.runtime.name,
-                ]),
-            ),
-        [runtimes],
     );
     const handleDismissMessage = useCallback(
         (messageId: string) => {
@@ -673,24 +582,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
 
         for (const presentationRow of presentationRows) {
             if (presentationRow.kind === "message") {
-                const provenance = presentationRow.message.turnProvenance;
-                if (
-                    presentationRow.message.role === "user" &&
-                    provenance?.startReason === "provider_switch"
-                ) {
-                    rows.push({
-                        key: scopeTimelineRowKey(
-                            sessionId,
-                            `provider-boundary:${presentationRow.id}`,
-                        ),
-                        kind: "provider-boundary",
-                        runtimeId: provenance.runtimeId,
-                        handoffTruncated:
-                            provenance.handoffTruncated === true,
-                        omittedTurnCount:
-                            provenance.handoffOmittedTurnCount ?? 0,
-                    });
-                }
                 rows.push({
                     key: scopeTimelineRowKey(sessionId, presentationRow.id),
                     kind: "message",
@@ -748,7 +639,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             forceExpandedForSearch: findOpen && findQuery.trim().length > 0,
             highlightedMessageId: outlineHighlightedMessageId,
             activityDisplayMode,
-            runtimeNamesById,
         }),
         [
             activityDisplayMode,
@@ -764,7 +654,6 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             onUrlElicitationResponse,
             pillMetrics,
             readOnly,
-            runtimeNamesById,
             sessionId,
             visibleWorkCycleId,
         ],

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -267,6 +267,91 @@ describe("AIChatSessionView", () => {
         });
     });
 
+    it("treats the staged provider as active while the first turn is pending", () => {
+        const sessionId = "session-a";
+        useChatStore.setState((state) => ({
+            ...state,
+            sessionsById: {
+                [sessionId]: {
+                    ...createSession(sessionId, "Workspace chat"),
+                    messages: [],
+                    persistedMessageCount: 0,
+                },
+            },
+            activeSessionId: sessionId,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B ACP",
+                        description: "Second provider",
+                        capabilities: ["create_session"],
+                    },
+                    models: [
+                        {
+                            id: "model-b",
+                            runtimeId: "provider-b",
+                            name: "Model B",
+                            description: "Provider B model",
+                        },
+                    ],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    runtimeId: "provider-b",
+                    binaryReady: true,
+                    binarySource: "bundled",
+                    authReady: true,
+                    authMethods: [],
+                    onboardingRequired: false,
+                },
+            },
+        }));
+        useChatStore.setState((state) => ({
+            conversationsById: {
+                ...state.conversationsById,
+                [sessionId]: {
+                    ...state.conversationsById[sessionId]!,
+                    status: "streaming",
+                    preferredSelection: {
+                        ...state.conversationsById[sessionId]!.preferredSelection,
+                        runtimeId: "provider-b",
+                        modelId: "model-b",
+                    },
+                },
+            },
+            preparedTurnCatalogByConversationId: {
+                ...state.preparedTurnCatalogByConversationId,
+                [sessionId]: {
+                    runtimeId: "provider-b",
+                    modelId: "model-b",
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                    effortsByModel: {},
+                },
+            },
+        }));
+        useEditorStore.getState().openChat(sessionId, {
+            title: "Workspace chat",
+            paneId: "primary",
+        });
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+
+        expect(agentControlsMockState.props?.runtimeId).toBe("provider-b");
+        expect(
+            agentControlsMockState.props?.providers?.find(
+                (provider) => provider.runtimeId === "provider-b",
+            )?.disabledReason,
+        ).toBeNull();
+    });
+
     it("renames the workspace chat from the local header title on double click", async () => {
         setupWorkspaceSession();
 

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import { invoke } from "@neverwrite/runtime";
+import { confirm, invoke } from "@neverwrite/runtime";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
@@ -20,6 +20,17 @@ import { AI_CHAT_CONTENT_MAX_WIDTH_PX } from "./chatContentLayout";
 
 const composerMockState = vi.hoisted(() => ({
     onPasteImage: undefined as ((file: File) => void) | undefined,
+    onSubmit: undefined as (() => void) | undefined,
+}));
+const agentControlsMockState = vi.hoisted(() => ({
+    props: null as null | {
+        runtimeId?: string;
+        providers?: Array<{
+            runtimeId: string;
+            disabledReason: string | null;
+        }>;
+        onProviderModelChange?: (runtimeId: string, modelId: string) => void;
+    },
 }));
 const messageListMockState = vi.hoisted(() => ({
     props: [] as Array<{
@@ -57,6 +68,7 @@ vi.mock("./AIChatComposer", () => ({
         footer,
         onToggleExpanded,
         onPasteImage,
+        onSubmit,
         placeholderText,
     }: {
         disabled?: boolean;
@@ -65,9 +77,11 @@ vi.mock("./AIChatComposer", () => ({
         footer?: ReactNode;
         onToggleExpanded?: () => void;
         onPasteImage?: (file: File) => void;
+        onSubmit?: () => void;
         placeholderText?: string;
-    }) => (
-        <div>
+    }) => {
+        composerMockState.onSubmit = onSubmit;
+        return <div>
             <button
                 type="button"
                 data-testid="chat-composer"
@@ -86,8 +100,8 @@ vi.mock("./AIChatComposer", () => ({
                     composerMockState.onPasteImage = onPasteImage;
                 }}
             />
-        </div>
-    ),
+        </div>;
+    },
 }));
 
 vi.mock("./AIChatContextBar", () => ({
@@ -95,7 +109,12 @@ vi.mock("./AIChatContextBar", () => ({
 }));
 
 vi.mock("./AIChatAgentControls", () => ({
-    AIChatAgentControls: () => <div data-testid="chat-agent-controls" />,
+    AIChatAgentControls: (
+        props: NonNullable<typeof agentControlsMockState.props>,
+    ) => {
+        agentControlsMockState.props = props;
+        return <div data-testid="chat-agent-controls" />;
+    },
 }));
 
 vi.mock("./EditedFilesBufferPanel", () => ({
@@ -170,6 +189,8 @@ describe("AIChatSessionView", () => {
         resetChatStore();
         useSettingsStore.getState().reset();
         composerMockState.onPasteImage = undefined;
+        composerMockState.onSubmit = undefined;
+        agentControlsMockState.props = null;
         messageListMockState.props = [];
         useVaultStore.setState({
             vaultPath: "/vault",
@@ -180,6 +201,86 @@ describe("AIChatSessionView", () => {
             tabs: [],
             activeTabId: null,
         });
+    });
+
+    it("confirms the first provider handoff and selects it for the next turn", async () => {
+        setupWorkspaceSession();
+        useChatStore.setState((state) => ({
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B ACP",
+                        description: "Second provider",
+                        capabilities: ["create_session"],
+                    },
+                    models: [
+                        {
+                            id: "model-b",
+                            runtimeId: "provider-b",
+                            name: "Model B",
+                            description: "Provider B model",
+                        },
+                    ],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    runtimeId: "provider-b",
+                    binaryReady: true,
+                    binarySource: "bundled",
+                    authReady: true,
+                    authMethods: [],
+                    onboardingRequired: false,
+                },
+            },
+        }));
+        const startConversationTurn = vi
+            .spyOn(useChatStore.getState(), "startConversationTurn")
+            .mockResolvedValue();
+
+        renderComponent(<AIChatSessionView paneId="primary" />);
+        expect(
+            agentControlsMockState.props?.providers?.map(
+                (provider) => provider.runtimeId,
+            ),
+        ).toContain("provider-b");
+
+        act(() => {
+            agentControlsMockState.props?.onProviderModelChange?.(
+                "provider-b",
+                "model-b",
+            );
+        });
+
+        await waitFor(() => {
+            expect(confirm).toHaveBeenCalledWith(
+                expect.stringContaining("bounded transcript handoff"),
+                expect.objectContaining({ title: "Switch ACP provider" }),
+            );
+            expect(
+                useChatStore.getState().conversationsById["session-a"]
+                    ?.preferredSelection,
+            ).toMatchObject({
+                runtimeId: "provider-b",
+                modelId: "model-b",
+            });
+        });
+
+        act(() => {
+            composerMockState.onSubmit?.();
+        });
+        expect(startConversationTurn).toHaveBeenCalledWith(
+            "session-a",
+            expect.objectContaining({
+                runtimeId: "provider-b",
+                modelId: "model-b",
+            }),
+        );
     });
 
     it("renames the workspace chat from the local header title on double click", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -25,7 +25,6 @@ const composerMockState = vi.hoisted(() => ({
 const agentControlsMockState = vi.hoisted(() => ({
     props: null as null | {
         runtimeId?: string;
-        providerSwitchLocked?: boolean;
         providers?: Array<{
             runtimeId: string;
             disabledReason: string | null;
@@ -247,8 +246,10 @@ describe("AIChatSessionView", () => {
             ),
         ).toContain("provider-b");
         expect(
-            agentControlsMockState.props?.providerSwitchLocked,
-        ).toBe(true);
+            agentControlsMockState.props?.providers?.find(
+                (provider) => provider.runtimeId === "provider-b",
+            )?.disabledReason,
+        ).toBe("Start a new chat to use another provider.");
 
         act(() => {
             agentControlsMockState.props?.onProviderModelChange?.(

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -1,5 +1,5 @@
 import { act, fireEvent, screen, waitFor } from "@testing-library/react";
-import { confirm, invoke } from "@neverwrite/runtime";
+import { invoke } from "@neverwrite/runtime";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useEditorStore } from "../../../app/store/editorStore";
@@ -25,6 +25,7 @@ const composerMockState = vi.hoisted(() => ({
 const agentControlsMockState = vi.hoisted(() => ({
     props: null as null | {
         runtimeId?: string;
+        providerSwitchLocked?: boolean;
         providers?: Array<{
             runtimeId: string;
             disabledReason: string | null;
@@ -203,7 +204,7 @@ describe("AIChatSessionView", () => {
         });
     });
 
-    it("confirms the first provider handoff and selects it for the next turn", async () => {
+    it("locks provider changes after the conversation starts", () => {
         setupWorkspaceSession();
         useChatStore.setState((state) => ({
             runtimes: [
@@ -239,16 +240,15 @@ describe("AIChatSessionView", () => {
                 },
             },
         }));
-        const startConversationTurn = vi
-            .spyOn(useChatStore.getState(), "startConversationTurn")
-            .mockResolvedValue();
-
         renderComponent(<AIChatSessionView paneId="primary" />);
         expect(
             agentControlsMockState.props?.providers?.map(
                 (provider) => provider.runtimeId,
             ),
         ).toContain("provider-b");
+        expect(
+            agentControlsMockState.props?.providerSwitchLocked,
+        ).toBe(true);
 
         act(() => {
             agentControlsMockState.props?.onProviderModelChange?.(
@@ -257,30 +257,13 @@ describe("AIChatSessionView", () => {
             );
         });
 
-        await waitFor(() => {
-            expect(confirm).toHaveBeenCalledWith(
-                expect.stringContaining("bounded transcript handoff"),
-                expect.objectContaining({ title: "Switch ACP provider" }),
-            );
-            expect(
-                useChatStore.getState().conversationsById["session-a"]
-                    ?.preferredSelection,
-            ).toMatchObject({
-                runtimeId: "provider-b",
-                modelId: "model-b",
-            });
+        expect(
+            useChatStore.getState().conversationsById["session-a"]
+                ?.preferredSelection,
+        ).toMatchObject({
+            runtimeId: "codex-acp",
+            modelId: "test-model",
         });
-
-        act(() => {
-            composerMockState.onSubmit?.();
-        });
-        expect(startConversationTurn).toHaveBeenCalledWith(
-            "session-a",
-            expect.objectContaining({
-                runtimeId: "provider-b",
-                modelId: "model-b",
-            }),
-        );
     });
 
     it("renames the workspace chat from the local header title on double click", async () => {

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -40,6 +40,7 @@ import {
     type AIComposerPart,
     type AIChatMessage,
     type AIRuntimeConnectionState,
+    type AIRuntimeDescriptor,
     type ConversationSelection,
     type DraftAttachmentId,
     type QueuedChatMessage,
@@ -96,6 +97,19 @@ import { getConversationSelection } from "../conversationModel";
 
 const EMPTY_COMPOSER_PARTS: AIComposerPart[] = [];
 const EMPTY_CONVERSATION_BINDINGS: AcpConversationBinding[] = [];
+
+function runtimeNeedsModelDiscovery(runtime: AIRuntimeDescriptor) {
+    const modelConfig = runtime.configOptions.find(
+        (option) => option.category === "model",
+    );
+    const modelIds = modelConfig
+        ? modelConfig.options.map((option) => option.value)
+        : runtime.models.map((model) => model.id);
+    return (
+        modelIds.length === 0 ||
+        (modelIds.length === 1 && modelIds[0] === "auto")
+    );
+}
 
 function managedAttachmentIds(parts: AIComposerPart[]) {
     return new Set(
@@ -606,6 +620,40 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             session,
             turnSelection,
             updateTurnSelection,
+        ],
+    );
+    const handleProviderActivate = useCallback(
+        async (runtimeId: string) => {
+            if (!conversationId || !session) return;
+            const option = providerOptions.find(
+                (candidate) => candidate.runtimeId === runtimeId,
+            );
+            const runtime = runtimes.find(
+                (candidate) => candidate.runtime.id === runtimeId,
+            );
+            if (
+                !option ||
+                option.disabledReason ||
+                !runtime ||
+                !runtimeNeedsModelDiscovery(runtime)
+            ) {
+                return;
+            }
+
+            // Provider navigation warms the shared catalog without changing
+            // the conversation selection. The concrete model is committed
+            // only when the user chooses one from the discovered list.
+            await chatActions.prepareConversationTurnCatalog(
+                conversationId,
+                getDefaultConversationSelection({ runtime }),
+            );
+        },
+        [
+            chatActions,
+            conversationId,
+            providerOptions,
+            runtimes,
+            session,
         ],
     );
 
@@ -1441,6 +1489,9 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                                             modes={agentCatalog.modes}
                                             configOptions={agentCatalog.configOptions}
                                             providers={providerOptions}
+                                            onProviderActivate={
+                                                handleProviderActivate
+                                            }
                                             onProviderModelChange={(
                                                 runtimeId,
                                                 modelId,

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -18,7 +18,7 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { confirm, open as runtimeOpen } from "@neverwrite/runtime";
+import { open as runtimeOpen } from "@neverwrite/runtime";
 import { useShallow } from "zustand/react/shallow";
 import {
     isChatTab,
@@ -90,7 +90,6 @@ import {
     buildConversationProviderOptions,
     getConversationTurnCatalog,
     getDefaultConversationSelection,
-    requiresFirstProviderHandoffConfirmation,
     updateConversationSelection,
 } from "../conversationPickerModel";
 import { getConversationSelection } from "../conversationModel";
@@ -540,6 +539,11 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         ) &&
         ((session?.messages.length ?? 0) > 0 ||
             (session?.persistedMessageCount ?? 0) > 0);
+    const providerSwitchLocked =
+        Math.max(
+            session?.messages.length ?? 0,
+            session?.persistedMessageCount ?? 0,
+        ) > 0;
 
     const updateTurnSelection = useCallback(
         (selection: ConversationSelection) => {
@@ -557,11 +561,15 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             if (!session || !turnSelection) {
                 return;
             }
-            if (runtimeId === turnSelection.runtimeId) {
-                if (modelId && modelId !== turnSelection.modelId) {
+            if (runtimeId === session.runtimeId) {
+                const currentSelection =
+                    turnSelection.runtimeId === runtimeId
+                        ? turnSelection
+                        : getConversationSelection(session);
+                if (modelId && modelId !== currentSelection.modelId) {
                     updateTurnSelection(
                         updateConversationSelection(
-                            turnSelection,
+                            currentSelection,
                             agentCatalog.configOptions,
                             { kind: "model", value: modelId },
                         ),
@@ -577,27 +585,8 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             );
             if (!option || option.disabledReason || !runtime) return;
 
-            if (
-                requiresFirstProviderHandoffConfirmation({
-                    activeRuntimeId: session.runtimeId,
-                    targetRuntimeId: runtimeId,
-                    bindings: conversationBindings,
-                    messageCount: Math.max(
-                        session.messages.length,
-                        session.persistedMessageCount ?? 0,
-                    ),
-                })
-            ) {
-                const approved = await confirm(
-                    `The next message will continue this conversation with ${option.label}. A bounded transcript handoff will be sent to the new provider.`,
-                    {
-                        title: "Switch ACP provider",
-                        kind: "warning",
-                        okLabel: "Switch provider",
-                        cancelLabel: "Cancel",
-                    },
-                );
-                if (!approved) return;
+            if (providerSwitchLocked) {
+                return;
             }
 
             let nextSelection = getDefaultConversationSelection({
@@ -623,6 +612,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             agentCatalog.configOptions,
             conversationBindings,
             providerOptions,
+            providerSwitchLocked,
             runtimes,
             session,
             turnSelection,
@@ -1452,6 +1442,9 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                                             runtimeId={turnSelection?.runtimeId}
                                             lockIncompatibleModelSwitches={
                                                 lockIncompatibleModelSwitches
+                                            }
+                                            providerSwitchLocked={
+                                                providerSwitchLocked
                                             }
                                             modelId={turnSelection?.modelId ?? ""}
                                             modeId={turnSelection?.modeId ?? ""}

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -261,6 +261,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         conversationId,
         conversation,
         conversationBindings,
+        preparedTurnCatalog,
         parentSession,
         composerParts,
         queuedMessages,
@@ -295,6 +296,11 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                 conversationBindings:
                     s?.conversationBindings?.providerBindings ??
                     EMPTY_CONVERSATION_BINDINGS,
+                preparedTurnCatalog: conversationId
+                    ? (state.preparedTurnCatalogByConversationId[
+                          conversationId
+                      ] ?? null)
+                    : null,
                 parentSession: parent,
                 composerParts: sid
                     ? (state.composerPartsBySessionId[sid] ??
@@ -360,6 +366,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                       session,
                       runtimes,
                       bindings: conversationBindings,
+                      preparedCatalog: preparedTurnCatalog,
                   })
                 : {
                       models: [],
@@ -367,8 +374,58 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                       configOptions: [],
                       effortsByModel: {},
                   },
-        [conversationBindings, runtimes, session, turnSelection],
+        [
+            conversationBindings,
+            preparedTurnCatalog,
+            runtimes,
+            session,
+            turnSelection,
+        ],
     );
+
+    useEffect(() => {
+        if (!conversationId || !session || !turnSelection) return;
+
+        // A staged provider/model switch has no live session yet, so its
+        // dynamic ACP options cannot be projected from the active provider.
+        // Prepare the exact target catalog before the user sends the turn.
+        const preparedMatches =
+            preparedTurnCatalog?.runtimeId === turnSelection.runtimeId &&
+            preparedTurnCatalog.modelId === turnSelection.modelId;
+        if (preparedMatches) return;
+
+        const liveSelection = getConversationSelection(session);
+        const selectionMatchesLiveSession =
+            liveSelection.runtimeId === turnSelection.runtimeId &&
+            liveSelection.modelId === turnSelection.modelId;
+        const runtimeAdvertisesReasoning =
+            selectedRuntime?.runtime.capabilities.includes("reasoning") ??
+            false;
+        const liveCatalogHasReasoning = session.configOptions.some(
+            (option) => option.category === "reasoning",
+        );
+        if (
+            selectionMatchesLiveSession &&
+            session.configOptions.length > 0 &&
+            (!runtimeAdvertisesReasoning || liveCatalogHasReasoning)
+        ) {
+            // Prefer the real live-session catalog when it already represents
+            // the selected provider/model; probing it again would be wasteful.
+            return;
+        }
+
+        void chatActions.prepareConversationTurnCatalog(
+            conversationId,
+            turnSelection,
+        );
+    }, [
+        chatActions,
+        conversationId,
+        preparedTurnCatalog,
+        selectedRuntime,
+        session,
+        turnSelection,
+    ]);
     const providerOptions = useMemo(
         () =>
             conversation && session

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -18,7 +18,7 @@ import {
     useState,
     type ReactNode,
 } from "react";
-import { open as runtimeOpen } from "@neverwrite/runtime";
+import { confirm, open as runtimeOpen } from "@neverwrite/runtime";
 import { useShallow } from "zustand/react/shallow";
 import {
     isChatTab,
@@ -36,9 +36,11 @@ import {
     vaultInvokeForPath,
 } from "../../../app/utils/vaultInvoke";
 import {
+    type AcpConversationBinding,
     type AIComposerPart,
     type AIChatMessage,
     type AIRuntimeConnectionState,
+    type ConversationSelection,
     type DraftAttachmentId,
     type QueuedChatMessage,
 } from "../types";
@@ -84,8 +86,17 @@ import {
     ChatPromptOutlineMenu,
     type ChatPromptOutlineItem,
 } from "./ChatPromptOutlineMenu";
+import {
+    buildConversationProviderOptions,
+    getConversationTurnCatalog,
+    getDefaultConversationSelection,
+    requiresFirstProviderHandoffConfirmation,
+    updateConversationSelection,
+} from "../conversationPickerModel";
+import { getConversationSelection } from "../conversationModel";
 
 const EMPTY_COMPOSER_PARTS: AIComposerPart[] = [];
+const EMPTY_CONVERSATION_BINDINGS: AcpConversationBinding[] = [];
 
 function managedAttachmentIds(parts: AIComposerPart[]) {
     return new Set(
@@ -247,6 +258,9 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     // Session data
     const {
         session,
+        conversationId,
+        conversation,
+        conversationBindings,
         parentSession,
         composerParts,
         queuedMessages,
@@ -260,6 +274,14 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                 ? (state.sessionsById[sessionId] ?? null)
                 : null;
             const sid = s?.sessionId ?? null;
+            const conversationId = sid
+                ? (state.conversationIdBySessionRef[sid] ??
+                  s?.historySessionId ??
+                  null)
+                : null;
+            const conversation = conversationId
+                ? (state.conversationsById[conversationId] ?? null)
+                : null;
             const parent = s?.parentSessionId
                 ? findSessionForHistorySelection(
                       state.sessionsById,
@@ -268,6 +290,11 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                 : null;
             return {
                 session: s,
+                conversationId,
+                conversation,
+                conversationBindings:
+                    s?.conversationBindings?.providerBindings ??
+                    EMPTY_CONVERSATION_BINDINGS,
                 parentSession: parent,
                 composerParts: sid
                     ? (state.composerPartsBySessionId[sid] ??
@@ -293,6 +320,9 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
 
     // Runtime resolution
     const runtimes = useChatStore((s) => s.runtimes);
+    const setupStatusByRuntimeId = useChatStore(
+        (state) => state.setupStatusByRuntimeId,
+    );
     const activeRuntimeId = session?.runtimeId ?? null;
     const activeRuntime = runtimes.find(
         (d) => d.runtime.id === activeRuntimeId,
@@ -313,21 +343,56 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
           }
         : activeConnection;
 
-    const agentCatalog = useMemo(() => {
-        const models =
-            session && session.models.length > 0
-                ? session.models
-                : (activeRuntime?.models ?? []);
-        const modes =
-            session && session.modes.length > 0
-                ? session.modes
-                : (activeRuntime?.modes ?? []);
-        const configOptions =
-            session && session.configOptions.length > 0
-                ? session.configOptions
-                : (activeRuntime?.configOptions ?? []);
-        return { models, modes, configOptions };
-    }, [session, activeRuntime]);
+    const turnSelection = useMemo<ConversationSelection | null>(() => {
+        if (conversation) {
+            return conversation.preferredSelection;
+        }
+        return session ? getConversationSelection(session) : null;
+    }, [conversation, session]);
+    const selectedRuntime = runtimes.find(
+        (runtime) => runtime.runtime.id === turnSelection?.runtimeId,
+    );
+    const agentCatalog = useMemo(
+        () =>
+            session && turnSelection
+                ? getConversationTurnCatalog({
+                      selection: turnSelection,
+                      session,
+                      runtimes,
+                      bindings: conversationBindings,
+                  })
+                : {
+                      models: [],
+                      modes: [],
+                      configOptions: [],
+                      effortsByModel: {},
+                  },
+        [conversationBindings, runtimes, session, turnSelection],
+    );
+    const providerOptions = useMemo(
+        () =>
+            conversation && session
+                ? buildConversationProviderOptions({
+                      runtimes,
+                      setupStatusByRuntimeId,
+                      conversation,
+                      bindings: conversationBindings,
+                      activeRuntimeId: session.runtimeId,
+                      hasQueuedMessages:
+                          queuedMessages.length > 0 ||
+                          queuedMessageEdit != null,
+                  })
+                : [],
+        [
+            conversation,
+            conversationBindings,
+            queuedMessageEdit,
+            queuedMessages.length,
+            runtimes,
+            session,
+            setupStatusByRuntimeId,
+        ],
+    );
 
     // Settings
     const requireCmdEnterToSend = useChatStore((s) => s.requireCmdEnterToSend);
@@ -400,7 +465,9 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     );
 
     const runtimeLabel =
-        activeRuntime?.runtime.name.replace(/ ACP$/, "") ?? "Assistant";
+        selectedRuntime?.runtime.name.replace(/ ACP$/, "") ??
+        activeRuntime?.runtime.name.replace(/ ACP$/, "") ??
+        "Assistant";
     const isClosedSubagent = Boolean(session?.parentSessionId && session.closedAt);
     const isRemovedGeminiAcpSession = session?.runtimeId === "gemini-acp";
     const agentControlsDisabled =
@@ -410,9 +477,101 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         isPendingSessionCreation ||
         Boolean(session.isResumingSession);
     const lockIncompatibleModelSwitches =
-        session?.runtimeId === "grok-acp" &&
-        (session.messages.length > 0 ||
-            (session.persistedMessageCount ?? 0) > 0);
+        turnSelection?.runtimeId === "grok-acp" &&
+        conversationBindings.some(
+            (binding) => binding.runtimeId === "grok-acp",
+        ) &&
+        ((session?.messages.length ?? 0) > 0 ||
+            (session?.persistedMessageCount ?? 0) > 0);
+
+    const updateTurnSelection = useCallback(
+        (selection: ConversationSelection) => {
+            if (!conversationId) return;
+            chatActions.setConversationTurnSelection(
+                conversationId,
+                selection,
+            );
+        },
+        [chatActions, conversationId],
+    );
+
+    const handleProviderModelChange = useCallback(
+        async (runtimeId: string, modelId: string) => {
+            if (!session || !turnSelection) {
+                return;
+            }
+            if (runtimeId === turnSelection.runtimeId) {
+                if (modelId && modelId !== turnSelection.modelId) {
+                    updateTurnSelection(
+                        updateConversationSelection(
+                            turnSelection,
+                            agentCatalog.configOptions,
+                            { kind: "model", value: modelId },
+                        ),
+                    );
+                }
+                return;
+            }
+            const option = providerOptions.find(
+                (candidate) => candidate.runtimeId === runtimeId,
+            );
+            const runtime = runtimes.find(
+                (candidate) => candidate.runtime.id === runtimeId,
+            );
+            if (!option || option.disabledReason || !runtime) return;
+
+            if (
+                requiresFirstProviderHandoffConfirmation({
+                    activeRuntimeId: session.runtimeId,
+                    targetRuntimeId: runtimeId,
+                    bindings: conversationBindings,
+                    messageCount: Math.max(
+                        session.messages.length,
+                        session.persistedMessageCount ?? 0,
+                    ),
+                })
+            ) {
+                const approved = await confirm(
+                    `The next message will continue this conversation with ${option.label}. A bounded transcript handoff will be sent to the new provider.`,
+                    {
+                        title: "Switch ACP provider",
+                        kind: "warning",
+                        okLabel: "Switch provider",
+                        cancelLabel: "Cancel",
+                    },
+                );
+                if (!approved) return;
+            }
+
+            let nextSelection = getDefaultConversationSelection({
+                runtime,
+                bindings: conversationBindings,
+            });
+            if (modelId && modelId !== nextSelection.modelId) {
+                const targetCatalog = getConversationTurnCatalog({
+                    selection: nextSelection,
+                    session,
+                    runtimes,
+                    bindings: conversationBindings,
+                });
+                nextSelection = updateConversationSelection(
+                    nextSelection,
+                    targetCatalog.configOptions,
+                    { kind: "model", value: modelId },
+                );
+            }
+            updateTurnSelection(nextSelection);
+        },
+        [
+            agentCatalog.configOptions,
+            conversationBindings,
+            providerOptions,
+            runtimes,
+            session,
+            turnSelection,
+            updateTurnSelection,
+        ],
+    );
 
     // Handlers
     const handleRemoveAttachment = useCallback(
@@ -1166,7 +1325,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                             files={fileOptions}
                             status={session?.status ?? "idle"}
                             runtimeName={runtimeLabel}
-                            runtimeId={session?.runtimeId}
+                            runtimeId={turnSelection?.runtimeId}
                             requireCmdEnterToSend={requireCmdEnterToSend}
                             composerFontSize={composerFontSize}
                             composerFontFamily={composerFontFamily}
@@ -1233,35 +1392,66 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                                     {!isPendingSessionCreation && (
                                         <AIChatAgentControls
                                             disabled={agentControlsDisabled}
-                                            runtimeId={session?.runtimeId}
+                                            runtimeId={turnSelection?.runtimeId}
                                             lockIncompatibleModelSwitches={
                                                 lockIncompatibleModelSwitches
                                             }
-                                            modelId={session?.modelId ?? ""}
-                                            modeId={session?.modeId ?? ""}
+                                            modelId={turnSelection?.modelId ?? ""}
+                                            modeId={turnSelection?.modeId ?? ""}
                                             effortsByModel={
-                                                session?.effortsByModel ?? {}
+                                                agentCatalog.effortsByModel
                                             }
                                             models={agentCatalog.models}
                                             modes={agentCatalog.modes}
                                             configOptions={agentCatalog.configOptions}
-                                            onModelChange={(modelId) => {
-                                                void chatActions.setModel(
+                                            providers={providerOptions}
+                                            onProviderModelChange={(
+                                                runtimeId,
+                                                modelId,
+                                            ) => {
+                                                void handleProviderModelChange(
+                                                    runtimeId,
                                                     modelId,
-                                                    sessionId,
+                                                );
+                                            }}
+                                            onModelChange={(modelId) => {
+                                                if (!turnSelection) return;
+                                                updateTurnSelection(
+                                                    updateConversationSelection(
+                                                        turnSelection,
+                                                        agentCatalog.configOptions,
+                                                        {
+                                                            kind: "model",
+                                                            value: modelId,
+                                                        },
+                                                    ),
                                                 );
                                             }}
                                             onModeChange={(modeId) => {
-                                                void chatActions.setMode(
-                                                    modeId,
-                                                    sessionId,
+                                                if (!turnSelection) return;
+                                                updateTurnSelection(
+                                                    updateConversationSelection(
+                                                        turnSelection,
+                                                        agentCatalog.configOptions,
+                                                        {
+                                                            kind: "mode",
+                                                            value: modeId,
+                                                        },
+                                                    ),
                                                 );
                                             }}
                                             onConfigOptionChange={(optionId, value) => {
-                                                void chatActions.setConfigOption(
-                                                    optionId,
-                                                    value,
-                                                    sessionId,
+                                                if (!turnSelection) return;
+                                                updateTurnSelection(
+                                                    updateConversationSelection(
+                                                        turnSelection,
+                                                        agentCatalog.configOptions,
+                                                        {
+                                                            kind: "option",
+                                                            optionId,
+                                                            value,
+                                                        },
+                                                    ),
                                                 );
                                             }}
                                         />
@@ -1279,7 +1469,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                             onAttachFile={handleAttachFile}
                             onPasteImage={handlePasteImage}
                             onImageAttachmentValidationFailure={(reason) => {
-                                const runtimeId = session?.runtimeId ?? null;
+                                const runtimeId = turnSelection?.runtimeId ?? null;
                                 setImageAttachmentNotice(
                                     imageAttachmentValidationMessage(reason, runtimeId),
                                 );
@@ -1299,7 +1489,14 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                             }}
                             onSubmit={() => {
                                 setComposerExpanded(false);
-                                void chatActions.sendMessage(sessionId);
+                                if (conversationId && turnSelection) {
+                                    void chatActions.startConversationTurn(
+                                        conversationId,
+                                        turnSelection,
+                                    );
+                                } else {
+                                    void chatActions.sendMessage(sessionId);
+                                }
                             }}
                             onStop={() => {
                                 void chatActions.stopStreaming(sessionId);

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -547,13 +547,15 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         isRemovedGeminiAcpSession ||
         isPendingSessionCreation ||
         Boolean(session.isResumingSession);
+    const conversationStarted =
+        (session?.messages.length ?? 0) > 0 ||
+        (session?.persistedMessageCount ?? 0) > 0;
     const lockIncompatibleModelSwitches =
         turnSelection?.runtimeId === "grok-acp" &&
         conversationBindings.some(
             (binding) => binding.runtimeId === "grok-acp",
         ) &&
-        ((session?.messages.length ?? 0) > 0 ||
-            (session?.persistedMessageCount ?? 0) > 0);
+        conversationStarted;
     const updateTurnSelection = useCallback(
         (selection: ConversationSelection) => {
             if (!conversationId) return;
@@ -1476,6 +1478,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                                     {!isPendingSessionCreation && (
                                         <AIChatAgentControls
                                             disabled={agentControlsDisabled}
+                                            conversationStarted={conversationStarted}
                                             runtimeId={turnSelection?.runtimeId}
                                             lockIncompatibleModelSwitches={
                                                 lockIncompatibleModelSwitches

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -427,13 +427,13 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     ]);
     const providerOptions = useMemo(
         () =>
-            conversation && session
+            conversation && session && turnSelection
                 ? buildConversationProviderOptions({
                       runtimes,
                       setupStatusByRuntimeId,
                       conversation,
                       bindings: conversationBindings,
-                      activeRuntimeId: session.runtimeId,
+                      activeRuntimeId: turnSelection.runtimeId,
                       hasQueuedMessages:
                           queuedMessages.length > 0 ||
                           queuedMessageEdit != null,
@@ -447,6 +447,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             runtimes,
             session,
             setupStatusByRuntimeId,
+            turnSelection,
         ],
     );
 

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -539,12 +539,6 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
         ) &&
         ((session?.messages.length ?? 0) > 0 ||
             (session?.persistedMessageCount ?? 0) > 0);
-    const providerSwitchLocked =
-        Math.max(
-            session?.messages.length ?? 0,
-            session?.persistedMessageCount ?? 0,
-        ) > 0;
-
     const updateTurnSelection = useCallback(
         (selection: ConversationSelection) => {
             if (!conversationId) return;
@@ -557,7 +551,7 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
     );
 
     const handleProviderModelChange = useCallback(
-        async (runtimeId: string, modelId: string) => {
+        (runtimeId: string, modelId: string) => {
             if (!session || !turnSelection) {
                 return;
             }
@@ -585,13 +579,8 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             );
             if (!option || option.disabledReason || !runtime) return;
 
-            if (providerSwitchLocked) {
-                return;
-            }
-
             let nextSelection = getDefaultConversationSelection({
                 runtime,
-                bindings: conversationBindings,
             });
             if (modelId && modelId !== nextSelection.modelId) {
                 const targetCatalog = getConversationTurnCatalog({
@@ -612,7 +601,6 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
             agentCatalog.configOptions,
             conversationBindings,
             providerOptions,
-            providerSwitchLocked,
             runtimes,
             session,
             turnSelection,
@@ -1442,9 +1430,6 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                                             runtimeId={turnSelection?.runtimeId}
                                             lockIncompatibleModelSwitches={
                                                 lockIncompatibleModelSwitches
-                                            }
-                                            providerSwitchLocked={
-                                                providerSwitchLocked
                                             }
                                             modelId={turnSelection?.modelId ?? ""}
                                             modeId={turnSelection?.modeId ?? ""}

--- a/apps/desktop/src/features/ai/components/AIProviderIcon.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderIcon.test.tsx
@@ -1,0 +1,21 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AIProviderIcon } from "./AIProviderIcon";
+
+describe("AIProviderIcon", () => {
+    it("keeps the Kilo mark for Kilo runtimes", () => {
+        const { container } = render(<AIProviderIcon runtimeId="kilo-acp" />);
+
+        expect(container.querySelectorAll("line")).toHaveLength(3);
+        expect(container.querySelector("circle")).not.toBeInTheDocument();
+    });
+
+    it("uses a settings mark for custom runtimes", () => {
+        const { container } = render(
+            <AIProviderIcon runtimeId="custom-acp:user-agent" />,
+        );
+
+        expect(container.querySelector("circle")).toBeInTheDocument();
+        expect(container.querySelectorAll("line")).toHaveLength(0);
+    });
+});

--- a/apps/desktop/src/features/ai/components/AIProviderIcon.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderIcon.tsx
@@ -95,6 +95,25 @@ export function AIProviderIcon({
         );
     }
 
+    if (runtimeId.includes("kilo")) {
+        return (
+            <svg
+                className={className}
+                fill="none"
+                height={size}
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                viewBox="0 0 16 16"
+                width={size}
+            >
+                <line strokeWidth="1.5" x1="4.75" x2="4.75" y1="2.75" y2="13.25" />
+                <line strokeWidth="1.5" x1="4.75" x2="11.25" y1="8" y2="2.75" />
+                <line strokeWidth="1.5" x1="4.75" x2="11.25" y1="8" y2="13.25" />
+            </svg>
+        );
+    }
+
     return (
         <svg
             className={className}
@@ -103,12 +122,12 @@ export function AIProviderIcon({
             stroke="currentColor"
             strokeLinecap="round"
             strokeLinejoin="round"
-            viewBox="0 0 16 16"
+            strokeWidth="1.75"
+            viewBox="0 0 24 24"
             width={size}
         >
-            <line strokeWidth="1.5" x1="4.75" x2="4.75" y1="2.75" y2="13.25" />
-            <line strokeWidth="1.5" x1="4.75" x2="11.25" y1="8" y2="2.75" />
-            <line strokeWidth="1.5" x1="4.75" x2="11.25" y1="8" y2="13.25" />
+            <path d="M9.7 2.7 9.4 4a8.2 8.2 0 0 0-1.8 1L6.3 4.6 4.6 6.3 5 7.6a8.2 8.2 0 0 0-1 1.8l-1.3.3v4.6l1.3.3a8.2 8.2 0 0 0 1 1.8l-.4 1.3 1.7 1.7 1.3-.4a8.2 8.2 0 0 0 1.8 1l.3 1.3h4.6l.3-1.3a8.2 8.2 0 0 0 1.8-1l1.3.4 1.7-1.7-.4-1.3a8.2 8.2 0 0 0 1-1.8l1.3-.3V9.7L20 9.4a8.2 8.2 0 0 0-1-1.8l.4-1.3-1.7-1.7-1.3.4a8.2 8.2 0 0 0-1.8-1l-.3-1.3H9.7Z" />
+            <circle cx="12" cy="12" r="3" />
         </svg>
     );
 }

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -698,25 +698,15 @@ export function AIProviderModelPicker({
                     {blockedProvider ? (
                         <div
                             aria-live="polite"
-                            className="pointer-events-none absolute bottom-2 left-12 z-20 max-w-64 rounded-md px-2.5 py-2 text-xs leading-snug"
-                            data-testid="provider-selection-blocked-popover"
+                            className="nw-chat-glass-menu pointer-events-none absolute right-2 bottom-2 left-[52px] z-20 rounded-lg px-3 py-2 text-xs leading-snug"
+                            data-testid="provider-selection-blocked-notice"
                             role="status"
                             style={{
-                                backgroundColor: "var(--bg-primary)",
                                 border: "1px solid var(--border)",
-                                boxShadow: "0 8px 24px rgba(0,0,0,0.28)",
+                                boxShadow: "0 8px 24px rgba(0,0,0,0.22)",
                                 color: "var(--text-primary)",
                             }}
                         >
-                            <span
-                                aria-hidden="true"
-                                className="absolute top-1/2 -left-1 size-2 -translate-y-1/2 rotate-45"
-                                style={{
-                                    backgroundColor: "var(--bg-primary)",
-                                    borderBottom: "1px solid var(--border)",
-                                    borderLeft: "1px solid var(--border)",
-                                }}
-                            />
                             {blockedProvider.disabledReason}
                         </div>
                     ) : null}

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -403,13 +403,6 @@ export function AIProviderModelPicker({
                                 title="Favorites"
                                 type="button"
                             >
-                                {selectedProviderId === FAVORITES_PROVIDER_ID ? (
-                                    <span
-                                        aria-hidden="true"
-                                        className="absolute -right-1 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-l-full"
-                                        style={{ backgroundColor: "var(--accent)" }}
-                                    />
-                                ) : null}
                                 <StarIcon filled />
                             </button>
                             <div
@@ -448,15 +441,6 @@ export function AIProviderModelPicker({
                                         title={provider.label}
                                         type="button"
                                     >
-                                        {selected ? (
-                                            <span
-                                                aria-hidden="true"
-                                                className="absolute -right-1 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-l-full"
-                                                style={{
-                                                    backgroundColor: "var(--accent)",
-                                                }}
-                                            />
-                                        ) : null}
                                         <AIProviderIcon
                                             className="shrink-0 opacity-80"
                                             runtimeId={provider.runtimeId}

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -17,6 +17,7 @@ import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 
 interface AIProviderModelPickerProps {
     disabled?: boolean;
+    conversationStarted?: boolean;
     runtimeId: string;
     modelId: string;
     providers: ConversationProviderPickerOption[];
@@ -168,6 +169,7 @@ function fallbackModels(
 
 export function AIProviderModelPicker({
     disabled = false,
+    conversationStarted = false,
     runtimeId,
     modelId,
     providers,
@@ -404,7 +406,11 @@ export function AIProviderModelPicker({
                         lastFocusedElementRef.current = activeElement;
                     }
                     setSelectedProviderId(
-                        favorites.length > 0 ? FAVORITES_PROVIDER_ID : runtimeId,
+                        conversationStarted
+                            ? runtimeId
+                            : favorites.length > 0
+                              ? FAVORITES_PROVIDER_ID
+                              : runtimeId,
                     );
                     setOpen(true);
                 }}

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -461,7 +461,7 @@ export function AIProviderModelPicker({
                                 <SearchIcon />
                                 <input
                                     aria-label="Provider and model search"
-                                    className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+                                    className="h-full min-w-0 flex-1 bg-transparent p-0 text-sm leading-none outline-none"
                                     onChange={(event) => setQuery(event.target.value)}
                                     onKeyDown={handleSearchKeyDown}
                                     placeholder="Search models..."

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -1,0 +1,604 @@
+import {
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type KeyboardEvent,
+} from "react";
+import {
+    safeStorageGetItem,
+    safeStorageSetItem,
+    subscribeSafeStorage,
+} from "../../../app/utils/safeStorage";
+import type { ConversationProviderPickerOption } from "../conversationPickerModel";
+import { AIProviderIcon } from "./AIProviderIcon";
+
+interface AIProviderModelPickerProps {
+    disabled?: boolean;
+    runtimeId: string;
+    modelId: string;
+    providers: ConversationProviderPickerOption[];
+    onChange: (runtimeId: string, modelId: string) => void;
+}
+
+interface FavoriteModel {
+    runtimeId: string;
+    modelId: string;
+}
+
+interface PickerModel {
+    key: string;
+    runtimeId: string;
+    providerLabel: string;
+    modelId: string;
+    modelLabel: string;
+    description: string;
+    disabledReason: string | null;
+}
+
+const FAVORITE_MODELS_STORAGE_KEY =
+    "neverwrite.ai.provider-model-picker-favorites";
+const FAVORITES_PROVIDER_ID = "__favorites__";
+
+function modelKey(runtimeId: string, modelId: string) {
+    return `${runtimeId}\u0000${modelId}`;
+}
+
+function readFavoriteModels(): FavoriteModel[] {
+    try {
+        const value = JSON.parse(
+            safeStorageGetItem(FAVORITE_MODELS_STORAGE_KEY) ?? "[]",
+        );
+        if (!Array.isArray(value)) return [];
+        return value.filter(
+            (item): item is FavoriteModel =>
+                typeof item === "object" &&
+                item !== null &&
+                typeof item.runtimeId === "string" &&
+                typeof item.modelId === "string",
+        );
+    } catch {
+        return [];
+    }
+}
+
+function SearchIcon() {
+    return (
+        <svg
+            aria-hidden="true"
+            className="shrink-0 opacity-50"
+            fill="none"
+            height="14"
+            viewBox="0 0 16 16"
+            width="14"
+        >
+            <circle cx="7" cy="7" r="4.75" stroke="currentColor" strokeWidth="1.5" />
+            <path
+                d="m10.5 10.5 3 3"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeWidth="1.5"
+            />
+        </svg>
+    );
+}
+
+function StarIcon({ filled = false }: { filled?: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            fill={filled ? "currentColor" : "none"}
+            height="14"
+            viewBox="0 0 16 16"
+            width="14"
+        >
+            <path
+                d="m8 1.75 1.82 3.69 4.07.59-2.95 2.87.7 4.06L8 11.05l-3.64 1.91.7-4.06L2.1 6.03l4.08-.59L8 1.75Z"
+                stroke="currentColor"
+                strokeLinejoin="round"
+                strokeWidth="1.25"
+            />
+        </svg>
+    );
+}
+
+function ChevronIcon({ open }: { open: boolean }) {
+    return (
+        <svg
+            aria-hidden="true"
+            fill="none"
+            height="10"
+            style={{
+                opacity: 0.5,
+                transform: open ? "rotate(180deg)" : "none",
+                transition: "transform 0.1s ease",
+            }}
+            viewBox="0 0 10 10"
+            width="10"
+        >
+            <path
+                d="M2.5 4 5 6.5 7.5 4"
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+            />
+        </svg>
+    );
+}
+
+function fallbackModels(provider: ConversationProviderPickerOption) {
+    if (provider.models.length > 0) return provider.models;
+    return [
+        {
+            modelId: provider.defaultModelId,
+            label: "Default model",
+            description: provider.description,
+            disabledReason: null,
+        },
+    ];
+}
+
+export function AIProviderModelPicker({
+    disabled = false,
+    runtimeId,
+    modelId,
+    providers,
+    onChange,
+}: AIProviderModelPickerProps) {
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState("");
+    const [selectedProviderId, setSelectedProviderId] = useState(runtimeId);
+    const [favorites, setFavorites] = useState(readFavoriteModels);
+    const [highlightedKey, setHighlightedKey] = useState<string | null>(null);
+    const rootRef = useRef<HTMLDivElement>(null);
+    const searchInputRef = useRef<HTMLInputElement>(null);
+    const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+
+    const rows = useMemo<PickerModel[]>(
+        () =>
+            providers.flatMap((provider) =>
+                fallbackModels(provider).map((model) => ({
+                    key: modelKey(provider.runtimeId, model.modelId),
+                    runtimeId: provider.runtimeId,
+                    providerLabel: provider.label,
+                    modelId: model.modelId,
+                    modelLabel: model.label,
+                    description: model.description ?? provider.description,
+                    disabledReason:
+                        provider.disabledReason ?? model.disabledReason ?? null,
+                })),
+            ),
+        [providers],
+    );
+    const favoriteKeys = useMemo(
+        () =>
+            new Set(
+                favorites.map((favorite) =>
+                    modelKey(favorite.runtimeId, favorite.modelId),
+                ),
+            ),
+        [favorites],
+    );
+    const normalizedQuery = query.trim().toLowerCase();
+    const visibleRows = useMemo(() => {
+        if (normalizedQuery) {
+            return rows.filter((row) =>
+                [
+                    row.modelLabel,
+                    row.modelId,
+                    row.providerLabel,
+                    row.description,
+                ].some((value) => value.toLowerCase().includes(normalizedQuery)),
+            );
+        }
+
+        if (selectedProviderId === FAVORITES_PROVIDER_ID) {
+            return rows.filter((row) => favoriteKeys.has(row.key));
+        }
+        return rows
+            .filter((row) => row.runtimeId === selectedProviderId)
+            .toSorted((left, right) => {
+                const favoriteDelta =
+                    Number(favoriteKeys.has(right.key)) -
+                    Number(favoriteKeys.has(left.key));
+                return favoriteDelta;
+            });
+    }, [favoriteKeys, normalizedQuery, rows, selectedProviderId]);
+    const selectableRows = useMemo(
+        () => visibleRows.filter((row) => !row.disabledReason),
+        [visibleRows],
+    );
+    const selectedRow =
+        rows.find(
+            (row) => row.runtimeId === runtimeId && row.modelId === modelId,
+        ) ?? rows.find((row) => row.runtimeId === runtimeId);
+    const triggerLabel = selectedRow?.modelLabel ?? (modelId || "Model");
+
+    const restoreFocus = () => {
+        const target = lastFocusedElementRef.current;
+        if (target?.isConnected) target.focus();
+    };
+    const closePicker = (shouldRestoreFocus = false) => {
+        setOpen(false);
+        setQuery("");
+        setHighlightedKey(null);
+        if (shouldRestoreFocus) {
+            window.requestAnimationFrame(restoreFocus);
+        }
+    };
+
+    useEffect(() => {
+        return subscribeSafeStorage((event) => {
+            if (event.key === FAVORITE_MODELS_STORAGE_KEY) {
+                setFavorites(readFavoriteModels());
+            }
+        });
+    }, []);
+
+    useEffect(() => {
+        if (!open) return;
+        const handlePointerDown = (event: MouseEvent) => {
+            if (!rootRef.current?.contains(event.target as Node)) {
+                setOpen(false);
+                setQuery("");
+                setHighlightedKey(null);
+            }
+        };
+        document.addEventListener("mousedown", handlePointerDown);
+        return () => document.removeEventListener("mousedown", handlePointerDown);
+    }, [open]);
+
+    useEffect(() => {
+        if (!open) return;
+        setSelectedProviderId((current) =>
+            current === FAVORITES_PROVIDER_ID && favorites.length === 0
+                ? runtimeId
+                : current,
+        );
+        const frame = window.requestAnimationFrame(() => {
+            searchInputRef.current?.focus();
+        });
+        return () => window.cancelAnimationFrame(frame);
+    }, [favorites.length, open, runtimeId]);
+
+    useEffect(() => {
+        if (!open) return;
+        const preferred = selectableRows.find(
+            (row) => row.runtimeId === runtimeId && row.modelId === modelId,
+        );
+        setHighlightedKey(preferred?.key ?? selectableRows[0]?.key ?? null);
+    }, [modelId, normalizedQuery, open, selectedProviderId, selectableRows, runtimeId]);
+
+    const toggleFavorite = (row: PickerModel) => {
+        const next = favoriteKeys.has(row.key)
+            ? favorites.filter(
+                  (favorite) =>
+                      favorite.runtimeId !== row.runtimeId ||
+                      favorite.modelId !== row.modelId,
+              )
+            : [
+                  ...favorites,
+                  { runtimeId: row.runtimeId, modelId: row.modelId },
+              ];
+        setFavorites(next);
+        safeStorageSetItem(FAVORITE_MODELS_STORAGE_KEY, JSON.stringify(next));
+    };
+
+    const selectRow = (row: PickerModel) => {
+        if (row.disabledReason) return;
+        onChange(row.runtimeId, row.modelId);
+        closePicker(true);
+    };
+
+    const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+        if (event.key === "Escape") {
+            event.preventDefault();
+            closePicker(true);
+            return;
+        }
+        if (event.key === "Enter") {
+            const highlighted = selectableRows.find(
+                (row) => row.key === highlightedKey,
+            );
+            if (highlighted) {
+                event.preventDefault();
+                selectRow(highlighted);
+            }
+            return;
+        }
+        if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+        event.preventDefault();
+        const currentIndex = selectableRows.findIndex(
+            (row) => row.key === highlightedKey,
+        );
+        const direction = event.key === "ArrowDown" ? 1 : -1;
+        const nextIndex =
+            currentIndex < 0
+                ? direction > 0
+                    ? 0
+                    : selectableRows.length - 1
+                : (currentIndex + direction + selectableRows.length) %
+                  selectableRows.length;
+        setHighlightedKey(selectableRows[nextIndex]?.key ?? null);
+    };
+
+    return (
+        <div className="relative" ref={rootRef}>
+            <button
+                aria-expanded={open}
+                aria-haspopup="dialog"
+                className="nw-control-trigger flex max-w-56 cursor-pointer items-center gap-1.5 rounded-md px-2 py-1 text-xs"
+                data-open={open ? "true" : undefined}
+                disabled={disabled || rows.length === 0}
+                onClick={() => {
+                    if (disabled || rows.length === 0) return;
+                    if (open) {
+                        closePicker(true);
+                        return;
+                    }
+                    const activeElement = document.activeElement;
+                    if (activeElement instanceof HTMLElement) {
+                        lastFocusedElementRef.current = activeElement;
+                    }
+                    setSelectedProviderId(
+                        favorites.length > 0 ? FAVORITES_PROVIDER_ID : runtimeId,
+                    );
+                    setOpen(true);
+                }}
+                onMouseDown={(event) => {
+                    if (!disabled) event.preventDefault();
+                }}
+                style={{
+                    backgroundColor: "transparent",
+                    border: "none",
+                    color: "var(--text-secondary)",
+                    opacity: disabled ? 0.45 : 1,
+                }}
+                title="Provider and model"
+                type="button"
+            >
+                <AIProviderIcon runtimeId={runtimeId} size={14} />
+                <span className="min-w-0 truncate">{triggerLabel}</span>
+                <ChevronIcon open={open} />
+            </button>
+
+            {open ? (
+                <div
+                    aria-label="Provider and model"
+                    className="absolute bottom-full left-0 z-50 mb-1 flex h-[346px] max-h-[min(346px,calc(100vh-32px))] w-[360px] max-w-[calc(100vw-32px)] overflow-hidden rounded-xl"
+                    role="dialog"
+                    style={{
+                        backgroundColor: "var(--bg-secondary)",
+                        border: "1px solid var(--border)",
+                        boxShadow: "0 18px 42px rgba(0,0,0,0.24)",
+                        color: "var(--text-primary)",
+                    }}
+                >
+                    {!normalizedQuery ? (
+                        <div
+                            aria-label="Providers"
+                            className="flex w-11 shrink-0 flex-col items-center gap-1 overflow-y-auto p-1"
+                            style={{
+                                backgroundColor:
+                                    "color-mix(in srgb, var(--bg-tertiary) 55%, transparent)",
+                                borderRight: "1px solid var(--border)",
+                            }}
+                        >
+                            <button
+                                aria-label="Favorites"
+                                className="relative flex aspect-square w-full items-center justify-center rounded-md"
+                                onClick={() => {
+                                    setSelectedProviderId(FAVORITES_PROVIDER_ID);
+                                    searchInputRef.current?.focus();
+                                }}
+                                style={{
+                                    backgroundColor:
+                                        selectedProviderId === FAVORITES_PROVIDER_ID
+                                            ? "var(--bg-primary)"
+                                            : "transparent",
+                                    border: "none",
+                                    color: "var(--text-primary)",
+                                }}
+                                title="Favorites"
+                                type="button"
+                            >
+                                {selectedProviderId === FAVORITES_PROVIDER_ID ? (
+                                    <span
+                                        aria-hidden="true"
+                                        className="absolute -right-1 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-l-full"
+                                        style={{ backgroundColor: "var(--accent)" }}
+                                    />
+                                ) : null}
+                                <StarIcon filled />
+                            </button>
+                            <div
+                                aria-hidden="true"
+                                className="mx-1 h-px w-7 shrink-0"
+                                style={{ backgroundColor: "var(--border)" }}
+                            />
+                            {providers.map((provider) => {
+                                const selected =
+                                    selectedProviderId === provider.runtimeId;
+                                return (
+                                    <button
+                                        aria-label={provider.label}
+                                        className="relative flex aspect-square w-full items-center justify-center rounded-md"
+                                        disabled={
+                                            provider.models.length === 0 &&
+                                            !provider.defaultModelId
+                                        }
+                                        key={provider.runtimeId}
+                                        onClick={() => {
+                                            setSelectedProviderId(provider.runtimeId);
+                                            searchInputRef.current?.focus();
+                                        }}
+                                        style={{
+                                            backgroundColor: selected
+                                                ? "var(--bg-primary)"
+                                                : "transparent",
+                                            border: "none",
+                                            color: "var(--text-primary)",
+                                            opacity:
+                                                provider.models.length === 0 &&
+                                                !provider.defaultModelId
+                                                    ? 0.4
+                                                    : 1,
+                                        }}
+                                        title={provider.label}
+                                        type="button"
+                                    >
+                                        {selected ? (
+                                            <span
+                                                aria-hidden="true"
+                                                className="absolute -right-1 top-1/2 h-5 w-[3px] -translate-y-1/2 rounded-l-full"
+                                                style={{
+                                                    backgroundColor: "var(--accent)",
+                                                }}
+                                            />
+                                        ) : null}
+                                        <AIProviderIcon
+                                            className="shrink-0 opacity-80"
+                                            runtimeId={provider.runtimeId}
+                                            size={19}
+                                        />
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    ) : null}
+
+                    <div className="flex min-w-0 flex-1 flex-col">
+                        <div className="px-2 pt-2">
+                            <div
+                                className="flex h-9 items-center gap-2 border-b px-1"
+                                style={{ borderColor: "var(--border)" }}
+                            >
+                                <SearchIcon />
+                                <input
+                                    aria-label="Provider and model search"
+                                    className="min-w-0 flex-1 bg-transparent text-sm outline-none"
+                                    onChange={(event) => setQuery(event.target.value)}
+                                    onKeyDown={handleSearchKeyDown}
+                                    placeholder="Search models..."
+                                    ref={searchInputRef}
+                                    style={{
+                                        border: "none",
+                                        color: "var(--text-primary)",
+                                        fontFamily: "inherit",
+                                        fontSize: "0.875rem",
+                                    }}
+                                    type="text"
+                                    value={query}
+                                />
+                            </div>
+                        </div>
+
+                        <div className="min-h-0 flex-1 overflow-y-auto p-2">
+                            {visibleRows.length === 0 ? (
+                                <div
+                                    className="px-2 py-8 text-center text-xs"
+                                    style={{ color: "var(--text-secondary)" }}
+                                >
+                                    {selectedProviderId === FAVORITES_PROVIDER_ID &&
+                                    !normalizedQuery
+                                        ? "No favorite models yet. Star a model to keep it here."
+                                        : "No providers or models match that search."}
+                                </div>
+                            ) : (
+                                <div className="flex flex-col gap-0.5">
+                                    {visibleRows.map((row) => {
+                                        const favorite = favoriteKeys.has(row.key);
+                                        const selected =
+                                            row.runtimeId === runtimeId &&
+                                            row.modelId === modelId;
+                                        const highlighted =
+                                            row.key === highlightedKey;
+                                        return (
+                                            <div
+                                                className="group flex min-w-0 items-center rounded-lg px-1"
+                                                key={row.key}
+                                                onMouseEnter={() =>
+                                                    !row.disabledReason &&
+                                                    setHighlightedKey(row.key)
+                                                }
+                                                style={{
+                                                    backgroundColor:
+                                                        highlighted || selected
+                                                            ? "var(--bg-tertiary)"
+                                                            : "transparent",
+                                                    opacity: row.disabledReason ? 0.45 : 1,
+                                                }}
+                                                title={
+                                                    row.disabledReason ?? row.description
+                                                }
+                                            >
+                                                <button
+                                                    aria-label={`${row.providerLabel} · ${row.modelLabel}`}
+                                                    className="min-w-0 flex-1 px-1.5 py-2 text-left"
+                                                    disabled={row.disabledReason != null}
+                                                    onClick={() => selectRow(row)}
+                                                    style={{
+                                                        backgroundColor: "transparent",
+                                                        border: "none",
+                                                        color: "var(--text-primary)",
+                                                    }}
+                                                    title={
+                                                        row.disabledReason ?? row.description
+                                                    }
+                                                    type="button"
+                                                >
+                                                    <span className="block truncate text-xs font-medium">
+                                                        {row.modelLabel}
+                                                    </span>
+                                                    <span
+                                                        className="mt-1 flex items-center gap-1.5 truncate text-[11px]"
+                                                        style={{
+                                                            color: "var(--text-secondary)",
+                                                        }}
+                                                    >
+                                                        <AIProviderIcon
+                                                            runtimeId={row.runtimeId}
+                                                            size={11}
+                                                        />
+                                                        {row.providerLabel}
+                                                    </span>
+                                                </button>
+                                                <button
+                                                    aria-label={
+                                                        favorite
+                                                            ? `Remove ${row.modelLabel} from favorites`
+                                                            : `Add ${row.modelLabel} to favorites`
+                                                    }
+                                                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md"
+                                                    disabled={row.disabledReason != null}
+                                                    onClick={() => toggleFavorite(row)}
+                                                    style={{
+                                                        backgroundColor: "transparent",
+                                                        border: "none",
+                                                        color: favorite
+                                                            ? "#eab308"
+                                                            : "var(--text-secondary)",
+                                                        opacity: favorite ? 1 : 0.65,
+                                                    }}
+                                                    title={
+                                                        favorite
+                                                            ? "Remove from favorites"
+                                                            : "Add to favorites"
+                                                    }
+                                                    type="button"
+                                                >
+                                                    <StarIcon filled={favorite} />
+                                                </button>
+                                            </div>
+                                        );
+                                    })}
+                                </div>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            ) : null}
+        </div>
+    );
+}

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -19,6 +19,7 @@ interface AIProviderModelPickerProps {
     disabled?: boolean;
     runtimeId: string;
     modelId: string;
+    providerSwitchLocked?: boolean;
     providers: ConversationProviderPickerOption[];
     onChange: (runtimeId: string, modelId: string) => void;
 }
@@ -145,6 +146,7 @@ export function AIProviderModelPicker({
     disabled = false,
     runtimeId,
     modelId,
+    providerSwitchLocked = false,
     providers,
     onChange,
 }: AIProviderModelPickerProps) {
@@ -153,6 +155,9 @@ export function AIProviderModelPicker({
     const [selectedProviderId, setSelectedProviderId] = useState(runtimeId);
     const [favorites, setFavorites] = useState(readFavoriteModels);
     const [highlightedKey, setHighlightedKey] = useState<string | null>(null);
+    const [blockedProviderId, setBlockedProviderId] = useState<string | null>(
+        null,
+    );
     const rootRef = useRef<HTMLDivElement>(null);
     const menuRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
@@ -217,6 +222,12 @@ export function AIProviderModelPicker({
             (row) => row.runtimeId === runtimeId && row.modelId === modelId,
         ) ?? rows.find((row) => row.runtimeId === runtimeId);
     const triggerLabel = selectedRow?.modelLabel ?? (modelId || "Model");
+    const activeProvider = providers.find(
+        (provider) => provider.runtimeId === runtimeId,
+    );
+    const blockedProvider = providers.find(
+        (provider) => provider.runtimeId === blockedProviderId,
+    );
     const menuPosition = useAnchoredChatMenuPosition(rootRef, menuRef, open);
 
     const restoreFocus = () => {
@@ -227,6 +238,7 @@ export function AIProviderModelPicker({
         setOpen(false);
         setQuery("");
         setHighlightedKey(null);
+        setBlockedProviderId(null);
         if (shouldRestoreFocus) {
             window.requestAnimationFrame(restoreFocus);
         }
@@ -250,6 +262,7 @@ export function AIProviderModelPicker({
                 setOpen(false);
                 setQuery("");
                 setHighlightedKey(null);
+                setBlockedProviderId(null);
             }
         };
         document.addEventListener("mousedown", handlePointerDown);
@@ -294,6 +307,10 @@ export function AIProviderModelPicker({
 
     const selectRow = (row: PickerModel) => {
         if (row.disabledReason) return;
+        if (providerSwitchLocked && row.runtimeId !== runtimeId) {
+            setBlockedProviderId(row.runtimeId);
+            return;
+        }
         onChange(row.runtimeId, row.modelId);
         closePicker(true);
     };
@@ -401,6 +418,7 @@ export function AIProviderModelPicker({
                                 className="relative flex aspect-square w-full items-center justify-center rounded-md"
                                 onClick={() => {
                                     setSelectedProviderId(FAVORITES_PROVIDER_ID);
+                                    setBlockedProviderId(null);
                                     searchInputRef.current?.focus();
                                 }}
                                 style={{
@@ -424,17 +442,32 @@ export function AIProviderModelPicker({
                             {providers.map((provider) => {
                                 const selected =
                                     selectedProviderId === provider.runtimeId;
+                                const providerLocked =
+                                    providerSwitchLocked &&
+                                    provider.runtimeId !== runtimeId;
                                 return (
                                     <button
+                                        aria-disabled={providerLocked || undefined}
                                         aria-label={provider.label}
-                                        className="relative flex aspect-square w-full items-center justify-center rounded-md"
+                                        className={`relative flex aspect-square w-full items-center justify-center rounded-md ${providerLocked ? "cursor-not-allowed" : ""}`}
                                         disabled={
                                             provider.models.length === 0 &&
                                             !provider.defaultModelId
                                         }
                                         key={provider.runtimeId}
                                         onClick={() => {
+                                            if (
+                                                providerSwitchLocked &&
+                                                provider.runtimeId !== runtimeId
+                                            ) {
+                                                setBlockedProviderId(
+                                                    provider.runtimeId,
+                                                );
+                                                searchInputRef.current?.focus();
+                                                return;
+                                            }
                                             setSelectedProviderId(provider.runtimeId);
+                                            setBlockedProviderId(null);
                                             searchInputRef.current?.focus();
                                         }}
                                         style={{
@@ -447,9 +480,15 @@ export function AIProviderModelPicker({
                                                 provider.models.length === 0 &&
                                                 !provider.defaultModelId
                                                     ? 0.4
-                                                    : 1,
+                                                    : providerLocked
+                                                      ? 0.45
+                                                      : 1,
                                         }}
-                                        title={provider.label}
+                                        title={
+                                            providerLocked
+                                                ? "Start a new chat to switch providers."
+                                                : provider.label
+                                        }
                                         type="button"
                                     >
                                         <AIProviderIcon
@@ -509,6 +548,12 @@ export function AIProviderModelPicker({
                                             row.modelId === modelId;
                                         const highlighted =
                                             row.key === highlightedKey;
+                                        const providerLocked =
+                                            providerSwitchLocked &&
+                                            row.runtimeId !== runtimeId;
+                                        const rowTitle = providerLocked
+                                            ? "Start a new chat to switch providers."
+                                            : (row.disabledReason ?? row.description);
                                         return (
                                             <div
                                                 className="group flex min-w-0 items-center rounded-lg px-1"
@@ -522,15 +567,20 @@ export function AIProviderModelPicker({
                                                         highlighted || selected
                                                             ? "var(--bg-tertiary)"
                                                             : "transparent",
-                                                    opacity: row.disabledReason ? 0.45 : 1,
+                                                    opacity:
+                                                        row.disabledReason ||
+                                                        providerLocked
+                                                            ? 0.45
+                                                            : 1,
                                                 }}
-                                                title={
-                                                    row.disabledReason ?? row.description
-                                                }
+                                                title={rowTitle}
                                             >
                                                 <button
+                                                    aria-disabled={
+                                                        providerLocked || undefined
+                                                    }
                                                     aria-label={`${row.providerLabel} · ${row.modelLabel}`}
-                                                    className="min-w-0 flex-1 px-1.5 py-2 text-left"
+                                                    className={`min-w-0 flex-1 px-1.5 py-2 text-left ${providerLocked ? "cursor-not-allowed" : ""}`}
                                                     disabled={row.disabledReason != null}
                                                     onClick={() => selectRow(row)}
                                                     style={{
@@ -538,9 +588,7 @@ export function AIProviderModelPicker({
                                                         border: "none",
                                                         color: "var(--text-primary)",
                                                     }}
-                                                    title={
-                                                        row.disabledReason ?? row.description
-                                                    }
+                                                    title={rowTitle}
                                                     type="button"
                                                 >
                                                     <span className="block truncate text-xs font-medium">
@@ -592,6 +640,32 @@ export function AIProviderModelPicker({
                             )}
                         </div>
                     </div>
+
+                    {blockedProvider ? (
+                        <div
+                            aria-live="polite"
+                            className="pointer-events-none absolute bottom-2 left-12 z-20 max-w-64 rounded-md px-2.5 py-2 text-xs leading-snug"
+                            data-testid="provider-switch-blocked-popover"
+                            role="status"
+                            style={{
+                                backgroundColor: "var(--bg-primary)",
+                                border: "1px solid var(--border)",
+                                boxShadow: "0 8px 24px rgba(0,0,0,0.28)",
+                                color: "var(--text-primary)",
+                            }}
+                        >
+                            <span
+                                aria-hidden="true"
+                                className="absolute top-1/2 -left-1 size-2 -translate-y-1/2 rotate-45"
+                                style={{
+                                    backgroundColor: "var(--bg-primary)",
+                                    borderBottom: "1px solid var(--border)",
+                                    borderLeft: "1px solid var(--border)",
+                                }}
+                            />
+                            This chat is locked to {activeProvider?.label ?? "its original provider"}. Start a new chat to use {blockedProvider.label}.
+                        </div>
+                    ) : null}
                 </div>,
                 document.body,
                 )

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -19,7 +19,6 @@ interface AIProviderModelPickerProps {
     disabled?: boolean;
     runtimeId: string;
     modelId: string;
-    providerSwitchLocked?: boolean;
     providers: ConversationProviderPickerOption[];
     onChange: (runtimeId: string, modelId: string) => void;
 }
@@ -36,6 +35,7 @@ interface PickerModel {
     modelId: string;
     modelLabel: string;
     description: string;
+    providerDisabledReason: string | null;
     disabledReason: string | null;
 }
 
@@ -146,7 +146,6 @@ export function AIProviderModelPicker({
     disabled = false,
     runtimeId,
     modelId,
-    providerSwitchLocked = false,
     providers,
     onChange,
 }: AIProviderModelPickerProps) {
@@ -173,6 +172,7 @@ export function AIProviderModelPicker({
                     modelId: model.modelId,
                     modelLabel: model.label,
                     description: model.description ?? provider.description,
+                    providerDisabledReason: provider.disabledReason,
                     disabledReason:
                         provider.disabledReason ?? model.disabledReason ?? null,
                 })),
@@ -222,11 +222,10 @@ export function AIProviderModelPicker({
             (row) => row.runtimeId === runtimeId && row.modelId === modelId,
         ) ?? rows.find((row) => row.runtimeId === runtimeId);
     const triggerLabel = selectedRow?.modelLabel ?? (modelId || "Model");
-    const activeProvider = providers.find(
-        (provider) => provider.runtimeId === runtimeId,
-    );
     const blockedProvider = providers.find(
-        (provider) => provider.runtimeId === blockedProviderId,
+        (provider) =>
+            provider.runtimeId === blockedProviderId &&
+            provider.disabledReason != null,
     );
     const menuPosition = useAnchoredChatMenuPosition(rootRef, menuRef, open);
 
@@ -306,11 +305,11 @@ export function AIProviderModelPicker({
     };
 
     const selectRow = (row: PickerModel) => {
-        if (row.disabledReason) return;
-        if (providerSwitchLocked && row.runtimeId !== runtimeId) {
+        if (row.providerDisabledReason) {
             setBlockedProviderId(row.runtimeId);
             return;
         }
+        if (row.disabledReason) return;
         onChange(row.runtimeId, row.modelId);
         closePicker(true);
     };
@@ -443,8 +442,8 @@ export function AIProviderModelPicker({
                                 const selected =
                                     selectedProviderId === provider.runtimeId;
                                 const providerLocked =
-                                    providerSwitchLocked &&
-                                    provider.runtimeId !== runtimeId;
+                                    provider.runtimeId !== runtimeId &&
+                                    provider.disabledReason != null;
                                 return (
                                     <button
                                         aria-disabled={providerLocked || undefined}
@@ -456,10 +455,7 @@ export function AIProviderModelPicker({
                                         }
                                         key={provider.runtimeId}
                                         onClick={() => {
-                                            if (
-                                                providerSwitchLocked &&
-                                                provider.runtimeId !== runtimeId
-                                            ) {
+                                            if (providerLocked) {
                                                 setBlockedProviderId(
                                                     provider.runtimeId,
                                                 );
@@ -486,7 +482,7 @@ export function AIProviderModelPicker({
                                         }}
                                         title={
                                             providerLocked
-                                                ? "Start a new chat to switch providers."
+                                                ? provider.disabledReason ?? provider.label
                                                 : provider.label
                                         }
                                         type="button"
@@ -549,11 +545,10 @@ export function AIProviderModelPicker({
                                         const highlighted =
                                             row.key === highlightedKey;
                                         const providerLocked =
-                                            providerSwitchLocked &&
-                                            row.runtimeId !== runtimeId;
-                                        const rowTitle = providerLocked
-                                            ? "Start a new chat to switch providers."
-                                            : (row.disabledReason ?? row.description);
+                                            row.runtimeId !== runtimeId &&
+                                            row.providerDisabledReason != null;
+                                        const rowTitle =
+                                            row.disabledReason ?? row.description;
                                         return (
                                             <div
                                                 className="group flex min-w-0 items-center rounded-lg px-1"
@@ -577,11 +572,14 @@ export function AIProviderModelPicker({
                                             >
                                                 <button
                                                     aria-disabled={
-                                                        providerLocked || undefined
+                                                        row.disabledReason != null || undefined
                                                     }
                                                     aria-label={`${row.providerLabel} · ${row.modelLabel}`}
                                                     className={`min-w-0 flex-1 px-1.5 py-2 text-left ${providerLocked ? "cursor-not-allowed" : ""}`}
-                                                    disabled={row.disabledReason != null}
+                                                    disabled={
+                                                        row.disabledReason != null &&
+                                                        row.providerDisabledReason == null
+                                                    }
                                                     onClick={() => selectRow(row)}
                                                     style={{
                                                         backgroundColor: "transparent",
@@ -645,7 +643,7 @@ export function AIProviderModelPicker({
                         <div
                             aria-live="polite"
                             className="pointer-events-none absolute bottom-2 left-12 z-20 max-w-64 rounded-md px-2.5 py-2 text-xs leading-snug"
-                            data-testid="provider-switch-blocked-popover"
+                            data-testid="provider-selection-blocked-popover"
                             role="status"
                             style={{
                                 backgroundColor: "var(--bg-primary)",
@@ -663,7 +661,7 @@ export function AIProviderModelPicker({
                                     borderLeft: "1px solid var(--border)",
                                 }}
                             />
-                            This chat is locked to {activeProvider?.label ?? "its original provider"}. Start a new chat to use {blockedProvider.label}.
+                            {blockedProvider.disabledReason}
                         </div>
                     ) : null}
                 </div>,

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -315,11 +315,6 @@ export function AIProviderModelPicker({
     };
 
     const handleSearchKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
-        if (event.key === "Escape") {
-            event.preventDefault();
-            closePicker(true);
-            return;
-        }
         if (event.key === "Enter") {
             const highlighted = selectableRows.find(
                 (row) => row.key === highlightedKey,
@@ -414,6 +409,9 @@ export function AIProviderModelPicker({
                         >
                             <button
                                 aria-label="Favorites"
+                                aria-pressed={
+                                    selectedProviderId === FAVORITES_PROVIDER_ID
+                                }
                                 className="relative flex aspect-square w-full items-center justify-center rounded-md"
                                 onClick={() => {
                                     setSelectedProviderId(FAVORITES_PROVIDER_ID);
@@ -448,6 +446,7 @@ export function AIProviderModelPicker({
                                     <button
                                         aria-disabled={providerLocked || undefined}
                                         aria-label={provider.label}
+                                        aria-pressed={selected}
                                         className={`relative flex aspect-square w-full items-center justify-center rounded-md ${providerLocked ? "cursor-not-allowed" : ""}`}
                                         disabled={
                                             provider.models.length === 0 &&
@@ -573,6 +572,9 @@ export function AIProviderModelPicker({
                                                 <button
                                                     aria-disabled={
                                                         row.disabledReason != null || undefined
+                                                    }
+                                                    aria-current={
+                                                        selected ? "true" : undefined
                                                     }
                                                     aria-label={`${row.providerLabel} · ${row.modelLabel}`}
                                                     className={`min-w-0 flex-1 px-1.5 py-2 text-left ${providerLocked ? "cursor-not-allowed" : ""}`}

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -21,6 +21,7 @@ interface AIProviderModelPickerProps {
     modelId: string;
     providers: ConversationProviderPickerOption[];
     onChange: (runtimeId: string, modelId: string) => void;
+    onProviderActivate?: (runtimeId: string) => void | Promise<void>;
 }
 
 interface FavoriteModel {
@@ -130,8 +131,31 @@ function ChevronIcon({ open }: { open: boolean }) {
     );
 }
 
-function fallbackModels(provider: ConversationProviderPickerOption) {
+function fallbackModels(
+    provider: ConversationProviderPickerOption,
+    loadingProviderId: string | null,
+) {
+    if (provider.runtimeId === loadingProviderId) {
+        return [
+            {
+                modelId: "__loading__",
+                label: "Loading models…",
+                description: `Connecting to ${provider.label} to discover its available models.`,
+                disabledReason: "Models are still loading.",
+            },
+        ];
+    }
     if (provider.models.length > 0) return provider.models;
+    if (!provider.defaultModelId) {
+        return [
+            {
+                modelId: "__discover__",
+                label: "Load available models",
+                description: `Connect to ${provider.label} to discover its available models.`,
+                disabledReason: "Select the provider icon to load its models.",
+            },
+        ];
+    }
     return [
         {
             modelId: provider.defaultModelId,
@@ -148,6 +172,7 @@ export function AIProviderModelPicker({
     modelId,
     providers,
     onChange,
+    onProviderActivate,
 }: AIProviderModelPickerProps) {
     const [open, setOpen] = useState(false);
     const [query, setQuery] = useState("");
@@ -155,6 +180,9 @@ export function AIProviderModelPicker({
     const [favorites, setFavorites] = useState(readFavoriteModels);
     const [highlightedKey, setHighlightedKey] = useState<string | null>(null);
     const [blockedProviderId, setBlockedProviderId] = useState<string | null>(
+        null,
+    );
+    const [loadingProviderId, setLoadingProviderId] = useState<string | null>(
         null,
     );
     const rootRef = useRef<HTMLDivElement>(null);
@@ -165,7 +193,7 @@ export function AIProviderModelPicker({
     const rows = useMemo<PickerModel[]>(
         () =>
             providers.flatMap((provider) =>
-                fallbackModels(provider).map((model) => ({
+                fallbackModels(provider, loadingProviderId).map((model) => ({
                     key: modelKey(provider.runtimeId, model.modelId),
                     runtimeId: provider.runtimeId,
                     providerLabel: provider.label,
@@ -177,8 +205,24 @@ export function AIProviderModelPicker({
                         provider.disabledReason ?? model.disabledReason ?? null,
                 })),
             ),
-        [providers],
+        [loadingProviderId, providers],
     );
+
+    const activateProvider = (provider: ConversationProviderPickerOption) => {
+        setSelectedProviderId(provider.runtimeId);
+        setBlockedProviderId(null);
+        searchInputRef.current?.focus();
+        if (!onProviderActivate) return;
+
+        setLoadingProviderId(provider.runtimeId);
+        void Promise.resolve(onProviderActivate(provider.runtimeId)).finally(
+            () => {
+                setLoadingProviderId((current) =>
+                    current === provider.runtimeId ? null : current,
+                );
+            },
+        );
+    };
     const favoriteKeys = useMemo(
         () =>
             new Set(
@@ -442,6 +486,10 @@ export function AIProviderModelPicker({
                                 const providerLocked =
                                     provider.runtimeId !== runtimeId &&
                                     provider.disabledReason != null;
+                                const providerCanDiscoverModels =
+                                    onProviderActivate != null &&
+                                    provider.models.length === 0 &&
+                                    !provider.defaultModelId;
                                 return (
                                     <button
                                         aria-disabled={providerLocked || undefined}
@@ -450,7 +498,8 @@ export function AIProviderModelPicker({
                                         className={`relative flex aspect-square w-full items-center justify-center rounded-md ${providerLocked ? "cursor-not-allowed" : ""}`}
                                         disabled={
                                             provider.models.length === 0 &&
-                                            !provider.defaultModelId
+                                            !provider.defaultModelId &&
+                                            !providerCanDiscoverModels
                                         }
                                         key={provider.runtimeId}
                                         onClick={() => {
@@ -461,9 +510,7 @@ export function AIProviderModelPicker({
                                                 searchInputRef.current?.focus();
                                                 return;
                                             }
-                                            setSelectedProviderId(provider.runtimeId);
-                                            setBlockedProviderId(null);
-                                            searchInputRef.current?.focus();
+                                            activateProvider(provider);
                                         }}
                                         style={{
                                             backgroundColor: selected
@@ -473,7 +520,8 @@ export function AIProviderModelPicker({
                                             color: "var(--text-primary)",
                                             opacity:
                                                 provider.models.length === 0 &&
-                                                !provider.defaultModelId
+                                                !provider.defaultModelId &&
+                                                !providerCanDiscoverModels
                                                     ? 0.4
                                                     : providerLocked
                                                       ? 0.45

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -5,6 +5,7 @@ import {
     useState,
     type KeyboardEvent,
 } from "react";
+import { createPortal } from "react-dom";
 import {
     safeStorageGetItem,
     safeStorageSetItem,
@@ -12,6 +13,7 @@ import {
 } from "../../../app/utils/safeStorage";
 import type { ConversationProviderPickerOption } from "../conversationPickerModel";
 import { AIProviderIcon } from "./AIProviderIcon";
+import { useAnchoredChatMenuPosition } from "./useAnchoredChatMenuPosition";
 
 interface AIProviderModelPickerProps {
     disabled?: boolean;
@@ -152,6 +154,7 @@ export function AIProviderModelPicker({
     const [favorites, setFavorites] = useState(readFavoriteModels);
     const [highlightedKey, setHighlightedKey] = useState<string | null>(null);
     const rootRef = useRef<HTMLDivElement>(null);
+    const menuRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
     const lastFocusedElementRef = useRef<HTMLElement | null>(null);
 
@@ -214,6 +217,7 @@ export function AIProviderModelPicker({
             (row) => row.runtimeId === runtimeId && row.modelId === modelId,
         ) ?? rows.find((row) => row.runtimeId === runtimeId);
     const triggerLabel = selectedRow?.modelLabel ?? (modelId || "Model");
+    const menuPosition = useAnchoredChatMenuPosition(rootRef, menuRef, open);
 
     const restoreFocus = () => {
         const target = lastFocusedElementRef.current;
@@ -239,7 +243,10 @@ export function AIProviderModelPicker({
     useEffect(() => {
         if (!open) return;
         const handlePointerDown = (event: MouseEvent) => {
-            if (!rootRef.current?.contains(event.target as Node)) {
+            if (
+                !rootRef.current?.contains(event.target as Node) &&
+                !menuRef.current?.contains(event.target as Node)
+            ) {
                 setOpen(false);
                 setQuery("");
                 setHighlightedKey(null);
@@ -363,16 +370,20 @@ export function AIProviderModelPicker({
                 <ChevronIcon open={open} />
             </button>
 
-            {open ? (
+            {open
+                ? createPortal(
                 <div
                     aria-label="Provider and model"
-                    className="absolute bottom-full left-0 z-50 mb-1 flex h-[346px] max-h-[min(346px,calc(100vh-32px))] w-[360px] max-w-[calc(100vw-32px)] overflow-hidden rounded-xl"
+                    className="nw-chat-glass-menu fixed z-50 flex h-[346px] max-h-[min(346px,calc(100vh-32px))] w-[360px] max-w-[calc(100vw-32px)] overflow-hidden rounded-xl"
+                    ref={menuRef}
                     role="dialog"
                     style={{
-                        backgroundColor: "var(--bg-secondary)",
                         border: "1px solid var(--border)",
                         boxShadow: "0 18px 42px rgba(0,0,0,0.24)",
                         color: "var(--text-primary)",
+                        left: menuPosition?.left ?? 8,
+                        top: menuPosition?.top ?? 8,
+                        visibility: menuPosition ? "visible" : "hidden",
                     }}
                 >
                     {!normalizedQuery ? (
@@ -581,8 +592,10 @@ export function AIProviderModelPicker({
                             )}
                         </div>
                     </div>
-                </div>
-            ) : null}
+                </div>,
+                document.body,
+                )
+                : null}
         </div>
     );
 }

--- a/apps/desktop/src/features/ai/components/ChatPromptOutlineMenu.tsx
+++ b/apps/desktop/src/features/ai/components/ChatPromptOutlineMenu.tsx
@@ -92,6 +92,7 @@ export function ChatPromptOutlineMenu({
 
     return createPortal(
         <div
+            className="nw-chat-glass-menu"
             ref={menuRef}
             role="menu"
             aria-label="User prompts"
@@ -105,7 +106,6 @@ export function ChatPromptOutlineMenu({
                 overflowY: "auto",
                 padding: 4,
                 borderRadius: 8,
-                backgroundColor: "var(--bg-secondary)",
                 border: "1px solid var(--border)",
                 boxShadow: "0 4px 16px rgba(0,0,0,0.25)",
             }}

--- a/apps/desktop/src/features/ai/components/useAnchoredChatMenuPosition.ts
+++ b/apps/desktop/src/features/ai/components/useAnchoredChatMenuPosition.ts
@@ -1,0 +1,87 @@
+import {
+    useCallback,
+    useEffect,
+    useLayoutEffect,
+    useState,
+    type RefObject,
+} from "react";
+import { getViewportSafeMenuPosition } from "../../../app/utils/menuPosition";
+
+const VIEWPORT_PADDING = 8;
+const MENU_GAP = 4;
+
+interface AnchoredChatMenuPosition {
+    left: number;
+    top: number;
+}
+
+/**
+ * Positions a portalled chat menu next to its composer control. Chat controls
+ * live inside an existing backdrop-filter surface, so their frosted menus must
+ * be portalled out of that backdrop root for Chromium to render another blur.
+ */
+export function useAnchoredChatMenuPosition(
+    anchorRef: RefObject<HTMLElement | null>,
+    menuRef: RefObject<HTMLElement | null>,
+    open: boolean,
+): AnchoredChatMenuPosition | null {
+    const [position, setPosition] = useState<AnchoredChatMenuPosition | null>(
+        null,
+    );
+
+    const updatePosition = useCallback(() => {
+        const anchorElement = anchorRef.current;
+        const menuElement = menuRef.current;
+        if (!anchorElement || !menuElement) return;
+
+        const anchorRect = anchorElement.getBoundingClientRect();
+        const menuRect = menuElement.getBoundingClientRect();
+        const width = Math.ceil(menuRect.width);
+        const height = Math.ceil(menuRect.height);
+        const availableAbove = anchorRect.top - MENU_GAP - VIEWPORT_PADDING;
+        const availableBelow =
+            window.innerHeight -
+            anchorRect.bottom -
+            MENU_GAP -
+            VIEWPORT_PADDING;
+        const openAbove =
+            availableAbove >= height || availableAbove >= availableBelow;
+        const desiredTop = openAbove
+            ? anchorRect.top - height - MENU_GAP
+            : anchorRect.bottom + MENU_GAP;
+        const safe = getViewportSafeMenuPosition(
+            anchorRect.left,
+            desiredTop,
+            width,
+            height,
+            VIEWPORT_PADDING,
+        );
+
+        setPosition({ left: safe.x, top: safe.y });
+    }, [anchorRef, menuRef]);
+
+    useLayoutEffect(() => {
+        if (!open) {
+            setPosition(null);
+            return;
+        }
+        updatePosition();
+    }, [open, updatePosition]);
+
+    useEffect(() => {
+        if (!open) return;
+
+        const handleViewportChange = () => updatePosition();
+        const observer = new ResizeObserver(handleViewportChange);
+        if (menuRef.current) observer.observe(menuRef.current);
+        window.addEventListener("resize", handleViewportChange);
+        window.addEventListener("scroll", handleViewportChange, true);
+        return () => {
+            observer.disconnect();
+            window.removeEventListener("resize", handleViewportChange);
+            window.removeEventListener("scroll", handleViewportChange, true);
+        };
+    }, [menuRef, open, updatePosition]);
+
+    return position;
+}

--- a/apps/desktop/src/features/ai/contextHandoff.test.ts
+++ b/apps/desktop/src/features/ai/contextHandoff.test.ts
@@ -189,16 +189,6 @@ describe("ACP context handoff", () => {
         );
     });
 
-    it("labels cross-provider handoffs without claiming native memory", () => {
-        const result = buildAcpContextHandoff({
-            messages: [message("m1", "user", "Prior provider context")],
-            newUserMessage: "Continue",
-            reason: "provider_switch",
-        });
-        expect(result.prompt).toContain("another ACP provider");
-        expect(result.metadata.reason).toBe("provider_switch");
-    });
-
     it("keeps compact handoffs identifiable when only the user message fits", () => {
         const result = buildAcpContextHandoff({
             messages: [

--- a/apps/desktop/src/features/ai/contextHandoff.test.ts
+++ b/apps/desktop/src/features/ai/contextHandoff.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import type { AIChatMessage } from "./types";
+import {
+    ACP_HANDOFF_TRANSCRIPT_MARKER,
+    ACP_HANDOFF_USER_MESSAGE_MARKER,
+    buildAcpContextHandoff,
+    extractAcpContextHandoffUserMessage,
+    isAcpContextHandoffPrompt,
+} from "./contextHandoff";
+
+function message(
+    id: string,
+    role: AIChatMessage["role"],
+    content: string,
+    overrides: Partial<AIChatMessage> = {},
+): AIChatMessage {
+    return {
+        id,
+        role,
+        kind: "text",
+        content,
+        timestamp: Number(id.replace(/\D/g, "")) || 1,
+        ...overrides,
+    };
+}
+
+describe("ACP context handoff", () => {
+    it("formats safe historical context without exposing interactive state", () => {
+        const result = buildAcpContextHandoff({
+            messages: [
+                message("m1", "user", "Inspect the vault", {
+                    attachments: [
+                        {
+                            id: "attachment-1",
+                            type: "file",
+                            noteId: null,
+                            label: "notes.md",
+                            path: "docs/notes.md",
+                            content: "private attachment payload",
+                        },
+                    ],
+                }),
+                message("m2", "assistant", "Read docs/notes.md", {
+                    kind: "tool",
+                    title: "Read file",
+                    meta: { status: "completed" },
+                }),
+                message("m3", "assistant", "Approve deletion?", {
+                    kind: "permission",
+                }),
+                message("m4", "assistant", "Pending tool payload", {
+                    kind: "tool",
+                    meta: { status: "pending" },
+                }),
+                message("m5", "assistant", "Finished inspection"),
+            ],
+            newUserMessage: "Continue",
+        });
+
+        expect(result.hasHandoff).toBe(true);
+        expect(result.prompt).toContain("User: Inspect the vault");
+        expect(result.prompt).toContain(
+            "Attachment (file): notes.md — docs/notes.md",
+        );
+        expect(result.prompt).toContain("Assistant (tool): Read docs/notes.md");
+        expect(result.prompt).not.toContain("private attachment payload");
+        expect(result.prompt).not.toContain("Approve deletion?");
+        expect(result.prompt).not.toContain("Pending tool payload");
+        expect(result.prompt).toContain(
+            `${ACP_HANDOFF_USER_MESSAGE_MARKER} Continue`,
+        );
+    });
+
+    it("redacts messages and inline blocks explicitly marked as secret", () => {
+        const result = buildAcpContextHandoff({
+            messages: [
+                message("m1", "user", "API key sk-live-secret", {
+                    meta: { secret: true },
+                }),
+                message(
+                    "m2",
+                    "assistant",
+                    "Stored <secret>another-secret</secret> safely",
+                ),
+            ],
+            contextSummary:
+                "Earlier token [secret]summary-secret[/secret] was configured.",
+            newUserMessage: "Continue safely",
+        });
+
+        expect(result.prompt).toContain("[Marked secret omitted]");
+        expect(result.prompt).not.toContain("sk-live-secret");
+        expect(result.prompt).not.toContain("another-secret");
+        expect(result.prompt).not.toContain("summary-secret");
+    });
+
+    it("keeps recent turns whole and explicitly reports budget truncation", () => {
+        const messages = Array.from({ length: 8 }, (_, index) => [
+            message(`u${index}`, "user", `Request ${index} ${"x".repeat(120)}`),
+            message(
+                `a${index}`,
+                "assistant",
+                `Response ${index} ${"y".repeat(120)}`,
+            ),
+        ]).flat();
+        const result = buildAcpContextHandoff({
+            messages,
+            newUserMessage: "Latest request",
+            maxCharacters: 1_500,
+        });
+
+        expect(result.prompt.length).toBeLessThanOrEqual(1_500);
+        expect(result.metadata.truncated).toBe(true);
+        expect(result.metadata.omittedTurnCount).toBeGreaterThan(0);
+        expect(result.metadata.nextCursor).toBe("a7");
+        expect(result.prompt).toContain(
+            "Some earlier context was summarized or omitted for this provider.",
+        );
+        expect(result.prompt).toContain("Request 7");
+        expect(result.prompt).toContain("Response 7");
+        for (let index = 0; index < 8; index += 1) {
+            expect(result.prompt.includes(`Request ${index}`)).toBe(
+                result.prompt.includes(`Response ${index}`),
+            );
+        }
+    });
+
+    it("uses only the delta after a binding cursor and is idempotent", () => {
+        const messages = [
+            message("m1", "user", "Old request"),
+            message("m2", "assistant", "Old response"),
+            message("m3", "user", "New request"),
+            message("m4", "assistant", "New response"),
+        ];
+        const delta = buildAcpContextHandoff({
+            messages,
+            contextCursor: "m2",
+            newUserMessage: "Next",
+        });
+
+        expect(delta.prompt).not.toContain("Old request");
+        expect(delta.prompt).toContain("New request");
+        expect(delta.metadata).toMatchObject({
+            fromCursor: "m2",
+            nextCursor: "m4",
+            cursorFound: true,
+            includedMessageIds: ["m3", "m4"],
+        });
+
+        const repeated = buildAcpContextHandoff({
+            messages,
+            contextCursor: delta.metadata.nextCursor,
+            newUserMessage: "Next",
+        });
+        expect(repeated).toMatchObject({
+            prompt: "Next",
+            hasHandoff: false,
+            metadata: {
+                nextCursor: "m4",
+                includedMessageIds: [],
+            },
+        });
+    });
+
+    it("does not recursively include a prior internal handoff prompt", () => {
+        const leaked = [
+            "Use the saved transcript below as prior conversation context for this session.",
+            "",
+            ACP_HANDOFF_TRANSCRIPT_MARKER,
+            "User: leaked",
+            "",
+            `${ACP_HANDOFF_USER_MESSAGE_MARKER} leaked`,
+        ].join("\n");
+        const result = buildAcpContextHandoff({
+            messages: [
+                message("m1", "user", leaked),
+                message("m2", "assistant", "Visible response"),
+                message("m3", "user", "Visible request"),
+            ],
+            newUserMessage: "Sigue",
+        });
+
+        expect(result.prompt).not.toContain("User: leaked");
+        expect(result.prompt).toContain("Visible response");
+        expect(result.prompt).toContain("Visible request");
+        expect(isAcpContextHandoffPrompt(result.prompt)).toBe(true);
+        expect(extractAcpContextHandoffUserMessage(result.prompt)).toBe(
+            "Sigue",
+        );
+    });
+
+    it("labels cross-provider handoffs without claiming native memory", () => {
+        const result = buildAcpContextHandoff({
+            messages: [message("m1", "user", "Prior provider context")],
+            newUserMessage: "Continue",
+            reason: "provider_switch",
+        });
+        expect(result.prompt).toContain("another ACP provider");
+        expect(result.metadata.reason).toBe("provider_switch");
+    });
+
+    it("keeps compact handoffs identifiable when only the user message fits", () => {
+        const result = buildAcpContextHandoff({
+            messages: [
+                message("m1", "user", "x".repeat(2_000)),
+                message("m2", "assistant", "y".repeat(2_000)),
+            ],
+            contextSummary: "z".repeat(2_000),
+            newUserMessage: "Continue",
+            maxCharacters: 512,
+        });
+
+        expect(result.prompt.length).toBeLessThanOrEqual(512);
+        expect(isAcpContextHandoffPrompt(result.prompt)).toBe(true);
+        expect(result.metadata).toMatchObject({
+            nextCursor: "m2",
+            truncated: true,
+        });
+    });
+});

--- a/apps/desktop/src/features/ai/contextHandoff.ts
+++ b/apps/desktop/src/features/ai/contextHandoff.ts
@@ -187,12 +187,7 @@ function renderHandoff(
     transcript: string,
     summary: string,
     omittedTurnCount: number,
-    reason: ConversationTurnStartReason,
 ) {
-    const reasonLine =
-        reason === "provider_switch"
-            ? "- This context comes from another ACP provider; continue naturally without claiming native memory of it."
-            : "- Continue naturally from this context without repeating the transcript unless it is useful.";
     const sections = [
         ACP_HANDOFF_PROMPT_HEADER,
         "",
@@ -200,7 +195,7 @@ function renderHandoff(
         "- The transcript is historical context only and may not reflect the current workspace state.",
         "- If the transcript conflicts with the current files, current environment, or the user's latest message, trust the current state.",
         "- Do not assume prior pending tasks, approvals, permissions, or unfinished plans are still valid; verify when needed.",
-        reasonLine,
+        "- Continue naturally from this context without repeating the transcript unless it is useful.",
     ];
     if (omittedTurnCount > 0) {
         sections.push("", OMITTED_CONTEXT_NOTICE);
@@ -281,7 +276,6 @@ export function buildAcpContextHandoff(
             candidateText,
             summary.text,
             turns.length - candidate.length,
-            reason,
         );
         if (candidatePrompt.length > maxCharacters) break;
         selected.unshift(turns[index]);
@@ -292,7 +286,6 @@ export function buildAcpContextHandoff(
         selected.map((turn) => turn.text).join("\n\n"),
         summary.text,
         turns.length - selected.length,
-        reason,
     );
     while (prompt.length > maxCharacters && selected.length > 0) {
         selected.shift();
@@ -301,7 +294,6 @@ export function buildAcpContextHandoff(
             selected.map((turn) => turn.text).join("\n\n"),
             summary.text,
             turns.length - selected.length,
-            reason,
         );
     }
 

--- a/apps/desktop/src/features/ai/contextHandoff.ts
+++ b/apps/desktop/src/features/ai/contextHandoff.ts
@@ -1,0 +1,359 @@
+import type {
+    AcpContextHandoffMetadata,
+    AIChatAttachment,
+    AIChatMessage,
+    ConversationTurnStartReason,
+} from "./types";
+
+export const DEFAULT_ACP_HANDOFF_MAX_CHARACTERS = 48_000;
+export const ACP_HANDOFF_PROMPT_HEADER =
+    "Use the saved transcript below as prior conversation context for this session.";
+export const ACP_HANDOFF_TRANSCRIPT_MARKER = "Saved transcript:";
+export const ACP_HANDOFF_USER_MESSAGE_MARKER = "New user message:";
+
+const OMITTED_CONTEXT_NOTICE =
+    "Some earlier context was summarized or omitted for this provider.";
+const SECRET_PLACEHOLDER = "[Marked secret omitted]";
+const EXCLUDED_MESSAGE_KINDS = new Set<AIChatMessage["kind"]>([
+    "thinking",
+    "permission",
+    "plan",
+    "status",
+    "user_input_request",
+    "url_elicitation_request",
+]);
+
+export interface AcpContextHandoffResult {
+    prompt: string;
+    hasHandoff: boolean;
+    metadata: AcpContextHandoffMetadata;
+}
+
+export interface BuildAcpContextHandoffInput {
+    messages: readonly AIChatMessage[];
+    newUserMessage: string;
+    bindingId?: string | null;
+    contextCursor?: string | null;
+    contextSummary?: string | null;
+    maxCharacters?: number;
+    reason?: ConversationTurnStartReason;
+}
+
+interface RenderedHandoffMessage {
+    id: string;
+    role: AIChatMessage["role"];
+    text: string;
+}
+
+interface HandoffTurn {
+    messages: RenderedHandoffMessage[];
+    text: string;
+}
+
+function isMarkedSecret(message: AIChatMessage) {
+    const meta = message.meta;
+    return (
+        meta?.secret === true ||
+        meta?.sensitive === true ||
+        meta?.redacted === true ||
+        meta?.visibility === "secret" ||
+        meta?.is_secret === true
+    );
+}
+
+function redactMarkedSecretBlocks(value: string) {
+    return value
+        .replace(/<secret\b[^>]*>[\s\S]*?<\/secret>/gi, SECRET_PLACEHOLDER)
+        .replace(/\[secret\][\s\S]*?\[\/secret\]/gi, SECRET_PLACEHOLDER)
+        .replace(/\{\{secret:[\s\S]*?\}\}/gi, SECRET_PLACEHOLDER);
+}
+
+function sanitizeText(value: string) {
+    return redactMarkedSecretBlocks(value)
+        .replaceAll("\u0000", "")
+        .trim();
+}
+
+function safeAttachmentReference(attachment: AIChatAttachment) {
+    const label = sanitizeText(attachment.label);
+    const path = sanitizeText(attachment.path ?? "");
+    if (!label && !path) return null;
+    const kind = attachment.type.replaceAll("_", " ");
+    return path
+        ? `Attachment (${kind}): ${label || "Untitled"} — ${path}`
+        : `Attachment (${kind}): ${label}`;
+}
+
+function formatMessage(message: AIChatMessage): RenderedHandoffMessage | null {
+    if (
+        message.inProgress ||
+        EXCLUDED_MESSAGE_KINDS.has(message.kind) ||
+        message.meta?.internal === true
+    ) {
+        return null;
+    }
+    if (
+        message.kind === "tool" &&
+        (message.meta?.status === "pending" ||
+            message.meta?.status === "in_progress")
+    ) {
+        return null;
+    }
+    if (
+        message.role === "user" &&
+        (isAcpContextHandoffPrompt(message.content) ||
+            message.content.includes("<attached_selection"))
+    ) {
+        return null;
+    }
+
+    const content = isMarkedSecret(message)
+        ? SECRET_PLACEHOLDER
+        : sanitizeText(message.content);
+    const attachmentLines = (message.attachments ?? [])
+        .map(safeAttachmentReference)
+        .filter((value): value is string => Boolean(value));
+    if (!content && attachmentLines.length === 0) return null;
+
+    const role =
+        message.role === "assistant"
+            ? "Assistant"
+            : message.role === "system"
+              ? "System"
+              : "User";
+    const label =
+        message.kind === "text"
+            ? role
+            : `${role} (${message.kind.replaceAll("_", " ")})`;
+    const body = [content, ...attachmentLines].filter(Boolean).join("\n");
+    return {
+        id: message.id,
+        role: message.role,
+        text: `${label}: ${body}`,
+    };
+}
+
+function groupCompleteTurns(messages: RenderedHandoffMessage[]) {
+    const turns: HandoffTurn[] = [];
+    let current: RenderedHandoffMessage[] = [];
+    const flush = () => {
+        if (current.length === 0) return;
+        turns.push({
+            messages: current,
+            text: current.map((message) => message.text).join("\n\n"),
+        });
+        current = [];
+    };
+
+    for (const message of messages) {
+        if (message.role === "user" && current.length > 0) flush();
+        current.push(message);
+    }
+    flush();
+    return turns;
+}
+
+function contextAfterCursor(
+    messages: readonly AIChatMessage[],
+    contextCursor: string | null,
+) {
+    if (!contextCursor) {
+        return { messages: [...messages], cursorFound: true };
+    }
+    const cursorIndex = messages.findIndex(
+        (message) => message.id === contextCursor,
+    );
+    return {
+        messages:
+            cursorIndex >= 0 ? messages.slice(cursorIndex + 1) : [...messages],
+        cursorFound: cursorIndex >= 0,
+    };
+}
+
+function truncateSummary(summary: string, maxCharacters: number) {
+    const clean = sanitizeText(summary);
+    if (clean.length <= maxCharacters) {
+        return { text: clean, truncated: false };
+    }
+    const marker = "\n[Summary truncated to fit context budget.]";
+    return {
+        text: `${clean.slice(0, Math.max(0, maxCharacters - marker.length)).trimEnd()}${marker}`,
+        truncated: true,
+    };
+}
+
+function renderHandoff(
+    newUserMessage: string,
+    transcript: string,
+    summary: string,
+    omittedTurnCount: number,
+    reason: ConversationTurnStartReason,
+) {
+    const reasonLine =
+        reason === "provider_switch"
+            ? "- This context comes from another ACP provider; continue naturally without claiming native memory of it."
+            : "- Continue naturally from this context without repeating the transcript unless it is useful.";
+    const sections = [
+        ACP_HANDOFF_PROMPT_HEADER,
+        "",
+        "Important:",
+        "- The transcript is historical context only and may not reflect the current workspace state.",
+        "- If the transcript conflicts with the current files, current environment, or the user's latest message, trust the current state.",
+        "- Do not assume prior pending tasks, approvals, permissions, or unfinished plans are still valid; verify when needed.",
+        reasonLine,
+    ];
+    if (omittedTurnCount > 0) {
+        sections.push("", OMITTED_CONTEXT_NOTICE);
+    }
+    if (summary) {
+        sections.push("", "Earlier context summary:", summary);
+    }
+    if (transcript) {
+        sections.push("", ACP_HANDOFF_TRANSCRIPT_MARKER, transcript);
+    }
+    sections.push("", `${ACP_HANDOFF_USER_MESSAGE_MARKER} ${newUserMessage}`);
+    return sections.join("\n");
+}
+
+export function isAcpContextHandoffPrompt(value: string) {
+    return (
+        value.includes(ACP_HANDOFF_PROMPT_HEADER) &&
+        value.includes(ACP_HANDOFF_USER_MESSAGE_MARKER)
+    );
+}
+
+export function extractAcpContextHandoffUserMessage(value: string) {
+    const index = value.lastIndexOf(ACP_HANDOFF_USER_MESSAGE_MARKER);
+    if (index < 0) return null;
+    return value
+        .slice(index + ACP_HANDOFF_USER_MESSAGE_MARKER.length)
+        .trim();
+}
+
+export function buildAcpContextHandoff(
+    input: BuildAcpContextHandoffInput,
+): AcpContextHandoffResult {
+    const contextCursor = input.contextCursor ?? null;
+    const bindingId = input.bindingId ?? null;
+    const reason = input.reason ?? "transcript_handoff";
+    const maxCharacters = Math.max(
+        512,
+        Math.floor(
+            input.maxCharacters ?? DEFAULT_ACP_HANDOFF_MAX_CHARACTERS,
+        ),
+    );
+    const cursorContext = contextAfterCursor(input.messages, contextCursor);
+    const renderedMessages = cursorContext.messages
+        .map(formatMessage)
+        .filter((message): message is RenderedHandoffMessage => Boolean(message))
+        .filter((message) => !isAcpContextHandoffPrompt(message.text));
+    const turns = groupCompleteTurns(renderedMessages);
+    const cleanUserMessage = input.newUserMessage.trim();
+
+    if (turns.length === 0 && !input.contextSummary?.trim()) {
+        return {
+            prompt: input.newUserMessage,
+            hasHandoff: false,
+            metadata: {
+                bindingId,
+                fromCursor: contextCursor,
+                nextCursor: contextCursor,
+                cursorFound: cursorContext.cursorFound,
+                includedMessageIds: [],
+                omittedTurnCount: 0,
+                truncated: false,
+                reason,
+            },
+        };
+    }
+
+    const summaryBudget = Math.min(8_000, Math.floor(maxCharacters * 0.25));
+    const summary = truncateSummary(
+        input.contextSummary ?? "",
+        summaryBudget,
+    );
+    const selected: HandoffTurn[] = [];
+    for (let index = turns.length - 1; index >= 0; index -= 1) {
+        const candidate = [turns[index], ...selected];
+        const candidateText = candidate.map((turn) => turn.text).join("\n\n");
+        const candidatePrompt = renderHandoff(
+            cleanUserMessage,
+            candidateText,
+            summary.text,
+            turns.length - candidate.length,
+            reason,
+        );
+        if (candidatePrompt.length > maxCharacters) break;
+        selected.unshift(turns[index]);
+    }
+
+    let prompt = renderHandoff(
+        cleanUserMessage,
+        selected.map((turn) => turn.text).join("\n\n"),
+        summary.text,
+        turns.length - selected.length,
+        reason,
+    );
+    while (prompt.length > maxCharacters && selected.length > 0) {
+        selected.shift();
+        prompt = renderHandoff(
+            cleanUserMessage,
+            selected.map((turn) => turn.text).join("\n\n"),
+            summary.text,
+            turns.length - selected.length,
+            reason,
+        );
+    }
+
+    let compacted = false;
+    if (prompt.length > maxCharacters) {
+        const compact = [
+            ACP_HANDOFF_PROMPT_HEADER,
+            "",
+            OMITTED_CONTEXT_NOTICE,
+            "",
+            `${ACP_HANDOFF_USER_MESSAGE_MARKER} ${cleanUserMessage}`,
+        ].join("\n");
+        if (compact.length > maxCharacters) {
+            return {
+                prompt: input.newUserMessage,
+                hasHandoff: false,
+                metadata: {
+                    bindingId,
+                    fromCursor: contextCursor,
+                    nextCursor: contextCursor,
+                    cursorFound: cursorContext.cursorFound,
+                    includedMessageIds: [],
+                    omittedTurnCount: turns.length,
+                    truncated: turns.length > 0 || summary.truncated,
+                    reason,
+                },
+            };
+        }
+        prompt = compact;
+        compacted = true;
+    }
+
+    const includedMessageIds = selected.flatMap((turn) =>
+        turn.messages.map((message) => message.id),
+    );
+    const processedCursor =
+        renderedMessages[renderedMessages.length - 1]?.id ?? contextCursor;
+    return {
+        prompt,
+        hasHandoff: true,
+        metadata: {
+            bindingId,
+            fromCursor: contextCursor,
+            nextCursor: processedCursor,
+            cursorFound: cursorContext.cursorFound,
+            includedMessageIds,
+            omittedTurnCount: turns.length - selected.length,
+            truncated:
+                compacted ||
+                turns.length > selected.length ||
+                summary.truncated,
+            reason,
+        },
+    };
+}

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -188,7 +188,7 @@ describe("canonical conversation model", () => {
         ]);
     });
 
-    it("allows provider switches only while fully idle", () => {
+    it("allows provider switches only between turns without pending work", () => {
         const { conversation } = projectLegacySessionToCanonical(
             createLegacySession(),
         );
@@ -200,12 +200,6 @@ describe("canonical conversation model", () => {
                 status: "streaming",
             }),
         ).toBe("conversation_not_idle");
-        expect(
-            getConversationSwitchBlocker({
-                ...conversation,
-                activeWorkCycleId: "cycle-1",
-            }),
-        ).toBe("work_cycle_active");
         expect(
             getConversationSwitchBlocker({
                 ...conversation,
@@ -274,6 +268,23 @@ describe("canonical conversation model", () => {
         });
 
         expect(updated.preferredSelection).toEqual(state.preferredSelection);
+    });
+
+    it("preserves a different model selected for the next turn on the active provider", () => {
+        const legacy = createLegacySession();
+        const state = createConversationBindingsFromLegacySession(legacy);
+        state.preferredSelection = {
+            ...state.preferredSelection,
+            modelId: "opus",
+        };
+
+        const updated = updateConversationBindingsFromLegacySession({
+            ...legacy,
+            conversationBindings: state,
+        });
+
+        expect(updated.preferredSelection).toEqual(state.preferredSelection);
+        expect(updated.providerBindings[0].modelId).toBe("sonnet");
     });
 
     it("resets each provider cursor when forking a canonical conversation", () => {

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -1,13 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
-    canSwitchConversationProvider,
     createConversationBindingsFromLegacySession,
     createLegacyBindingId,
     deserializeConversationBindings,
     forkConversationBindings,
-    getConversationSwitchBlocker,
+    getConversationProviderSelectionBlocker,
     getLegacyConversationId,
-    projectCanonicalConversationToLegacy,
     projectLegacySessionToCanonical,
     serializeConversationBindings,
     updateConversationBindingsFromLegacySession,
@@ -124,49 +122,6 @@ describe("canonical conversation model", () => {
         );
     });
 
-    it("projects the active binding back for legacy consumers", () => {
-        const legacy = createLegacySession();
-        const { conversation, bindings } =
-            projectLegacySessionToCanonical(legacy);
-        const binding = {
-            ...bindings[0],
-            runtimeId: "codex-acp",
-            runtimeDisplayName: "Codex",
-            runtimeSessionId: "codex-native",
-            modelId: "gpt-5",
-            modeId: "agent",
-            options: { reasoning: "medium" },
-            models: [],
-            modes: [],
-            configOptions: legacy.configOptions.map((option) => ({
-                ...option,
-                runtimeId: "codex-acp",
-            })),
-        };
-        const changedConversation = {
-            ...conversation,
-            preferredSelection: {
-                runtimeId: "future-provider",
-                modelId: "future-model",
-                modeId: "default",
-                options: {},
-            },
-        };
-
-        const projected = projectCanonicalConversationToLegacy(
-            changedConversation,
-            binding,
-            legacy,
-        );
-
-        expect(projected.sessionId).toBe("local-session");
-        expect(projected.historySessionId).toBe("history-session");
-        expect(projected.runtimeId).toBe("codex-acp");
-        expect(projected.runtimeSessionId).toBe("codex-native");
-        expect(projected.modelId).toBe("gpt-5");
-        expect(projected.configOptions[0]?.value).toBe("medium");
-    });
-
     it("reports ownership, identity and active-binding violations", () => {
         const { conversation, bindings } = projectLegacySessionToCanonical(
             createLegacySession(),
@@ -182,35 +137,45 @@ describe("canonical conversation model", () => {
                 [invalidBinding, invalidBinding],
             ),
         ).toEqual([
+            "multiple_provider_bindings",
             "binding_conversation_mismatch",
             "duplicate_binding_id",
             "missing_active_binding",
         ]);
     });
 
-    it("allows provider switches only between turns without pending work", () => {
+    it("allows provider selection only while the conversation is empty", () => {
         const { conversation } = projectLegacySessionToCanonical(
-            createLegacySession(),
+            createLegacySession({
+                messages: [],
+                persistedMessageCount: 0,
+            }),
         );
 
-        expect(canSwitchConversationProvider(conversation)).toBe(true);
+        expect(getConversationProviderSelectionBlocker(conversation)).toBeNull();
         expect(
-            getConversationSwitchBlocker({
+            getConversationProviderSelectionBlocker({
                 ...conversation,
                 status: "streaming",
             }),
         ).toBe("conversation_not_idle");
         expect(
-            getConversationSwitchBlocker({
+            getConversationProviderSelectionBlocker({
                 ...conversation,
                 isResumingSession: true,
             }),
         ).toBe("session_transition_pending");
         expect(
-            getConversationSwitchBlocker(conversation, {
+            getConversationProviderSelectionBlocker(conversation, {
                 hasQueuedMessages: true,
             }),
         ).toBe("queued_messages_pending");
+        expect(
+            getConversationProviderSelectionBlocker({
+                ...conversation,
+                messages: createLegacySession().messages,
+            }),
+        ).toBe("conversation_started");
     });
 
     it("roundtrips the versioned provider bindings sidecar", () => {
@@ -221,6 +186,7 @@ describe("canonical conversation model", () => {
         state.providerBindings[0].contextCursor = "message-1";
         state.providerBindings[0].contextGeneration = 2;
         state.providerBindings[0].options.fast = "on";
+        state.preferredSelection.options.fast = "on";
         state.providerBindings[0].configOptions.push({
             id: "fast",
             runtimeId: "claude-acp",
@@ -246,7 +212,7 @@ describe("canonical conversation model", () => {
         );
     });
 
-    it("updates the active legacy projection without dropping prior bindings", () => {
+    it("drops bindings from the retired mid-conversation switching flow", () => {
         const legacy = createLegacySession();
         const state = createConversationBindingsFromLegacySession(legacy);
         state.providerBindings.push({
@@ -262,14 +228,12 @@ describe("canonical conversation model", () => {
             conversationBindings: state,
         });
 
-        expect(updated.providerBindings).toHaveLength(2);
+        expect(updated.providerBindings).toHaveLength(1);
         expect(updated.providerBindings[0].modelId).toBe("opus");
-        expect(updated.providerBindings[1].runtimeSessionId).toBe(
-            "codex-native",
-        );
+        expect(updated.providerBindings[0].runtimeId).toBe("claude-acp");
     });
 
-    it("preserves a different provider selected for the next turn", () => {
+    it("discards a staged provider after the conversation has started", () => {
         const legacy = createLegacySession();
         const state = createConversationBindingsFromLegacySession(legacy);
         state.preferredSelection = {
@@ -284,7 +248,7 @@ describe("canonical conversation model", () => {
             conversationBindings: state,
         });
 
-        expect(updated.preferredSelection).toEqual(state.preferredSelection);
+        expect(updated.preferredSelection.runtimeId).toBe("claude-acp");
     });
 
     it("preserves a different model selected for the next turn on the active provider", () => {
@@ -316,10 +280,10 @@ describe("canonical conversation model", () => {
         expect(forked).toMatchObject({
             conversationId: "fork-history",
             revision: source.revision + 1,
-            activeBindingId: "fork:fork-history:claude-acp:0",
+            activeBindingId: "fork:fork-history:claude-acp",
         });
         expect(forked.providerBindings[0]).toMatchObject({
-            bindingId: "fork:fork-history:claude-acp:0",
+            bindingId: "fork:fork-history:claude-acp",
             conversationId: "fork-history",
             contextCursor: null,
             contextGeneration: 5,

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -220,6 +220,19 @@ describe("canonical conversation model", () => {
         state.contextSummary = "Earlier decisions";
         state.providerBindings[0].contextCursor = "message-1";
         state.providerBindings[0].contextGeneration = 2;
+        state.providerBindings[0].options.fast = "on";
+        state.providerBindings[0].configOptions.push({
+            id: "fast",
+            runtimeId: "claude-acp",
+            category: "service_tier",
+            label: "Fast mode",
+            type: "select",
+            value: "on",
+            options: [
+                { value: "on", label: "On" },
+                { value: "off", label: "Off" },
+            ],
+        });
 
         const serialized = serializeConversationBindings(state);
         const restored = deserializeConversationBindings(serialized);
@@ -227,6 +240,10 @@ describe("canonical conversation model", () => {
         expect(serializeConversationBindings(restored)).toEqual(serialized);
         expect(restored.contextSummary).toBe("Earlier decisions");
         expect(restored.providerBindings[0].contextCursor).toBe("message-1");
+        expect(restored.providerBindings[0].options.fast).toBe("on");
+        expect(restored.providerBindings[0].configOptions[1]?.category).toBe(
+            "service_tier",
+        );
     });
 
     it("updates the active legacy projection without dropping prior bindings", () => {

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -1,11 +1,15 @@
 import { describe, expect, it } from "vitest";
 import {
     canSwitchConversationProvider,
+    createConversationBindingsFromLegacySession,
     createLegacyBindingId,
+    deserializeConversationBindings,
     getConversationSwitchBlocker,
     getLegacyConversationId,
     projectCanonicalConversationToLegacy,
     projectLegacySessionToCanonical,
+    serializeConversationBindings,
+    updateConversationBindingsFromLegacySession,
     validateCanonicalConversation,
 } from "./conversationModel";
 import type { AIChatSession } from "./types";
@@ -212,5 +216,44 @@ describe("canonical conversation model", () => {
                 hasQueuedMessages: true,
             }),
         ).toBe("queued_messages_pending");
+    });
+
+    it("roundtrips the versioned provider bindings sidecar", () => {
+        const state = createConversationBindingsFromLegacySession(
+            createLegacySession(),
+        );
+        state.contextSummary = "Earlier decisions";
+        state.providerBindings[0].contextCursor = "message-1";
+        state.providerBindings[0].contextGeneration = 2;
+
+        const serialized = serializeConversationBindings(state);
+        const restored = deserializeConversationBindings(serialized);
+
+        expect(serializeConversationBindings(restored)).toEqual(serialized);
+        expect(restored.contextSummary).toBe("Earlier decisions");
+        expect(restored.providerBindings[0].contextCursor).toBe("message-1");
+    });
+
+    it("updates the active legacy projection without dropping prior bindings", () => {
+        const legacy = createLegacySession();
+        const state = createConversationBindingsFromLegacySession(legacy);
+        state.providerBindings.push({
+            ...state.providerBindings[0],
+            bindingId: "binding:codex",
+            runtimeId: "codex-acp",
+            runtimeSessionId: "codex-native",
+        });
+
+        const updated = updateConversationBindingsFromLegacySession({
+            ...legacy,
+            modelId: "opus",
+            conversationBindings: state,
+        });
+
+        expect(updated.providerBindings).toHaveLength(2);
+        expect(updated.providerBindings[0].modelId).toBe("opus");
+        expect(updated.providerBindings[1].runtimeSessionId).toBe(
+            "codex-native",
+        );
     });
 });

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -258,6 +258,24 @@ describe("canonical conversation model", () => {
         );
     });
 
+    it("preserves a different provider selected for the next turn", () => {
+        const legacy = createLegacySession();
+        const state = createConversationBindingsFromLegacySession(legacy);
+        state.preferredSelection = {
+            runtimeId: "codex-acp",
+            modelId: "gpt-5",
+            modeId: "default",
+            options: {},
+        };
+
+        const updated = updateConversationBindingsFromLegacySession({
+            ...legacy,
+            conversationBindings: state,
+        });
+
+        expect(updated.preferredSelection).toEqual(state.preferredSelection);
+    });
+
     it("resets each provider cursor when forking a canonical conversation", () => {
         const source = createConversationBindingsFromLegacySession(
             createLegacySession(),

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "vitest";
+import {
+    canSwitchConversationProvider,
+    createLegacyBindingId,
+    getConversationSwitchBlocker,
+    getLegacyConversationId,
+    projectCanonicalConversationToLegacy,
+    projectLegacySessionToCanonical,
+    validateCanonicalConversation,
+} from "./conversationModel";
+import type { AIChatSession } from "./types";
+
+function createLegacySession(
+    overrides: Partial<AIChatSession> = {},
+): AIChatSession {
+    return {
+        sessionId: "local-session",
+        historySessionId: "history-session",
+        parentSessionId: "parent-history",
+        runtimeSessionId: "native-session",
+        vaultPath: "/vault",
+        status: "idle",
+        runtimeId: "claude-acp",
+        runtimeDisplayName: "Claude",
+        runtimeRevision: 3,
+        runtimeLaunchFingerprint: "launch-3",
+        continuationStrategy: "resume",
+        modelId: "sonnet",
+        modeId: "default",
+        models: [
+            {
+                id: "sonnet",
+                runtimeId: "claude-acp",
+                name: "Sonnet",
+                description: "",
+            },
+        ],
+        modes: [
+            {
+                id: "default",
+                runtimeId: "claude-acp",
+                name: "Default",
+                description: "",
+            },
+        ],
+        configOptions: [
+            {
+                id: "reasoning",
+                runtimeId: "claude-acp",
+                category: "reasoning",
+                label: "Reasoning",
+                type: "select",
+                value: "high",
+                options: [{ value: "high", label: "High" }],
+            },
+        ],
+        effortsByModel: { sonnet: ["high"] },
+        messages: [
+            {
+                id: "message-1",
+                role: "user",
+                kind: "text",
+                content: "Continue",
+                timestamp: 10,
+            },
+        ],
+        attachments: [],
+        persistedCreatedAt: 10,
+        persistedUpdatedAt: 20,
+        persistedTitle: "Canonical chat",
+        isPersistedSession: true,
+        runtimeState: "persisted_only",
+        ...overrides,
+    };
+}
+
+describe("canonical conversation model", () => {
+    it("reuses the durable history id as the conversation identity", () => {
+        expect(getLegacyConversationId(createLegacySession())).toBe(
+            "history-session",
+        );
+        expect(
+            getLegacyConversationId(
+                createLegacySession({ historySessionId: "   " }),
+            ),
+        ).toBe("local-session");
+    });
+
+    it("projects a legacy session without changing routing state", () => {
+        const legacy = createLegacySession();
+        const { conversation, bindings } =
+            projectLegacySessionToCanonical(legacy);
+        const binding = bindings[0];
+
+        expect(conversation.conversationId).toBe("history-session");
+        expect(conversation.parentConversationId).toBe("parent-history");
+        expect(conversation.preferredSelection).toEqual({
+            runtimeId: "claude-acp",
+            modelId: "sonnet",
+            modeId: "default",
+            options: { reasoning: "high" },
+        });
+        expect(conversation.activeBindingId).toBe(
+            createLegacyBindingId("history-session", "claude-acp"),
+        );
+        expect(binding).toMatchObject({
+            conversationId: "history-session",
+            runtimeId: "claude-acp",
+            runtimeSessionId: "native-session",
+            continuationStrategy: "resume",
+            modelId: "sonnet",
+            modeId: "default",
+            options: { reasoning: "high" },
+            runtimeState: "persisted_only",
+        });
+        expect(conversation.messages).toBe(legacy.messages);
+        expect(validateCanonicalConversation(conversation, bindings)).toEqual(
+            [],
+        );
+    });
+
+    it("projects the active binding back for legacy consumers", () => {
+        const legacy = createLegacySession();
+        const { conversation, bindings } =
+            projectLegacySessionToCanonical(legacy);
+        const binding = {
+            ...bindings[0],
+            runtimeId: "codex-acp",
+            runtimeDisplayName: "Codex",
+            runtimeSessionId: "codex-native",
+            modelId: "gpt-5",
+            modeId: "agent",
+            options: { reasoning: "medium" },
+            models: [],
+            modes: [],
+            configOptions: legacy.configOptions.map((option) => ({
+                ...option,
+                runtimeId: "codex-acp",
+            })),
+        };
+        const changedConversation = {
+            ...conversation,
+            preferredSelection: {
+                runtimeId: "future-provider",
+                modelId: "future-model",
+                modeId: "default",
+                options: {},
+            },
+        };
+
+        const projected = projectCanonicalConversationToLegacy(
+            changedConversation,
+            binding,
+            legacy,
+        );
+
+        expect(projected.sessionId).toBe("local-session");
+        expect(projected.historySessionId).toBe("history-session");
+        expect(projected.runtimeId).toBe("codex-acp");
+        expect(projected.runtimeSessionId).toBe("codex-native");
+        expect(projected.modelId).toBe("gpt-5");
+        expect(projected.configOptions[0]?.value).toBe("medium");
+    });
+
+    it("reports ownership, identity and active-binding violations", () => {
+        const { conversation, bindings } = projectLegacySessionToCanonical(
+            createLegacySession(),
+        );
+        const invalidBinding = {
+            ...bindings[0],
+            conversationId: "another-conversation",
+        };
+
+        expect(
+            validateCanonicalConversation(
+                { ...conversation, activeBindingId: "missing" },
+                [invalidBinding, invalidBinding],
+            ),
+        ).toEqual([
+            "binding_conversation_mismatch",
+            "duplicate_binding_id",
+            "missing_active_binding",
+        ]);
+    });
+
+    it("allows provider switches only while fully idle", () => {
+        const { conversation } = projectLegacySessionToCanonical(
+            createLegacySession(),
+        );
+
+        expect(canSwitchConversationProvider(conversation)).toBe(true);
+        expect(
+            getConversationSwitchBlocker({
+                ...conversation,
+                status: "streaming",
+            }),
+        ).toBe("conversation_not_idle");
+        expect(
+            getConversationSwitchBlocker({
+                ...conversation,
+                activeWorkCycleId: "cycle-1",
+            }),
+        ).toBe("work_cycle_active");
+        expect(
+            getConversationSwitchBlocker({
+                ...conversation,
+                isResumingSession: true,
+            }),
+        ).toBe("session_transition_pending");
+        expect(
+            getConversationSwitchBlocker(conversation, {
+                hasQueuedMessages: true,
+            }),
+        ).toBe("queued_messages_pending");
+    });
+});

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -4,6 +4,7 @@ import {
     createConversationBindingsFromLegacySession,
     createLegacyBindingId,
     deserializeConversationBindings,
+    forkConversationBindings,
     getConversationSwitchBlocker,
     getLegacyConversationId,
     projectCanonicalConversationToLegacy,
@@ -255,5 +256,29 @@ describe("canonical conversation model", () => {
         expect(updated.providerBindings[1].runtimeSessionId).toBe(
             "codex-native",
         );
+    });
+
+    it("resets each provider cursor when forking a canonical conversation", () => {
+        const source = createConversationBindingsFromLegacySession(
+            createLegacySession(),
+        );
+        source.providerBindings[0].contextCursor = "message-1";
+        source.providerBindings[0].contextGeneration = 4;
+
+        const forked = forkConversationBindings(source, "fork-history", 30);
+
+        expect(forked).toMatchObject({
+            conversationId: "fork-history",
+            revision: source.revision + 1,
+            activeBindingId: "fork:fork-history:claude-acp:0",
+        });
+        expect(forked.providerBindings[0]).toMatchObject({
+            bindingId: "fork:fork-history:claude-acp:0",
+            conversationId: "fork-history",
+            contextCursor: null,
+            contextGeneration: 5,
+            createdAt: 30,
+            updatedAt: 30,
+        });
     });
 });

--- a/apps/desktop/src/features/ai/conversationModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationModel.test.ts
@@ -285,6 +285,8 @@ describe("canonical conversation model", () => {
         expect(forked.providerBindings[0]).toMatchObject({
             bindingId: "fork:fork-history:claude-acp",
             conversationId: "fork-history",
+            runtimeSessionId: null,
+            continuationStrategy: "new_session_only",
             contextCursor: null,
             contextGeneration: 5,
             createdAt: 30,

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -1,0 +1,279 @@
+import type {
+    AcpConversationBinding,
+    AIChatSession,
+    AIConfigOption,
+    AIConversation,
+    ConversationSelection,
+} from "./types";
+
+export interface CanonicalConversationProjection {
+    conversation: AIConversation;
+    bindings: AcpConversationBinding[];
+}
+
+export type ConversationInvariantViolation =
+    | "missing_conversation_id"
+    | "duplicate_binding_id"
+    | "binding_conversation_mismatch"
+    | "binding_runtime_mismatch"
+    | "missing_active_binding";
+
+export type ConversationSwitchBlocker =
+    | "conversation_not_idle"
+    | "work_cycle_active"
+    | "session_transition_pending"
+    | "queued_messages_pending";
+
+export interface ConversationSwitchContext {
+    hasQueuedMessages?: boolean;
+}
+
+function nonEmpty(value: string | null | undefined) {
+    const normalized = value?.trim();
+    return normalized ? normalized : null;
+}
+
+function selectionOptions(configOptions: readonly AIConfigOption[]) {
+    return Object.fromEntries(
+        configOptions.map((option) => [option.id, option.value]),
+    );
+}
+
+function applySelectionOptions(
+    configOptions: readonly AIConfigOption[],
+    options: Readonly<Record<string, string>>,
+) {
+    return configOptions.map((option) => ({
+        ...option,
+        value: options[option.id] ?? option.value,
+    }));
+}
+
+/**
+ * The existing durable history id becomes the canonical identity. New code
+ * should use this helper instead of treating a native runtime id as durable.
+ */
+export function getLegacyConversationId(
+    session: Pick<AIChatSession, "historySessionId" | "sessionId">,
+) {
+    return nonEmpty(session.historySessionId) ?? session.sessionId;
+}
+
+export function createLegacyBindingId(conversationId: string, runtimeId: string) {
+    return `legacy:${encodeURIComponent(conversationId)}:${encodeURIComponent(runtimeId)}`;
+}
+
+export function getConversationSelection(
+    session: Pick<
+        AIChatSession,
+        "runtimeId" | "modelId" | "modeId" | "configOptions"
+    >,
+): ConversationSelection {
+    return {
+        runtimeId: session.runtimeId,
+        modelId: session.modelId,
+        modeId: session.modeId,
+        options: selectionOptions(session.configOptions),
+    };
+}
+
+/**
+ * Read adapter for phase A1. It is intentionally side-effect free: loading a
+ * legacy session does not write or migrate persistence.
+ */
+export function projectLegacySessionToCanonical(
+    session: AIChatSession,
+): CanonicalConversationProjection {
+    const conversationId = getLegacyConversationId(session);
+    const bindingId = createLegacyBindingId(conversationId, session.runtimeId);
+    const selection = getConversationSelection(session);
+    const binding: AcpConversationBinding = {
+        bindingId,
+        conversationId,
+        runtimeId: session.runtimeId,
+        runtimeDisplayName: session.runtimeDisplayName ?? null,
+        runtimeRevision: session.runtimeRevision ?? null,
+        runtimeLaunchFingerprint: session.runtimeLaunchFingerprint ?? null,
+        runtimeSessionId: session.runtimeSessionId ?? null,
+        continuationStrategy: session.continuationStrategy ?? null,
+        capabilities: [],
+        modelId: session.modelId,
+        modeId: session.modeId,
+        options: { ...selection.options },
+        models: session.models,
+        modes: session.modes,
+        configOptions: session.configOptions,
+        availableCommands: session.availableCommands,
+        effortsByModel: session.effortsByModel ?? {},
+        runtimeState: session.runtimeState ?? "live",
+        contextCursor: null,
+        contextGeneration: 0,
+        createdAt: session.persistedCreatedAt ?? null,
+        updatedAt: session.persistedUpdatedAt ?? null,
+    };
+
+    return {
+        conversation: {
+            conversationId,
+            parentConversationId: session.parentSessionId ?? null,
+            vaultPath: session.vaultPath ?? null,
+            closedAt: session.closedAt ?? null,
+            status: session.status,
+            activeWorkCycleId: session.activeWorkCycleId ?? null,
+            visibleWorkCycleId: session.visibleWorkCycleId ?? null,
+            actionLog: session.actionLog,
+            messages: session.messages,
+            attachments: session.attachments,
+            preferredSelection: selection,
+            activeBindingId: bindingId,
+            persistedCreatedAt: session.persistedCreatedAt ?? null,
+            persistedUpdatedAt: session.persistedUpdatedAt ?? null,
+            persistedTitle: session.persistedTitle ?? null,
+            customTitle: session.customTitle ?? null,
+            persistedPreview: session.persistedPreview ?? null,
+            persistedMessageCount: session.persistedMessageCount,
+            loadedPersistedMessageStart:
+                session.loadedPersistedMessageStart ?? null,
+            isLoadingPersistedMessages: session.isLoadingPersistedMessages,
+            isPersistedSession: session.isPersistedSession ?? false,
+            isPendingSessionCreation:
+                session.isPendingSessionCreation ?? false,
+            isResumingSession: session.isResumingSession ?? false,
+        },
+        bindings: [binding],
+    };
+}
+
+/**
+ * Compatibility adapter for legacy consumers. The active binding, not the
+ * preferred next-turn selection, remains the projected runtime until routing
+ * moves to canonical conversations in a later commit.
+ */
+export function projectCanonicalConversationToLegacy(
+    conversation: AIConversation,
+    binding: AcpConversationBinding,
+    template: AIChatSession,
+): AIChatSession {
+    if (binding.conversationId !== conversation.conversationId) {
+        throw new Error("Cannot project a binding owned by another conversation");
+    }
+    if (conversation.activeBindingId !== binding.bindingId) {
+        throw new Error("Cannot project a binding that is not active");
+    }
+
+    return {
+        ...template,
+        historySessionId: conversation.conversationId,
+        parentSessionId: conversation.parentConversationId,
+        vaultPath: conversation.vaultPath,
+        closedAt: conversation.closedAt,
+        status: conversation.status,
+        activeWorkCycleId: conversation.activeWorkCycleId,
+        visibleWorkCycleId: conversation.visibleWorkCycleId,
+        actionLog: conversation.actionLog,
+        messages: conversation.messages,
+        attachments: conversation.attachments,
+        persistedCreatedAt: conversation.persistedCreatedAt,
+        persistedUpdatedAt: conversation.persistedUpdatedAt,
+        persistedTitle: conversation.persistedTitle,
+        customTitle: conversation.customTitle,
+        persistedPreview: conversation.persistedPreview,
+        persistedMessageCount: conversation.persistedMessageCount,
+        loadedPersistedMessageStart:
+            conversation.loadedPersistedMessageStart,
+        isLoadingPersistedMessages: conversation.isLoadingPersistedMessages,
+        isPersistedSession: conversation.isPersistedSession,
+        isPendingSessionCreation: conversation.isPendingSessionCreation,
+        isResumingSession: conversation.isResumingSession,
+        runtimeId: binding.runtimeId,
+        runtimeDisplayName: binding.runtimeDisplayName,
+        runtimeRevision: binding.runtimeRevision,
+        runtimeLaunchFingerprint: binding.runtimeLaunchFingerprint,
+        runtimeSessionId: binding.runtimeSessionId,
+        continuationStrategy: binding.continuationStrategy,
+        modelId: binding.modelId,
+        modeId: binding.modeId,
+        models: binding.models,
+        modes: binding.modes,
+        configOptions: applySelectionOptions(
+            binding.configOptions,
+            binding.options,
+        ),
+        availableCommands: binding.availableCommands,
+        effortsByModel: binding.effortsByModel,
+        runtimeState: binding.runtimeState,
+    };
+}
+
+export function validateCanonicalConversation(
+    conversation: AIConversation,
+    bindings: readonly AcpConversationBinding[],
+): ConversationInvariantViolation[] {
+    const violations = new Set<ConversationInvariantViolation>();
+    if (!nonEmpty(conversation.conversationId)) {
+        violations.add("missing_conversation_id");
+    }
+
+    const seenBindingIds = new Set<string>();
+    for (const binding of bindings) {
+        if (seenBindingIds.has(binding.bindingId)) {
+            violations.add("duplicate_binding_id");
+        }
+        seenBindingIds.add(binding.bindingId);
+        if (binding.conversationId !== conversation.conversationId) {
+            violations.add("binding_conversation_mismatch");
+        }
+        if (
+            binding.configOptions.some(
+                (option) => option.runtimeId !== binding.runtimeId,
+            )
+        ) {
+            violations.add("binding_runtime_mismatch");
+        }
+        if (
+            binding.models.some((model) => model.runtimeId !== binding.runtimeId) ||
+            binding.modes.some((mode) => mode.runtimeId !== binding.runtimeId)
+        ) {
+            violations.add("binding_runtime_mismatch");
+        }
+    }
+
+    if (
+        conversation.activeBindingId !== null &&
+        !seenBindingIds.has(conversation.activeBindingId)
+    ) {
+        violations.add("missing_active_binding");
+    }
+
+    return [...violations];
+}
+
+/** Provider changes are only valid between turns and without queued work. */
+export function getConversationSwitchBlocker(
+    conversation: Pick<
+        AIConversation,
+        | "status"
+        | "activeWorkCycleId"
+        | "isPendingSessionCreation"
+        | "isResumingSession"
+    >,
+    context: ConversationSwitchContext = {},
+): ConversationSwitchBlocker | null {
+    if (conversation.status !== "idle") return "conversation_not_idle";
+    if (conversation.activeWorkCycleId) return "work_cycle_active";
+    if (
+        conversation.isPendingSessionCreation ||
+        conversation.isResumingSession
+    ) {
+        return "session_transition_pending";
+    }
+    if (context.hasQueuedMessages) return "queued_messages_pending";
+    return null;
+}
+
+export function canSwitchConversationProvider(
+    conversation: Parameters<typeof getConversationSwitchBlocker>[0],
+    context?: ConversationSwitchContext,
+) {
+    return getConversationSwitchBlocker(conversation, context) === null;
+}

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -22,7 +22,6 @@ export type ConversationInvariantViolation =
 
 export type ConversationSwitchBlocker =
     | "conversation_not_idle"
-    | "work_cycle_active"
     | "session_transition_pending"
     | "queued_messages_pending";
 
@@ -49,6 +48,27 @@ function applySelectionOptions(
         ...option,
         value: options[option.id] ?? option.value,
     }));
+}
+
+function selectionMatchesBinding(
+    selection: ConversationSelection,
+    binding: AcpConversationBinding,
+) {
+    if (
+        selection.runtimeId !== binding.runtimeId ||
+        selection.modelId !== binding.modelId ||
+        selection.modeId !== binding.modeId
+    ) {
+        return false;
+    }
+
+    const optionIds = new Set([
+        ...Object.keys(selection.options),
+        ...Object.keys(binding.options),
+    ]);
+    return [...optionIds].every(
+        (optionId) => selection.options[optionId] === binding.options[optionId],
+    );
 }
 
 /**
@@ -206,14 +226,20 @@ export function updateConversationBindingsFromLegacySession(
                   : binding,
           )
         : [...current.providerBindings, nextBinding];
+    const preferredSelectionTracksActiveBinding =
+        activeBinding != null &&
+        selectionMatchesBinding(current.preferredSelection, activeBinding);
 
     return {
         ...current,
         conversationId: projected.conversation.conversationId,
-        preferredSelection:
-            current.preferredSelection.runtimeId === activeBinding?.runtimeId
-                ? projected.conversation.preferredSelection
-                : current.preferredSelection,
+        // A different model/mode for the active provider is still a staged
+        // next-turn selection. Preserve it until that turn is accepted. Only
+        // follow the live legacy session when the preference still describes
+        // the binding we are replacing.
+        preferredSelection: preferredSelectionTracksActiveBinding
+            ? projected.conversation.preferredSelection
+            : current.preferredSelection,
         activeBindingId: nextBinding.bindingId,
         providerBindings,
     };
@@ -520,14 +546,12 @@ export function getConversationSwitchBlocker(
     conversation: Pick<
         AIConversation,
         | "status"
-        | "activeWorkCycleId"
         | "isPendingSessionCreation"
         | "isResumingSession"
     >,
     context: ConversationSwitchContext = {},
 ): ConversationSwitchBlocker | null {
     if (conversation.status !== "idle") return "conversation_not_idle";
-    if (conversation.activeWorkCycleId) return "work_cycle_active";
     if (
         conversation.isPendingSessionCreation ||
         conversation.isResumingSession

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -216,6 +216,52 @@ export function updateConversationBindingsFromLegacySession(
     };
 }
 
+/**
+ * A transcript fork owns fresh binding identities and must replay context to
+ * every provider independently from the beginning of the copied transcript.
+ */
+export function forkConversationBindings(
+    source: ConversationBindingsState,
+    conversationId: string,
+    now: number,
+): ConversationBindingsState {
+    let activeBindingId: string | null = null;
+    const providerBindings = source.providerBindings.map((binding, index) => {
+        const bindingId = `fork:${conversationId}:${binding.runtimeId}:${index}`;
+        if (binding.bindingId === source.activeBindingId) {
+            activeBindingId = bindingId;
+        }
+        const isCustomRuntime = binding.runtimeId.startsWith("custom:");
+        return {
+            ...binding,
+            bindingId,
+            conversationId,
+            runtimeSessionId: isCustomRuntime
+                ? null
+                : binding.runtimeSessionId,
+            continuationStrategy: isCustomRuntime
+                ? "new_session_only"
+                : binding.continuationStrategy,
+            contextCursor: null,
+            contextGeneration: binding.contextGeneration + 1,
+            createdAt: now,
+            updatedAt: now,
+        };
+    });
+
+    return {
+        ...source,
+        revision: source.revision + 1,
+        conversationId,
+        activeBindingId,
+        providerBindings,
+        transcriptObservation: {
+            ...source.transcriptObservation,
+            updatedAt: now,
+        },
+    };
+}
+
 export function serializeConversationBindings(
     state: ConversationBindingsState,
 ): PersistedConversationBindings {

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -264,20 +264,14 @@ export function forkConversationBindings(
         source.providerBindings.find(
             (binding) => binding.bindingId === source.activeBindingId,
         ) ?? source.providerBindings[0];
-    const providerBindings = sourceBinding
+    const providerBindings: AcpConversationBinding[] = sourceBinding
         ? [
               {
                   ...sourceBinding,
                   bindingId: `fork:${conversationId}:${sourceBinding.runtimeId}`,
                   conversationId,
-                  runtimeSessionId: sourceBinding.runtimeId.startsWith("custom:")
-                      ? null
-                      : sourceBinding.runtimeSessionId,
-                  continuationStrategy: sourceBinding.runtimeId.startsWith(
-                      "custom:",
-                  )
-                      ? "new_session_only"
-                      : sourceBinding.continuationStrategy,
+                  runtimeSessionId: null,
+                  continuationStrategy: "new_session_only",
                   contextCursor: null,
                   contextGeneration: sourceBinding.contextGeneration + 1,
                   createdAt: now,

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -210,7 +210,10 @@ export function updateConversationBindingsFromLegacySession(
     return {
         ...current,
         conversationId: projected.conversation.conversationId,
-        preferredSelection: projected.conversation.preferredSelection,
+        preferredSelection:
+            current.preferredSelection.runtimeId === activeBinding?.runtimeId
+                ? projected.conversation.preferredSelection
+                : current.preferredSelection,
         activeBindingId: nextBinding.bindingId,
         providerBindings,
     };

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -3,7 +3,9 @@ import type {
     AIChatSession,
     AIConfigOption,
     AIConversation,
+    ConversationBindingsState,
     ConversationSelection,
+    PersistedConversationBindings,
 } from "./types";
 
 export interface CanonicalConversationProjection {
@@ -141,6 +143,222 @@ export function projectLegacySessionToCanonical(
             isResumingSession: session.isResumingSession ?? false,
         },
         bindings: [binding],
+    };
+}
+
+export function createConversationBindingsFromLegacySession(
+    session: AIChatSession,
+): ConversationBindingsState {
+    const { conversation, bindings } = projectLegacySessionToCanonical(session);
+    return {
+        version: 1,
+        revision: 0,
+        conversationId: conversation.conversationId,
+        preferredSelection: conversation.preferredSelection,
+        activeBindingId: conversation.activeBindingId,
+        providerBindings: bindings,
+        contextSummary: null,
+        transcriptObservation: {
+            messageCount: session.persistedMessageCount ?? session.messages.length,
+            updatedAt: session.persistedUpdatedAt ?? 0,
+            transcriptFingerprint: null,
+        },
+    };
+}
+
+export function updateConversationBindingsFromLegacySession(
+    session: AIChatSession,
+): ConversationBindingsState {
+    const projected = projectLegacySessionToCanonical(session);
+    const current =
+        session.conversationBindings ??
+        createConversationBindingsFromLegacySession(session);
+    const projectedBinding = projected.bindings[0];
+    const activeBinding = current.providerBindings.find(
+        (binding) => binding.bindingId === current.activeBindingId,
+    );
+    const nextBinding: AcpConversationBinding = activeBinding
+        ? {
+              ...activeBinding,
+              runtimeId: projectedBinding.runtimeId,
+              runtimeDisplayName: projectedBinding.runtimeDisplayName,
+              runtimeRevision: projectedBinding.runtimeRevision,
+              runtimeLaunchFingerprint:
+                  projectedBinding.runtimeLaunchFingerprint,
+              runtimeSessionId: projectedBinding.runtimeSessionId,
+              continuationStrategy: projectedBinding.continuationStrategy,
+              modelId: projectedBinding.modelId,
+              modeId: projectedBinding.modeId,
+              options: projectedBinding.options,
+              models: projectedBinding.models,
+              modes: projectedBinding.modes,
+              configOptions: projectedBinding.configOptions,
+              availableCommands: projectedBinding.availableCommands,
+              effortsByModel: projectedBinding.effortsByModel,
+              runtimeState: projectedBinding.runtimeState,
+              updatedAt: projectedBinding.updatedAt,
+          }
+        : projectedBinding;
+    const providerBindings = activeBinding
+        ? current.providerBindings.map((binding) =>
+              binding.bindingId === activeBinding.bindingId
+                  ? nextBinding
+                  : binding,
+          )
+        : [...current.providerBindings, nextBinding];
+
+    return {
+        ...current,
+        conversationId: projected.conversation.conversationId,
+        preferredSelection: projected.conversation.preferredSelection,
+        activeBindingId: nextBinding.bindingId,
+        providerBindings,
+    };
+}
+
+export function serializeConversationBindings(
+    state: ConversationBindingsState,
+): PersistedConversationBindings {
+    return {
+        version: state.version,
+        revision: state.revision,
+        conversation_id: state.conversationId,
+        preferred_selection: {
+            runtime_id: state.preferredSelection.runtimeId,
+            model_id: state.preferredSelection.modelId,
+            mode_id: state.preferredSelection.modeId,
+            options: state.preferredSelection.options,
+        },
+        active_binding_id: state.activeBindingId,
+        provider_bindings: state.providerBindings.map((binding) => ({
+            binding_id: binding.bindingId,
+            conversation_id: binding.conversationId,
+            runtime_id: binding.runtimeId,
+            runtime_display_name: binding.runtimeDisplayName,
+            runtime_revision: binding.runtimeRevision,
+            runtime_launch_fingerprint: binding.runtimeLaunchFingerprint,
+            runtime_session_id: binding.runtimeSessionId,
+            continuation_strategy: binding.continuationStrategy,
+            capabilities: binding.capabilities,
+            model_id: binding.modelId,
+            mode_id: binding.modeId,
+            options: binding.options,
+            models: binding.models.map((model) => ({
+                id: model.id,
+                runtime_id: model.runtimeId,
+                name: model.name,
+                description: model.description,
+                agent_type: model.agentType,
+            })),
+            modes: binding.modes.map((mode) => ({
+                id: mode.id,
+                runtime_id: mode.runtimeId,
+                name: mode.name,
+                description: mode.description,
+                disabled: mode.disabled ?? false,
+            })),
+            config_options: binding.configOptions.map((option) => ({
+                id: option.id,
+                runtime_id: option.runtimeId,
+                category: option.category,
+                label: option.label,
+                description: option.description,
+                type: option.type,
+                value: option.value,
+                options: option.options.map((item) => ({
+                    value: item.value,
+                    label: item.label,
+                    description: item.description,
+                    agent_type: item.agentType,
+                })),
+            })),
+            efforts_by_model: binding.effortsByModel,
+            runtime_state: binding.runtimeState,
+            context_cursor: binding.contextCursor,
+            context_generation: binding.contextGeneration,
+            created_at: binding.createdAt,
+            updated_at: binding.updatedAt,
+        })),
+        context_summary: state.contextSummary,
+        transcript_observation: {
+            message_count: state.transcriptObservation.messageCount,
+            updated_at: state.transcriptObservation.updatedAt,
+            transcript_fingerprint:
+                state.transcriptObservation.transcriptFingerprint,
+        },
+    };
+}
+
+export function deserializeConversationBindings(
+    persisted: PersistedConversationBindings,
+): ConversationBindingsState {
+    return {
+        version: persisted.version,
+        revision: persisted.revision,
+        conversationId: persisted.conversation_id,
+        preferredSelection: {
+            runtimeId: persisted.preferred_selection.runtime_id,
+            modelId: persisted.preferred_selection.model_id,
+            modeId: persisted.preferred_selection.mode_id,
+            options: persisted.preferred_selection.options,
+        },
+        activeBindingId: persisted.active_binding_id,
+        providerBindings: persisted.provider_bindings.map((binding) => ({
+            bindingId: binding.binding_id,
+            conversationId: binding.conversation_id,
+            runtimeId: binding.runtime_id,
+            runtimeDisplayName: binding.runtime_display_name,
+            runtimeRevision: binding.runtime_revision,
+            runtimeLaunchFingerprint: binding.runtime_launch_fingerprint,
+            runtimeSessionId: binding.runtime_session_id,
+            continuationStrategy: binding.continuation_strategy,
+            capabilities: binding.capabilities,
+            modelId: binding.model_id,
+            modeId: binding.mode_id,
+            options: binding.options,
+            models: (binding.models ?? []).map((model) => ({
+                id: model.id,
+                runtimeId: model.runtime_id,
+                name: model.name,
+                description: model.description,
+                agentType: model.agent_type ?? undefined,
+            })),
+            modes: (binding.modes ?? []).map((mode) => ({
+                id: mode.id,
+                runtimeId: mode.runtime_id,
+                name: mode.name,
+                description: mode.description,
+                disabled: mode.disabled,
+            })),
+            configOptions: (binding.config_options ?? []).map((option) => ({
+                id: option.id,
+                runtimeId: option.runtime_id,
+                category: option.category,
+                label: option.label,
+                description: option.description ?? undefined,
+                type: option.type,
+                value: option.value,
+                options: option.options.map((item) => ({
+                    value: item.value,
+                    label: item.label,
+                    description: item.description ?? undefined,
+                    agentType: item.agent_type ?? undefined,
+                })),
+            })),
+            effortsByModel: binding.efforts_by_model ?? {},
+            runtimeState: binding.runtime_state,
+            contextCursor: binding.context_cursor,
+            contextGeneration: binding.context_generation,
+            createdAt: binding.created_at,
+            updatedAt: binding.updated_at,
+        })),
+        contextSummary: persisted.context_summary,
+        transcriptObservation: {
+            messageCount: persisted.transcript_observation.message_count,
+            updatedAt: persisted.transcript_observation.updated_at,
+            transcriptFingerprint:
+                persisted.transcript_observation.transcript_fingerprint,
+        },
     };
 }
 

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -15,18 +15,31 @@ export interface CanonicalConversationProjection {
 
 export type ConversationInvariantViolation =
     | "missing_conversation_id"
+    | "multiple_provider_bindings"
     | "duplicate_binding_id"
     | "binding_conversation_mismatch"
     | "binding_runtime_mismatch"
     | "missing_active_binding";
 
-export type ConversationSwitchBlocker =
+export type ConversationProviderSelectionBlocker =
+    | "conversation_started"
     | "conversation_not_idle"
     | "session_transition_pending"
     | "queued_messages_pending";
 
-export interface ConversationSwitchContext {
+export interface ConversationProviderSelectionContext {
     hasQueuedMessages?: boolean;
+}
+
+export function hasConversationHistory(
+    conversation: Pick<AIConversation, "messages" | "persistedMessageCount">,
+) {
+    return (
+        Math.max(
+            conversation.messages.length,
+            conversation.persistedMessageCount ?? 0,
+        ) > 0
+    );
 }
 
 function nonEmpty(value: string | null | undefined) {
@@ -38,16 +51,6 @@ function selectionOptions(configOptions: readonly AIConfigOption[]) {
     return Object.fromEntries(
         configOptions.map((option) => [option.id, option.value]),
     );
-}
-
-function applySelectionOptions(
-    configOptions: readonly AIConfigOption[],
-    options: Readonly<Record<string, string>>,
-) {
-    return configOptions.map((option) => ({
-        ...option,
-        value: options[option.id] ?? option.value,
-    }));
 }
 
 function selectionMatchesBinding(
@@ -195,7 +198,9 @@ export function updateConversationBindingsFromLegacySession(
         createConversationBindingsFromLegacySession(session);
     const projectedBinding = projected.bindings[0];
     const activeBinding = current.providerBindings.find(
-        (binding) => binding.bindingId === current.activeBindingId,
+        (binding) =>
+            binding.bindingId === current.activeBindingId &&
+            binding.runtimeId === projectedBinding.runtimeId,
     );
     const nextBinding: AcpConversationBinding = activeBinding
         ? {
@@ -219,16 +224,14 @@ export function updateConversationBindingsFromLegacySession(
               updatedAt: projectedBinding.updatedAt,
           }
         : projectedBinding;
-    const providerBindings = activeBinding
-        ? current.providerBindings.map((binding) =>
-              binding.bindingId === activeBinding.bindingId
-                  ? nextBinding
-                  : binding,
-          )
-        : [...current.providerBindings, nextBinding];
+    // A conversation is bound to exactly one provider after its first turn.
+    // Drop stale bindings created by the former mid-conversation switching flow.
+    const providerBindings = [nextBinding];
     const preferredSelectionTracksActiveBinding =
         activeBinding != null &&
         selectionMatchesBinding(current.preferredSelection, activeBinding);
+    const preferredProviderMatchesActiveBinding =
+        current.preferredSelection.runtimeId === projectedBinding.runtimeId;
 
     return {
         ...current,
@@ -237,46 +240,52 @@ export function updateConversationBindingsFromLegacySession(
         // next-turn selection. Preserve it until that turn is accepted. Only
         // follow the live legacy session when the preference still describes
         // the binding we are replacing.
-        preferredSelection: preferredSelectionTracksActiveBinding
-            ? projected.conversation.preferredSelection
-            : current.preferredSelection,
+        preferredSelection:
+            (hasConversationHistory(session) &&
+                !preferredProviderMatchesActiveBinding) ||
+            preferredSelectionTracksActiveBinding
+                ? projected.conversation.preferredSelection
+                : current.preferredSelection,
         activeBindingId: nextBinding.bindingId,
         providerBindings,
     };
 }
 
 /**
- * A transcript fork owns fresh binding identities and must replay context to
- * every provider independently from the beginning of the copied transcript.
+ * A transcript fork owns a fresh binding identity and must replay context to
+ * its fixed provider from the beginning of the copied transcript.
  */
 export function forkConversationBindings(
     source: ConversationBindingsState,
     conversationId: string,
     now: number,
 ): ConversationBindingsState {
-    let activeBindingId: string | null = null;
-    const providerBindings = source.providerBindings.map((binding, index) => {
-        const bindingId = `fork:${conversationId}:${binding.runtimeId}:${index}`;
-        if (binding.bindingId === source.activeBindingId) {
-            activeBindingId = bindingId;
-        }
-        const isCustomRuntime = binding.runtimeId.startsWith("custom:");
-        return {
-            ...binding,
-            bindingId,
-            conversationId,
-            runtimeSessionId: isCustomRuntime
-                ? null
-                : binding.runtimeSessionId,
-            continuationStrategy: isCustomRuntime
-                ? "new_session_only"
-                : binding.continuationStrategy,
-            contextCursor: null,
-            contextGeneration: binding.contextGeneration + 1,
-            createdAt: now,
-            updatedAt: now,
-        };
-    });
+    const sourceBinding =
+        source.providerBindings.find(
+            (binding) => binding.bindingId === source.activeBindingId,
+        ) ?? source.providerBindings[0];
+    const providerBindings = sourceBinding
+        ? [
+              {
+                  ...sourceBinding,
+                  bindingId: `fork:${conversationId}:${sourceBinding.runtimeId}`,
+                  conversationId,
+                  runtimeSessionId: sourceBinding.runtimeId.startsWith("custom:")
+                      ? null
+                      : sourceBinding.runtimeSessionId,
+                  continuationStrategy: sourceBinding.runtimeId.startsWith(
+                      "custom:",
+                  )
+                      ? "new_session_only"
+                      : sourceBinding.continuationStrategy,
+                  contextCursor: null,
+                  contextGeneration: sourceBinding.contextGeneration + 1,
+                  createdAt: now,
+                  updatedAt: now,
+              },
+          ]
+        : [];
+    const activeBindingId = providerBindings[0]?.bindingId ?? null;
 
     return {
         ...source,
@@ -294,6 +303,10 @@ export function forkConversationBindings(
 export function serializeConversationBindings(
     state: ConversationBindingsState,
 ): PersistedConversationBindings {
+    const activeBinding =
+        state.providerBindings.find(
+            (binding) => binding.bindingId === state.activeBindingId,
+        ) ?? state.providerBindings[0];
     return {
         version: state.version,
         revision: state.revision,
@@ -304,56 +317,58 @@ export function serializeConversationBindings(
             mode_id: state.preferredSelection.modeId,
             options: state.preferredSelection.options,
         },
-        active_binding_id: state.activeBindingId,
-        provider_bindings: state.providerBindings.map((binding) => ({
-            binding_id: binding.bindingId,
-            conversation_id: binding.conversationId,
-            runtime_id: binding.runtimeId,
-            runtime_display_name: binding.runtimeDisplayName,
-            runtime_revision: binding.runtimeRevision,
-            runtime_launch_fingerprint: binding.runtimeLaunchFingerprint,
-            runtime_session_id: binding.runtimeSessionId,
-            continuation_strategy: binding.continuationStrategy,
-            capabilities: binding.capabilities,
-            model_id: binding.modelId,
-            mode_id: binding.modeId,
-            options: binding.options,
-            models: binding.models.map((model) => ({
-                id: model.id,
-                runtime_id: model.runtimeId,
-                name: model.name,
-                description: model.description,
-                agent_type: model.agentType,
-            })),
-            modes: binding.modes.map((mode) => ({
-                id: mode.id,
-                runtime_id: mode.runtimeId,
-                name: mode.name,
-                description: mode.description,
-                disabled: mode.disabled ?? false,
-            })),
-            config_options: binding.configOptions.map((option) => ({
-                id: option.id,
-                runtime_id: option.runtimeId,
-                category: option.category,
-                label: option.label,
-                description: option.description,
-                type: option.type,
-                value: option.value,
-                options: option.options.map((item) => ({
-                    value: item.value,
-                    label: item.label,
-                    description: item.description,
-                    agent_type: item.agentType,
+        active_binding_id: activeBinding?.bindingId ?? null,
+        provider_bindings: (activeBinding ? [activeBinding] : []).map(
+            (binding) => ({
+                binding_id: binding.bindingId,
+                conversation_id: binding.conversationId,
+                runtime_id: binding.runtimeId,
+                runtime_display_name: binding.runtimeDisplayName,
+                runtime_revision: binding.runtimeRevision,
+                runtime_launch_fingerprint: binding.runtimeLaunchFingerprint,
+                runtime_session_id: binding.runtimeSessionId,
+                continuation_strategy: binding.continuationStrategy,
+                capabilities: binding.capabilities,
+                model_id: binding.modelId,
+                mode_id: binding.modeId,
+                options: binding.options,
+                models: binding.models.map((model) => ({
+                    id: model.id,
+                    runtime_id: model.runtimeId,
+                    name: model.name,
+                    description: model.description,
+                    agent_type: model.agentType,
                 })),
-            })),
-            efforts_by_model: binding.effortsByModel,
-            runtime_state: binding.runtimeState,
-            context_cursor: binding.contextCursor,
-            context_generation: binding.contextGeneration,
-            created_at: binding.createdAt,
-            updated_at: binding.updatedAt,
-        })),
+                modes: binding.modes.map((mode) => ({
+                    id: mode.id,
+                    runtime_id: mode.runtimeId,
+                    name: mode.name,
+                    description: mode.description,
+                    disabled: mode.disabled ?? false,
+                })),
+                config_options: binding.configOptions.map((option) => ({
+                    id: option.id,
+                    runtime_id: option.runtimeId,
+                    category: option.category,
+                    label: option.label,
+                    description: option.description,
+                    type: option.type,
+                    value: option.value,
+                    options: option.options.map((item) => ({
+                        value: item.value,
+                        label: item.label,
+                        description: item.description,
+                        agent_type: item.agentType,
+                    })),
+                })),
+                efforts_by_model: binding.effortsByModel,
+                runtime_state: binding.runtimeState,
+                context_cursor: binding.contextCursor,
+                context_generation: binding.contextGeneration,
+                created_at: binding.createdAt,
+                updated_at: binding.updatedAt,
+            }),
+        ),
         context_summary: state.contextSummary,
         transcript_observation: {
             message_count: state.transcriptObservation.messageCount,
@@ -367,66 +382,80 @@ export function serializeConversationBindings(
 export function deserializeConversationBindings(
     persisted: PersistedConversationBindings,
 ): ConversationBindingsState {
+    const deserializedBindings = persisted.provider_bindings.map((binding) => ({
+        bindingId: binding.binding_id,
+        conversationId: binding.conversation_id,
+        runtimeId: binding.runtime_id,
+        runtimeDisplayName: binding.runtime_display_name,
+        runtimeRevision: binding.runtime_revision,
+        runtimeLaunchFingerprint: binding.runtime_launch_fingerprint,
+        runtimeSessionId: binding.runtime_session_id,
+        continuationStrategy: binding.continuation_strategy,
+        capabilities: binding.capabilities,
+        modelId: binding.model_id,
+        modeId: binding.mode_id,
+        options: binding.options,
+        models: (binding.models ?? []).map((model) => ({
+            id: model.id,
+            runtimeId: model.runtime_id,
+            name: model.name,
+            description: model.description,
+            agentType: model.agent_type ?? undefined,
+        })),
+        modes: (binding.modes ?? []).map((mode) => ({
+            id: mode.id,
+            runtimeId: mode.runtime_id,
+            name: mode.name,
+            description: mode.description,
+            disabled: mode.disabled,
+        })),
+        configOptions: (binding.config_options ?? []).map((option) => ({
+            id: option.id,
+            runtimeId: option.runtime_id,
+            category: option.category,
+            label: option.label,
+            description: option.description ?? undefined,
+            type: option.type,
+            value: option.value,
+            options: option.options.map((item) => ({
+                value: item.value,
+                label: item.label,
+                description: item.description ?? undefined,
+                agentType: item.agent_type ?? undefined,
+            })),
+        })),
+        effortsByModel: binding.efforts_by_model ?? {},
+        runtimeState: binding.runtime_state,
+        contextCursor: binding.context_cursor,
+        contextGeneration: binding.context_generation,
+        createdAt: binding.created_at,
+        updatedAt: binding.updated_at,
+    }));
+    const activeBinding =
+        deserializedBindings.find(
+            (binding) => binding.bindingId === persisted.active_binding_id,
+        ) ?? deserializedBindings[0];
+    const preferredSelection =
+        persisted.transcript_observation.message_count > 0 && activeBinding
+            ? {
+                  runtimeId: activeBinding.runtimeId,
+                  modelId: activeBinding.modelId,
+                  modeId: activeBinding.modeId,
+                  options: { ...activeBinding.options },
+              }
+            : {
+                  runtimeId: persisted.preferred_selection.runtime_id,
+                  modelId: persisted.preferred_selection.model_id,
+                  modeId: persisted.preferred_selection.mode_id,
+                  options: persisted.preferred_selection.options,
+              };
     return {
         version: persisted.version,
         revision: persisted.revision,
         conversationId: persisted.conversation_id,
-        preferredSelection: {
-            runtimeId: persisted.preferred_selection.runtime_id,
-            modelId: persisted.preferred_selection.model_id,
-            modeId: persisted.preferred_selection.mode_id,
-            options: persisted.preferred_selection.options,
-        },
-        activeBindingId: persisted.active_binding_id,
-        providerBindings: persisted.provider_bindings.map((binding) => ({
-            bindingId: binding.binding_id,
-            conversationId: binding.conversation_id,
-            runtimeId: binding.runtime_id,
-            runtimeDisplayName: binding.runtime_display_name,
-            runtimeRevision: binding.runtime_revision,
-            runtimeLaunchFingerprint: binding.runtime_launch_fingerprint,
-            runtimeSessionId: binding.runtime_session_id,
-            continuationStrategy: binding.continuation_strategy,
-            capabilities: binding.capabilities,
-            modelId: binding.model_id,
-            modeId: binding.mode_id,
-            options: binding.options,
-            models: (binding.models ?? []).map((model) => ({
-                id: model.id,
-                runtimeId: model.runtime_id,
-                name: model.name,
-                description: model.description,
-                agentType: model.agent_type ?? undefined,
-            })),
-            modes: (binding.modes ?? []).map((mode) => ({
-                id: mode.id,
-                runtimeId: mode.runtime_id,
-                name: mode.name,
-                description: mode.description,
-                disabled: mode.disabled,
-            })),
-            configOptions: (binding.config_options ?? []).map((option) => ({
-                id: option.id,
-                runtimeId: option.runtime_id,
-                category: option.category,
-                label: option.label,
-                description: option.description ?? undefined,
-                type: option.type,
-                value: option.value,
-                options: option.options.map((item) => ({
-                    value: item.value,
-                    label: item.label,
-                    description: item.description ?? undefined,
-                    agentType: item.agent_type ?? undefined,
-                })),
-            })),
-            effortsByModel: binding.efforts_by_model ?? {},
-            runtimeState: binding.runtime_state,
-            contextCursor: binding.context_cursor,
-            contextGeneration: binding.context_generation,
-            createdAt: binding.created_at,
-            updatedAt: binding.updated_at,
-        })),
+        preferredSelection,
+        activeBindingId: activeBinding?.bindingId ?? null,
+        providerBindings: activeBinding ? [activeBinding] : [],
         contextSummary: persisted.context_summary,
         transcriptObservation: {
             messageCount: persisted.transcript_observation.message_count,
@@ -434,67 +463,6 @@ export function deserializeConversationBindings(
             transcriptFingerprint:
                 persisted.transcript_observation.transcript_fingerprint,
         },
-    };
-}
-
-/**
- * Compatibility adapter for legacy consumers. The active binding, not the
- * preferred next-turn selection, remains the projected runtime until routing
- * moves to canonical conversations in a later commit.
- */
-export function projectCanonicalConversationToLegacy(
-    conversation: AIConversation,
-    binding: AcpConversationBinding,
-    template: AIChatSession,
-): AIChatSession {
-    if (binding.conversationId !== conversation.conversationId) {
-        throw new Error("Cannot project a binding owned by another conversation");
-    }
-    if (conversation.activeBindingId !== binding.bindingId) {
-        throw new Error("Cannot project a binding that is not active");
-    }
-
-    return {
-        ...template,
-        historySessionId: conversation.conversationId,
-        parentSessionId: conversation.parentConversationId,
-        vaultPath: conversation.vaultPath,
-        closedAt: conversation.closedAt,
-        status: conversation.status,
-        activeWorkCycleId: conversation.activeWorkCycleId,
-        visibleWorkCycleId: conversation.visibleWorkCycleId,
-        actionLog: conversation.actionLog,
-        messages: conversation.messages,
-        attachments: conversation.attachments,
-        persistedCreatedAt: conversation.persistedCreatedAt,
-        persistedUpdatedAt: conversation.persistedUpdatedAt,
-        persistedTitle: conversation.persistedTitle,
-        customTitle: conversation.customTitle,
-        persistedPreview: conversation.persistedPreview,
-        persistedMessageCount: conversation.persistedMessageCount,
-        loadedPersistedMessageStart:
-            conversation.loadedPersistedMessageStart,
-        isLoadingPersistedMessages: conversation.isLoadingPersistedMessages,
-        isPersistedSession: conversation.isPersistedSession,
-        isPendingSessionCreation: conversation.isPendingSessionCreation,
-        isResumingSession: conversation.isResumingSession,
-        runtimeId: binding.runtimeId,
-        runtimeDisplayName: binding.runtimeDisplayName,
-        runtimeRevision: binding.runtimeRevision,
-        runtimeLaunchFingerprint: binding.runtimeLaunchFingerprint,
-        runtimeSessionId: binding.runtimeSessionId,
-        continuationStrategy: binding.continuationStrategy,
-        modelId: binding.modelId,
-        modeId: binding.modeId,
-        models: binding.models,
-        modes: binding.modes,
-        configOptions: applySelectionOptions(
-            binding.configOptions,
-            binding.options,
-        ),
-        availableCommands: binding.availableCommands,
-        effortsByModel: binding.effortsByModel,
-        runtimeState: binding.runtimeState,
     };
 }
 
@@ -508,6 +476,9 @@ export function validateCanonicalConversation(
     }
 
     const seenBindingIds = new Set<string>();
+    if (bindings.length > 1) {
+        violations.add("multiple_provider_bindings");
+    }
     for (const binding of bindings) {
         if (seenBindingIds.has(binding.bindingId)) {
             violations.add("duplicate_binding_id");
@@ -541,16 +512,19 @@ export function validateCanonicalConversation(
     return [...violations];
 }
 
-/** Provider changes are only valid between turns and without queued work. */
-export function getConversationSwitchBlocker(
+/** A provider can be chosen only before the conversation has any history. */
+export function getConversationProviderSelectionBlocker(
     conversation: Pick<
         AIConversation,
         | "status"
+        | "messages"
+        | "persistedMessageCount"
         | "isPendingSessionCreation"
         | "isResumingSession"
     >,
-    context: ConversationSwitchContext = {},
-): ConversationSwitchBlocker | null {
+    context: ConversationProviderSelectionContext = {},
+): ConversationProviderSelectionBlocker | null {
+    if (hasConversationHistory(conversation)) return "conversation_started";
     if (conversation.status !== "idle") return "conversation_not_idle";
     if (
         conversation.isPendingSessionCreation ||
@@ -560,11 +534,4 @@ export function getConversationSwitchBlocker(
     }
     if (context.hasQueuedMessages) return "queued_messages_pending";
     return null;
-}
-
-export function canSwitchConversationProvider(
-    conversation: Parameters<typeof getConversationSwitchBlocker>[0],
-    context?: ConversationSwitchContext,
-) {
-    return getConversationSwitchBlocker(conversation, context) === null;
 }

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from "vitest";
+import { createConversationBindingsFromLegacySession } from "./conversationModel";
+import {
+    buildConversationProviderOptions,
+    getConversationTurnCatalog,
+    requiresFirstProviderHandoffConfirmation,
+    updateConversationSelection,
+} from "./conversationPickerModel";
+import type {
+    AIChatSession,
+    AIRuntimeDescriptor,
+    AIRuntimeSetupStatus,
+} from "./types";
+
+function session(): AIChatSession {
+    return {
+        sessionId: "local-a",
+        historySessionId: "conversation-1",
+        status: "idle",
+        activeWorkCycleId: null,
+        runtimeId: "provider-a",
+        modelId: "model-a",
+        modeId: "default",
+        models: [],
+        modes: [],
+        configOptions: [],
+        messages: [],
+        attachments: [],
+        runtimeState: "live",
+    };
+}
+
+function runtime(id: string): AIRuntimeDescriptor {
+    return {
+        runtime: {
+            id,
+            name: `${id} ACP`,
+            description: `${id} description`,
+            capabilities: ["create_session"],
+        },
+        models: [
+            {
+                id: `model-${id}`,
+                runtimeId: id,
+                name: `Model ${id}`,
+                description: "Model description",
+            },
+        ],
+        modes: [],
+        configOptions: [],
+    };
+}
+
+function ready(runtimeId: string): AIRuntimeSetupStatus {
+    return {
+        runtimeId,
+        binaryReady: true,
+        binarySource: "bundled",
+        authReady: true,
+        authMethods: [],
+        onboardingRequired: false,
+    };
+}
+
+describe("conversation provider picker model", () => {
+    it("excludes terminal and unready providers", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        const conversation = {
+            ...current,
+            conversationId: bindings.conversationId,
+            parentConversationId: null,
+            vaultPath: null,
+            closedAt: null,
+            activeWorkCycleId: null,
+            visibleWorkCycleId: null,
+            preferredSelection: bindings.preferredSelection,
+            activeBindingId: bindings.activeBindingId,
+            persistedCreatedAt: null,
+            persistedUpdatedAt: null,
+            persistedTitle: null,
+            customTitle: null,
+            persistedPreview: null,
+            isPersistedSession: false,
+            isPendingSessionCreation: false,
+            isResumingSession: false,
+        };
+
+        const options = buildConversationProviderOptions({
+            runtimes: [
+                runtime("provider-a"),
+                runtime("provider-b"),
+                runtime("provider-c"),
+                runtime("claude-code-terminal"),
+            ],
+            setupStatusByRuntimeId: {
+                "provider-a": ready("provider-a"),
+                "provider-b": ready("provider-b"),
+            },
+            conversation,
+            bindings: bindings.providerBindings,
+            activeRuntimeId: "provider-a",
+            hasQueuedMessages: false,
+        });
+
+        expect(options.map((option) => option.runtimeId)).toEqual([
+            "provider-a",
+            "provider-b",
+        ]);
+    });
+
+    it("explains why another provider is disabled during active work", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        const conversation = {
+            ...current,
+            conversationId: bindings.conversationId,
+            parentConversationId: null,
+            vaultPath: null,
+            closedAt: null,
+            activeWorkCycleId: "work-1",
+            visibleWorkCycleId: null,
+            preferredSelection: bindings.preferredSelection,
+            activeBindingId: bindings.activeBindingId,
+            persistedCreatedAt: null,
+            persistedUpdatedAt: null,
+            persistedTitle: null,
+            customTitle: null,
+            persistedPreview: null,
+            isPersistedSession: false,
+            isPendingSessionCreation: false,
+            isResumingSession: false,
+        };
+
+        const options = buildConversationProviderOptions({
+            runtimes: [runtime("provider-a"), runtime("provider-b")],
+            setupStatusByRuntimeId: {
+                "provider-a": ready("provider-a"),
+                "provider-b": ready("provider-b"),
+            },
+            conversation,
+            bindings: bindings.providerBindings,
+            activeRuntimeId: "provider-a",
+            hasQueuedMessages: false,
+        });
+
+        expect(options[0].disabledReason).toBeNull();
+        expect(options[1].disabledReason).toContain("work cycle");
+    });
+
+    it("projects the selected provider catalog and updates its model option", () => {
+        const current = session();
+        const providerB = runtime("provider-b");
+        providerB.configOptions = [
+            {
+                id: "model",
+                runtimeId: "provider-b",
+                category: "model",
+                label: "Model",
+                type: "select",
+                value: "model-provider-b",
+                options: [
+                    {
+                        value: "model-provider-b",
+                        label: "Model B",
+                    },
+                    { value: "model-b-2", label: "Model B 2" },
+                ],
+            },
+        ];
+        const selection = {
+            runtimeId: "provider-b",
+            modelId: "model-b-2",
+            modeId: "default",
+            options: { model: "model-b-2" },
+        };
+        const catalog = getConversationTurnCatalog({
+            selection,
+            session: current,
+            runtimes: [providerB],
+            bindings: [],
+        });
+
+        expect(catalog.configOptions[0].value).toBe("model-b-2");
+        expect(
+            updateConversationSelection(selection, catalog.configOptions, {
+                kind: "model",
+                value: "model-provider-b",
+            }),
+        ).toMatchObject({
+            modelId: "model-provider-b",
+            options: { model: "model-provider-b" },
+        });
+    });
+
+    it("confirms only the first transcript handoff to a provider", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        expect(
+            requiresFirstProviderHandoffConfirmation({
+                activeRuntimeId: "provider-a",
+                targetRuntimeId: "provider-b",
+                bindings: bindings.providerBindings,
+                messageCount: 2,
+            }),
+        ).toBe(true);
+
+        bindings.providerBindings.push({
+            ...bindings.providerBindings[0],
+            bindingId: "binding-b",
+            runtimeId: "provider-b",
+        });
+        expect(
+            requiresFirstProviderHandoffConfirmation({
+                activeRuntimeId: "provider-a",
+                targetRuntimeId: "provider-b",
+                bindings: bindings.providerBindings,
+                messageCount: 2,
+            }),
+        ).toBe(false);
+    });
+});

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -187,6 +187,56 @@ describe("conversation provider picker model", () => {
     expect(options[1].disabledReason).toBeNull();
   });
 
+  it("locks the provider after the first conversation message", () => {
+    const current = session();
+    current.messages = [
+      {
+        id: "user-1",
+        role: "user",
+        kind: "text",
+        content: "Start",
+        timestamp: 1,
+      },
+    ];
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const conversation = {
+      ...current,
+      conversationId: bindings.conversationId,
+      parentConversationId: null,
+      vaultPath: null,
+      closedAt: null,
+      activeWorkCycleId: null,
+      visibleWorkCycleId: null,
+      preferredSelection: bindings.preferredSelection,
+      activeBindingId: bindings.activeBindingId,
+      persistedCreatedAt: null,
+      persistedUpdatedAt: null,
+      persistedTitle: null,
+      customTitle: null,
+      persistedPreview: null,
+      isPersistedSession: false,
+      isPendingSessionCreation: false,
+      isResumingSession: false,
+    };
+
+    const options = buildConversationProviderOptions({
+      runtimes: [runtime("provider-a"), runtime("provider-b")],
+      setupStatusByRuntimeId: {
+        "provider-a": ready("provider-a"),
+        "provider-b": ready("provider-b"),
+      },
+      conversation,
+      bindings: bindings.providerBindings,
+      activeRuntimeId: "provider-a",
+      hasQueuedMessages: false,
+    });
+
+    expect(options[0].disabledReason).toBeNull();
+    expect(options[1].disabledReason).toBe(
+      "Start a new chat to use another provider.",
+    );
+  });
+
   it("projects the selected provider catalog and updates its model option", () => {
     const current = session();
     const providerB = runtime("provider-b");
@@ -236,26 +286,6 @@ describe("conversation provider picker model", () => {
     const current = session();
     const bindings = createConversationBindingsFromLegacySession(current);
     const codex = runtime("codex-acp");
-    bindings.providerBindings.push({
-      ...bindings.providerBindings[0],
-      bindingId: "binding-codex",
-      runtimeId: "codex-acp",
-      modelId: "gpt-5.6-sol",
-      configOptions: [
-        {
-          id: "service_tier",
-          runtimeId: "codex-acp",
-          category: "service_tier",
-          label: "Fast Mode",
-          type: "select",
-          value: "off",
-          options: [
-            { value: "off", label: "Off" },
-            { value: "fast", label: "Fast" },
-          ],
-        },
-      ],
-    });
 
     const catalog = getConversationTurnCatalog({
       selection: {

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -1,262 +1,326 @@
 import { describe, expect, it } from "vitest";
 import { createConversationBindingsFromLegacySession } from "./conversationModel";
 import {
-    buildConversationProviderOptions,
-    getConversationTurnCatalog,
-    requiresFirstProviderHandoffConfirmation,
-    updateConversationSelection,
+  buildConversationProviderOptions,
+  getConversationTurnCatalog,
+  requiresFirstProviderHandoffConfirmation,
+  updateConversationSelection,
 } from "./conversationPickerModel";
 import type {
-    AIChatSession,
-    AIRuntimeDescriptor,
-    AIRuntimeSetupStatus,
+  AIChatSession,
+  AIRuntimeDescriptor,
+  AIRuntimeSetupStatus,
 } from "./types";
 
 function session(): AIChatSession {
-    return {
-        sessionId: "local-a",
-        historySessionId: "conversation-1",
-        status: "idle",
-        activeWorkCycleId: null,
-        runtimeId: "provider-a",
-        modelId: "model-a",
-        modeId: "default",
-        models: [],
-        modes: [],
-        configOptions: [],
-        messages: [],
-        attachments: [],
-        runtimeState: "live",
-    };
+  return {
+    sessionId: "local-a",
+    historySessionId: "conversation-1",
+    status: "idle",
+    activeWorkCycleId: null,
+    runtimeId: "provider-a",
+    modelId: "model-a",
+    modeId: "default",
+    models: [],
+    modes: [],
+    configOptions: [],
+    messages: [],
+    attachments: [],
+    runtimeState: "live",
+  };
 }
 
 function runtime(id: string): AIRuntimeDescriptor {
-    return {
-        runtime: {
-            id,
-            name: `${id} ACP`,
-            description: `${id} description`,
-            capabilities: ["create_session"],
-        },
-        models: [
-            {
-                id: `model-${id}`,
-                runtimeId: id,
-                name: `Model ${id}`,
-                description: "Model description",
-            },
-        ],
-        modes: [],
-        configOptions: [],
-    };
+  return {
+    runtime: {
+      id,
+      name: `${id} ACP`,
+      description: `${id} description`,
+      capabilities: ["create_session"],
+    },
+    models: [
+      {
+        id: `model-${id}`,
+        runtimeId: id,
+        name: `Model ${id}`,
+        description: "Model description",
+      },
+    ],
+    modes: [],
+    configOptions: [],
+  };
 }
 
 function ready(runtimeId: string): AIRuntimeSetupStatus {
-    return {
-        runtimeId,
-        binaryReady: true,
-        binarySource: "bundled",
-        authReady: true,
-        authMethods: [],
-        onboardingRequired: false,
-    };
+  return {
+    runtimeId,
+    binaryReady: true,
+    binarySource: "bundled",
+    authReady: true,
+    authMethods: [],
+    onboardingRequired: false,
+  };
 }
 
 describe("conversation provider picker model", () => {
-    it("excludes terminal and unready providers", () => {
-        const current = session();
-        const bindings = createConversationBindingsFromLegacySession(current);
-        const conversation = {
-            ...current,
-            conversationId: bindings.conversationId,
-            parentConversationId: null,
-            vaultPath: null,
-            closedAt: null,
-            activeWorkCycleId: null,
-            visibleWorkCycleId: null,
-            preferredSelection: bindings.preferredSelection,
-            activeBindingId: bindings.activeBindingId,
-            persistedCreatedAt: null,
-            persistedUpdatedAt: null,
-            persistedTitle: null,
-            customTitle: null,
-            persistedPreview: null,
-            isPersistedSession: false,
-            isPendingSessionCreation: false,
-            isResumingSession: false,
-        };
+  it("excludes terminal and unready providers", () => {
+    const current = session();
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const conversation = {
+      ...current,
+      conversationId: bindings.conversationId,
+      parentConversationId: null,
+      vaultPath: null,
+      closedAt: null,
+      activeWorkCycleId: null,
+      visibleWorkCycleId: null,
+      preferredSelection: bindings.preferredSelection,
+      activeBindingId: bindings.activeBindingId,
+      persistedCreatedAt: null,
+      persistedUpdatedAt: null,
+      persistedTitle: null,
+      customTitle: null,
+      persistedPreview: null,
+      isPersistedSession: false,
+      isPendingSessionCreation: false,
+      isResumingSession: false,
+    };
 
-        const options = buildConversationProviderOptions({
-            runtimes: [
-                runtime("provider-a"),
-                runtime("provider-b"),
-                runtime("provider-c"),
-                runtime("claude-code-terminal"),
+    const options = buildConversationProviderOptions({
+      runtimes: [
+        runtime("provider-a"),
+        runtime("provider-b"),
+        runtime("provider-c"),
+        runtime("claude-code-terminal"),
+      ],
+      setupStatusByRuntimeId: {
+        "provider-a": ready("provider-a"),
+        "provider-b": ready("provider-b"),
+      },
+      conversation,
+      bindings: bindings.providerBindings,
+      activeRuntimeId: "provider-a",
+      hasQueuedMessages: false,
+    });
+
+    expect(options.map((option) => option.runtimeId)).toEqual([
+      "provider-a",
+      "provider-b",
+    ]);
+  });
+
+  it("blocks another provider during a running turn", () => {
+    const current = session();
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const conversation = {
+      ...current,
+      conversationId: bindings.conversationId,
+      parentConversationId: null,
+      vaultPath: null,
+      closedAt: null,
+      status: "streaming" as const,
+      activeWorkCycleId: "work-1",
+      visibleWorkCycleId: null,
+      preferredSelection: bindings.preferredSelection,
+      activeBindingId: bindings.activeBindingId,
+      persistedCreatedAt: null,
+      persistedUpdatedAt: null,
+      persistedTitle: null,
+      customTitle: null,
+      persistedPreview: null,
+      isPersistedSession: false,
+      isPendingSessionCreation: false,
+      isResumingSession: false,
+    };
+
+    const options = buildConversationProviderOptions({
+      runtimes: [runtime("provider-a"), runtime("provider-b")],
+      setupStatusByRuntimeId: {
+        "provider-a": ready("provider-a"),
+        "provider-b": ready("provider-b"),
+      },
+      conversation,
+      bindings: bindings.providerBindings,
+      activeRuntimeId: "provider-a",
+      hasQueuedMessages: false,
+    });
+
+    expect(options[0].disabledReason).toBeNull();
+    expect(options[1].disabledReason).toContain("current turn");
+  });
+
+  it("allows another provider when an idle chat has a stale work cycle", () => {
+    const current = session();
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const conversation = {
+      ...current,
+      conversationId: bindings.conversationId,
+      parentConversationId: null,
+      vaultPath: null,
+      closedAt: null,
+      activeWorkCycleId: "stale-work-1",
+      visibleWorkCycleId: null,
+      preferredSelection: bindings.preferredSelection,
+      activeBindingId: bindings.activeBindingId,
+      persistedCreatedAt: null,
+      persistedUpdatedAt: null,
+      persistedTitle: null,
+      customTitle: null,
+      persistedPreview: null,
+      isPersistedSession: false,
+      isPendingSessionCreation: false,
+      isResumingSession: false,
+    };
+
+    const options = buildConversationProviderOptions({
+      runtimes: [runtime("provider-a"), runtime("provider-b")],
+      setupStatusByRuntimeId: {
+        "provider-a": ready("provider-a"),
+        "provider-b": ready("provider-b"),
+      },
+      conversation,
+      bindings: bindings.providerBindings,
+      activeRuntimeId: "provider-a",
+      hasQueuedMessages: false,
+    });
+
+    expect(options[0].disabledReason).toBeNull();
+    expect(options[1].disabledReason).toBeNull();
+  });
+
+  it("projects the selected provider catalog and updates its model option", () => {
+    const current = session();
+    const providerB = runtime("provider-b");
+    providerB.configOptions = [
+      {
+        id: "model",
+        runtimeId: "provider-b",
+        category: "model",
+        label: "Model",
+        type: "select",
+        value: "model-provider-b",
+        options: [
+          {
+            value: "model-provider-b",
+            label: "Model B",
+          },
+          { value: "model-b-2", label: "Model B 2" },
+        ],
+      },
+    ];
+    const selection = {
+      runtimeId: "provider-b",
+      modelId: "model-b-2",
+      modeId: "default",
+      options: { model: "model-b-2" },
+    };
+    const catalog = getConversationTurnCatalog({
+      selection,
+      session: current,
+      runtimes: [providerB],
+      bindings: [],
+    });
+
+    expect(catalog.configOptions[0].value).toBe("model-b-2");
+    expect(
+      updateConversationSelection(selection, catalog.configOptions, {
+        kind: "model",
+        value: "model-provider-b",
+      }),
+    ).toMatchObject({
+      modelId: "model-provider-b",
+      options: { model: "model-provider-b" },
+    });
+  });
+
+  it("uses the prepared catalog for a staged provider and model", () => {
+    const current = session();
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const codex = runtime("codex-acp");
+    bindings.providerBindings.push({
+      ...bindings.providerBindings[0],
+      bindingId: "binding-codex",
+      runtimeId: "codex-acp",
+      modelId: "gpt-5.6-sol",
+      configOptions: [
+        {
+          id: "service_tier",
+          runtimeId: "codex-acp",
+          category: "service_tier",
+          label: "Fast Mode",
+          type: "select",
+          value: "off",
+          options: [
+            { value: "off", label: "Off" },
+            { value: "fast", label: "Fast" },
+          ],
+        },
+      ],
+    });
+
+    const catalog = getConversationTurnCatalog({
+      selection: {
+        runtimeId: "codex-acp",
+        modelId: "gpt-5.6-sol",
+        modeId: "default",
+        options: { service_tier: "off" },
+      },
+      session: current,
+      runtimes: [codex],
+      bindings: bindings.providerBindings,
+      preparedCatalog: {
+        runtimeId: "codex-acp",
+        modelId: "gpt-5.6-sol",
+        models: [],
+        modes: [],
+        configOptions: [
+          {
+            id: "reasoning_effort",
+            runtimeId: "codex-acp",
+            category: "reasoning",
+            label: "Reasoning Effort",
+            type: "select",
+            value: "medium",
+            options: [
+              { value: "low", label: "Low" },
+              { value: "medium", label: "Medium" },
+              { value: "high", label: "High" },
             ],
-            setupStatusByRuntimeId: {
-                "provider-a": ready("provider-a"),
-                "provider-b": ready("provider-b"),
-            },
-            conversation,
-            bindings: bindings.providerBindings,
-            activeRuntimeId: "provider-a",
-            hasQueuedMessages: false,
-        });
-
-        expect(options.map((option) => option.runtimeId)).toEqual([
-            "provider-a",
-            "provider-b",
-        ]);
+          },
+        ],
+        effortsByModel: {},
+      },
     });
 
-    it("blocks another provider during a running turn", () => {
-        const current = session();
-        const bindings = createConversationBindingsFromLegacySession(current);
-        const conversation = {
-            ...current,
-            conversationId: bindings.conversationId,
-            parentConversationId: null,
-            vaultPath: null,
-            closedAt: null,
-            status: "streaming" as const,
-            activeWorkCycleId: "work-1",
-            visibleWorkCycleId: null,
-            preferredSelection: bindings.preferredSelection,
-            activeBindingId: bindings.activeBindingId,
-            persistedCreatedAt: null,
-            persistedUpdatedAt: null,
-            persistedTitle: null,
-            customTitle: null,
-            persistedPreview: null,
-            isPersistedSession: false,
-            isPendingSessionCreation: false,
-            isResumingSession: false,
-        };
+    expect(catalog.configOptions.map((option) => option.id)).toEqual([
+      "reasoning_effort",
+    ]);
+  });
 
-        const options = buildConversationProviderOptions({
-            runtimes: [runtime("provider-a"), runtime("provider-b")],
-            setupStatusByRuntimeId: {
-                "provider-a": ready("provider-a"),
-                "provider-b": ready("provider-b"),
-            },
-            conversation,
-            bindings: bindings.providerBindings,
-            activeRuntimeId: "provider-a",
-            hasQueuedMessages: false,
-        });
+  it("confirms only the first transcript handoff to a provider", () => {
+    const current = session();
+    const bindings = createConversationBindingsFromLegacySession(current);
+    expect(
+      requiresFirstProviderHandoffConfirmation({
+        activeRuntimeId: "provider-a",
+        targetRuntimeId: "provider-b",
+        bindings: bindings.providerBindings,
+        messageCount: 2,
+      }),
+    ).toBe(true);
 
-        expect(options[0].disabledReason).toBeNull();
-        expect(options[1].disabledReason).toContain("current turn");
+    bindings.providerBindings.push({
+      ...bindings.providerBindings[0],
+      bindingId: "binding-b",
+      runtimeId: "provider-b",
     });
-
-    it("allows another provider when an idle chat has a stale work cycle", () => {
-        const current = session();
-        const bindings = createConversationBindingsFromLegacySession(current);
-        const conversation = {
-            ...current,
-            conversationId: bindings.conversationId,
-            parentConversationId: null,
-            vaultPath: null,
-            closedAt: null,
-            activeWorkCycleId: "stale-work-1",
-            visibleWorkCycleId: null,
-            preferredSelection: bindings.preferredSelection,
-            activeBindingId: bindings.activeBindingId,
-            persistedCreatedAt: null,
-            persistedUpdatedAt: null,
-            persistedTitle: null,
-            customTitle: null,
-            persistedPreview: null,
-            isPersistedSession: false,
-            isPendingSessionCreation: false,
-            isResumingSession: false,
-        };
-
-        const options = buildConversationProviderOptions({
-            runtimes: [runtime("provider-a"), runtime("provider-b")],
-            setupStatusByRuntimeId: {
-                "provider-a": ready("provider-a"),
-                "provider-b": ready("provider-b"),
-            },
-            conversation,
-            bindings: bindings.providerBindings,
-            activeRuntimeId: "provider-a",
-            hasQueuedMessages: false,
-        });
-
-        expect(options[0].disabledReason).toBeNull();
-        expect(options[1].disabledReason).toBeNull();
-    });
-
-    it("projects the selected provider catalog and updates its model option", () => {
-        const current = session();
-        const providerB = runtime("provider-b");
-        providerB.configOptions = [
-            {
-                id: "model",
-                runtimeId: "provider-b",
-                category: "model",
-                label: "Model",
-                type: "select",
-                value: "model-provider-b",
-                options: [
-                    {
-                        value: "model-provider-b",
-                        label: "Model B",
-                    },
-                    { value: "model-b-2", label: "Model B 2" },
-                ],
-            },
-        ];
-        const selection = {
-            runtimeId: "provider-b",
-            modelId: "model-b-2",
-            modeId: "default",
-            options: { model: "model-b-2" },
-        };
-        const catalog = getConversationTurnCatalog({
-            selection,
-            session: current,
-            runtimes: [providerB],
-            bindings: [],
-        });
-
-        expect(catalog.configOptions[0].value).toBe("model-b-2");
-        expect(
-            updateConversationSelection(selection, catalog.configOptions, {
-                kind: "model",
-                value: "model-provider-b",
-            }),
-        ).toMatchObject({
-            modelId: "model-provider-b",
-            options: { model: "model-provider-b" },
-        });
-    });
-
-    it("confirms only the first transcript handoff to a provider", () => {
-        const current = session();
-        const bindings = createConversationBindingsFromLegacySession(current);
-        expect(
-            requiresFirstProviderHandoffConfirmation({
-                activeRuntimeId: "provider-a",
-                targetRuntimeId: "provider-b",
-                bindings: bindings.providerBindings,
-                messageCount: 2,
-            }),
-        ).toBe(true);
-
-        bindings.providerBindings.push({
-            ...bindings.providerBindings[0],
-            bindingId: "binding-b",
-            runtimeId: "provider-b",
-        });
-        expect(
-            requiresFirstProviderHandoffConfirmation({
-                activeRuntimeId: "provider-a",
-                targetRuntimeId: "provider-b",
-                bindings: bindings.providerBindings,
-                messageCount: 2,
-            }),
-        ).toBe(false);
-    });
+    expect(
+      requiresFirstProviderHandoffConfirmation({
+        activeRuntimeId: "provider-a",
+        targetRuntimeId: "provider-b",
+        bindings: bindings.providerBindings,
+        messageCount: 2,
+      }),
+    ).toBe(false);
+  });
 });

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -109,7 +109,7 @@ describe("conversation provider picker model", () => {
         ]);
     });
 
-    it("explains why another provider is disabled during active work", () => {
+    it("blocks another provider during a running turn", () => {
         const current = session();
         const bindings = createConversationBindingsFromLegacySession(current);
         const conversation = {
@@ -118,6 +118,7 @@ describe("conversation provider picker model", () => {
             parentConversationId: null,
             vaultPath: null,
             closedAt: null,
+            status: "streaming" as const,
             activeWorkCycleId: "work-1",
             visibleWorkCycleId: null,
             preferredSelection: bindings.preferredSelection,
@@ -145,7 +146,46 @@ describe("conversation provider picker model", () => {
         });
 
         expect(options[0].disabledReason).toBeNull();
-        expect(options[1].disabledReason).toContain("work cycle");
+        expect(options[1].disabledReason).toContain("current turn");
+    });
+
+    it("allows another provider when an idle chat has a stale work cycle", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        const conversation = {
+            ...current,
+            conversationId: bindings.conversationId,
+            parentConversationId: null,
+            vaultPath: null,
+            closedAt: null,
+            activeWorkCycleId: "stale-work-1",
+            visibleWorkCycleId: null,
+            preferredSelection: bindings.preferredSelection,
+            activeBindingId: bindings.activeBindingId,
+            persistedCreatedAt: null,
+            persistedUpdatedAt: null,
+            persistedTitle: null,
+            customTitle: null,
+            persistedPreview: null,
+            isPersistedSession: false,
+            isPendingSessionCreation: false,
+            isResumingSession: false,
+        };
+
+        const options = buildConversationProviderOptions({
+            runtimes: [runtime("provider-a"), runtime("provider-b")],
+            setupStatusByRuntimeId: {
+                "provider-a": ready("provider-a"),
+                "provider-b": ready("provider-b"),
+            },
+            conversation,
+            bindings: bindings.providerBindings,
+            activeRuntimeId: "provider-a",
+            hasQueuedMessages: false,
+        });
+
+        expect(options[0].disabledReason).toBeNull();
+        expect(options[1].disabledReason).toBeNull();
     });
 
     it("projects the selected provider catalog and updates its model option", () => {

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -3,7 +3,6 @@ import { createConversationBindingsFromLegacySession } from "./conversationModel
 import {
   buildConversationProviderOptions,
   getConversationTurnCatalog,
-  requiresFirstProviderHandoffConfirmation,
   updateConversationSelection,
 } from "./conversationPickerModel";
 import type {
@@ -297,30 +296,4 @@ describe("conversation provider picker model", () => {
     ]);
   });
 
-  it("confirms only the first transcript handoff to a provider", () => {
-    const current = session();
-    const bindings = createConversationBindingsFromLegacySession(current);
-    expect(
-      requiresFirstProviderHandoffConfirmation({
-        activeRuntimeId: "provider-a",
-        targetRuntimeId: "provider-b",
-        bindings: bindings.providerBindings,
-        messageCount: 2,
-      }),
-    ).toBe(true);
-
-    bindings.providerBindings.push({
-      ...bindings.providerBindings[0],
-      bindingId: "binding-b",
-      runtimeId: "provider-b",
-    });
-    expect(
-      requiresFirstProviderHandoffConfirmation({
-        activeRuntimeId: "provider-a",
-        targetRuntimeId: "provider-b",
-        bindings: bindings.providerBindings,
-        messageCount: 2,
-      }),
-    ).toBe(false);
-  });
 });

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -1,363 +1,378 @@
 import { getConversationSwitchBlocker } from "./conversationModel";
 import type {
-    AcpConversationBinding,
-    AIChatSession,
-    AIConfigOption,
-    AIConversation,
-    AIModeOption,
-    AIModelOption,
-    AIRuntimeDescriptor,
-    AIRuntimeSetupStatus,
-    ConversationSelection,
+  AcpConversationBinding,
+  AIChatSession,
+  AIConfigOption,
+  AIConversation,
+  AIModeOption,
+  AIModelOption,
+  AIRuntimeDescriptor,
+  AIRuntimeSetupStatus,
+  ConversationSelection,
 } from "./types";
 import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
 
 export interface ConversationProviderPickerOption {
-    runtimeId: string;
-    label: string;
-    description: string;
-    disabledReason: string | null;
-    defaultModelId: string;
-    models: ConversationProviderModelOption[];
+  runtimeId: string;
+  label: string;
+  description: string;
+  disabledReason: string | null;
+  defaultModelId: string;
+  models: ConversationProviderModelOption[];
 }
 
 export interface ConversationProviderModelOption {
-    modelId: string;
-    label: string;
-    description?: string;
-    agentType?: string;
-    disabledReason: string | null;
+  modelId: string;
+  label: string;
+  description?: string;
+  agentType?: string;
+  disabledReason: string | null;
 }
 
 export interface ConversationTurnCatalog {
-    models: AIModelOption[];
-    modes: AIModeOption[];
-    configOptions: AIConfigOption[];
-    effortsByModel: Record<string, string[]>;
+  models: AIModelOption[];
+  modes: AIModeOption[];
+  configOptions: AIConfigOption[];
+  effortsByModel: Record<string, string[]>;
+}
+
+export interface PreparedConversationTurnCatalog
+  extends ConversationTurnCatalog {
+  runtimeId: string;
+  modelId: string;
 }
 
 function isRuntimeReady(status?: AIRuntimeSetupStatus | null) {
-    return status?.authReady === true && !status.onboardingRequired;
+  return status?.authReady === true && !status.onboardingRequired;
 }
 
 function switchBlockerLabel(
-    blocker: ReturnType<typeof getConversationSwitchBlocker>,
+  blocker: ReturnType<typeof getConversationSwitchBlocker>,
 ) {
-    switch (blocker) {
-        case "conversation_not_idle":
-            return "Finish the current turn before switching providers.";
-        case "session_transition_pending":
-            return "Wait for the current session transition to finish.";
-        case "queued_messages_pending":
-            return "Send or remove queued messages before switching providers.";
-        default:
-            return null;
-    }
+  switch (blocker) {
+    case "conversation_not_idle":
+      return "Finish the current turn before switching providers.";
+    case "session_transition_pending":
+      return "Wait for the current session transition to finish.";
+    case "queued_messages_pending":
+      return "Send or remove queued messages before switching providers.";
+    default:
+      return null;
+  }
 }
 
 function canStartRuntime(
-    runtime: AIRuntimeDescriptor,
-    binding: AcpConversationBinding | null,
+  runtime: AIRuntimeDescriptor,
+  binding: AcpConversationBinding | null,
 ) {
-    if (runtime.runtime.capabilities.includes("create_session")) return true;
-    if (!binding?.runtimeSessionId) return false;
-    if (
-        binding.continuationStrategy === "load" ||
-        binding.continuationStrategy === "resume"
-    ) {
-        return true;
-    }
-    return (
-        runtime.runtime.capabilities.includes("load_session") ||
-        runtime.runtime.capabilities.includes("resume_session")
-    );
+  if (runtime.runtime.capabilities.includes("create_session")) return true;
+  if (!binding?.runtimeSessionId) return false;
+  if (
+    binding.continuationStrategy === "load" ||
+    binding.continuationStrategy === "resume"
+  ) {
+    return true;
+  }
+  return (
+    runtime.runtime.capabilities.includes("load_session") ||
+    runtime.runtime.capabilities.includes("resume_session")
+  );
 }
 
 function latestBindingForRuntime(
-    bindings: readonly AcpConversationBinding[],
-    runtimeId: string,
+  bindings: readonly AcpConversationBinding[],
+  runtimeId: string,
 ) {
-    return (
-        bindings
-            .filter((binding) => binding.runtimeId === runtimeId)
-            .sort(
-                (left, right) =>
-                    (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
-            )[0] ?? null
-    );
+  return (
+    bindings
+      .filter((binding) => binding.runtimeId === runtimeId)
+      .sort(
+        (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+      )[0] ?? null
+  );
 }
 
 function providerModelOptions(
-    runtime: AIRuntimeDescriptor,
-    binding: AcpConversationBinding | null,
-    hasTranscript: boolean,
+  runtime: AIRuntimeDescriptor,
+  binding: AcpConversationBinding | null,
+  hasTranscript: boolean,
 ) {
-    const modelConfig =
-        binding?.configOptions.find(
-            (option) => option.category === "model",
-        ) ??
-        runtime.configOptions.find(
-            (option) => option.category === "model",
-        );
-    const models: ConversationProviderModelOption[] = modelConfig
-        ? modelConfig.options.map((model) => ({
-              modelId: model.value,
-              label: model.label,
-              description: model.description,
-              agentType: model.agentType,
-              disabledReason: null,
-          }))
-        : (binding?.models.length ? binding.models : runtime.models).map(
-              (model) => ({
-                  modelId: model.id,
-                  label: model.name,
-                  description: model.description,
-                  agentType: model.agentType,
-                  disabledReason: null,
-              }),
-          );
-    const defaultModelId =
-        binding?.modelId ?? modelConfig?.value ?? models[0]?.modelId ?? "";
-    if (
-        defaultModelId &&
-        !models.some((model) => model.modelId === defaultModelId)
-    ) {
-        models.unshift({
-            modelId: defaultModelId,
-            label: defaultModelId,
-            disabledReason: null,
-        });
-    }
+  const modelConfig =
+    binding?.configOptions.find((option) => option.category === "model") ??
+    runtime.configOptions.find((option) => option.category === "model");
+  const models: ConversationProviderModelOption[] = modelConfig
+    ? modelConfig.options.map((model) => ({
+        modelId: model.value,
+        label: model.label,
+        description: model.description,
+        agentType: model.agentType,
+        disabledReason: null,
+      }))
+    : (binding?.models.length ? binding.models : runtime.models).map(
+        (model) => ({
+          modelId: model.id,
+          label: model.name,
+          description: model.description,
+          agentType: model.agentType,
+          disabledReason: null,
+        }),
+      );
+  const defaultModelId =
+    binding?.modelId ?? modelConfig?.value ?? models[0]?.modelId ?? "";
+  if (
+    defaultModelId &&
+    !models.some((model) => model.modelId === defaultModelId)
+  ) {
+    models.unshift({
+      modelId: defaultModelId,
+      label: defaultModelId,
+      disabledReason: null,
+    });
+  }
 
-    if (
-        runtime.runtime.id === "grok-acp" &&
-        binding &&
-        hasTranscript
-    ) {
-        const activeAgentType = models.find(
-            (model) => model.modelId === defaultModelId,
-        )?.agentType;
-        if (activeAgentType) {
-            for (const model of models) {
-                if (model.agentType && model.agentType !== activeAgentType) {
-                    model.disabledReason =
-                        "Start a new Grok chat to switch to this model.";
-                }
-            }
+  if (runtime.runtime.id === "grok-acp" && binding && hasTranscript) {
+    const activeAgentType = models.find(
+      (model) => model.modelId === defaultModelId,
+    )?.agentType;
+    if (activeAgentType) {
+      for (const model of models) {
+        if (model.agentType && model.agentType !== activeAgentType) {
+          model.disabledReason =
+            "Start a new Grok chat to switch to this model.";
         }
+      }
     }
+  }
 
-    return { defaultModelId, models };
+  return { defaultModelId, models };
 }
 
 export function buildConversationProviderOptions(input: {
-    runtimes: readonly AIRuntimeDescriptor[];
-    setupStatusByRuntimeId: Readonly<
-        Record<string, AIRuntimeSetupStatus | undefined>
-    >;
-    conversation: AIConversation;
-    bindings: readonly AcpConversationBinding[];
-    activeRuntimeId: string;
-    hasQueuedMessages: boolean;
+  runtimes: readonly AIRuntimeDescriptor[];
+  setupStatusByRuntimeId: Readonly<
+    Record<string, AIRuntimeSetupStatus | undefined>
+  >;
+  conversation: AIConversation;
+  bindings: readonly AcpConversationBinding[];
+  activeRuntimeId: string;
+  hasQueuedMessages: boolean;
 }) {
-    const blocker = getConversationSwitchBlocker(input.conversation, {
-        hasQueuedMessages: input.hasQueuedMessages,
+  const blocker = getConversationSwitchBlocker(input.conversation, {
+    hasQueuedMessages: input.hasQueuedMessages,
+  });
+  const blockerDescription = switchBlockerLabel(blocker);
+
+  return input.runtimes
+    .filter(
+      (runtime) =>
+        runtime.runtime.id !== CLAUDE_TERMINAL_RUNTIME_ID &&
+        (runtime.runtime.id === input.activeRuntimeId ||
+          isRuntimeReady(input.setupStatusByRuntimeId[runtime.runtime.id])),
+    )
+    .map((runtime): ConversationProviderPickerOption => {
+      const runtimeId = runtime.runtime.id;
+      const isActive = runtimeId === input.activeRuntimeId;
+      const binding = latestBindingForRuntime(input.bindings, runtimeId);
+      const modelOptions = providerModelOptions(
+        runtime,
+        binding,
+        Math.max(
+          input.conversation.messages.length,
+          input.conversation.persistedMessageCount ?? 0,
+        ) > 0,
+      );
+      let disabledReason: string | null = null;
+      if (!isActive && blockerDescription) {
+        disabledReason = blockerDescription;
+      } else if (
+        !isActive &&
+        !isRuntimeReady(input.setupStatusByRuntimeId[runtimeId])
+      ) {
+        disabledReason = "Finish provider setup before using it in this chat.";
+      } else if (!isActive && !canStartRuntime(runtime, binding)) {
+        disabledReason =
+          "This provider cannot create or continue an ACP session.";
+      }
+
+      return {
+        runtimeId,
+        label: runtime.runtime.name.replace(/ ACP$/, ""),
+        description: runtime.runtime.description,
+        disabledReason,
+        ...modelOptions,
+      };
     });
-    const blockerDescription = switchBlockerLabel(blocker);
-
-    return input.runtimes
-        .filter(
-            (runtime) =>
-                runtime.runtime.id !== CLAUDE_TERMINAL_RUNTIME_ID &&
-                (runtime.runtime.id === input.activeRuntimeId ||
-                    isRuntimeReady(
-                        input.setupStatusByRuntimeId[runtime.runtime.id],
-                    )),
-        )
-        .map((runtime): ConversationProviderPickerOption => {
-            const runtimeId = runtime.runtime.id;
-            const isActive = runtimeId === input.activeRuntimeId;
-            const binding = latestBindingForRuntime(
-                input.bindings,
-                runtimeId,
-            );
-            const modelOptions = providerModelOptions(
-                runtime,
-                binding,
-                Math.max(
-                    input.conversation.messages.length,
-                    input.conversation.persistedMessageCount ?? 0,
-                ) > 0,
-            );
-            let disabledReason: string | null = null;
-            if (!isActive && blockerDescription) {
-                disabledReason = blockerDescription;
-            } else if (
-                !isActive &&
-                !isRuntimeReady(input.setupStatusByRuntimeId[runtimeId])
-            ) {
-                disabledReason = "Finish provider setup before using it in this chat.";
-            } else if (!isActive && !canStartRuntime(runtime, binding)) {
-                disabledReason =
-                    "This provider cannot create or continue an ACP session.";
-            }
-
-            return {
-                runtimeId,
-                label: runtime.runtime.name.replace(/ ACP$/, ""),
-                description: runtime.runtime.description,
-                disabledReason,
-                ...modelOptions,
-            };
-        });
 }
 
 function cloneConfigOptions(
-    options: readonly AIConfigOption[],
-    selection: ConversationSelection,
+  options: readonly AIConfigOption[],
+  selection: ConversationSelection,
 ) {
-    return options.map((option) => ({
-        ...option,
-        options: option.options.map((item) => ({ ...item })),
-        value:
-            option.category === "model"
-                ? selection.modelId
-                : option.category === "mode"
-                  ? selection.modeId
-                  : (selection.options[option.id] ?? option.value),
-    }));
+  return options.map((option) => ({
+    ...option,
+    options: option.options.map((item) => ({ ...item })),
+    value:
+      option.category === "model"
+        ? selection.modelId
+        : option.category === "mode"
+          ? selection.modeId
+          : (selection.options[option.id] ?? option.value),
+  }));
 }
 
 export function getConversationTurnCatalog(input: {
-    selection: ConversationSelection;
-    session: AIChatSession;
-    runtimes: readonly AIRuntimeDescriptor[];
-    bindings: readonly AcpConversationBinding[];
+  selection: ConversationSelection;
+  session: AIChatSession;
+  runtimes: readonly AIRuntimeDescriptor[];
+  bindings: readonly AcpConversationBinding[];
+  preparedCatalog?: PreparedConversationTurnCatalog | null;
 }): ConversationTurnCatalog {
-    const runtime = input.runtimes.find(
-        (candidate) => candidate.runtime.id === input.selection.runtimeId,
-    );
-    const binding = latestBindingForRuntime(
-        input.bindings,
-        input.selection.runtimeId,
-    );
-    const sessionMatches = input.session.runtimeId === input.selection.runtimeId;
-    const models =
-        (sessionMatches && input.session.models.length > 0
-            ? input.session.models
-            : binding?.models.length
-              ? binding.models
-              : runtime?.models) ?? [];
-    const modes =
-        (sessionMatches && input.session.modes.length > 0
-            ? input.session.modes
-            : binding?.modes.length
-              ? binding.modes
-              : runtime?.modes) ?? [];
-    const configOptions =
-        (sessionMatches && input.session.configOptions.length > 0
-            ? input.session.configOptions
-            : binding?.configOptions.length
-              ? binding.configOptions
-              : runtime?.configOptions) ?? [];
+  const liveModelId =
+    input.session.configOptions.find((option) => option.category === "model")
+      ?.value ?? input.session.modelId;
+  const selectionMatchesLiveSession =
+    input.session.runtimeId === input.selection.runtimeId &&
+    liveModelId === input.selection.modelId;
+  // Prepared catalogs are only a bridge for staged selections. Once the live
+  // session reaches that provider/model, its latest ACP catalog wins again.
+  const preparedCatalog =
+    !selectionMatchesLiveSession &&
+    input.preparedCatalog?.runtimeId === input.selection.runtimeId &&
+    input.preparedCatalog.modelId === input.selection.modelId
+      ? input.preparedCatalog
+      : null;
+  const runtime = input.runtimes.find(
+    (candidate) => candidate.runtime.id === input.selection.runtimeId,
+  );
+  const binding = latestBindingForRuntime(
+    input.bindings,
+    input.selection.runtimeId,
+  );
+  const sessionMatches = input.session.runtimeId === input.selection.runtimeId;
+  // Catalog precedence is deliberately scoped to this conversation: an exact
+  // prepared target, then its existing provider binding, and only then the
+  // runtime-wide discovery snapshot. This prevents one chat's partial catalog
+  // from hiding another chat's model-specific options.
+  const models =
+    (preparedCatalog?.models.length
+      ? preparedCatalog.models
+      : sessionMatches && input.session.models.length > 0
+      ? input.session.models
+      : binding?.models.length
+        ? binding.models
+        : runtime?.models) ?? [];
+  const modes =
+    (preparedCatalog?.modes.length
+      ? preparedCatalog.modes
+      : sessionMatches && input.session.modes.length > 0
+      ? input.session.modes
+      : binding?.modes.length
+        ? binding.modes
+        : runtime?.modes) ?? [];
+  const configOptions =
+    (preparedCatalog?.configOptions.length
+      ? preparedCatalog.configOptions
+      : sessionMatches && input.session.configOptions.length > 0
+      ? input.session.configOptions
+      : binding?.configOptions.length
+        ? binding.configOptions
+        : runtime?.configOptions) ?? [];
 
-    return {
-        models,
-        modes,
-        configOptions: cloneConfigOptions(configOptions, input.selection),
-        effortsByModel:
-            (sessionMatches
-                ? input.session.effortsByModel
-                : binding?.effortsByModel) ?? {},
-    };
+  return {
+    models,
+    modes,
+    configOptions: cloneConfigOptions(configOptions, input.selection),
+    effortsByModel:
+      preparedCatalog?.effortsByModel ??
+      (sessionMatches
+        ? input.session.effortsByModel
+        : binding?.effortsByModel) ?? {},
+  };
 }
 
 export function getDefaultConversationSelection(input: {
-    runtime: AIRuntimeDescriptor;
-    bindings: readonly AcpConversationBinding[];
+  runtime: AIRuntimeDescriptor;
+  bindings: readonly AcpConversationBinding[];
 }): ConversationSelection {
-    const binding = latestBindingForRuntime(
-        input.bindings,
-        input.runtime.runtime.id,
-    );
-    if (binding) {
-        return {
-            runtimeId: binding.runtimeId,
-            modelId: binding.modelId,
-            modeId: binding.modeId,
-            options: { ...binding.options },
-        };
-    }
-
-    const modelOption = input.runtime.configOptions.find(
-        (option) => option.category === "model",
-    );
-    const modeOption = input.runtime.configOptions.find(
-        (option) => option.category === "mode",
-    );
+  const binding = latestBindingForRuntime(
+    input.bindings,
+    input.runtime.runtime.id,
+  );
+  if (binding) {
     return {
-        runtimeId: input.runtime.runtime.id,
-        modelId: modelOption?.value ?? input.runtime.models[0]?.id ?? "",
-        modeId:
-            modeOption?.value ??
-            input.runtime.modes.find((mode) => !mode.disabled)?.id ??
-            input.runtime.modes[0]?.id ??
-            "",
-        options: Object.fromEntries(
-            input.runtime.configOptions.map((option) => [
-                option.id,
-                option.value,
-            ]),
-        ),
+      runtimeId: binding.runtimeId,
+      modelId: binding.modelId,
+      modeId: binding.modeId,
+      options: { ...binding.options },
     };
+  }
+
+  const modelOption = input.runtime.configOptions.find(
+    (option) => option.category === "model",
+  );
+  const modeOption = input.runtime.configOptions.find(
+    (option) => option.category === "mode",
+  );
+  return {
+    runtimeId: input.runtime.runtime.id,
+    modelId: modelOption?.value ?? input.runtime.models[0]?.id ?? "",
+    modeId:
+      modeOption?.value ??
+      input.runtime.modes.find((mode) => !mode.disabled)?.id ??
+      input.runtime.modes[0]?.id ??
+      "",
+    options: Object.fromEntries(
+      input.runtime.configOptions.map((option) => [option.id, option.value]),
+    ),
+  };
 }
 
 export function updateConversationSelection(
-    selection: ConversationSelection,
-    configOptions: readonly AIConfigOption[],
-    input:
-        | { kind: "model"; value: string }
-        | { kind: "mode"; value: string }
-        | { kind: "option"; optionId: string; value: string },
+  selection: ConversationSelection,
+  configOptions: readonly AIConfigOption[],
+  input:
+    | { kind: "model"; value: string }
+    | { kind: "mode"; value: string }
+    | { kind: "option"; optionId: string; value: string },
 ) {
-    const options = { ...selection.options };
-    let modelId = selection.modelId;
-    let modeId = selection.modeId;
-    if (input.kind === "model") {
-        modelId = input.value;
-        const modelOption = configOptions.find(
-            (option) => option.category === "model",
-        );
-        if (modelOption) options[modelOption.id] = input.value;
-    } else if (input.kind === "mode") {
-        modeId = input.value;
-        const modeOption = configOptions.find(
-            (option) => option.category === "mode",
-        );
-        if (modeOption) options[modeOption.id] = input.value;
-    } else {
-        options[input.optionId] = input.value;
-        const option = configOptions.find(
-            (candidate) => candidate.id === input.optionId,
-        );
-        if (option?.category === "model") modelId = input.value;
-        if (option?.category === "mode") modeId = input.value;
-    }
+  const options = { ...selection.options };
+  let modelId = selection.modelId;
+  let modeId = selection.modeId;
+  if (input.kind === "model") {
+    modelId = input.value;
+    const modelOption = configOptions.find(
+      (option) => option.category === "model",
+    );
+    if (modelOption) options[modelOption.id] = input.value;
+  } else if (input.kind === "mode") {
+    modeId = input.value;
+    const modeOption = configOptions.find(
+      (option) => option.category === "mode",
+    );
+    if (modeOption) options[modeOption.id] = input.value;
+  } else {
+    options[input.optionId] = input.value;
+    const option = configOptions.find(
+      (candidate) => candidate.id === input.optionId,
+    );
+    if (option?.category === "model") modelId = input.value;
+    if (option?.category === "mode") modeId = input.value;
+  }
 
-    return { ...selection, modelId, modeId, options };
+  return { ...selection, modelId, modeId, options };
 }
 
 export function requiresFirstProviderHandoffConfirmation(input: {
-    activeRuntimeId: string;
-    targetRuntimeId: string;
-    bindings: readonly AcpConversationBinding[];
-    messageCount: number;
+  activeRuntimeId: string;
+  targetRuntimeId: string;
+  bindings: readonly AcpConversationBinding[];
+  messageCount: number;
 }) {
-    return (
-        input.activeRuntimeId !== input.targetRuntimeId &&
-        input.messageCount > 0 &&
-        !input.bindings.some(
-            (binding) => binding.runtimeId === input.targetRuntimeId,
-        )
-    );
+  return (
+    input.activeRuntimeId !== input.targetRuntimeId &&
+    input.messageCount > 0 &&
+    !input.bindings.some(
+      (binding) => binding.runtimeId === input.targetRuntimeId,
+    )
+  );
 }

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -361,18 +361,3 @@ export function updateConversationSelection(
 
   return { ...selection, modelId, modeId, options };
 }
-
-export function requiresFirstProviderHandoffConfirmation(input: {
-  activeRuntimeId: string;
-  targetRuntimeId: string;
-  bindings: readonly AcpConversationBinding[];
-  messageCount: number;
-}) {
-  return (
-    input.activeRuntimeId !== input.targetRuntimeId &&
-    input.messageCount > 0 &&
-    !input.bindings.some(
-      (binding) => binding.runtimeId === input.targetRuntimeId,
-    )
-  );
-}

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -1,4 +1,4 @@
-import { getConversationSwitchBlocker } from "./conversationModel";
+import { getConversationProviderSelectionBlocker } from "./conversationModel";
 import type {
   AcpConversationBinding,
   AIChatSession,
@@ -46,50 +46,32 @@ function isRuntimeReady(status?: AIRuntimeSetupStatus | null) {
   return status?.authReady === true && !status.onboardingRequired;
 }
 
-function switchBlockerLabel(
-  blocker: ReturnType<typeof getConversationSwitchBlocker>,
+function providerSelectionBlockerLabel(
+  blocker: ReturnType<typeof getConversationProviderSelectionBlocker>,
 ) {
   switch (blocker) {
+    case "conversation_started":
+      return "Start a new chat to use another provider.";
     case "conversation_not_idle":
-      return "Finish the current turn before switching providers.";
+      return "Finish the current turn before choosing another provider.";
     case "session_transition_pending":
       return "Wait for the current session transition to finish.";
     case "queued_messages_pending":
-      return "Send or remove queued messages before switching providers.";
+      return "Send or remove queued messages before choosing another provider.";
     default:
       return null;
   }
 }
 
-function canStartRuntime(
-  runtime: AIRuntimeDescriptor,
-  binding: AcpConversationBinding | null,
-) {
-  if (runtime.runtime.capabilities.includes("create_session")) return true;
-  if (!binding?.runtimeSessionId) return false;
-  if (
-    binding.continuationStrategy === "load" ||
-    binding.continuationStrategy === "resume"
-  ) {
-    return true;
-  }
-  return (
-    runtime.runtime.capabilities.includes("load_session") ||
-    runtime.runtime.capabilities.includes("resume_session")
-  );
+function canStartRuntime(runtime: AIRuntimeDescriptor) {
+  return runtime.runtime.capabilities.includes("create_session");
 }
 
-function latestBindingForRuntime(
+function bindingForRuntime(
   bindings: readonly AcpConversationBinding[],
   runtimeId: string,
 ) {
-  return (
-    bindings
-      .filter((binding) => binding.runtimeId === runtimeId)
-      .sort(
-        (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
-      )[0] ?? null
-  );
+  return bindings.find((binding) => binding.runtimeId === runtimeId) ?? null;
 }
 
 function providerModelOptions(
@@ -157,10 +139,19 @@ export function buildConversationProviderOptions(input: {
   activeRuntimeId: string;
   hasQueuedMessages: boolean;
 }) {
-  const blocker = getConversationSwitchBlocker(input.conversation, {
-    hasQueuedMessages: input.hasQueuedMessages,
-  });
-  const blockerDescription = switchBlockerLabel(blocker);
+  const blocker = getConversationProviderSelectionBlocker(
+    input.conversation,
+    {
+      hasQueuedMessages: input.hasQueuedMessages,
+    },
+  );
+  const blockerDescription = providerSelectionBlockerLabel(blocker);
+  const activeBinding = input.conversation.activeBindingId
+    ? input.bindings.find(
+        (binding) =>
+          binding.bindingId === input.conversation.activeBindingId,
+      ) ?? null
+    : null;
 
   return input.runtimes
     .filter(
@@ -172,7 +163,10 @@ export function buildConversationProviderOptions(input: {
     .map((runtime): ConversationProviderPickerOption => {
       const runtimeId = runtime.runtime.id;
       const isActive = runtimeId === input.activeRuntimeId;
-      const binding = latestBindingForRuntime(input.bindings, runtimeId);
+      const binding =
+        isActive && activeBinding?.runtimeId === runtimeId
+          ? activeBinding
+          : null;
       const modelOptions = providerModelOptions(
         runtime,
         binding,
@@ -189,7 +183,7 @@ export function buildConversationProviderOptions(input: {
         !isRuntimeReady(input.setupStatusByRuntimeId[runtimeId])
       ) {
         disabledReason = "Finish provider setup before using it in this chat.";
-      } else if (!isActive && !canStartRuntime(runtime, binding)) {
+      } else if (!isActive && !canStartRuntime(runtime)) {
         disabledReason =
           "This provider cannot create or continue an ACP session.";
       }
@@ -244,7 +238,7 @@ export function getConversationTurnCatalog(input: {
   const runtime = input.runtimes.find(
     (candidate) => candidate.runtime.id === input.selection.runtimeId,
   );
-  const binding = latestBindingForRuntime(
+  const binding = bindingForRuntime(
     input.bindings,
     input.selection.runtimeId,
   );
@@ -292,21 +286,7 @@ export function getConversationTurnCatalog(input: {
 
 export function getDefaultConversationSelection(input: {
   runtime: AIRuntimeDescriptor;
-  bindings: readonly AcpConversationBinding[];
 }): ConversationSelection {
-  const binding = latestBindingForRuntime(
-    input.bindings,
-    input.runtime.runtime.id,
-  );
-  if (binding) {
-    return {
-      runtimeId: binding.runtimeId,
-      modelId: binding.modelId,
-      modeId: binding.modeId,
-      options: { ...binding.options },
-    };
-  }
-
   const modelOption = input.runtime.configOptions.find(
     (option) => option.category === "model",
   );

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -46,8 +46,6 @@ function switchBlockerLabel(
     switch (blocker) {
         case "conversation_not_idle":
             return "Finish the current turn before switching providers.";
-        case "work_cycle_active":
-            return "Finish or settle the current work cycle before switching providers.";
         case "session_transition_pending":
             return "Wait for the current session transition to finish.";
         case "queued_messages_pending":

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -1,0 +1,365 @@
+import { getConversationSwitchBlocker } from "./conversationModel";
+import type {
+    AcpConversationBinding,
+    AIChatSession,
+    AIConfigOption,
+    AIConversation,
+    AIModeOption,
+    AIModelOption,
+    AIRuntimeDescriptor,
+    AIRuntimeSetupStatus,
+    ConversationSelection,
+} from "./types";
+import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
+
+export interface ConversationProviderPickerOption {
+    runtimeId: string;
+    label: string;
+    description: string;
+    disabledReason: string | null;
+    defaultModelId: string;
+    models: ConversationProviderModelOption[];
+}
+
+export interface ConversationProviderModelOption {
+    modelId: string;
+    label: string;
+    description?: string;
+    agentType?: string;
+    disabledReason: string | null;
+}
+
+export interface ConversationTurnCatalog {
+    models: AIModelOption[];
+    modes: AIModeOption[];
+    configOptions: AIConfigOption[];
+    effortsByModel: Record<string, string[]>;
+}
+
+function isRuntimeReady(status?: AIRuntimeSetupStatus | null) {
+    return status?.authReady === true && !status.onboardingRequired;
+}
+
+function switchBlockerLabel(
+    blocker: ReturnType<typeof getConversationSwitchBlocker>,
+) {
+    switch (blocker) {
+        case "conversation_not_idle":
+            return "Finish the current turn before switching providers.";
+        case "work_cycle_active":
+            return "Finish or settle the current work cycle before switching providers.";
+        case "session_transition_pending":
+            return "Wait for the current session transition to finish.";
+        case "queued_messages_pending":
+            return "Send or remove queued messages before switching providers.";
+        default:
+            return null;
+    }
+}
+
+function canStartRuntime(
+    runtime: AIRuntimeDescriptor,
+    binding: AcpConversationBinding | null,
+) {
+    if (runtime.runtime.capabilities.includes("create_session")) return true;
+    if (!binding?.runtimeSessionId) return false;
+    if (
+        binding.continuationStrategy === "load" ||
+        binding.continuationStrategy === "resume"
+    ) {
+        return true;
+    }
+    return (
+        runtime.runtime.capabilities.includes("load_session") ||
+        runtime.runtime.capabilities.includes("resume_session")
+    );
+}
+
+function latestBindingForRuntime(
+    bindings: readonly AcpConversationBinding[],
+    runtimeId: string,
+) {
+    return (
+        bindings
+            .filter((binding) => binding.runtimeId === runtimeId)
+            .sort(
+                (left, right) =>
+                    (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+            )[0] ?? null
+    );
+}
+
+function providerModelOptions(
+    runtime: AIRuntimeDescriptor,
+    binding: AcpConversationBinding | null,
+    hasTranscript: boolean,
+) {
+    const modelConfig =
+        binding?.configOptions.find(
+            (option) => option.category === "model",
+        ) ??
+        runtime.configOptions.find(
+            (option) => option.category === "model",
+        );
+    const models: ConversationProviderModelOption[] = modelConfig
+        ? modelConfig.options.map((model) => ({
+              modelId: model.value,
+              label: model.label,
+              description: model.description,
+              agentType: model.agentType,
+              disabledReason: null,
+          }))
+        : (binding?.models.length ? binding.models : runtime.models).map(
+              (model) => ({
+                  modelId: model.id,
+                  label: model.name,
+                  description: model.description,
+                  agentType: model.agentType,
+                  disabledReason: null,
+              }),
+          );
+    const defaultModelId =
+        binding?.modelId ?? modelConfig?.value ?? models[0]?.modelId ?? "";
+    if (
+        defaultModelId &&
+        !models.some((model) => model.modelId === defaultModelId)
+    ) {
+        models.unshift({
+            modelId: defaultModelId,
+            label: defaultModelId,
+            disabledReason: null,
+        });
+    }
+
+    if (
+        runtime.runtime.id === "grok-acp" &&
+        binding &&
+        hasTranscript
+    ) {
+        const activeAgentType = models.find(
+            (model) => model.modelId === defaultModelId,
+        )?.agentType;
+        if (activeAgentType) {
+            for (const model of models) {
+                if (model.agentType && model.agentType !== activeAgentType) {
+                    model.disabledReason =
+                        "Start a new Grok chat to switch to this model.";
+                }
+            }
+        }
+    }
+
+    return { defaultModelId, models };
+}
+
+export function buildConversationProviderOptions(input: {
+    runtimes: readonly AIRuntimeDescriptor[];
+    setupStatusByRuntimeId: Readonly<
+        Record<string, AIRuntimeSetupStatus | undefined>
+    >;
+    conversation: AIConversation;
+    bindings: readonly AcpConversationBinding[];
+    activeRuntimeId: string;
+    hasQueuedMessages: boolean;
+}) {
+    const blocker = getConversationSwitchBlocker(input.conversation, {
+        hasQueuedMessages: input.hasQueuedMessages,
+    });
+    const blockerDescription = switchBlockerLabel(blocker);
+
+    return input.runtimes
+        .filter(
+            (runtime) =>
+                runtime.runtime.id !== CLAUDE_TERMINAL_RUNTIME_ID &&
+                (runtime.runtime.id === input.activeRuntimeId ||
+                    isRuntimeReady(
+                        input.setupStatusByRuntimeId[runtime.runtime.id],
+                    )),
+        )
+        .map((runtime): ConversationProviderPickerOption => {
+            const runtimeId = runtime.runtime.id;
+            const isActive = runtimeId === input.activeRuntimeId;
+            const binding = latestBindingForRuntime(
+                input.bindings,
+                runtimeId,
+            );
+            const modelOptions = providerModelOptions(
+                runtime,
+                binding,
+                Math.max(
+                    input.conversation.messages.length,
+                    input.conversation.persistedMessageCount ?? 0,
+                ) > 0,
+            );
+            let disabledReason: string | null = null;
+            if (!isActive && blockerDescription) {
+                disabledReason = blockerDescription;
+            } else if (
+                !isActive &&
+                !isRuntimeReady(input.setupStatusByRuntimeId[runtimeId])
+            ) {
+                disabledReason = "Finish provider setup before using it in this chat.";
+            } else if (!isActive && !canStartRuntime(runtime, binding)) {
+                disabledReason =
+                    "This provider cannot create or continue an ACP session.";
+            }
+
+            return {
+                runtimeId,
+                label: runtime.runtime.name.replace(/ ACP$/, ""),
+                description: runtime.runtime.description,
+                disabledReason,
+                ...modelOptions,
+            };
+        });
+}
+
+function cloneConfigOptions(
+    options: readonly AIConfigOption[],
+    selection: ConversationSelection,
+) {
+    return options.map((option) => ({
+        ...option,
+        options: option.options.map((item) => ({ ...item })),
+        value:
+            option.category === "model"
+                ? selection.modelId
+                : option.category === "mode"
+                  ? selection.modeId
+                  : (selection.options[option.id] ?? option.value),
+    }));
+}
+
+export function getConversationTurnCatalog(input: {
+    selection: ConversationSelection;
+    session: AIChatSession;
+    runtimes: readonly AIRuntimeDescriptor[];
+    bindings: readonly AcpConversationBinding[];
+}): ConversationTurnCatalog {
+    const runtime = input.runtimes.find(
+        (candidate) => candidate.runtime.id === input.selection.runtimeId,
+    );
+    const binding = latestBindingForRuntime(
+        input.bindings,
+        input.selection.runtimeId,
+    );
+    const sessionMatches = input.session.runtimeId === input.selection.runtimeId;
+    const models =
+        (sessionMatches && input.session.models.length > 0
+            ? input.session.models
+            : binding?.models.length
+              ? binding.models
+              : runtime?.models) ?? [];
+    const modes =
+        (sessionMatches && input.session.modes.length > 0
+            ? input.session.modes
+            : binding?.modes.length
+              ? binding.modes
+              : runtime?.modes) ?? [];
+    const configOptions =
+        (sessionMatches && input.session.configOptions.length > 0
+            ? input.session.configOptions
+            : binding?.configOptions.length
+              ? binding.configOptions
+              : runtime?.configOptions) ?? [];
+
+    return {
+        models,
+        modes,
+        configOptions: cloneConfigOptions(configOptions, input.selection),
+        effortsByModel:
+            (sessionMatches
+                ? input.session.effortsByModel
+                : binding?.effortsByModel) ?? {},
+    };
+}
+
+export function getDefaultConversationSelection(input: {
+    runtime: AIRuntimeDescriptor;
+    bindings: readonly AcpConversationBinding[];
+}): ConversationSelection {
+    const binding = latestBindingForRuntime(
+        input.bindings,
+        input.runtime.runtime.id,
+    );
+    if (binding) {
+        return {
+            runtimeId: binding.runtimeId,
+            modelId: binding.modelId,
+            modeId: binding.modeId,
+            options: { ...binding.options },
+        };
+    }
+
+    const modelOption = input.runtime.configOptions.find(
+        (option) => option.category === "model",
+    );
+    const modeOption = input.runtime.configOptions.find(
+        (option) => option.category === "mode",
+    );
+    return {
+        runtimeId: input.runtime.runtime.id,
+        modelId: modelOption?.value ?? input.runtime.models[0]?.id ?? "",
+        modeId:
+            modeOption?.value ??
+            input.runtime.modes.find((mode) => !mode.disabled)?.id ??
+            input.runtime.modes[0]?.id ??
+            "",
+        options: Object.fromEntries(
+            input.runtime.configOptions.map((option) => [
+                option.id,
+                option.value,
+            ]),
+        ),
+    };
+}
+
+export function updateConversationSelection(
+    selection: ConversationSelection,
+    configOptions: readonly AIConfigOption[],
+    input:
+        | { kind: "model"; value: string }
+        | { kind: "mode"; value: string }
+        | { kind: "option"; optionId: string; value: string },
+) {
+    const options = { ...selection.options };
+    let modelId = selection.modelId;
+    let modeId = selection.modeId;
+    if (input.kind === "model") {
+        modelId = input.value;
+        const modelOption = configOptions.find(
+            (option) => option.category === "model",
+        );
+        if (modelOption) options[modelOption.id] = input.value;
+    } else if (input.kind === "mode") {
+        modeId = input.value;
+        const modeOption = configOptions.find(
+            (option) => option.category === "mode",
+        );
+        if (modeOption) options[modeOption.id] = input.value;
+    } else {
+        options[input.optionId] = input.value;
+        const option = configOptions.find(
+            (candidate) => candidate.id === input.optionId,
+        );
+        if (option?.category === "model") modelId = input.value;
+        if (option?.category === "mode") modeId = input.value;
+    }
+
+    return { ...selection, modelId, modeId, options };
+}
+
+export function requiresFirstProviderHandoffConfirmation(input: {
+    activeRuntimeId: string;
+    targetRuntimeId: string;
+    bindings: readonly AcpConversationBinding[];
+    messageCount: number;
+}) {
+    return (
+        input.activeRuntimeId !== input.targetRuntimeId &&
+        input.messageCount > 0 &&
+        !input.bindings.some(
+            (binding) => binding.runtimeId === input.targetRuntimeId,
+        )
+    );
+}

--- a/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
@@ -110,6 +110,31 @@ describe("canonical conversation turn routing", () => {
         });
     });
 
+    it("honors new-session-only before runtime continuation capabilities", () => {
+        const current = session();
+        current.runtimeState = "persisted_only";
+        const bindings = createConversationBindingsFromLegacySession(current);
+        bindings.providerBindings[0].continuationStrategy = "new_session_only";
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-a"),
+                runtimeCapabilities: [
+                    "create_session",
+                    "load_session",
+                    "resume_session",
+                ],
+                hasTranscript: true,
+            }),
+        ).toMatchObject({
+            strategy: "create",
+            startReason: "transcript_handoff",
+            initialProviderChanged: false,
+        });
+    });
+
     it("uses load to restore the fixed provider binding", () => {
         const current = session();
         current.runtimeState = "persisted_only";

--- a/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from "vitest";
+import { createConversationBindingsFromLegacySession } from "./conversationModel";
+import { planConversationTurnRoute } from "./conversationTurnRouting";
+import type { AIChatSession, ConversationSelection } from "./types";
+
+function session(): AIChatSession {
+    return {
+        sessionId: "local-a",
+        historySessionId: "conversation-1",
+        runtimeSessionId: "native-a",
+        status: "idle",
+        runtimeId: "provider-a",
+        modelId: "model-a",
+        modeId: "default",
+        models: [],
+        modes: [],
+        configOptions: [],
+        messages: [],
+        attachments: [],
+        runtimeState: "live",
+        isPersistedSession: false,
+    };
+}
+
+function selection(runtimeId: string): ConversationSelection {
+    return {
+        runtimeId,
+        modelId: `model-${runtimeId.at(-1)}`,
+        modeId: "default",
+        options: {},
+    };
+}
+
+describe("canonical conversation turn routing", () => {
+    it("continues the live active binding", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-a"),
+                runtimeCapabilities: ["create_session", "resume_session"],
+                hasTranscript: true,
+            }),
+        ).toMatchObject({
+            strategy: "continue",
+            startReason: "normal",
+            providerChanged: false,
+            targetBinding: { runtimeId: "provider-a" },
+        });
+    });
+
+    it("resumes a prior provider binding when switching back", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        bindings.providerBindings.push({
+            ...bindings.providerBindings[0],
+            bindingId: "binding-b",
+            runtimeId: "provider-b",
+            runtimeSessionId: "native-b",
+            continuationStrategy: "resume",
+            updatedAt: 20,
+        });
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-b"),
+                runtimeCapabilities: ["create_session", "resume_session"],
+                hasTranscript: true,
+            }),
+        ).toMatchObject({
+            strategy: "resume",
+            startReason: "provider_switch",
+            providerChanged: true,
+            targetBinding: { bindingId: "binding-b" },
+        });
+    });
+
+    it("creates an isolated binding when the provider cannot continue", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-b"),
+                runtimeCapabilities: ["create_session"],
+                hasTranscript: true,
+            }),
+        ).toMatchObject({
+            strategy: "create",
+            startReason: "provider_switch",
+            providerChanged: true,
+            targetBinding: null,
+        });
+    });
+
+    it("creates a fresh session when a prior binding is not resumable", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        bindings.providerBindings.push({
+            ...bindings.providerBindings[0],
+            bindingId: "binding-b",
+            runtimeId: "provider-b",
+            runtimeSessionId: "native-b",
+            continuationStrategy: "new_session_only",
+        });
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-b"),
+                runtimeCapabilities: ["create_session"],
+                hasTranscript: true,
+            }),
+        ).toMatchObject({
+            strategy: "create",
+            startReason: "provider_switch",
+            providerChanged: true,
+            targetBinding: { bindingId: "binding-b" },
+        });
+    });
+
+    it("uses load for bindings that explicitly require it", () => {
+        const current = session();
+        const bindings = createConversationBindingsFromLegacySession(current);
+        bindings.providerBindings.push({
+            ...bindings.providerBindings[0],
+            bindingId: "binding-b",
+            runtimeId: "provider-b",
+            runtimeSessionId: "native-b",
+            continuationStrategy: "load",
+        });
+
+        expect(
+            planConversationTurnRoute({
+                session: current,
+                bindings,
+                selection: selection("provider-b"),
+                runtimeCapabilities: ["create_session"],
+                hasTranscript: true,
+            }).strategy,
+        ).toBe("load");
+    });
+});

--- a/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.test.ts
@@ -47,40 +47,12 @@ describe("canonical conversation turn routing", () => {
         ).toMatchObject({
             strategy: "continue",
             startReason: "normal",
-            providerChanged: false,
+            initialProviderChanged: false,
             targetBinding: { runtimeId: "provider-a" },
         });
     });
 
-    it("resumes a prior provider binding when switching back", () => {
-        const current = session();
-        const bindings = createConversationBindingsFromLegacySession(current);
-        bindings.providerBindings.push({
-            ...bindings.providerBindings[0],
-            bindingId: "binding-b",
-            runtimeId: "provider-b",
-            runtimeSessionId: "native-b",
-            continuationStrategy: "resume",
-            updatedAt: 20,
-        });
-
-        expect(
-            planConversationTurnRoute({
-                session: current,
-                bindings,
-                selection: selection("provider-b"),
-                runtimeCapabilities: ["create_session", "resume_session"],
-                hasTranscript: true,
-            }),
-        ).toMatchObject({
-            strategy: "resume",
-            startReason: "provider_switch",
-            providerChanged: true,
-            targetBinding: { bindingId: "binding-b" },
-        });
-    });
-
-    it("creates an isolated binding when the provider cannot continue", () => {
+    it("creates the selected provider session before the first turn", () => {
         const current = session();
         const bindings = createConversationBindingsFromLegacySession(current);
 
@@ -90,62 +62,72 @@ describe("canonical conversation turn routing", () => {
                 bindings,
                 selection: selection("provider-b"),
                 runtimeCapabilities: ["create_session"],
-                hasTranscript: true,
+                hasTranscript: false,
             }),
         ).toMatchObject({
             strategy: "create",
-            startReason: "provider_switch",
-            providerChanged: true,
+            startReason: "normal",
+            initialProviderChanged: true,
             targetBinding: null,
         });
     });
 
-    it("creates a fresh session when a prior binding is not resumable", () => {
+    it("rejects provider changes after the conversation starts", () => {
         const current = session();
         const bindings = createConversationBindingsFromLegacySession(current);
-        bindings.providerBindings.push({
-            ...bindings.providerBindings[0],
-            bindingId: "binding-b",
-            runtimeId: "provider-b",
-            runtimeSessionId: "native-b",
-            continuationStrategy: "new_session_only",
-        });
+
+        expect(
+            () =>
+                planConversationTurnRoute({
+                    session: current,
+                    bindings,
+                    selection: selection("provider-b"),
+                    runtimeCapabilities: ["create_session"],
+                    hasTranscript: true,
+                }),
+        ).toThrow("Cannot change the provider after the conversation has started");
+    });
+
+    it("creates a fresh same-provider session with transcript handoff", () => {
+        const current = session();
+        current.runtimeState = "persisted_only";
+        const bindings = createConversationBindingsFromLegacySession(current);
+        bindings.providerBindings[0].runtimeSessionId = null;
 
         expect(
             planConversationTurnRoute({
                 session: current,
                 bindings,
-                selection: selection("provider-b"),
+                selection: selection("provider-a"),
                 runtimeCapabilities: ["create_session"],
                 hasTranscript: true,
             }),
         ).toMatchObject({
             strategy: "create",
-            startReason: "provider_switch",
-            providerChanged: true,
-            targetBinding: { bindingId: "binding-b" },
+            startReason: "transcript_handoff",
+            initialProviderChanged: false,
+            targetBinding: { runtimeId: "provider-a" },
         });
     });
 
-    it("uses load for bindings that explicitly require it", () => {
+    it("uses load to restore the fixed provider binding", () => {
         const current = session();
+        current.runtimeState = "persisted_only";
         const bindings = createConversationBindingsFromLegacySession(current);
-        bindings.providerBindings.push({
-            ...bindings.providerBindings[0],
-            bindingId: "binding-b",
-            runtimeId: "provider-b",
-            runtimeSessionId: "native-b",
-            continuationStrategy: "load",
-        });
+        bindings.providerBindings[0].continuationStrategy = "load";
 
         expect(
             planConversationTurnRoute({
                 session: current,
                 bindings,
-                selection: selection("provider-b"),
+                selection: selection("provider-a"),
                 runtimeCapabilities: ["create_session"],
                 hasTranscript: true,
-            }).strategy,
-        ).toBe("load");
+            }),
+        ).toMatchObject({
+            strategy: "load",
+            startReason: "native_resume",
+            initialProviderChanged: false,
+        });
     });
 });

--- a/apps/desktop/src/features/ai/conversationTurnRouting.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.ts
@@ -42,7 +42,12 @@ function connectionStrategy(
     ) {
         return "continue";
     }
-    if (!targetBinding?.runtimeSessionId) return "create";
+    if (
+        !targetBinding?.runtimeSessionId ||
+        targetBinding.continuationStrategy === "new_session_only"
+    ) {
+        return "create";
+    }
     if (
         targetBinding.continuationStrategy === "load" ||
         capabilities.includes("load_session")

--- a/apps/desktop/src/features/ai/conversationTurnRouting.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.ts
@@ -17,24 +17,14 @@ export interface ConversationTurnRoute {
     targetBinding: AcpConversationBinding | null;
     strategy: ConversationTurnConnectionStrategy;
     startReason: ConversationTurnStartReason;
-    providerChanged: boolean;
+    initialProviderChanged: boolean;
 }
 
-function selectReusableBinding(
-    bindings: ConversationBindingsState,
-    runtimeId: string,
-) {
-    const candidates = bindings.providerBindings.filter(
-        (binding) => binding.runtimeId === runtimeId,
-    );
+function selectActiveBinding(bindings: ConversationBindingsState) {
     return (
-        candidates.find(
+        bindings.providerBindings.find(
             (binding) => binding.bindingId === bindings.activeBindingId,
-        ) ??
-        candidates.sort(
-            (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
-        )[0] ??
-        null
+        ) ?? null
     );
 }
 
@@ -75,25 +65,23 @@ export function planConversationTurnRoute(input: {
     runtimeCapabilities: readonly string[];
     hasTranscript: boolean;
 }): ConversationTurnRoute {
-    const activeBinding = input.bindings.providerBindings.find(
-        (binding) => binding.bindingId === input.bindings.activeBindingId,
-    );
-    const targetBinding = selectReusableBinding(
-        input.bindings,
-        input.selection.runtimeId,
-    );
-    const providerChanged =
-        activeBinding != null &&
-        activeBinding.runtimeId !== input.selection.runtimeId;
+    const activeBinding = selectActiveBinding(input.bindings);
+    const initialProviderChanged =
+        input.session.runtimeId !== input.selection.runtimeId;
+    if (initialProviderChanged && input.hasTranscript) {
+        throw new Error(
+            "Cannot change the provider after the conversation has started.",
+        );
+    }
+    const targetBinding = initialProviderChanged ? null : activeBinding;
     const strategy = connectionStrategy(
         input.session,
         input.bindings,
         targetBinding,
         input.runtimeCapabilities,
     );
-    const startReason: ConversationTurnStartReason = providerChanged
-        ? "provider_switch"
-        : strategy === "load" || strategy === "resume"
+    const startReason: ConversationTurnStartReason =
+        strategy === "load" || strategy === "resume"
           ? "native_resume"
           : strategy === "create" && input.hasTranscript
             ? "transcript_handoff"
@@ -107,6 +95,6 @@ export function planConversationTurnRoute(input: {
         targetBinding,
         strategy,
         startReason,
-        providerChanged,
+        initialProviderChanged,
     };
 }

--- a/apps/desktop/src/features/ai/conversationTurnRouting.ts
+++ b/apps/desktop/src/features/ai/conversationTurnRouting.ts
@@ -1,0 +1,112 @@
+import type {
+    AcpConversationBinding,
+    AIChatSession,
+    ConversationBindingsState,
+    ConversationSelection,
+    ConversationTurnStartReason,
+} from "./types";
+
+export type ConversationTurnConnectionStrategy =
+    | "continue"
+    | "load"
+    | "resume"
+    | "create";
+
+export interface ConversationTurnRoute {
+    selection: ConversationSelection;
+    targetBinding: AcpConversationBinding | null;
+    strategy: ConversationTurnConnectionStrategy;
+    startReason: ConversationTurnStartReason;
+    providerChanged: boolean;
+}
+
+function selectReusableBinding(
+    bindings: ConversationBindingsState,
+    runtimeId: string,
+) {
+    const candidates = bindings.providerBindings.filter(
+        (binding) => binding.runtimeId === runtimeId,
+    );
+    return (
+        candidates.find(
+            (binding) => binding.bindingId === bindings.activeBindingId,
+        ) ??
+        candidates.sort(
+            (left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0),
+        )[0] ??
+        null
+    );
+}
+
+function connectionStrategy(
+    session: AIChatSession,
+    bindings: ConversationBindingsState,
+    targetBinding: AcpConversationBinding | null,
+    capabilities: readonly string[],
+): ConversationTurnConnectionStrategy {
+    if (
+        targetBinding?.bindingId === bindings.activeBindingId &&
+        targetBinding.runtimeId === session.runtimeId &&
+        session.runtimeState === "live" &&
+        !session.isPersistedSession
+    ) {
+        return "continue";
+    }
+    if (!targetBinding?.runtimeSessionId) return "create";
+    if (
+        targetBinding.continuationStrategy === "load" ||
+        capabilities.includes("load_session")
+    ) {
+        return "load";
+    }
+    if (
+        targetBinding.continuationStrategy === "resume" ||
+        capabilities.includes("resume_session")
+    ) {
+        return "resume";
+    }
+    return "create";
+}
+
+export function planConversationTurnRoute(input: {
+    session: AIChatSession;
+    bindings: ConversationBindingsState;
+    selection: ConversationSelection;
+    runtimeCapabilities: readonly string[];
+    hasTranscript: boolean;
+}): ConversationTurnRoute {
+    const activeBinding = input.bindings.providerBindings.find(
+        (binding) => binding.bindingId === input.bindings.activeBindingId,
+    );
+    const targetBinding = selectReusableBinding(
+        input.bindings,
+        input.selection.runtimeId,
+    );
+    const providerChanged =
+        activeBinding != null &&
+        activeBinding.runtimeId !== input.selection.runtimeId;
+    const strategy = connectionStrategy(
+        input.session,
+        input.bindings,
+        targetBinding,
+        input.runtimeCapabilities,
+    );
+    const startReason: ConversationTurnStartReason = providerChanged
+        ? "provider_switch"
+        : strategy === "load" || strategy === "resume"
+          ? "native_resume"
+          : strategy === "create" && input.hasTranscript
+            ? "transcript_handoff"
+            : "normal";
+
+    return {
+        selection: {
+            ...input.selection,
+            options: { ...input.selection.options },
+        },
+        targetBinding,
+        strategy,
+        startReason,
+        providerChanged,
+    };
+}

--- a/apps/desktop/src/features/ai/newAgentCreation.ts
+++ b/apps/desktop/src/features/ai/newAgentCreation.ts
@@ -1,0 +1,25 @@
+import { useSettingsStore } from "../../app/store/settingsStore";
+import { openClaudeCodeTerminalWithContext } from "../terminal/claudeCodeTerminal";
+import { createNewChatInWorkspace } from "./chatPaneMovement";
+import { useChatStore } from "./store/chatStore";
+import { CLAUDE_TERMINAL_RUNTIME_ID } from "./utils/runtimeMetadata";
+
+export function canCreateClaudeCodeAgent() {
+    if (!useSettingsStore.getState().claudeCodeEnabled) return false;
+
+    const setupStatus =
+        useChatStore.getState().setupStatusByRuntimeId[
+            CLAUDE_TERMINAL_RUNTIME_ID
+        ];
+    return setupStatus?.authReady === true && !setupStatus.onboardingRequired;
+}
+
+export function createCanonicalAgent(paneId?: string) {
+    return paneId
+        ? createNewChatInWorkspace(undefined, { paneId })
+        : createNewChatInWorkspace();
+}
+
+export function createClaudeCodeAgent(paneId?: string) {
+    return openClaudeCodeTerminalWithContext(undefined, paneId);
+}

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -16122,10 +16122,24 @@ describe("chatStore", () => {
         };
         const conversationBindings =
             updateConversationBindingsFromLegacySession(persistedSession);
+        conversationBindings.revision = 7;
+        conversationBindings.contextSummary = "Preserved canonical summary";
+        conversationBindings.transcriptObservation = {
+            messageCount: 12,
+            updatedAt: 345,
+            transcriptFingerprint: "canonical-fingerprint",
+        };
         conversationBindings.providerBindings[0] = {
             ...conversationBindings.providerBindings[0],
+            bindingId: "binding-provider-b",
             runtimeSessionId: nativeSessionId,
+            capabilities: ["resume_session", "permissions"],
+            contextCursor: "message-cursor-9",
+            contextGeneration: 4,
+            createdAt: 100,
+            updatedAt: 345,
         };
+        conversationBindings.activeBindingId = "binding-provider-b";
 
         useChatStore.setState((state) => ({
             ...state,
@@ -16175,6 +16189,10 @@ describe("chatStore", () => {
             .resumeSession(persistedSessionId);
 
         expect(resumedSessionId).toBe(nativeSessionId);
+        expect(
+            useChatStore.getState().sessionsById[nativeSessionId]
+                ?.conversationBindings,
+        ).toEqual(conversationBindings);
         expect(
             invokeMock.mock.calls.some(
                 ([command, args]) =>

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14404,6 +14404,406 @@ describe("chatStore", () => {
         ).toBe("handoff-assistant");
     });
 
+    it("routes A to B to A through canonical bindings with delta handoff", async () => {
+        await useChatStore.getState().initialize();
+
+        const providerASessionId = getActiveSessionId();
+        const providerASession = {
+            ...useChatStore.getState().sessionsById[providerASessionId]!,
+            runtimeSessionId: "native-a",
+            continuationStrategy: "resume" as const,
+            activeWorkCycleId: null,
+            visibleWorkCycleId: null,
+            status: "idle" as const,
+            messages: [
+                {
+                    id: "a-user",
+                    role: "user" as const,
+                    kind: "text" as const,
+                    content: "Original provider context",
+                    timestamp: 10,
+                },
+                {
+                    id: "a-assistant",
+                    role: "assistant" as const,
+                    kind: "text" as const,
+                    content: "Original provider response",
+                    timestamp: 20,
+                },
+            ],
+        };
+        const conversationBindings =
+            updateConversationBindingsFromLegacySession(providerASession);
+        conversationBindings.providerBindings[0].contextCursor =
+            "a-assistant";
+        const providerBPayload = {
+            ...sessionPayload,
+            session_id: "local-b",
+            runtime_id: "provider-b",
+            runtime_session_id: "native-b",
+            continuation_strategy: "resume" as const,
+            model_id: "model-b",
+            models: [],
+            modes: [],
+            config_options: [],
+        };
+        const resumedProviderAPayload = {
+            ...sessionPayload,
+            session_id: "local-a-resumed",
+            runtime_session_id: "native-a",
+            continuation_strategy: "resume" as const,
+        };
+        const sentPrompts: { sessionId: string; content: string }[] = [];
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    ...readySetupStatusState,
+                    runtimeId: "provider-b",
+                },
+            },
+            sessionsById: {
+                ...state.sessionsById,
+                [providerASessionId]: {
+                    ...providerASession,
+                    conversationBindings,
+                },
+            },
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                expect(args).toMatchObject({
+                    input: { runtime_id: "provider-b" },
+                });
+                return providerBPayload;
+            }
+            if (command === "ai_resume_runtime_session") {
+                expect(args).toMatchObject({
+                    input: {
+                        runtime_id: "codex-acp",
+                        session_id: "native-a",
+                    },
+                });
+                return resumedProviderAPayload;
+            }
+            if (command === "ai_send_message") {
+                const input = args as { sessionId: string; content: string };
+                sentPrompts.push(input);
+                return input.sessionId === "local-b"
+                    ? { ...providerBPayload, status: "streaming" }
+                    : { ...resumedProviderAPayload, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        const conversationId =
+            useChatStore.getState().activeConversationId!;
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Question for B"), providerASessionId);
+        await useChatStore.getState().startConversationTurn(conversationId, {
+            runtimeId: "provider-b",
+            modelId: "model-b",
+            modeId: "default",
+            options: {},
+        });
+
+        expect(sentPrompts[0]).toMatchObject({ sessionId: "local-b" });
+        expect(sentPrompts[0].content).toContain("another ACP provider");
+        expect(sentPrompts[0].content).toContain("Original provider context");
+        let switched = useChatStore.getState().sessionsById["local-b"]!;
+        expect(switched.historySessionId).toBe(conversationId);
+        expect(switched.conversationBindings).toMatchObject({
+            activeBindingId: expect.stringContaining("provider-b"),
+            preferredSelection: { runtimeId: "provider-b" },
+        });
+        expect(
+            switched.messages.find(
+                (message) => message.content === "Question for B",
+            )?.turnProvenance,
+        ).toMatchObject({
+            runtimeId: "provider-b",
+            startReason: "provider_switch",
+        });
+        expect(
+            switched.messages.some((message) =>
+                message.content.includes("Use the saved transcript below"),
+            ),
+        ).toBe(false);
+
+        useChatStore.getState().applyMessageStarted({
+            session_id: "local-b",
+            message_id: "b-assistant",
+            role: "assistant",
+        });
+        useChatStore.getState().applyMessageDelta({
+            session_id: "local-b",
+            message_id: "b-assistant",
+            delta: "Provider B response",
+            role: "assistant",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageCompleted({
+            session_id: "local-b",
+            message_id: "b-assistant",
+            role: "assistant",
+            turn_complete: true,
+        });
+        switched = useChatStore.getState().sessionsById["local-b"]!;
+        expect(
+            switched.messages.find((message) => message.id === "b-assistant")
+                ?.turnProvenance,
+        ).toMatchObject({ runtimeId: "provider-b" });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Back to A"), "local-b");
+        await useChatStore.getState().startConversationTurn(conversationId, {
+            runtimeId: "codex-acp",
+            modelId: "test-model",
+            modeId: "default",
+            options: { model: "test-model", reasoning_effort: "medium" },
+        });
+
+        expect(sentPrompts[1]).toMatchObject({
+            sessionId: "local-a-resumed",
+        });
+        expect(sentPrompts[1].content).not.toContain(
+            "Original provider context",
+        );
+        expect(sentPrompts[1].content).toContain("Question for B");
+        expect(sentPrompts[1].content).toContain("Provider B response");
+        const returned =
+            useChatStore.getState().sessionsById["local-a-resumed"]!;
+        expect(returned.conversationBindings?.providerBindings).toHaveLength(2);
+        expect(returned.conversationBindings?.preferredSelection.runtimeId).toBe(
+            "codex-acp",
+        );
+    });
+
+    it("rolls back a new provider binding and restores the composer on send failure", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId =
+            useChatStore.getState().activeConversationId!;
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    ...readySetupStatusState,
+                    runtimeId: "provider-b",
+                },
+            },
+            sessionsById: {
+                ...state.sessionsById,
+                [sourceSessionId]: {
+                    ...state.sessionsById[sourceSessionId]!,
+                    activeWorkCycleId: null,
+                    visibleWorkCycleId: null,
+                    status: "idle",
+                    messages: [
+                        {
+                            id: "existing",
+                            role: "user",
+                            kind: "text",
+                            content: "Existing transcript",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+        }));
+        const bindingsBefore =
+            updateConversationBindingsFromLegacySession(
+                useChatStore.getState().sessionsById[sourceSessionId]!,
+            );
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                return {
+                    ...sessionPayload,
+                    session_id: "failed-provider-b",
+                    runtime_id: "provider-b",
+                    runtime_session_id: "native-b",
+                    model_id: "model-b",
+                    models: [],
+                    modes: [],
+                    config_options: [],
+                };
+            }
+            if (command === "ai_send_message") {
+                throw new Error("Provider B rejected the turn");
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Do not lose this"), sourceSessionId);
+        await useChatStore.getState().startConversationTurn(conversationId, {
+            runtimeId: "provider-b",
+            modelId: "model-b",
+            modeId: "default",
+            options: {},
+        });
+
+        const state = useChatStore.getState();
+        expect(state.activeSessionId).toBe(sourceSessionId);
+        expect(
+            state.sessionsById[sourceSessionId]?.conversationBindings
+                ?.providerBindings ?? bindingsBefore.providerBindings,
+        ).toHaveLength(1);
+        expect(
+            serializeComposerParts(
+                state.composerPartsBySessionId[sourceSessionId] ?? [],
+            ),
+        ).toContain("Do not lose this");
+        expect(invokeMock).toHaveBeenCalledWith("ai_delete_runtime_session", {
+            sessionId: "failed-provider-b",
+        });
+    });
+
+    it("keeps the active provider and composer when a prior binding cannot resume", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const sourceSession = {
+            ...useChatStore.getState().sessionsById[sourceSessionId]!,
+            runtimeSessionId: "native-a",
+            continuationStrategy: "resume" as const,
+            activeWorkCycleId: null,
+            visibleWorkCycleId: null,
+            status: "idle" as const,
+            messages: [
+                {
+                    id: "existing",
+                    role: "user" as const,
+                    kind: "text" as const,
+                    content: "Existing transcript",
+                    timestamp: 1,
+                },
+            ],
+        };
+        const bindings =
+            updateConversationBindingsFromLegacySession(sourceSession);
+        const activeBindingId = bindings.activeBindingId;
+        bindings.providerBindings.push({
+            ...bindings.providerBindings[0],
+            bindingId: "binding-b",
+            runtimeId: "provider-b",
+            runtimeSessionId: "native-b",
+            continuationStrategy: "resume",
+            modelId: "model-b",
+            options: {},
+            contextCursor: "existing",
+        });
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    ...readySetupStatusState,
+                    runtimeId: "provider-b",
+                },
+            },
+            sessionsById: {
+                ...state.sessionsById,
+                [sourceSessionId]: {
+                    ...sourceSession,
+                    conversationBindings: bindings,
+                },
+            },
+        }));
+        const conversationId =
+            useChatStore.getState().activeConversationId!;
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_resume_runtime_session") {
+                expect(args).toMatchObject({
+                    input: {
+                        runtime_id: "provider-b",
+                        session_id: "native-b",
+                    },
+                });
+                throw new Error("Native resume failed");
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Retry without loss"), sourceSessionId);
+        await useChatStore.getState().startConversationTurn(conversationId, {
+            runtimeId: "provider-b",
+            modelId: "model-b",
+            modeId: "default",
+            options: {},
+        });
+
+        const state = useChatStore.getState();
+        expect(state.activeSessionId).toBe(sourceSessionId);
+        expect(
+            state.sessionsById[sourceSessionId]?.conversationBindings
+                ?.activeBindingId,
+        ).toBe(activeBindingId);
+        expect(
+            serializeComposerParts(
+                state.composerPartsBySessionId[sourceSessionId] ?? [],
+            ),
+        ).toContain("Retry without loss");
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_send_message",
+            ),
+        ).toBe(false);
+    });
+
     it("omits internal runtime user echoes from saved transcript recovery prompts", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -10,6 +10,7 @@ import {
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { serializeComposerParts } from "../composerParts";
+import { updateConversationBindingsFromLegacySession } from "../conversationModel";
 import type {
     AIChatAttachment,
     AIChatSession,
@@ -14331,6 +14332,76 @@ describe("chatStore", () => {
                 ([command]) => command === "ai_create_session",
             ),
         ).toBe(false);
+    });
+
+    it("advances the active binding cursor only after a handoff is accepted", async () => {
+        await useChatStore.getState().initialize();
+
+        const activeSessionId = getActiveSessionId();
+        const session = useChatStore.getState().sessionsById[activeSessionId]!;
+        const conversationBindings =
+            updateConversationBindingsFromLegacySession(session);
+        const bindingId = conversationBindings.activeBindingId!;
+
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [activeSessionId]: {
+                    ...state.sessionsById[activeSessionId]!,
+                    runtimeState: "live",
+                    status: "idle",
+                    resumeContextPending: true,
+                    conversationBindings,
+                    messages: [
+                        {
+                            id: "handoff-user",
+                            role: "user",
+                            kind: "text",
+                            content: "Retain this context",
+                            timestamp: 10,
+                        },
+                        {
+                            id: "handoff-assistant",
+                            role: "assistant",
+                            kind: "text",
+                            content: "Context retained",
+                            timestamp: 20,
+                        },
+                    ],
+                },
+            },
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_send_message") {
+                expect((args as { content: string }).content).toContain(
+                    "Assistant: Context retained",
+                );
+                return {
+                    ...sessionPayload,
+                    session_id: activeSessionId,
+                    status: "streaming",
+                };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Continue"), activeSessionId);
+        await useChatStore.getState().sendMessage(activeSessionId);
+
+        const acceptedBindings =
+            useChatStore.getState().sessionsById[activeSessionId]!
+                .conversationBindings!;
+        expect(acceptedBindings.revision).toBe(
+            conversationBindings.revision + 1,
+        );
+        expect(
+            acceptedBindings.providerBindings.find(
+                (binding) => binding.bindingId === bindingId,
+            )?.contextCursor,
+        ).toBe("handoff-assistant");
     });
 
     it("omits internal runtime user echoes from saved transcript recovery prompts", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -16566,6 +16566,15 @@ describe("chatStore", () => {
                                 status: "completed",
                                 target: "/vault/src/watcher.rs",
                             },
+                            turnProvenance: {
+                                bindingId: "binding-codex",
+                                runtimeId: "codex-acp",
+                                runtimeSessionId: "runtime-session-1",
+                                modelId: "test-model",
+                                modeId: "default",
+                                options: { reasoning_effort: "medium" },
+                                startReason: "normal",
+                            },
                         },
                     ],
                 },
@@ -16598,6 +16607,20 @@ describe("chatStore", () => {
                         value: "medium",
                     }),
                 ]),
+                conversation_bindings: expect.objectContaining({
+                    version: 1,
+                    revision: 0,
+                    conversation_id: activeSessionId,
+                    active_binding_id: expect.any(String),
+                    provider_bindings: [
+                        expect.objectContaining({
+                            conversation_id: activeSessionId,
+                            runtime_id: "codex-acp",
+                            model_id: "test-model",
+                            mode_id: "default",
+                        }),
+                    ],
+                }),
                 messages: expect.arrayContaining([
                     expect.objectContaining({
                         kind: "tool",
@@ -16609,6 +16632,15 @@ describe("chatStore", () => {
                                 new_text: "new line",
                             },
                         ],
+                        turn_provenance: {
+                            binding_id: "binding-codex",
+                            runtime_id: "codex-acp",
+                            runtime_session_id: "runtime-session-1",
+                            model_id: "test-model",
+                            mode_id: "default",
+                            options: { reasoning_effort: "medium" },
+                            start_reason: "normal",
+                        },
                     }),
                 ]),
             }),

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14989,7 +14989,7 @@ describe("chatStore", () => {
         ]);
     });
 
-    it("starts the first turn with the live default when discovery has not finished", async () => {
+    it("drops catalog options unavailable for the discovered model", async () => {
         await useChatStore.getState().initialize();
 
         const sourceSessionId = getActiveSessionId();
@@ -15031,7 +15031,17 @@ describe("chatStore", () => {
                         },
                     ],
                     modes: [],
-                    configOptions: [],
+                    configOptions: [
+                        {
+                            id: "effort",
+                            runtimeId,
+                            category: "reasoning",
+                            label: "Effort",
+                            type: "select",
+                            value: "high",
+                            options: [{ value: "high", label: "High" }],
+                        },
+                    ],
                 },
             ],
             setupStatusByRuntimeId: {
@@ -15077,11 +15087,154 @@ describe("chatStore", () => {
             runtimeId,
             modelId: "auto",
             modeId: "",
-            options: {},
+            options: {
+                effort: "high",
+            },
         });
         useChatStore
             .getState()
             .setComposerParts(createTextParts("Start immediately"), sourceSessionId);
+        await useChatStore.getState().sendMessage(sourceSessionId);
+
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) => command === "ai_start_conversation_turn",
+            ),
+        ).toHaveLength(1);
+    });
+
+    it("drops an ACP option removed after applying the selected model", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const runtimeId = "provider-with-model-specific-options";
+        const modelOption = {
+            id: "model",
+            runtime_id: runtimeId,
+            category: "model" as const,
+            label: "Model",
+            type: "select" as const,
+            value: "sonnet",
+            options: [
+                { value: "sonnet", label: "Sonnet" },
+                { value: "haiku", label: "Haiku" },
+            ],
+        };
+        const effortOption = {
+            id: "effort",
+            runtime_id: runtimeId,
+            category: "reasoning" as const,
+            label: "Effort",
+            type: "select" as const,
+            value: "high",
+            options: [{ value: "high", label: "High" }],
+        };
+        const models = [
+            {
+                id: "sonnet",
+                runtime_id: runtimeId,
+                name: "Sonnet",
+                description: "Supports effort.",
+            },
+            {
+                id: "haiku",
+                runtime_id: runtimeId,
+                name: "Haiku",
+                description: "Does not expose effort.",
+            },
+        ];
+        const liveSession = {
+            session_id: "model-specific-session",
+            runtime_id: runtimeId,
+            model_id: "sonnet",
+            mode_id: "",
+            status: "idle" as const,
+            models,
+            modes: [],
+            config_options: [modelOption, effortOption],
+        };
+        const haikuSession = {
+            ...liveSession,
+            model_id: "haiku",
+            config_options: [{ ...modelOption, value: "haiku" }],
+        };
+        useChatStore.setState((state) => ({
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: runtimeId,
+                        name: "Model-specific Provider",
+                        description: "Provider with model-specific options.",
+                        capabilities: ["create_session"],
+                    },
+                    models: models.map((model) => ({
+                        id: model.id,
+                        runtimeId,
+                        name: model.name,
+                        description: model.description,
+                    })),
+                    modes: [],
+                    configOptions: [
+                        {
+                            ...modelOption,
+                            runtimeId,
+                        },
+                        {
+                            ...effortOption,
+                            runtimeId,
+                        },
+                    ],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                [runtimeId]: {
+                    ...readySetupStatusState,
+                    runtimeId,
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") return liveSession;
+            if (command === "ai_set_config_option") {
+                expect(args).toMatchObject({
+                    input: { option_id: "model", value: "haiku" },
+                });
+                return haikuSession;
+            }
+            if (command === "ai_start_conversation_turn") {
+                expect(args).toMatchObject({
+                    input: {
+                        conversation_id: conversationId,
+                        runtime_id: runtimeId,
+                        session_id: liveSession.session_id,
+                        selection: {
+                            runtime_id: runtimeId,
+                            model_id: "haiku",
+                            mode_id: "",
+                            options: { model: "haiku" },
+                        },
+                    },
+                });
+                return null;
+            }
+            if (command === "ai_send_message") {
+                return { ...haikuSession, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            runtimeId,
+            modelId: "haiku",
+            modeId: "",
+            options: { model: "haiku", effort: "high" },
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Use Haiku"), sourceSessionId);
         await useChatStore.getState().sendMessage(sourceSessionId);
 
         expect(

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -15646,6 +15646,8 @@ describe("chatStore", () => {
                 isPersistedSession: false,
                 resumeContextPending: true,
                 resumeReconnectFailed: false,
+                status: "idle",
+                activeWorkCycleId: null,
             },
         );
         expect(useChatStore.getState().sessionsById[persistedSessionId]).toBe(

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -621,6 +621,90 @@ describe("chatStore", () => {
         );
     });
 
+    it("projects session state under its canonical conversation identity", () => {
+        const session = createSessionWithTrackedFiles("local-session", []);
+        session.historySessionId = "conversation-1";
+        session.runtimeSessionId = "native-session";
+        useChatStore.getState().upsertSession(session, true);
+        const bindingId = useChatStore.getState().conversationsById[
+            "conversation-1"
+        ]?.activeBindingId;
+        expect(bindingId).toBeTruthy();
+
+        const queued = createQueuedMessage("queued-1", "Continue");
+        useChatStore.setState((state) => ({
+            composerPartsBySessionId: {
+                ...state.composerPartsBySessionId,
+                [session.sessionId]: createTextParts("Draft"),
+            },
+            queuedMessagesBySessionId: {
+                ...state.queuedMessagesBySessionId,
+                [session.sessionId]: [queued],
+            },
+        }));
+        useChatStore.getState().applyTokenUsage({
+            session_id: bindingId!,
+            used: 12,
+            size: 100,
+        });
+
+        const state = useChatStore.getState();
+        expect(state.activeConversationId).toBe("conversation-1");
+        expect(state.conversationOrder).toEqual(["conversation-1"]);
+        expect(state.conversationsById["conversation-1"]).toMatchObject({
+            conversationId: "conversation-1",
+            actionLog: session.actionLog,
+        });
+        expect(state.composerPartsByConversationId["conversation-1"]).toEqual(
+            createTextParts("Draft"),
+        );
+        expect(state.queuedMessagesByConversationId["conversation-1"]).toEqual(
+            [queued],
+        );
+        expect(state.tokenUsageByConversationId["conversation-1"]).toMatchObject(
+            { used: 12, size: 100 },
+        );
+        expect(state.conversationIdBySessionRef["native-session"]).toBe(
+            "conversation-1",
+        );
+        expect(state.conversationIdBySessionRef[bindingId!]).toBe(
+            "conversation-1",
+        );
+    });
+
+    it("keeps one canonical conversation when the local session id changes", () => {
+        const persisted = createSessionWithTrackedFiles(
+            "persisted:conversation-1",
+            [],
+        );
+        persisted.historySessionId = "conversation-1";
+        persisted.runtimeState = "persisted_only";
+        useChatStore.getState().upsertSession(persisted, true);
+        useChatStore.setState((state) => ({
+            composerPartsBySessionId: {
+                ...state.composerPartsBySessionId,
+                [persisted.sessionId]: createTextParts("Survives resume"),
+            },
+        }));
+
+        const live = cloneSessionForTest(persisted, "local-live", {
+            historySessionId: "conversation-1",
+            runtimeSessionId: "native-live",
+            runtimeState: "live",
+            isPersistedSession: false,
+        });
+        useChatStore.getState().upsertSession(live, true);
+
+        const state = useChatStore.getState();
+        expect(state.conversationOrder).toEqual(["conversation-1"]);
+        expect(state.sessionIdByConversationId["conversation-1"]).toBe(
+            "local-live",
+        );
+        expect(state.composerPartsByConversationId["conversation-1"]).toEqual(
+            createTextParts("Survives resume"),
+        );
+    });
+
     it("does not let an older storage refresh overwrite a newer snapshot", async () => {
         disposeChatStoreRuntime();
         useVaultStore.setState({ vaultPath: "/vault" });
@@ -6713,6 +6797,7 @@ describe("chatStore", () => {
         expect(useChatTabsStore.getState().tabs).toEqual([
             {
                 id: "tab-detached",
+                conversationId: "history-42",
                 sessionId: resumedSessionId,
                 historySessionId: "history-42",
                 runtimeId: "codex-acp",
@@ -17101,6 +17186,7 @@ describe("chatStore", () => {
         expect(useChatTabsStore.getState().tabs).toEqual([
             {
                 id: "tab-history-1",
+                conversationId: "history-1",
                 sessionId: "codex-session-1",
                 historySessionId: "history-1",
                 runtimeId: "codex-acp",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -10,7 +10,10 @@ import {
 import { useSettingsStore } from "../../../app/store/settingsStore";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { serializeComposerParts } from "../composerParts";
-import { updateConversationBindingsFromLegacySession } from "../conversationModel";
+import {
+    getConversationSelection,
+    updateConversationBindingsFromLegacySession,
+} from "../conversationModel";
 import type {
     AIChatAttachment,
     AIChatMessage,
@@ -14887,6 +14890,22 @@ describe("chatStore", () => {
                 );
                 return { ...providerBSession, status: "streaming" };
             }
+            if (command === "ai_start_conversation_turn") {
+                expect(args).toMatchObject({
+                    input: {
+                        conversation_id: conversationId,
+                        runtime_id: "provider-b",
+                        session_id: "provider-b-session-1",
+                        selection: {
+                            runtime_id: "provider-b",
+                            model_id: "model-b",
+                            mode_id: "default",
+                            options: {},
+                        },
+                    },
+                });
+                return null;
+            }
             return defaultInvokeImplementation(command, args);
         });
 
@@ -14937,6 +14956,88 @@ describe("chatStore", () => {
                     ],
                 }),
             }),
+        });
+    });
+
+    it("validates the requested selection before every conversation turn", async () => {
+        await useChatStore.getState().initialize();
+
+        const sessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const session = useChatStore.getState().sessionsById[sessionId]!;
+        const requestedSelection = getConversationSelection(session);
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_start_conversation_turn") {
+                expect(args).toMatchObject({
+                    input: {
+                        conversation_id: conversationId,
+                        runtime_id: session.runtimeId,
+                        session_id: sessionId,
+                        selection: {
+                            runtime_id: requestedSelection.runtimeId,
+                            model_id: requestedSelection.modelId,
+                            mode_id: requestedSelection.modeId,
+                            options: requestedSelection.options,
+                        },
+                    },
+                });
+                return null;
+            }
+            if (command === "ai_send_message") {
+                return { ...sessionPayload, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Continue normally"), sessionId);
+        await useChatStore.getState().sendMessage(sessionId);
+
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) => command === "ai_start_conversation_turn",
+            ),
+        ).toHaveLength(1);
+    });
+
+    it("rejects an unavailable requested option before sending", async () => {
+        await useChatStore.getState().initialize();
+
+        const sessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const session = useChatStore.getState().sessionsById[sessionId]!;
+        const selection = getConversationSelection(session);
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            ...selection,
+            options: {
+                ...selection.options,
+                unavailable_option: "requested-value",
+            },
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Do not send this"), sessionId);
+        invokeMock.mockClear();
+
+        await useChatStore.getState().sendMessage(sessionId);
+
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_start_conversation_turn",
+            ),
+        ).toBe(false);
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_send_message",
+            ),
+        ).toBe(false);
+        expect(
+            useChatStore.getState().sessionsById[sessionId]?.messages.at(-1),
+        ).toMatchObject({
+            kind: "error",
+            content:
+                "The selected ACP option is unavailable: unavailable_option",
         });
     });
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14836,6 +14836,261 @@ describe("chatStore", () => {
         ).toBe("provider-b");
     });
 
+    it("replaces a bootstrap Auto selection with the discovered ACP default", async () => {
+        await useChatStore.getState().initialize();
+
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const bootstrapRuntime = {
+            runtime: {
+                id: "claude-acp",
+                name: "Claude ACP",
+                description: "Claude ACP provider.",
+                capabilities: ["create_session"],
+            },
+            models: [
+                {
+                    id: "auto",
+                    runtimeId: "claude-acp",
+                    name: "Auto",
+                    description: "Use the runtime default model.",
+                },
+            ],
+            modes: [
+                {
+                    id: "default",
+                    runtimeId: "claude-acp",
+                    name: "Default",
+                    description: "Default mode.",
+                    disabled: false,
+                },
+            ],
+            configOptions: [
+                {
+                    id: "model",
+                    runtimeId: "claude-acp",
+                    category: "model" as const,
+                    label: "Model",
+                    type: "select" as const,
+                    value: "auto",
+                    options: [{ value: "auto", label: "Auto" }],
+                },
+            ],
+        };
+        const claudeSession = {
+            session_id: "claude-probe-session",
+            runtime_id: "claude-acp",
+            model_id: "claude-sonnet",
+            mode_id: "default",
+            status: "idle" as const,
+            models: [
+                {
+                    id: "claude-sonnet",
+                    runtime_id: "claude-acp",
+                    name: "Claude Sonnet",
+                    description: "Claude Sonnet model.",
+                },
+            ],
+            modes: [
+                {
+                    id: "default",
+                    runtime_id: "claude-acp",
+                    name: "Default",
+                    description: "Default mode.",
+                    disabled: false,
+                },
+            ],
+            config_options: [
+                {
+                    id: "model",
+                    runtime_id: "claude-acp",
+                    category: "model" as const,
+                    label: "Model",
+                    type: "select" as const,
+                    value: "claude-sonnet",
+                    options: [
+                        {
+                            value: "claude-sonnet",
+                            label: "Claude Sonnet",
+                        },
+                        {
+                            value: "claude-opus",
+                            label: "Claude Opus",
+                        },
+                    ],
+                },
+            ],
+        };
+        useChatStore.setState((state) => ({
+            runtimes: [...state.runtimes, bootstrapRuntime],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "claude-acp": {
+                    ...readySetupStatusState,
+                    runtimeId: "claude-acp",
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                const runtimeId = (
+                    args as { input?: { runtime_id?: string } } | undefined
+                )?.input?.runtime_id;
+                return runtimeId === "claude-acp"
+                    ? claudeSession
+                    : sessionPayload;
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        const bootstrapSelection = {
+            runtimeId: "claude-acp",
+            modelId: "auto",
+            modeId: "default",
+            options: { model: "auto" },
+        };
+        useChatStore
+            .getState()
+            .setConversationTurnSelection(
+                conversationId,
+                bootstrapSelection,
+            );
+        await useChatStore
+            .getState()
+            .prepareConversationTurnCatalog(
+                conversationId,
+                bootstrapSelection,
+            );
+
+        expect(
+            useChatStore.getState().conversationsById[conversationId]
+                ?.preferredSelection,
+        ).toMatchObject({
+            runtimeId: "claude-acp",
+            modelId: "claude-sonnet",
+            options: { model: "claude-sonnet" },
+        });
+        expect(
+            useChatStore.getState().preparedTurnCatalogByConversationId[
+                conversationId
+            ],
+        ).toMatchObject({
+            runtimeId: "claude-acp",
+            modelId: "claude-sonnet",
+            models: [expect.objectContaining({ id: "claude-sonnet" })],
+        });
+        expect(
+            useChatStore
+                .getState()
+                .runtimes.find(
+                    (runtime) => runtime.runtime.id === "claude-acp",
+                )?.models,
+        ).toEqual([
+            expect.objectContaining({ id: "claude-sonnet" }),
+        ]);
+    });
+
+    it("starts the first turn with the live default when discovery has not finished", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const runtimeId = "provider-with-live-default";
+        const liveSession = {
+            session_id: "provider-live-session",
+            runtime_id: runtimeId,
+            model_id: "live-default-model",
+            mode_id: "",
+            status: "idle" as const,
+            models: [
+                {
+                    id: "live-default-model",
+                    runtime_id: runtimeId,
+                    name: "Live Default Model",
+                    description: "The default reported by the ACP.",
+                },
+            ],
+            modes: [],
+            config_options: [],
+        };
+        useChatStore.setState((state) => ({
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: runtimeId,
+                        name: "Live Default Provider",
+                        description: "Provider with a runtime-owned default.",
+                        capabilities: ["create_session"],
+                    },
+                    models: [
+                        {
+                            id: "auto",
+                            runtimeId,
+                            name: "Auto",
+                            description: "Bootstrap default.",
+                        },
+                    ],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                [runtimeId]: {
+                    ...readySetupStatusState,
+                    runtimeId,
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                const requestedRuntimeId = (
+                    args as { input?: { runtime_id?: string } } | undefined
+                )?.input?.runtime_id;
+                return requestedRuntimeId === runtimeId
+                    ? liveSession
+                    : sessionPayload;
+            }
+            if (command === "ai_start_conversation_turn") {
+                expect(args).toMatchObject({
+                    input: {
+                        conversation_id: conversationId,
+                        runtime_id: runtimeId,
+                        session_id: liveSession.session_id,
+                        selection: {
+                            runtime_id: runtimeId,
+                            model_id: "live-default-model",
+                            mode_id: "",
+                            options: {},
+                        },
+                    },
+                });
+                return null;
+            }
+            if (command === "ai_send_message") {
+                return { ...liveSession, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            runtimeId,
+            modelId: "auto",
+            modeId: "",
+            options: {},
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Start immediately"), sourceSessionId);
+        await useChatStore.getState().sendMessage(sourceSessionId);
+
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) => command === "ai_start_conversation_turn",
+            ),
+        ).toHaveLength(1);
+    });
+
     it("persists the selected provider native session before the first message", async () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
         await useChatStore.getState().initialize();

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -42,7 +42,6 @@ import {
     initializeChatStoreRuntime,
     REMOVED_GEMINI_ACP_COMPOSER_MESSAGE,
     resetChatStore,
-    resolveChatSessionId,
     useChatStore,
 } from "./chatStore";
 import { resolveEditorTargetForOpenTab } from "../../editor/editorTargetResolver";
@@ -14403,57 +14402,11 @@ describe("chatStore", () => {
         ).toBe("handoff-assistant");
     });
 
-    it("routes A to B to A through canonical bindings with delta handoff", async () => {
+    it("allows choosing a provider before the first message", async () => {
         await useChatStore.getState().initialize();
 
-        const providerASessionId = getActiveSessionId();
-        const providerASession = {
-            ...useChatStore.getState().sessionsById[providerASessionId]!,
-            runtimeSessionId: "native-a",
-            continuationStrategy: "resume" as const,
-            activeWorkCycleId: null,
-            visibleWorkCycleId: null,
-            status: "idle" as const,
-            messages: [
-                {
-                    id: "a-user",
-                    role: "user" as const,
-                    kind: "text" as const,
-                    content: "Original provider context",
-                    timestamp: 10,
-                },
-                {
-                    id: "a-assistant",
-                    role: "assistant" as const,
-                    kind: "text" as const,
-                    content: "Original provider response",
-                    timestamp: 20,
-                },
-            ],
-        };
-        const conversationBindings =
-            updateConversationBindingsFromLegacySession(providerASession);
-        conversationBindings.providerBindings[0].contextCursor =
-            "a-assistant";
-        const providerBPayload = {
-            ...sessionPayload,
-            session_id: "local-b",
-            runtime_id: "provider-b",
-            runtime_session_id: "native-b",
-            continuation_strategy: "resume" as const,
-            model_id: "model-b",
-            models: [],
-            modes: [],
-            config_options: [],
-        };
-        const resumedProviderAPayload = {
-            ...sessionPayload,
-            session_id: "local-a-resumed",
-            runtime_session_id: "native-a",
-            continuation_strategy: "resume" as const,
-        };
-        const sentPrompts: { sessionId: string; content: string }[] = [];
-
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
         useChatStore.setState((state) => ({
             ...state,
             runtimes: [
@@ -14463,7 +14416,7 @@ describe("chatStore", () => {
                         id: "provider-b",
                         name: "Provider B",
                         description: "Second ACP provider.",
-                        capabilities: ["create_session", "resume_session"],
+                        capabilities: ["create_session"],
                     },
                     models: [],
                     modes: [],
@@ -14477,191 +14430,22 @@ describe("chatStore", () => {
                     runtimeId: "provider-b",
                 },
             },
-            sessionsById: {
-                ...state.sessionsById,
-                [providerASessionId]: {
-                    ...providerASession,
-                    conversationBindings,
-                },
-            },
         }));
 
-        invokeMock.mockImplementation(async (command, args) => {
-            if (command === "ai_create_session") {
-                expect(args).toMatchObject({
-                    input: { runtime_id: "provider-b" },
-                });
-                return providerBPayload;
-            }
-            if (command === "ai_resume_runtime_session") {
-                expect(args).toMatchObject({
-                    input: {
-                        runtime_id: "codex-acp",
-                        session_id: "native-a",
-                    },
-                });
-                return resumedProviderAPayload;
-            }
-            if (command === "ai_send_message") {
-                const input = args as { sessionId: string; content: string };
-                sentPrompts.push(input);
-                if (input.sessionId === "local-b") {
-                    const routedSessionId = resolveChatSessionId(
-                        useChatStore.getState(),
-                        input.sessionId,
-                    );
-                    expect(routedSessionId).toBe(providerASessionId);
-                    useChatStore.getState().applyMessageStarted({
-                        session_id: routedSessionId!,
-                        message_id: "b-first-event",
-                    });
-                    useChatStore.getState().applyMessageDelta({
-                        session_id: routedSessionId!,
-                        message_id: "b-first-event",
-                        delta: "Provider B started before send resolved",
-                        role: "assistant",
-                    });
-                    useChatStore.getState().applyMessageCompleted({
-                        session_id: routedSessionId!,
-                        message_id: "b-first-event",
-                        role: "assistant",
-                        turn_complete: true,
-                    });
-                }
-                return input.sessionId === "local-b"
-                    ? { ...providerBPayload, status: "streaming" }
-                    : { ...resumedProviderAPayload, status: "streaming" };
-            }
-            return defaultInvokeImplementation(command, args);
-        });
-
-        const conversationId =
-            useChatStore.getState().activeConversationId!;
-        useChatStore
-            .getState()
-            .setComposerParts(createTextParts("Question for B"), providerASessionId);
-        await useChatStore.getState().startConversationTurn(conversationId, {
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
             runtimeId: "provider-b",
             modelId: "model-b",
             modeId: "default",
             options: {},
         });
 
-        expect(sentPrompts[0]).toMatchObject({ sessionId: "local-b" });
-        expect(sentPrompts[0].content).toContain("another ACP provider");
-        expect(sentPrompts[0].content).toContain("Original provider context");
-        const switched = useChatStore.getState().sessionsById["local-b"]!;
-        expect(switched.historySessionId).toBe(conversationId);
-        expect(switched.conversationBindings).toMatchObject({
-            activeBindingId: expect.stringContaining("provider-b"),
-            preferredSelection: { runtimeId: "provider-b" },
-        });
         expect(
-            switched.messages.find(
-                (message) => message.content === "Question for B",
-            )?.turnProvenance,
-        ).toMatchObject({
-            runtimeId: "provider-b",
-            startReason: "provider_switch",
-        });
-        expect(
-            switched.messages.some((message) =>
-                message.content.includes("Use the saved transcript below"),
-            ),
-        ).toBe(false);
-        expect(
-            switched.messages.find(
-                (message) => message.id === "b-first-event",
-            )?.content,
-        ).toBe("Provider B started before send resolved");
-        expect(
-            switched.messages.find(
-                (message) => message.id === "b-first-event",
-            )
-                ?.turnProvenance,
-        ).toMatchObject({ runtimeId: "provider-b" });
-        expect(
-            switched.conversationBindings?.providerBindings.find(
-                (binding) => binding.runtimeId === "provider-b",
-            )?.contextCursor,
-        ).toBe("b-first-event");
-
-        useChatStore
-            .getState()
-            .setComposerParts(createTextParts("Back to A"), "local-b");
-        await useChatStore.getState().startConversationTurn(conversationId, {
-            runtimeId: "codex-acp",
-            modelId: "test-model",
-            modeId: "default",
-            options: { model: "test-model", reasoning_effort: "medium" },
-        });
-
-        expect(sentPrompts[1]).toMatchObject({
-            sessionId: "local-a-resumed",
-        });
-        expect(sentPrompts[1].content).not.toContain(
-            "Original provider context",
-        );
-        expect(sentPrompts[1].content).toContain("Question for B");
-        expect(sentPrompts[1].content).toContain(
-            "Provider B started before send resolved",
-        );
-        const returned =
-            useChatStore.getState().sessionsById["local-a-resumed"]!;
-        expect(returned.conversationBindings?.providerBindings).toHaveLength(2);
-        expect(returned.conversationBindings?.preferredSelection.runtimeId).toBe(
-            "codex-acp",
-        );
-
-        useChatStore.getState().applyMessageDelta({
-            session_id: "local-a-resumed",
-            message_id: "a-returned",
-            delta: "Provider A resumed",
-            role: "assistant",
-        });
-        flushDeltasSync();
-        useChatStore.getState().applyMessageCompleted({
-            session_id: "local-a-resumed",
-            message_id: "a-returned",
-            role: "assistant",
-            turn_complete: true,
-        });
-        const afterReturn =
-            useChatStore.getState().sessionsById["local-a-resumed"]!;
-        const messageCount = afterReturn.messages.length;
-        const bindingRevision = afterReturn.conversationBindings?.revision;
-        useChatStore.getState().applyMessageDelta({
-            session_id: "local-b",
-            message_id: "delayed-b-event",
-            delta: "This must remain isolated",
-            role: "assistant",
-        });
-        flushDeltasSync();
-        useChatStore.getState().applyMessageCompleted({
-            session_id: "local-a-resumed",
-            message_id: "a-returned",
-            role: "assistant",
-            turn_complete: true,
-        });
-        expect(
-            useChatStore.getState().sessionsById["local-a-resumed"]?.messages,
-        ).toHaveLength(messageCount);
-        expect(
-            useChatStore.getState().sessionsById["local-a-resumed"]
-                ?.conversationBindings?.revision,
-        ).toBe(bindingRevision);
-        expect(
-            resolveChatSessionId(useChatStore.getState(), "local-b"),
-        ).toBeNull();
+            useChatStore.getState().sessionsById[sourceSessionId]
+                ?.conversationBindings?.preferredSelection.runtimeId,
+        ).toBe("provider-b");
     });
 
-    it.each(["ai_start_conversation_turn", "ai_send_message"] as const)(
-        "rolls back a new provider binding and restores the composer when %s fails",
-        async (failingCommand) => {
-        window.__neverwriteLogs?.enable("chat-store");
-        const debugSpy = vi
-            .spyOn(console, "debug")
-            .mockImplementation(() => {});
+    it("keeps a started conversation bound to its active provider", async () => {
         await useChatStore.getState().initialize();
 
         const sourceSessionId = getActiveSessionId();
@@ -14694,8 +14478,6 @@ describe("chatStore", () => {
                 ...state.sessionsById,
                 [sourceSessionId]: {
                     ...state.sessionsById[sourceSessionId]!,
-                    activeWorkCycleId: null,
-                    visibleWorkCycleId: null,
                     status: "idle",
                     messages: [
                         {
@@ -14709,193 +14491,116 @@ describe("chatStore", () => {
                 },
             },
         }));
-        const bindingsBefore =
-            updateConversationBindingsFromLegacySession(
-                useChatStore.getState().sessionsById[sourceSessionId]!,
-            );
-
-        invokeMock.mockImplementation(async (command, args) => {
-            if (command === "ai_create_session") {
-                return {
-                    ...sessionPayload,
-                    session_id: "failed-provider-b",
-                    runtime_id: "provider-b",
-                    runtime_session_id: "native-b",
-                    model_id: "model-b",
-                    models: [],
-                    modes: [],
-                    config_options: [],
-                };
-            }
-            if (command === failingCommand) {
-                throw new Error(
-                    "Provider B rejected /private/vault SECRET_PROMPT",
-                );
-            }
-            return defaultInvokeImplementation(command, args);
-        });
-
-        useChatStore
-            .getState()
-            .setComposerParts(createTextParts("Do not lose this"), sourceSessionId);
-        await useChatStore.getState().startConversationTurn(conversationId, {
+        const targetSelection = {
             runtimeId: "provider-b",
             modelId: "model-b",
             modeId: "default",
             options: {},
-        });
+        };
 
-        const state = useChatStore.getState();
-        expect(state.activeSessionId).toBe(sourceSessionId);
+        useChatStore
+            .getState()
+            .setConversationTurnSelection(conversationId, targetSelection);
+
+        const selectionAfterAttempt =
+            updateConversationBindingsFromLegacySession(
+                useChatStore.getState().sessionsById[sourceSessionId]!,
+            ).preferredSelection;
+        expect(selectionAfterAttempt.runtimeId).toBe("codex-acp");
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Keep this draft"), sourceSessionId);
+        invokeMock.mockClear();
+
+        await useChatStore
+            .getState()
+            .startConversationTurn(conversationId, targetSelection);
+
         expect(
-            state.sessionsById[sourceSessionId]?.conversationBindings
-                ?.providerBindings ?? bindingsBefore.providerBindings,
-        ).toHaveLength(1);
+            invokeMock.mock.calls.some(([command]) =>
+                [
+                    "ai_create_session",
+                    "ai_start_conversation_turn",
+                    "ai_send_message",
+                ].includes(command),
+            ),
+        ).toBe(false);
         expect(
             serializeComposerParts(
-                state.composerPartsBySessionId[sourceSessionId] ?? [],
+                useChatStore.getState().composerPartsBySessionId[
+                    sourceSessionId
+                ] ?? [],
             ),
-        ).toContain("Do not lose this");
-        expect(invokeMock).toHaveBeenCalledWith("ai_delete_runtime_session", {
-            sessionId: "failed-provider-b",
-        });
+        ).toContain("Keep this draft");
         expect(
-            resolveChatSessionId(
-                useChatStore.getState(),
-                "failed-provider-b",
-            ),
-        ).toBeNull();
-        expect(
-            invokeMock.mock.calls.some(
-                ([command]) => command === "ai_send_message",
-            ),
-        ).toBe(failingCommand === "ai_send_message");
-        const failedDiagnostic = debugSpy.mock.calls.find(
-            ([message]) =>
-                message ===
-                "[chat-store] canonical conversation turn failed",
-        )?.[1];
-        debugSpy.mockRestore();
-        window.__neverwriteLogs?.disable("chat-store");
-        expect(failedDiagnostic).toMatchObject({
-            target_runtime_id: "provider-b",
-            error_code: "turn_rejected",
-        });
-        expect(JSON.stringify(failedDiagnostic)).not.toContain(
-            "/private/vault",
-        );
-        expect(JSON.stringify(failedDiagnostic)).not.toContain(
-            "SECRET_PROMPT",
-        );
-        },
-    );
+            useChatStore.getState().sessionsById[sourceSessionId]?.runtimeId,
+        ).toBe("codex-acp");
+    });
 
-    it("keeps the active provider and composer when a prior binding cannot resume", async () => {
+    it("ignores a persisted cross-provider selection when sending", async () => {
         await useChatStore.getState().initialize();
 
         const sourceSessionId = getActiveSessionId();
-        const sourceSession = {
-            ...useChatStore.getState().sessionsById[sourceSessionId]!,
-            runtimeSessionId: "native-a",
-            continuationStrategy: "resume" as const,
-            activeWorkCycleId: null,
-            visibleWorkCycleId: null,
-            status: "idle" as const,
-            messages: [
-                {
-                    id: "existing",
-                    role: "user" as const,
-                    kind: "text" as const,
-                    content: "Existing transcript",
-                    timestamp: 1,
-                },
-            ],
-        };
-        const bindings =
+        const sourceSession = useChatStore.getState().sessionsById[
+            sourceSessionId
+        ]!;
+        const conversationBindings =
             updateConversationBindingsFromLegacySession(sourceSession);
-        const activeBindingId = bindings.activeBindingId;
-        bindings.providerBindings.push({
-            ...bindings.providerBindings[0],
-            bindingId: "binding-b",
+        conversationBindings.preferredSelection = {
             runtimeId: "provider-b",
-            runtimeSessionId: "native-b",
-            continuationStrategy: "resume",
             modelId: "model-b",
+            modeId: "default",
             options: {},
-            contextCursor: "existing",
-        });
+        };
         useChatStore.setState((state) => ({
-            ...state,
-            runtimes: [
-                ...state.runtimes,
-                {
-                    runtime: {
-                        id: "provider-b",
-                        name: "Provider B",
-                        description: "Second ACP provider.",
-                        capabilities: ["create_session", "resume_session"],
-                    },
-                    models: [],
-                    modes: [],
-                    configOptions: [],
-                },
-            ],
-            setupStatusByRuntimeId: {
-                ...state.setupStatusByRuntimeId,
-                "provider-b": {
-                    ...readySetupStatusState,
-                    runtimeId: "provider-b",
-                },
-            },
             sessionsById: {
                 ...state.sessionsById,
                 [sourceSessionId]: {
                     ...sourceSession,
-                    conversationBindings: bindings,
+                    status: "idle",
+                    runtimeState: "live",
+                    conversationBindings,
+                    messages: [
+                        {
+                            id: "existing",
+                            role: "user",
+                            kind: "text",
+                            content: "Existing transcript",
+                            timestamp: 1,
+                        },
+                    ],
                 },
             },
         }));
-        const conversationId =
-            useChatStore.getState().activeConversationId!;
+        let sentContent = "";
+        invokeMock.mockClear();
         invokeMock.mockImplementation(async (command, args) => {
-            if (command === "ai_resume_runtime_session") {
-                expect(args).toMatchObject({
-                    input: {
-                        runtime_id: "provider-b",
-                        session_id: "native-b",
-                    },
-                });
-                throw new Error("Native resume failed");
+            if (command === "ai_send_message") {
+                sentContent = (args as { content: string }).content;
+                return {
+                    ...sessionPayload,
+                    session_id: sourceSessionId,
+                    status: "streaming",
+                };
             }
             return defaultInvokeImplementation(command, args);
         });
 
         useChatStore
             .getState()
-            .setComposerParts(createTextParts("Retry without loss"), sourceSessionId);
-        await useChatStore.getState().startConversationTurn(conversationId, {
-            runtimeId: "provider-b",
-            modelId: "model-b",
-            modeId: "default",
-            options: {},
-        });
+            .setComposerParts(createTextParts("Continue here"), sourceSessionId);
+        await useChatStore.getState().sendMessage(sourceSessionId);
 
-        const state = useChatStore.getState();
-        expect(state.activeSessionId).toBe(sourceSessionId);
-        expect(
-            state.sessionsById[sourceSessionId]?.conversationBindings
-                ?.activeBindingId,
-        ).toBe(activeBindingId);
-        expect(
-            serializeComposerParts(
-                state.composerPartsBySessionId[sourceSessionId] ?? [],
-            ),
-        ).toContain("Retry without loss");
+        expect(sentContent).toBe("Continue here");
         expect(
             invokeMock.mock.calls.some(
-                ([command]) => command === "ai_send_message",
+                ([command]) => command === "ai_create_session",
             ),
         ).toBe(false);
+        expect(
+            useChatStore.getState().sessionsById[sourceSessionId]?.runtimeId,
+        ).toBe("codex-acp");
     });
 
     it("omits internal runtime user echoes from saved transcript recovery prompts", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -707,6 +707,156 @@ describe("chatStore", () => {
         );
     });
 
+    it("updates only the active canonical conversation for timeline events", () => {
+        const background = createSessionWithTrackedFiles(
+            "background-session",
+            [],
+        );
+        background.historySessionId = "background-conversation";
+        const active = createSessionWithTrackedFiles("active-session", []);
+        active.historySessionId = "active-conversation";
+
+        useChatStore.getState().upsertSession(background, true);
+        useChatStore.getState().upsertSession(active, true);
+
+        const stagedSelection = {
+            ...useChatStore.getState().conversationsById[
+                "active-conversation"
+            ].preferredSelection,
+            modelId: "staged-model",
+        };
+        useChatStore.setState((state) => ({
+            conversationsById: {
+                ...state.conversationsById,
+                "active-conversation": {
+                    ...state.conversationsById["active-conversation"],
+                    preferredSelection: stagedSelection,
+                },
+            },
+        }));
+
+        const before = useChatStore.getState();
+        const backgroundConversation =
+            before.conversationsById["background-conversation"];
+        const bindingsById = before.bindingsById;
+        const conversationOrder = before.conversationOrder;
+        const sessionOrder = before.sessionOrder;
+        const conversationIdBySessionRef =
+            before.conversationIdBySessionRef;
+        const sessionIdByConversationId =
+            before.sessionIdByConversationId;
+
+        useChatStore.getState().applyStatusEvent({
+            session_id: active.sessionId,
+            event_id: "status-1",
+            kind: "progress",
+            status: "in_progress",
+            title: "Working",
+            detail: "Inspecting files",
+            emphasis: "neutral",
+        });
+
+        const after = useChatStore.getState();
+        expect(after.conversationsById["active-conversation"]).not.toBe(
+            before.conversationsById["active-conversation"],
+        );
+        expect(after.conversationsById["background-conversation"]).toBe(
+            backgroundConversation,
+        );
+        expect(
+            after.conversationsById["active-conversation"].preferredSelection,
+        ).toBe(stagedSelection);
+        expect(after.bindingsById).toBe(bindingsById);
+        expect(after.conversationOrder).toBe(conversationOrder);
+        expect(after.sessionOrder).toBe(sessionOrder);
+        expect(after.conversationIdBySessionRef).toBe(
+            conversationIdBySessionRef,
+        );
+        expect(after.sessionIdByConversationId).toBe(
+            sessionIdByConversationId,
+        );
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: active.sessionId,
+            message_id: "assistant-1",
+            delta: "Streaming reply",
+            role: "assistant",
+        });
+        flushDeltasSync();
+
+        const afterDelta = useChatStore.getState();
+        expect(afterDelta.conversationsById["background-conversation"]).toBe(
+            backgroundConversation,
+        );
+        expect(afterDelta.bindingsById).toBe(bindingsById);
+        expect(
+            afterDelta.conversationsById["active-conversation"].messages.at(
+                -1,
+            )?.content,
+        ).toBe("Streaming reply");
+        expect(
+            afterDelta.conversationsById["active-conversation"]
+                .preferredSelection,
+        ).toBe(stagedSelection);
+    });
+
+    it("updates token usage without rebuilding conversations or other maps", () => {
+        const session = createSessionWithTrackedFiles("local-session", []);
+        session.historySessionId = "conversation-1";
+        useChatStore.getState().upsertSession(session, true);
+
+        const before = useChatStore.getState();
+        useChatStore.getState().applyTokenUsage({
+            session_id: session.sessionId,
+            used: 21,
+            size: 100,
+        });
+
+        const after = useChatStore.getState();
+        expect(after.conversationsById).toBe(before.conversationsById);
+        expect(after.bindingsById).toBe(before.bindingsById);
+        expect(after.composerPartsByConversationId).toBe(
+            before.composerPartsByConversationId,
+        );
+        expect(after.queuedMessagesByConversationId).toBe(
+            before.queuedMessagesByConversationId,
+        );
+        expect(after.tokenUsageByConversationId).not.toBe(
+            before.tokenUsageByConversationId,
+        );
+        expect(after.tokenUsageByConversationId["conversation-1"]).toMatchObject(
+            { used: 21, size: 100 },
+        );
+    });
+
+    it("falls back to full reconciliation when session routing changes", () => {
+        const session = createSessionWithTrackedFiles("local-session", []);
+        session.historySessionId = "conversation-1";
+        session.runtimeSessionId = "native-old";
+        useChatStore.getState().upsertSession(session, true);
+
+        const before = useChatStore.getState();
+        useChatStore.setState((state) => ({
+            sessionsById: {
+                ...state.sessionsById,
+                [session.sessionId]: {
+                    ...state.sessionsById[session.sessionId],
+                    runtimeSessionId: "native-new",
+                },
+            },
+        }));
+
+        const after = useChatStore.getState();
+        expect(after.bindingsById).not.toBe(before.bindingsById);
+        expect(after.conversationIdBySessionRef).not.toBe(
+            before.conversationIdBySessionRef,
+        );
+        expect(after.conversationIdBySessionRef["native-old"]).toBeUndefined();
+        expect(after.conversationIdBySessionRef["native-new"]).toBe(
+            "conversation-1",
+        );
+    });
+
     it("does not let an older storage refresh overwrite a newer snapshot", async () => {
         disposeChatStoreRuntime();
         useVaultStore.setState({ vaultPath: "/vault" });

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -15244,6 +15244,171 @@ describe("chatStore", () => {
         ).toHaveLength(1);
     });
 
+    it("applies an ACP option exposed only after selecting the target model", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const runtimeId = "provider-with-late-model-options";
+        const modelOption = {
+            id: "model",
+            runtime_id: runtimeId,
+            category: "model" as const,
+            label: "Model",
+            type: "select" as const,
+            value: "haiku",
+            options: [
+                { value: "haiku", label: "Haiku" },
+                { value: "opus", label: "Opus" },
+            ],
+        };
+        const effortOption = {
+            id: "effort",
+            runtime_id: runtimeId,
+            category: "reasoning" as const,
+            label: "Effort",
+            type: "select" as const,
+            value: "medium",
+            options: [
+                { value: "medium", label: "Medium" },
+                { value: "high", label: "High" },
+            ],
+        };
+        const models = [
+            {
+                id: "haiku",
+                runtime_id: runtimeId,
+                name: "Haiku",
+                description: "Does not expose effort.",
+            },
+            {
+                id: "opus",
+                runtime_id: runtimeId,
+                name: "Opus",
+                description: "Exposes effort after selection.",
+            },
+        ];
+        const initialSession = {
+            session_id: "late-options-session",
+            runtime_id: runtimeId,
+            model_id: "haiku",
+            mode_id: "",
+            status: "idle" as const,
+            models,
+            modes: [],
+            config_options: [modelOption],
+        };
+        const opusSession = {
+            ...initialSession,
+            model_id: "opus",
+            config_options: [
+                { ...modelOption, value: "opus" },
+                effortOption,
+            ],
+        };
+        const configuredSession = {
+            ...opusSession,
+            config_options: [
+                { ...modelOption, value: "opus" },
+                { ...effortOption, value: "high" },
+            ],
+        };
+        useChatStore.setState((state) => ({
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: runtimeId,
+                        name: "Late Options Provider",
+                        description: "Provider with model-specific options.",
+                        capabilities: ["create_session"],
+                    },
+                    models: models.map((model) => ({
+                        id: model.id,
+                        runtimeId,
+                        name: model.name,
+                        description: model.description,
+                    })),
+                    modes: [],
+                    configOptions: [{ ...modelOption, runtimeId }],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                [runtimeId]: {
+                    ...readySetupStatusState,
+                    runtimeId,
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") return initialSession;
+            if (command === "ai_set_config_option") {
+                const input = (args as {
+                    input?: { option_id?: string; value?: string };
+                }).input;
+                if (input?.option_id === "model") return opusSession;
+                if (input?.option_id === "effort") return configuredSession;
+            }
+            if (command === "ai_start_conversation_turn") {
+                expect(args).toMatchObject({
+                    input: {
+                        conversation_id: conversationId,
+                        runtime_id: runtimeId,
+                        session_id: initialSession.session_id,
+                        selection: {
+                            runtime_id: runtimeId,
+                            model_id: "opus",
+                            mode_id: "",
+                            options: { model: "opus", effort: "high" },
+                        },
+                    },
+                });
+                return null;
+            }
+            if (command === "ai_send_message") {
+                return { ...configuredSession, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            runtimeId,
+            modelId: "opus",
+            modeId: "",
+            options: { model: "opus", effort: "high" },
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Use high effort"), sourceSessionId);
+        await useChatStore.getState().sendMessage(sourceSessionId);
+
+        expect(
+            invokeMock.mock.calls.filter(
+                ([command]) => command === "ai_set_config_option",
+            ),
+        ).toEqual([
+            [
+                "ai_set_config_option",
+                expect.objectContaining({
+                    input: expect.objectContaining({
+                        option_id: "model",
+                        value: "opus",
+                    }),
+                }),
+            ],
+            [
+                "ai_set_config_option",
+                expect.objectContaining({
+                    input: expect.objectContaining({
+                        option_id: "effort",
+                        value: "high",
+                    }),
+                }),
+            ],
+        ]);
+    });
+
     it("persists the selected provider native session before the first message", async () => {
         useVaultStore.setState({ vaultPath: "/vault", notes: [] });
         await useChatStore.getState().initialize();

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -17132,6 +17132,85 @@ describe("chatStore", () => {
         );
     });
 
+    it("starts a fresh ACP session when reopening a built-in runtime fork", async () => {
+        const runtimeId = "codex-acp";
+        const persistedSessionId = "persisted:built-in-fork";
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                {
+                    runtime: {
+                        id: runtimeId,
+                        name: "Codex",
+                        description: "Built-in ACP runtime.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                [persistedSessionId]: {
+                    ...createSessionWithTrackedFiles(persistedSessionId, []),
+                    historySessionId: "built-in-fork",
+                    runtimeId,
+                    runtimeSessionId: null,
+                    continuationStrategy: "new_session_only",
+                    runtimeState: "persisted_only",
+                    isPersistedSession: true,
+                    persistedMessageCount: 1,
+                    loadedPersistedMessageStart: 0,
+                    messages: [
+                        {
+                            id: "user:source",
+                            role: "user",
+                            kind: "text",
+                            content: "Inspect this change",
+                            timestamp: 1,
+                        },
+                    ],
+                },
+            },
+            sessionOrder: [persistedSessionId],
+            activeSessionId: persistedSessionId,
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                expect(args).toMatchObject({
+                    input: { runtime_id: runtimeId },
+                    vaultPath: "/vault",
+                });
+                return {
+                    ...sessionPayload,
+                    session_id: "fresh-built-in-runtime-session",
+                    runtime_session_id: "fresh-built-in-runtime-session",
+                };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await expect(
+            useChatStore.getState().resumeSession(persistedSessionId),
+        ).resolves.toBe("fresh-built-in-runtime-session");
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_resume_runtime_session",
+            ),
+        ).toBe(false);
+        expect(
+            useChatStore.getState().sessionsById[
+                "fresh-built-in-runtime-session"
+            ],
+        ).toMatchObject({
+            historySessionId: "built-in-fork",
+            runtimeSessionId: "fresh-built-in-runtime-session",
+            resumeContextPending: true,
+        });
+    });
+
     it("starts a fresh ACP session when reopening a custom runtime fork", async () => {
         const runtimeId = "custom:123e4567-e89b-12d3-a456-426614174000";
         const persistedSessionId = "persisted:custom-fork";
@@ -17268,6 +17347,65 @@ describe("chatStore", () => {
             ],
         ).toMatchObject({
             historySessionId: "forked-custom-history",
+            runtimeSessionId: null,
+            continuationStrategy: "new_session_only",
+            runtimeState: "persisted_only",
+        });
+    });
+
+    it("forks built-in history without retaining the source ACP session", async () => {
+        const runtimeId = "codex-acp";
+        const sourceSessionId = "source-built-in-session";
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                {
+                    runtime: {
+                        id: runtimeId,
+                        name: "Codex",
+                        description: "Built-in ACP runtime.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                [sourceSessionId]: {
+                    ...createSessionWithTrackedFiles(sourceSessionId, []),
+                    historySessionId: "source-built-in-history",
+                    runtimeId,
+                    runtimeSessionId: "source-runtime-session",
+                    continuationStrategy: "resume",
+                    runtimeState: "live",
+                    persistedMessageCount: 1,
+                },
+            },
+            sessionOrder: [sourceSessionId],
+            activeSessionId: sourceSessionId,
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_fork_session_history") {
+                expect(args).toEqual({
+                    vaultPath: "/vault",
+                    sourceSessionId: "source-built-in-history",
+                });
+                return "forked-built-in-history";
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        await useChatStore.getState().forkSession(sourceSessionId);
+
+        expect(
+            useChatStore.getState().sessionsById[
+                "persisted:forked-built-in-history"
+            ],
+        ).toMatchObject({
+            historySessionId: "forked-built-in-history",
             runtimeSessionId: null,
             continuationStrategy: "new_session_only",
             runtimeState: "persisted_only",

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -42,6 +42,7 @@ import {
     initializeChatStoreRuntime,
     REMOVED_GEMINI_ACP_COMPOSER_MESSAGE,
     resetChatStore,
+    resolveChatSessionId,
     useChatStore,
 } from "./chatStore";
 import { resolveEditorTargetForOpenTab } from "../../editor/editorTargetResolver";
@@ -14506,6 +14507,29 @@ describe("chatStore", () => {
             if (command === "ai_send_message") {
                 const input = args as { sessionId: string; content: string };
                 sentPrompts.push(input);
+                if (input.sessionId === "local-b") {
+                    const routedSessionId = resolveChatSessionId(
+                        useChatStore.getState(),
+                        input.sessionId,
+                    );
+                    expect(routedSessionId).toBe(providerASessionId);
+                    useChatStore.getState().applyMessageStarted({
+                        session_id: routedSessionId!,
+                        message_id: "b-first-event",
+                    });
+                    useChatStore.getState().applyMessageDelta({
+                        session_id: routedSessionId!,
+                        message_id: "b-first-event",
+                        delta: "Provider B started before send resolved",
+                        role: "assistant",
+                    });
+                    useChatStore.getState().applyMessageCompleted({
+                        session_id: routedSessionId!,
+                        message_id: "b-first-event",
+                        role: "assistant",
+                        turn_complete: true,
+                    });
+                }
                 return input.sessionId === "local-b"
                     ? { ...providerBPayload, status: "streaming" }
                     : { ...resumedProviderAPayload, status: "streaming" };
@@ -14528,7 +14552,7 @@ describe("chatStore", () => {
         expect(sentPrompts[0]).toMatchObject({ sessionId: "local-b" });
         expect(sentPrompts[0].content).toContain("another ACP provider");
         expect(sentPrompts[0].content).toContain("Original provider context");
-        let switched = useChatStore.getState().sessionsById["local-b"]!;
+        const switched = useChatStore.getState().sessionsById["local-b"]!;
         expect(switched.historySessionId).toBe(conversationId);
         expect(switched.conversationBindings).toMatchObject({
             activeBindingId: expect.stringContaining("provider-b"),
@@ -14547,30 +14571,22 @@ describe("chatStore", () => {
                 message.content.includes("Use the saved transcript below"),
             ),
         ).toBe(false);
-
-        useChatStore.getState().applyMessageStarted({
-            session_id: "local-b",
-            message_id: "b-assistant",
-            role: "assistant",
-        });
-        useChatStore.getState().applyMessageDelta({
-            session_id: "local-b",
-            message_id: "b-assistant",
-            delta: "Provider B response",
-            role: "assistant",
-        });
-        flushDeltasSync();
-        useChatStore.getState().applyMessageCompleted({
-            session_id: "local-b",
-            message_id: "b-assistant",
-            role: "assistant",
-            turn_complete: true,
-        });
-        switched = useChatStore.getState().sessionsById["local-b"]!;
         expect(
-            switched.messages.find((message) => message.id === "b-assistant")
+            switched.messages.find(
+                (message) => message.id === "b-first-event",
+            )?.content,
+        ).toBe("Provider B started before send resolved");
+        expect(
+            switched.messages.find(
+                (message) => message.id === "b-first-event",
+            )
                 ?.turnProvenance,
         ).toMatchObject({ runtimeId: "provider-b" });
+        expect(
+            switched.conversationBindings?.providerBindings.find(
+                (binding) => binding.runtimeId === "provider-b",
+            )?.contextCursor,
+        ).toBe("b-first-event");
 
         useChatStore
             .getState()
@@ -14589,16 +14605,65 @@ describe("chatStore", () => {
             "Original provider context",
         );
         expect(sentPrompts[1].content).toContain("Question for B");
-        expect(sentPrompts[1].content).toContain("Provider B response");
+        expect(sentPrompts[1].content).toContain(
+            "Provider B started before send resolved",
+        );
         const returned =
             useChatStore.getState().sessionsById["local-a-resumed"]!;
         expect(returned.conversationBindings?.providerBindings).toHaveLength(2);
         expect(returned.conversationBindings?.preferredSelection.runtimeId).toBe(
             "codex-acp",
         );
+
+        useChatStore.getState().applyMessageDelta({
+            session_id: "local-a-resumed",
+            message_id: "a-returned",
+            delta: "Provider A resumed",
+            role: "assistant",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageCompleted({
+            session_id: "local-a-resumed",
+            message_id: "a-returned",
+            role: "assistant",
+            turn_complete: true,
+        });
+        const afterReturn =
+            useChatStore.getState().sessionsById["local-a-resumed"]!;
+        const messageCount = afterReturn.messages.length;
+        const bindingRevision = afterReturn.conversationBindings?.revision;
+        useChatStore.getState().applyMessageDelta({
+            session_id: "local-b",
+            message_id: "delayed-b-event",
+            delta: "This must remain isolated",
+            role: "assistant",
+        });
+        flushDeltasSync();
+        useChatStore.getState().applyMessageCompleted({
+            session_id: "local-a-resumed",
+            message_id: "a-returned",
+            role: "assistant",
+            turn_complete: true,
+        });
+        expect(
+            useChatStore.getState().sessionsById["local-a-resumed"]?.messages,
+        ).toHaveLength(messageCount);
+        expect(
+            useChatStore.getState().sessionsById["local-a-resumed"]
+                ?.conversationBindings?.revision,
+        ).toBe(bindingRevision);
+        expect(
+            resolveChatSessionId(useChatStore.getState(), "local-b"),
+        ).toBeNull();
     });
 
-    it("rolls back a new provider binding and restores the composer on send failure", async () => {
+    it.each(["ai_start_conversation_turn", "ai_send_message"] as const)(
+        "rolls back a new provider binding and restores the composer when %s fails",
+        async (failingCommand) => {
+        window.__neverwriteLogs?.enable("chat-store");
+        const debugSpy = vi
+            .spyOn(console, "debug")
+            .mockImplementation(() => {});
         await useChatStore.getState().initialize();
 
         const sourceSessionId = getActiveSessionId();
@@ -14664,8 +14729,10 @@ describe("chatStore", () => {
                     config_options: [],
                 };
             }
-            if (command === "ai_send_message") {
-                throw new Error("Provider B rejected the turn");
+            if (command === failingCommand) {
+                throw new Error(
+                    "Provider B rejected /private/vault SECRET_PROMPT",
+                );
             }
             return defaultInvokeImplementation(command, args);
         });
@@ -14694,7 +14761,36 @@ describe("chatStore", () => {
         expect(invokeMock).toHaveBeenCalledWith("ai_delete_runtime_session", {
             sessionId: "failed-provider-b",
         });
-    });
+        expect(
+            resolveChatSessionId(
+                useChatStore.getState(),
+                "failed-provider-b",
+            ),
+        ).toBeNull();
+        expect(
+            invokeMock.mock.calls.some(
+                ([command]) => command === "ai_send_message",
+            ),
+        ).toBe(failingCommand === "ai_send_message");
+        const failedDiagnostic = debugSpy.mock.calls.find(
+            ([message]) =>
+                message ===
+                "[chat-store] canonical conversation turn failed",
+        )?.[1];
+        debugSpy.mockRestore();
+        window.__neverwriteLogs?.disable("chat-store");
+        expect(failedDiagnostic).toMatchObject({
+            target_runtime_id: "provider-b",
+            error_code: "turn_rejected",
+        });
+        expect(JSON.stringify(failedDiagnostic)).not.toContain(
+            "/private/vault",
+        );
+        expect(JSON.stringify(failedDiagnostic)).not.toContain(
+            "SECRET_PROMPT",
+        );
+        },
+    );
 
     it("keeps the active provider and composer when a prior binding cannot resume", async () => {
         await useChatStore.getState().initialize();

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14654,6 +14654,112 @@ describe("chatStore", () => {
         expect(sentContent).toContain("New user message: Continue from there");
     });
 
+    it("loads unloaded saved history before planning same-provider session creation", async () => {
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [],
+        });
+
+        const sourceSessionId = "live-history-shell";
+        const historySessionId = "history-live-shell";
+        const replacementSessionId = "codex-session-replacement";
+        let sentContent = "";
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                {
+                    runtime: runtimePayload[0].runtime,
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                [sourceSessionId]: {
+                    ...createSessionWithTrackedFiles(sourceSessionId, []),
+                    historySessionId,
+                    runtimeId: "codex-acp",
+                    runtimeState: "live",
+                    runtimeSessionId: null,
+                    continuationStrategy: "new_session_only",
+                    isPersistedSession: true,
+                    persistedMessageCount: 2,
+                    loadedPersistedMessageStart: null,
+                    messages: [],
+                },
+            },
+            sessionOrder: [sourceSessionId],
+            activeSessionId: sourceSessionId,
+            selectedRuntimeId: "codex-acp",
+            composerPartsBySessionId: {
+                [sourceSessionId]: [],
+            },
+        }));
+
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_load_session_history_page") {
+                expect(args).toMatchObject({
+                    sessionId: historySessionId,
+                    vaultPath: "/vault",
+                    startIndex: 0,
+                    limit: 2,
+                });
+                return {
+                    session_id: historySessionId,
+                    total_messages: 2,
+                    start_index: 0,
+                    end_index: 2,
+                    messages: [
+                        {
+                            id: "saved-user",
+                            role: "user",
+                            kind: "text",
+                            content: "Keep the saved constraint",
+                            timestamp: 10,
+                        },
+                        {
+                            id: "saved-assistant",
+                            role: "assistant",
+                            kind: "text",
+                            content: "The constraint is retained.",
+                            timestamp: 20,
+                        },
+                    ],
+                };
+            }
+            if (command === "ai_create_session") {
+                return {
+                    ...sessionPayload,
+                    session_id: replacementSessionId,
+                };
+            }
+            if (command === "ai_start_conversation_turn") return null;
+            if (command === "ai_send_message") {
+                sentContent = (args as { content: string }).content;
+                return {
+                    ...sessionPayload,
+                    session_id: replacementSessionId,
+                    status: "streaming",
+                };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore
+            .getState()
+            .setComposerParts(createTextParts("Continue safely"), sourceSessionId);
+        await useChatStore.getState().sendMessage(sourceSessionId);
+
+        expect(invokeMock).toHaveBeenCalledWith(
+            "ai_load_session_history_page",
+            expect.objectContaining({ sessionId: historySessionId }),
+        );
+        expect(sentContent).toContain("Saved transcript:");
+        expect(sentContent).toContain("User: Keep the saved constraint");
+        expect(sentContent).toContain("New user message: Continue safely");
+    });
+
     it("includes saved transcript context for live Codex sessions with pending recovery", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14941,6 +14941,15 @@ describe("chatStore", () => {
             runtimeId: "provider-b",
             runtimeSessionId: "provider-b-session-1",
         });
+        expect(
+            invokeMock.mock.calls
+                .filter(
+                    ([command]) => command === "ai_delete_runtime_session",
+                )
+                .map(([, args]) =>
+                    (args as { sessionId?: string }).sessionId,
+                ),
+        ).toEqual([sourceSessionId]);
         expect(invokeMock).toHaveBeenCalledWith("ai_save_session_history", {
             vaultPath: "/vault",
             history: expect.objectContaining({
@@ -14999,6 +15008,89 @@ describe("chatStore", () => {
                 ([command]) => command === "ai_start_conversation_turn",
             ),
         ).toHaveLength(1);
+    });
+
+    it("keeps the source runtime session when the initial provider turn fails", async () => {
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const providerBSessionId = "provider-b-failed-session";
+        const providerBSession = {
+            ...sessionPayload,
+            session_id: providerBSessionId,
+            runtime_id: "provider-b",
+            model_id: "model-b",
+            models: [],
+            modes: [],
+            config_options: [],
+        };
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    ...readySetupStatusState,
+                    runtimeId: "provider-b",
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                const runtimeId = (
+                    args as { input?: { runtime_id?: string } } | undefined
+                )?.input?.runtime_id;
+                return runtimeId === "provider-b"
+                    ? providerBSession
+                    : sessionPayload;
+            }
+            if (command === "ai_start_conversation_turn") return null;
+            if (command === "ai_send_message") {
+                throw new Error("Provider B rejected the turn");
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            runtimeId: "provider-b",
+            modelId: "model-b",
+            modeId: "default",
+            options: {},
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(
+                createTextParts("Try provider B"),
+                sourceSessionId,
+            );
+        await useChatStore.getState().sendMessage(sourceSessionId);
+
+        expect(
+            invokeMock.mock.calls
+                .filter(
+                    ([command]) => command === "ai_delete_runtime_session",
+                )
+                .map(([, args]) =>
+                    (args as { sessionId?: string }).sessionId,
+                ),
+        ).toEqual([providerBSessionId]);
+        expect(
+            useChatStore.getState().sessionsById[sourceSessionId],
+        ).toBeDefined();
     });
 
     it("rejects an unavailable requested option before sending", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -14833,6 +14833,113 @@ describe("chatStore", () => {
         ).toBe("provider-b");
     });
 
+    it("persists the selected provider native session before the first message", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        await useChatStore.getState().initialize();
+
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const providerBSession = {
+            ...sessionPayload,
+            session_id: "provider-b-session-1",
+            runtime_id: "provider-b",
+            model_id: "model-b",
+            models: [],
+            modes: [],
+            config_options: [],
+        };
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                ...state.runtimes,
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            setupStatusByRuntimeId: {
+                ...state.setupStatusByRuntimeId,
+                "provider-b": {
+                    ...readySetupStatusState,
+                    runtimeId: "provider-b",
+                },
+            },
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") {
+                const runtimeId = (
+                    args as { input?: { runtime_id?: string } } | undefined
+                )?.input?.runtime_id;
+                return runtimeId === "provider-b"
+                    ? providerBSession
+                    : sessionPayload;
+            }
+            if (command === "ai_send_message") {
+                expect((args as { sessionId?: string }).sessionId).toBe(
+                    "provider-b-session-1",
+                );
+                return { ...providerBSession, status: "streaming" };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        useChatStore.getState().setConversationTurnSelection(conversationId, {
+            runtimeId: "provider-b",
+            modelId: "model-b",
+            modeId: "default",
+            options: {},
+        });
+        useChatStore
+            .getState()
+            .setComposerParts(
+                createTextParts("Start with provider B"),
+                sourceSessionId,
+            );
+        await useChatStore.getState().sendMessage(sourceSessionId);
+        await Promise.resolve();
+
+        const acceptedSession =
+            useChatStore.getState().sessionsById["provider-b-session-1"]!;
+        const activeBinding =
+            acceptedSession.conversationBindings?.providerBindings.find(
+                (binding) =>
+                    binding.bindingId ===
+                    acceptedSession.conversationBindings?.activeBindingId,
+            );
+        expect(acceptedSession).toMatchObject({
+            historySessionId: sourceSessionId,
+            runtimeId: "provider-b",
+            runtimeSessionId: "provider-b-session-1",
+        });
+        expect(activeBinding).toMatchObject({
+            runtimeId: "provider-b",
+            runtimeSessionId: "provider-b-session-1",
+        });
+        expect(invokeMock).toHaveBeenCalledWith("ai_save_session_history", {
+            vaultPath: "/vault",
+            history: expect.objectContaining({
+                session_id: sourceSessionId,
+                runtime_id: "provider-b",
+                runtime_session_id: "provider-b-session-1",
+                conversation_bindings: expect.objectContaining({
+                    provider_bindings: [
+                        expect.objectContaining({
+                            runtime_id: "provider-b",
+                            runtime_session_id: "provider-b-session-1",
+                        }),
+                    ],
+                }),
+            }),
+        });
+    });
+
     it("keeps a started conversation bound to its active provider", async () => {
         await useChatStore.getState().initialize();
 
@@ -15892,6 +15999,87 @@ describe("chatStore", () => {
                     command === "ai_resume_runtime_session" &&
                     (args as { input?: { session_id?: string } }).input
                         ?.session_id === "persisted:history-1",
+            ),
+        ).toBe(false);
+    });
+
+    it("resumes a saved chat with the active binding native session id", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+
+        const persistedSessionId = "persisted:history-provider-b";
+        const historySessionId = "history-provider-b";
+        const nativeSessionId = "provider-b-native-session";
+        const persistedSession = {
+            ...createSessionWithTrackedFiles(persistedSessionId, []),
+            historySessionId,
+            runtimeId: "provider-b",
+            runtimeSessionId: null,
+            runtimeState: "persisted_only" as const,
+            isPersistedSession: true,
+            persistedMessageCount: 0,
+            loadedPersistedMessageStart: 0,
+        };
+        const conversationBindings =
+            updateConversationBindingsFromLegacySession(persistedSession);
+        conversationBindings.providerBindings[0] = {
+            ...conversationBindings.providerBindings[0],
+            runtimeSessionId: nativeSessionId,
+        };
+
+        useChatStore.setState((state) => ({
+            ...state,
+            runtimes: [
+                {
+                    runtime: {
+                        id: "provider-b",
+                        name: "Provider B",
+                        description: "Second ACP provider.",
+                        capabilities: ["create_session", "resume_session"],
+                    },
+                    models: [],
+                    modes: [],
+                    configOptions: [],
+                },
+            ],
+            sessionsById: {
+                [persistedSessionId]: {
+                    ...persistedSession,
+                    conversationBindings,
+                },
+            },
+            sessionOrder: [persistedSessionId],
+            activeSessionId: persistedSessionId,
+            selectedRuntimeId: "provider-b",
+        }));
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_resume_runtime_session") {
+                expect(args).toMatchObject({
+                    input: {
+                        runtime_id: "provider-b",
+                        session_id: nativeSessionId,
+                    },
+                    vaultPath: "/vault",
+                });
+                return {
+                    ...sessionPayload,
+                    session_id: nativeSessionId,
+                    runtime_id: "provider-b",
+                };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+
+        const resumedSessionId = await useChatStore
+            .getState()
+            .resumeSession(persistedSessionId);
+
+        expect(resumedSessionId).toBe(nativeSessionId);
+        expect(
+            invokeMock.mock.calls.some(
+                ([command, args]) =>
+                    command === "ai_resume_runtime_session" &&
+                    (args as { input?: { session_id?: string } }).input
+                        ?.session_id === historySessionId,
             ),
         ).toBe(false);
     });

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1428,7 +1428,7 @@ describe("chatStore", () => {
         ).toBeUndefined();
     });
 
-    it("respects an explicit Claude Code default preference", async () => {
+    it("migrates a Claude Code default back to the automatic ACP provider", async () => {
         localStorage.setItem(
             AI_PREFS_KEY,
             JSON.stringify({
@@ -1448,15 +1448,13 @@ describe("chatStore", () => {
             .initialize({ createDefaultSession: false });
 
         const state = useChatStore.getState();
-        expect(state.defaultRuntimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
-        expect(state.selectedRuntimeId).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
-        expect(state.getDefaultNewChatRuntimeId()).toBe(
-            CLAUDE_TERMINAL_RUNTIME_ID,
-        );
+        expect(state.defaultRuntimeId).toBeNull();
+        expect(state.selectedRuntimeId).toBe("codex-acp");
+        expect(state.getDefaultNewChatRuntimeId()).toBe("codex-acp");
         expect(
             JSON.parse(localStorage.getItem(AI_PREFS_KEY) ?? "{}")
                 .defaultRuntimeId,
-        ).toBe(CLAUDE_TERMINAL_RUNTIME_ID);
+        ).toBeUndefined();
     });
 
     it("keeps Automatic when the default is cleared during initialization", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -9070,47 +9070,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         runtime: AIRuntimeDescriptor,
         session: AIChatSession,
         requestedSelection: ConversationSelection,
-        sourceSession: AIChatSession,
     ) {
-        const targetOptionIds = new Set(
-            session.configOptions.map((option) => option.id),
-        );
-        const knownCatalogOptionIds = new Set([
-            ...runtime.configOptions.map((option) => option.id),
-            ...sourceSession.configOptions.map((option) => option.id),
-        ]);
-        const normalizedSelection = {
-            ...requestedSelection,
-            options: Object.fromEntries(
-                Object.entries(requestedSelection.options).filter(
-                    ([optionId]) =>
-                        targetOptionIds.has(optionId) ||
-                        !knownCatalogOptionIds.has(optionId),
-                ),
-            ),
-        };
         if (
             sessionCanApplyConversationSelection(
                 session,
-                normalizedSelection,
+                requestedSelection,
             )
         ) {
-            return normalizedSelection;
+            return requestedSelection;
         }
 
         const descriptorDefault = getDefaultConversationSelection({ runtime });
-        const liveDescriptorDefault = {
-            ...descriptorDefault,
-            options: Object.fromEntries(
-                Object.entries(descriptorDefault.options).filter(
-                    ([optionId]) => targetOptionIds.has(optionId),
-                ),
-            ),
-        };
         if (
             conversationSelectionsEqual(
-                normalizedSelection,
-                liveDescriptorDefault,
+                requestedSelection,
+                descriptorDefault,
             )
         ) {
             // Runtime descriptors are only bootstrap metadata. In particular,
@@ -9121,8 +9095,9 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
 
         // Explicit user selections remain strict. The normal configuration
-        // path below will report which requested value is unavailable.
-        return normalizedSelection;
+        // path applies the model first, then reconciles options against the
+        // model-specific catalog returned by the ACP.
+        return requestedSelection;
     }
 
     async function connectCustomConversationBinding(
@@ -9258,7 +9233,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                   runtime,
                   runtimeSession,
                   input.route.selection,
-                  input.sourceSession,
               )
             : input.route.selection;
 
@@ -13344,7 +13318,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         runtime,
                         probeSession,
                         selection,
-                        sourceSession,
                     );
                 // Configure the probe exactly like the eventual turn. Several
                 // ACPs reveal reasoning and service-tier options only after the

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -180,7 +180,8 @@ import {
     deserializeConversationBindings,
     forkConversationBindings,
     getConversationSelection,
-    getConversationSwitchBlocker,
+    getConversationProviderSelectionBlocker,
+    hasConversationHistory,
     serializeConversationBindings,
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
@@ -2804,15 +2805,6 @@ function sanitizePersistedDisplayText(value?: string | null) {
         : value;
 }
 
-function sessionHasConversationHistory(session: AIChatSession) {
-    return (
-        Math.max(
-            getSessionTranscriptLength(session),
-            session.persistedMessageCount ?? 0,
-        ) > 0
-    );
-}
-
 function buildPromptWithContextHandoff(
     session: AIChatSession,
     prompt: string,
@@ -2932,21 +2924,12 @@ function commitAcceptedConversationTurn(input: {
         contextCursor,
         updatedAt: Date.now(),
     };
-    const providerBindings = bindings.providerBindings.some(
-        (binding) => binding.bindingId === targetBinding.bindingId,
-    )
-        ? bindings.providerBindings.map((binding) =>
-              binding.bindingId === targetBinding.bindingId
-                  ? targetBinding
-                  : binding,
-          )
-        : [...bindings.providerBindings, targetBinding];
     const conversationBindings = {
         ...bindings,
         revision: bindings.revision + 1,
         preferredSelection: acceptedSelection,
         activeBindingId: targetBinding.bindingId,
-        providerBindings,
+        providerBindings: [targetBinding],
     };
     const provenance = createConversationTurnProvenance(
         targetBinding,
@@ -8661,7 +8644,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             });
             if (!approved) {
                 const cancelled = new Error(
-                    "Conversation provider switch cancelled.",
+                    "Custom provider continuation cancelled.",
                 );
                 cancelled.name = "ConversationTurnCancelledError";
                 throw cancelled;
@@ -8845,24 +8828,24 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
 
         const requestedRuntimeId = currentItem.runtimeId ?? session.runtimeId;
-        const providerSwitchRequested =
+        const initialProviderChangeRequested =
             requestedRuntimeId !== session.runtimeId;
         if (
-            providerSwitchRequested &&
-            sessionHasConversationHistory(session)
+            initialProviderChangeRequested &&
+            hasConversationHistory(session)
         ) {
             throw new Error(
-                "This conversation cannot switch ACP providers. Start a new chat to use another provider.",
+                "This conversation is already bound to an ACP provider. Start a new chat to use another provider.",
             );
         }
-        if (providerSwitchRequested) {
+        if (initialProviderChangeRequested) {
             const state = get();
             const conversationId =
                 resolveConversationId(state, activeSessionId) ??
                 session.historySessionId;
             const conversation = state.conversationsById[conversationId];
             const blocker = conversation
-                ? getConversationSwitchBlocker(conversation, {
+                ? getConversationProviderSelectionBlocker(conversation, {
                       hasQueuedMessages:
                           (state.queuedMessagesBySessionId[activeSessionId]
                               ?.length ?? 0) > 0 ||
@@ -8906,7 +8889,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
 
         clearInterruptedTurnState(activeSessionId);
 
-        if (!providerSwitchRequested && !isLiveRuntimeSession(session)) {
+        if (!initialProviderChangeRequested && !isLiveRuntimeSession(session)) {
                 const resumedSessionId =
                     await get().resumeSession(activeSessionId);
             if (!resumedSessionId) {
@@ -8968,7 +8951,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
 
         try {
-            if (!providerSwitchRequested && source === "immediate") {
+            if (!initialProviderChangeRequested && source === "immediate") {
                 const replacementSessionId =
                     await replaceEmptySessionForAdditionalRoots(
                         activeSessionId,
@@ -8994,7 +8977,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 }
             }
 
-            if (!providerSwitchRequested) {
+            if (!initialProviderChangeRequested) {
                 session =
                     (await syncQueuedMessageConfig(
                         activeSessionId,
@@ -9034,7 +9017,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 hasTranscript:
                     getSessionTranscriptMessages(session).length > 0,
             });
-            if (session.resumeContextPending && !route.providerChanged) {
+            if (session.resumeContextPending && !route.initialProviderChanged) {
                 route = { ...route, startReason: "transcript_handoff" };
             }
             plannedRoute = route;
@@ -9051,7 +9034,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     start_reason: route.startReason,
                     source_runtime_id: session.runtimeId,
                     target_runtime_id: connected.runtimeSession.runtimeId,
-                    provider_changed: route.providerChanged,
+                    initial_provider_changed: route.initialProviderChanged,
                     reused_binding: route.targetBinding != null,
                     created_session: connected.created,
                 },
@@ -9176,7 +9159,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     return;
                 }
 
-                if (preflightOwnership && !route.providerChanged) {
+                if (preflightOwnership && !route.initialProviderChanged) {
                     const releasedOwnership =
                         releaseComposerPreflightOwnership(
                             activeSessionId,
@@ -9190,7 +9173,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 cleanupPromotedDrafts(promotedDrafts.promotions);
 
             const afterSend = get().sessionsById[activeSessionId];
-            if (afterSend && !route.providerChanged) {
+            if (afterSend && !route.initialProviderChanged) {
                 void persistSession(afterSend);
             }
 
@@ -9205,7 +9188,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 };
             }
 
-            if (route.providerChanged) {
+            if (route.initialProviderChanged) {
                 await aiStartConversationTurn({
                     conversationId: bindings.conversationId,
                     bindingId: connected.targetBinding.bindingId,
@@ -9278,7 +9261,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     start_reason: route.startReason,
                     source_runtime_id: session.runtimeId,
                     target_runtime_id: committedSession.runtimeId,
-                    provider_changed: route.providerChanged,
+                    initial_provider_changed: route.initialProviderChanged,
                     reused_binding: route.targetBinding != null,
                     created_session: connected.created,
                     handoff_truncated:
@@ -9318,7 +9301,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         source_runtime_id: session.runtimeId,
                         target_runtime_id:
                             plannedRoute.selection.runtimeId,
-                        provider_changed: plannedRoute.providerChanged,
+                        initial_provider_changed:
+                            plannedRoute.initialProviderChanged,
                         reused_binding:
                             plannedRoute.targetBinding != null,
                         created_session: preparedTurn?.created ?? false,
@@ -9331,7 +9315,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             }
             shouldRecoverPromptForRetry =
                 source === "immediate" &&
-                (providerSwitchRequested ||
+                (initialProviderChangeRequested ||
                     isRuntimeSessionDisconnectedErrorMessage(message));
             const failedOptimisticMessageId = shouldRecoverPromptForRetry
                 ? optimisticMessageId
@@ -12746,7 +12730,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             }
             if (
                 selection.runtimeId !== sourceSession.runtimeId &&
-                sessionHasConversationHistory(sourceSession)
+                hasConversationHistory(sourceSession)
             ) {
                 return;
             }
@@ -12891,15 +12875,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     : null;
                 const activeRuntimeId =
                     activeBinding?.runtimeId ?? session.runtimeId;
-                const providerChanged =
+                const initialProviderChanged =
                     activeRuntimeId !== selection.runtimeId;
                 const setupStatus =
                     currentState.setupStatusByRuntimeId[selection.runtimeId];
                 if (
                     isClaudeTerminalRuntimeId(selection.runtimeId) ||
-                    (providerChanged &&
-                        (sessionHasConversationHistory(session) ||
-                            getConversationSwitchBlocker(conversation, {
+                    (initialProviderChanged &&
+                        (getConversationProviderSelectionBlocker(
+                            conversation,
+                            {
                                 hasQueuedMessages:
                                     (currentState.queuedMessagesBySessionId[
                                         sessionId
@@ -12907,7 +12892,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                                     currentState.activeQueuedMessageBySessionId[
                                         sessionId
                                     ] != null,
-                            }) != null ||
+                            },
+                        ) != null ||
                             (setupStatus != null &&
                                 !isRuntimeSetupReady(setupStatus))))
                 ) {
@@ -13200,18 +13186,19 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 : null;
             const activeRuntimeId =
                 activeBinding?.runtimeId ?? session.runtimeId;
-            const providerChanged =
+            const initialProviderChanged =
                 activeRuntimeId !== selection.runtimeId;
-            if (providerChanged) {
-                if (sessionHasConversationHistory(session)) {
-                    return;
-                }
-                const blocker = getConversationSwitchBlocker(conversation, {
-                    hasQueuedMessages:
-                        (state.queuedMessagesBySessionId[sessionId]?.length ??
-                            0) > 0 ||
-                        state.activeQueuedMessageBySessionId[sessionId] != null,
-                });
+            if (initialProviderChanged) {
+                const blocker = getConversationProviderSelectionBlocker(
+                    conversation,
+                    {
+                        hasQueuedMessages:
+                            (state.queuedMessagesBySessionId[sessionId]
+                                ?.length ?? 0) > 0 ||
+                            state.activeQueuedMessageBySessionId[sessionId] !=
+                                null,
+                    },
+                );
                 const runtime = state.runtimes.find(
                     (candidate) =>
                         candidate.runtime.id === selection.runtimeId,
@@ -13273,14 +13260,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     .preferredSelection;
             const selection =
                 requestedSelection.runtimeId !== session.runtimeId &&
-                sessionHasConversationHistory(session)
+                hasConversationHistory(session)
                     ? getConversationSelection(session)
                     : requestedSelection;
-            const providerChanged = selection.runtimeId !== session.runtimeId;
+            const initialProviderChanged =
+                selection.runtimeId !== session.runtimeId;
 
             if (
-                (!providerChanged && !isLiveRuntimeSession(session)) ||
-                (!providerChanged && needsFullResumeContextTranscript(session))
+                (!initialProviderChanged && !isLiveRuntimeSession(session)) ||
+                (!initialProviderChanged &&
+                    needsFullResumeContextTranscript(session))
             ) {
                 const preparedSessionId =
                     await prepareSessionForPromptBuild(resolvedSessionId);

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -6155,9 +6155,8 @@ function needsFullResumeContextTranscript(session: AIChatSession) {
     );
 }
 
-function isCustomRuntimeTranscriptFork(session: AIChatSession) {
+function isTranscriptForkSession(session: AIChatSession) {
     return (
-        session.runtimeId.startsWith("custom:") &&
         session.continuationStrategy === "new_session_only" &&
         !session.runtimeSessionId?.trim()
     );
@@ -6880,10 +6879,11 @@ function getResumeRecoveryStrategy(
     runtimes: AIRuntimeDescriptor[],
     session: AIChatSession,
 ): ResumeRecoveryStrategy {
+    if (isTranscriptForkSession(session)) {
+        return "transcript_prompt_injection";
+    }
     if (session.runtimeId.startsWith("custom:")) {
-        return isCustomRuntimeTranscriptFork(session)
-            ? "transcript_prompt_injection"
-            : "custom_acp_continuation";
+        return "custom_acp_continuation";
     }
     return runtimeSupportsCapability(
         runtimes,
@@ -12398,13 +12398,15 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const vaultPath = useVaultStore.getState().vaultPath;
                 const isCustomRuntime =
                     currentSession.runtimeId.startsWith("custom:");
-                const customRuntimeTranscriptFork =
-                    isCustomRuntimeTranscriptFork(currentSession);
-                const supportsNativeResume = runtimeSupportsCapability(
-                    get().runtimes,
-                    currentSession.runtimeId,
-                    "resume_session",
-                );
+                const transcriptFork =
+                    isTranscriptForkSession(currentSession);
+                const supportsNativeResume =
+                    !transcriptFork &&
+                    runtimeSupportsCapability(
+                        get().runtimes,
+                        currentSession.runtimeId,
+                        "resume_session",
+                    );
                 resumeStrategy = getResumeRecoveryStrategy(
                     get().runtimes,
                     currentSession,
@@ -12413,13 +12415,13 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     getSessionRuntimeStateForLog(currentSession);
                 const transcriptLoaded =
                     supportsNativeResume ||
-                    (isCustomRuntime && !customRuntimeTranscriptFork)
+                    (isCustomRuntime && !transcriptFork)
                         ? await loadPersistedTranscript(sessionId, "latest")
                         : await loadPersistedTranscript(sessionId, "full");
                 if (!transcriptLoaded) {
                     throw new Error(
                         supportsNativeResume ||
-                            (isCustomRuntime && !customRuntimeTranscriptFork)
+                            (isCustomRuntime && !transcriptFork)
                             ? "Failed to load the latest saved transcript before resuming."
                             : "Failed to load the full saved transcript before resuming.",
                     );
@@ -12447,7 +12449,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 let resumedSession: AIChatSession;
                 let resumeContextPending = false;
 
-                if (isCustomRuntime && !customRuntimeTranscriptFork) {
+                if (isCustomRuntime && !transcriptFork) {
                     const continuationStrategy =
                         latestSession.continuationStrategy;
                     const launchFingerprint =
@@ -16104,12 +16106,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     ...session,
                     sessionId: forkedSessionId,
                     historySessionId: newHistoryId,
-                    runtimeSessionId: session.runtimeId.startsWith("custom:")
-                        ? null
-                        : session.runtimeSessionId,
-                    continuationStrategy: session.runtimeId.startsWith("custom:")
-                        ? "new_session_only"
-                        : session.continuationStrategy,
+                    runtimeSessionId: null,
+                    continuationStrategy: "new_session_only",
                     status: "idle",
                     isResumingSession: false,
                     isPersistedSession: true,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1,4 +1,4 @@
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 import { confirm, openUrl } from "@neverwrite/runtime";
 import {
     normalizeEditorFontFamily,
@@ -131,6 +131,8 @@ import {
     type AIChatNoteSummary,
     type AIChatRole,
     type AIChatSession,
+    type AIConversation,
+    type AcpConversationBinding,
     type AIClaudeProviderRouting,
     type AIComposerPart,
     type DraftAttachmentId,
@@ -163,6 +165,12 @@ import {
     serializeConversationBindings,
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
+import {
+    projectChatStoreToCanonical,
+    projectSessionMapToConversations,
+    resolveConversationId,
+    resolveLegacySessionId,
+} from "./chatStoreConversationProjection";
 import {
     getLastTranscriptMessage,
     getSessionTranscriptLength,
@@ -1555,6 +1563,13 @@ interface ChatStore {
     runtimeConnectionByRuntimeId: Record<string, AIRuntimeConnectionState>;
     setupStatusByRuntimeId: Record<string, AIRuntimeSetupStatus>;
     runtimes: AIRuntimeDescriptor[];
+    /** Canonical chat authority. AIChatSession below is a compatibility view. */
+    conversationsById: Record<string, AIConversation>;
+    bindingsById: Record<string, AcpConversationBinding>;
+    conversationOrder: string[];
+    activeConversationId: string | null;
+    conversationIdBySessionRef: Record<string, string>;
+    sessionIdByConversationId: Record<string, string>;
     sessionsById: Record<string, AIChatSession>;
     sessionOrder: string[];
     pendingAvailableCommandsBySessionId: Record<
@@ -1582,12 +1597,25 @@ interface ChatStore {
     screenshotRetentionSeconds: number;
     toolActivityDisplayMode: ActivityDisplayMode;
     composerPartsBySessionId: Record<string, AIComposerPart[]>;
+    composerPartsByConversationId: Record<string, AIComposerPart[]>;
     queuedMessagesBySessionId: Record<string, QueuedChatMessage[]>;
+    queuedMessagesByConversationId: Record<string, QueuedChatMessage[]>;
     queuedMessageEditBySessionId: Record<string, QueuedMessageEditState>;
+    queuedMessageEditByConversationId: Record<string, QueuedMessageEditState>;
     activeQueuedMessageBySessionId: Record<string, DeferredQueuedMessage>;
+    activeQueuedMessageByConversationId: Record<
+        string,
+        DeferredQueuedMessage
+    >;
     pausedQueueBySessionId: Record<string, PausedQueueState>;
+    pausedQueueByConversationId: Record<string, PausedQueueState>;
     interruptedTurnStateBySessionId: Record<string, InterruptedTurnState>;
+    interruptedTurnStateByConversationId: Record<
+        string,
+        InterruptedTurnState
+    >;
     tokenUsageBySessionId: Record<string, AITokenUsage>;
+    tokenUsageByConversationId: Record<string, AITokenUsage>;
     initialize: (options?: {
         createDefaultSession?: boolean;
     }) => Promise<ChatInitializationResult>;
@@ -7417,7 +7445,196 @@ function restoreMessagesFromHistory(
         .filter((message) => !isInternalRuntimeUserEchoMessage(message));
 }
 
-export const useChatStore = create<ChatStore>((set, get) => {
+function migrateConversationScopedSessionMap<T>(
+    valuesBySessionId: Record<string, T>,
+    valuesByConversationId: Record<string, T>,
+    previousSessionIdByConversationId: Record<string, string>,
+    nextSessionIdByConversationId: Record<string, string>,
+) {
+    let next = valuesBySessionId;
+    for (const [conversationId, nextSessionId] of Object.entries(
+        nextSessionIdByConversationId,
+    )) {
+        const previousSessionId =
+            previousSessionIdByConversationId[conversationId];
+        if (!previousSessionId || previousSessionId === nextSessionId) {
+            continue;
+        }
+        const value =
+            valuesByConversationId[conversationId] ??
+            valuesBySessionId[previousSessionId];
+        if (value === undefined) continue;
+        if (next === valuesBySessionId) next = { ...valuesBySessionId };
+        delete next[previousSessionId];
+        next[nextSessionId] = value;
+    }
+    return next;
+}
+
+function synchronizeCanonicalChatProjection(state: ChatStore): ChatStore {
+    const projection = projectChatStoreToCanonical(state);
+    const composerPartsBySessionId = migrateConversationScopedSessionMap(
+        state.composerPartsBySessionId,
+        state.composerPartsByConversationId,
+        state.sessionIdByConversationId,
+        projection.sessionIdByConversationId,
+    );
+    const queuedMessagesBySessionId = migrateConversationScopedSessionMap(
+        state.queuedMessagesBySessionId,
+        state.queuedMessagesByConversationId,
+        state.sessionIdByConversationId,
+        projection.sessionIdByConversationId,
+    );
+    const queuedMessageEditBySessionId = migrateConversationScopedSessionMap(
+        state.queuedMessageEditBySessionId,
+        state.queuedMessageEditByConversationId,
+        state.sessionIdByConversationId,
+        projection.sessionIdByConversationId,
+    );
+    const activeQueuedMessageBySessionId =
+        migrateConversationScopedSessionMap(
+            state.activeQueuedMessageBySessionId,
+            state.activeQueuedMessageByConversationId,
+            state.sessionIdByConversationId,
+            projection.sessionIdByConversationId,
+        );
+    const pausedQueueBySessionId = migrateConversationScopedSessionMap(
+        state.pausedQueueBySessionId,
+        state.pausedQueueByConversationId,
+        state.sessionIdByConversationId,
+        projection.sessionIdByConversationId,
+    );
+    const interruptedTurnStateBySessionId =
+        migrateConversationScopedSessionMap(
+            state.interruptedTurnStateBySessionId,
+            state.interruptedTurnStateByConversationId,
+            state.sessionIdByConversationId,
+            projection.sessionIdByConversationId,
+        );
+    const tokenUsageBySessionId = migrateConversationScopedSessionMap(
+        state.tokenUsageBySessionId,
+        state.tokenUsageByConversationId,
+        state.sessionIdByConversationId,
+        projection.sessionIdByConversationId,
+    );
+    return {
+        ...state,
+        ...projection,
+        composerPartsBySessionId,
+        queuedMessagesBySessionId,
+        queuedMessageEditBySessionId,
+        activeQueuedMessageBySessionId,
+        pausedQueueBySessionId,
+        interruptedTurnStateBySessionId,
+        tokenUsageBySessionId,
+        composerPartsByConversationId: projectSessionMapToConversations(
+            composerPartsBySessionId,
+            projection,
+        ),
+        queuedMessagesByConversationId: projectSessionMapToConversations(
+            queuedMessagesBySessionId,
+            projection,
+        ),
+        queuedMessageEditByConversationId: projectSessionMapToConversations(
+            queuedMessageEditBySessionId,
+            projection,
+        ),
+        activeQueuedMessageByConversationId: projectSessionMapToConversations(
+            activeQueuedMessageBySessionId,
+            projection,
+        ),
+        pausedQueueByConversationId: projectSessionMapToConversations(
+            pausedQueueBySessionId,
+            projection,
+        ),
+        interruptedTurnStateByConversationId:
+            projectSessionMapToConversations(
+                interruptedTurnStateBySessionId,
+                projection,
+            ),
+        tokenUsageByConversationId: projectSessionMapToConversations(
+            tokenUsageBySessionId,
+            projection,
+        ),
+    };
+}
+
+function canonicalChatProjectionInputsEqual(
+    left: ChatStore,
+    right: ChatStore,
+) {
+    return (
+        left.sessionsById === right.sessionsById &&
+        left.sessionOrder === right.sessionOrder &&
+        left.activeSessionId === right.activeSessionId &&
+        left.composerPartsBySessionId === right.composerPartsBySessionId &&
+        left.queuedMessagesBySessionId === right.queuedMessagesBySessionId &&
+        left.queuedMessageEditBySessionId ===
+            right.queuedMessageEditBySessionId &&
+        left.activeQueuedMessageBySessionId ===
+            right.activeQueuedMessageBySessionId &&
+        left.pausedQueueBySessionId === right.pausedQueueBySessionId &&
+        left.interruptedTurnStateBySessionId ===
+            right.interruptedTurnStateBySessionId &&
+        left.tokenUsageBySessionId === right.tokenUsageBySessionId
+    );
+}
+
+function withCanonicalChatProjection(
+    configure: StateCreator<ChatStore>,
+): StateCreator<ChatStore> {
+    return (set, get, api) => {
+        const projectedSet = ((partial, replace) => {
+            const update = (state: ChatStore) => {
+                const patch =
+                    typeof partial === "function" ? partial(state) : partial;
+                if (!replace && patch === state) return state;
+                const nextState = replace
+                    ? (patch as ChatStore)
+                    : ({ ...state, ...patch } as ChatStore);
+                return !replace &&
+                    canonicalChatProjectionInputsEqual(state, nextState)
+                    ? nextState
+                    : synchronizeCanonicalChatProjection(nextState);
+            };
+
+            if (replace) {
+                set(update, true);
+            } else {
+                set(update);
+            }
+        }) as typeof set;
+
+        api.setState = projectedSet;
+        return synchronizeCanonicalChatProjection(
+            configure(projectedSet, get, api),
+        );
+    };
+}
+
+export function resolveChatConversationId(
+    state: Pick<
+        ChatStore,
+        "conversationIdBySessionRef" | "conversationsById"
+    >,
+    ref: string | null | undefined,
+) {
+    return resolveConversationId(state, ref);
+}
+
+export function resolveChatSessionId(
+    state: Pick<
+        ChatStore,
+        | "conversationIdBySessionRef"
+        | "conversationsById"
+        | "sessionIdByConversationId"
+    >,
+    ref: string | null | undefined,
+) {
+    return resolveLegacySessionId(state, ref);
+}
+
+const createChatStore: StateCreator<ChatStore> = (set, get) => {
     async function loadPersistedTranscript(
         sessionId: string,
         mode: "latest" | "full" | "older",
@@ -8408,6 +8625,12 @@ export const useChatStore = create<ChatStore>((set, get) => {
     }
 
     return {
+        conversationsById: {},
+        bindingsById: {},
+        conversationOrder: [],
+        activeConversationId: null,
+        conversationIdBySessionRef: {},
+        sessionIdByConversationId: {},
         runtimeConnectionByRuntimeId: {},
         setupStatusByRuntimeId: {},
         runtimes: [],
@@ -8436,12 +8659,19 @@ export const useChatStore = create<ChatStore>((set, get) => {
             DEFAULT_AI_PREFERENCES.screenshotRetentionSeconds,
         toolActivityDisplayMode: DEFAULT_AI_PREFERENCES.toolActivityDisplayMode,
         composerPartsBySessionId: {},
+        composerPartsByConversationId: {},
         queuedMessagesBySessionId: {},
+        queuedMessagesByConversationId: {},
         queuedMessageEditBySessionId: {},
+        queuedMessageEditByConversationId: {},
         activeQueuedMessageBySessionId: {},
+        activeQueuedMessageByConversationId: {},
         pausedQueueBySessionId: {},
+        pausedQueueByConversationId: {},
         interruptedTurnStateBySessionId: {},
+        interruptedTurnStateByConversationId: {},
         tokenUsageBySessionId: {},
+        tokenUsageByConversationId: {},
 
         syncAutoContextForVault: (vaultPath) => {
             const next = loadAutoContextPreference(vaultPath);
@@ -9719,8 +9949,10 @@ export const useChatStore = create<ChatStore>((set, get) => {
             }
         },
 
-        applyTokenUsage: ({ session_id, used, size, cost }) => {
+        applyTokenUsage: ({ session_id: sessionRef, used, size, cost }) => {
             set((state) => {
+                const session_id =
+                    resolveLegacySessionId(state, sessionRef) ?? sessionRef;
                 if (!state.sessionsById[session_id]) {
                     return state;
                 }
@@ -14282,7 +14514,11 @@ export const useChatStore = create<ChatStore>((set, get) => {
             }
         },
     };
-});
+};
+
+export const useChatStore = create<ChatStore>()(
+    withCanonicalChatProjection(createChatStore),
+);
 
 // Stop retaining agent-owned review state as soon as the current vault turns
 // AI change review off. File writes and the ordinary vault watcher are not

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -133,6 +133,7 @@ import {
     type AIChatSession,
     type AIConversation,
     type AcpConversationBinding,
+    type AcpContextHandoffMetadata,
     type AIClaudeProviderRouting,
     type AIComposerPart,
     type DraftAttachmentId,
@@ -159,9 +160,16 @@ import {
     type QueuedChatMessage,
     type QueuedChatMessageStatus,
 } from "../types";
+import {
+    ACP_HANDOFF_PROMPT_HEADER,
+    buildAcpContextHandoff,
+    extractAcpContextHandoffUserMessage,
+    isAcpContextHandoffPrompt,
+} from "../contextHandoff";
 import { isCancellableChatTurnStatus } from "../chatTurnStatus";
 import {
     deserializeConversationBindings,
+    forkConversationBindings,
     serializeConversationBindings,
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
@@ -2718,18 +2726,11 @@ function findMostRecentSessionIdForRuntime(
     );
 }
 
-const RESUME_CONTEXT_PROMPT_HEADER =
-    "Use the saved transcript below as prior conversation context for this session.";
-const SAVED_TRANSCRIPT_MARKER = "Saved transcript:";
-const NEW_USER_MESSAGE_MARKER = "New user message:";
+const RESUME_CONTEXT_PROMPT_HEADER = ACP_HANDOFF_PROMPT_HEADER;
 const ATTACHED_SELECTION_OPEN_TAG = "<attached_selection";
 
 function isResumeContextPromptText(text: string) {
-    return (
-        text.includes(RESUME_CONTEXT_PROMPT_HEADER) &&
-        text.includes(SAVED_TRANSCRIPT_MARKER) &&
-        text.includes(NEW_USER_MESSAGE_MARKER)
-    );
+    return isAcpContextHandoffPrompt(text);
 }
 
 function isPotentialResumeContextPromptText(text: string) {
@@ -2741,9 +2742,7 @@ function isPotentialResumeContextPromptText(text: string) {
 }
 
 function extractResumeContextNewUserMessage(text: string) {
-    const index = text.lastIndexOf(NEW_USER_MESSAGE_MARKER);
-    if (index < 0) return null;
-    return text.slice(index + NEW_USER_MESSAGE_MARKER.length).trim();
+    return extractAcpContextHandoffUserMessage(text);
 }
 
 function hasAttachedSelectionMarkup(text: string) {
@@ -2771,54 +2770,69 @@ function sanitizePersistedDisplayText(value?: string | null) {
 
 function buildPromptWithResumeContext(session: AIChatSession, prompt: string) {
     if (!session.resumeContextPending) {
-        return prompt;
+        return { prompt, contextHandoff: undefined };
     }
 
-    const history = getSessionTranscriptMessages(session)
-        .filter((message) => !message.inProgress)
-        .filter(
-            (message) =>
-                message.kind !== "permission" &&
-                message.kind !== "plan" &&
-                message.kind !== "user_input_request" &&
-                message.kind !== "url_elicitation_request" &&
-                message.kind !== "status",
-        )
-        .filter((message) => !isInternalRuntimeUserEchoMessage(message))
-        .map((message) => {
-            const role =
-                message.role === "assistant"
-                    ? "Assistant"
-                    : message.role === "system"
-                      ? "System"
-                      : "User";
-            const label =
-                message.kind === "text"
-                    ? role
-                    : `${role} (${message.kind.replaceAll("_", " ")})`;
-            return `${label}: ${message.content}`.trim();
-        })
-        .filter(Boolean)
-        .join("\n\n");
+    const bindings = updateConversationBindingsFromLegacySession(session);
+    const activeBinding = bindings.providerBindings.find(
+        (binding) => binding.bindingId === bindings.activeBindingId,
+    );
+    const result = buildAcpContextHandoff({
+        messages: getSessionTranscriptMessages(session),
+        newUserMessage: prompt,
+        bindingId: activeBinding?.bindingId ?? null,
+        contextCursor: activeBinding?.contextCursor ?? null,
+        contextSummary: bindings.contextSummary,
+        reason: "transcript_handoff",
+    });
 
-    if (!history) {
-        return prompt;
+    return {
+        prompt: result.prompt,
+        contextHandoff: result.hasHandoff ? result.metadata : undefined,
+    };
+}
+
+function acceptContextHandoff(
+    session: AIChatSession,
+    contextHandoff: AcpContextHandoffMetadata | undefined,
+) {
+    if (!contextHandoff?.nextCursor || !contextHandoff.bindingId) {
+        return { ...session, resumeContextPending: false };
     }
 
-    return [
-        "Use the saved transcript below as prior conversation context for this session.",
-        "",
-        "Important:",
-        "- The transcript is historical context only and may not reflect the current workspace state.",
-        "- If the transcript conflicts with the current files, current environment, or the user's latest message, trust the current state.",
-        "- Do not assume prior pending tasks, approvals, permissions, or unfinished plans are still valid; verify when needed.",
-        "- Continue naturally from this context without repeating the transcript unless it is useful.",
-        "",
-        "Saved transcript:",
-        history,
-        "",
-        `New user message: ${prompt}`,
-    ].join("\n");
+    const bindings = updateConversationBindingsFromLegacySession(session);
+    if (bindings.activeBindingId !== contextHandoff.bindingId) {
+        return session;
+    }
+
+    const now = Date.now();
+    let didAdvanceCursor = false;
+    const providerBindings = bindings.providerBindings.map((binding) => {
+        if (
+            binding.bindingId !== contextHandoff.bindingId ||
+            binding.contextCursor === contextHandoff.nextCursor
+        ) {
+            return binding;
+        }
+        didAdvanceCursor = true;
+        return {
+            ...binding,
+            contextCursor: contextHandoff.nextCursor,
+            updatedAt: now,
+        };
+    });
+
+    return {
+        ...session,
+        resumeContextPending: false,
+        conversationBindings: didAdvanceCursor
+            ? {
+                  ...bindings,
+                  revision: bindings.revision + 1,
+                  providerBindings,
+              }
+            : bindings,
+    };
 }
 
 function cloneAttachment(attachment: AIChatAttachment): AIChatAttachment {
@@ -3261,10 +3275,11 @@ function buildQueuedMessage(
         return null;
     }
 
+    const preparedPrompt = buildPromptWithResumeContext(session, prompt);
     return {
         id: crypto.randomUUID(),
         content,
-        prompt: buildPromptWithResumeContext(session, prompt),
+        prompt: preparedPrompt.prompt,
         composerParts: composerPartsSnapshot,
         attachments,
         createdAt: Date.now(),
@@ -3274,6 +3289,7 @@ function buildQueuedMessage(
         optionsSnapshot: Object.fromEntries(
             session.configOptions.map((option) => [option.id, option.value]),
         ),
+        contextHandoff: preparedPrompt.contextHandoff,
     };
 }
 
@@ -8433,16 +8449,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 sessionsById: updateSessionById(
                     state,
                     activeSessionId,
-                    (current) => ({
-                        ...current,
-                        resumeContextPending: false,
-                    }),
+                    (current) =>
+                        acceptContextHandoff(
+                            current,
+                            currentItem.contextHandoff,
+                        ),
                 ),
             }));
+            const acceptedSession = get().sessionsById[activeSessionId];
             get().upsertSession({
                 ...nextSession,
                 historySessionId: session.historySessionId,
                 resumeContextPending: false,
+                conversationBindings:
+                    acceptedSession?.conversationBindings ??
+                    nextSession.conversationBindings,
             });
         } catch (error) {
             const message = getAiErrorMessage(
@@ -14462,6 +14483,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const forkedTitle = `${getSessionTitle(session)} (fork)`;
                 const now = Date.now();
                 const forkedSessionId = `persisted:${newHistoryId}`;
+                const forkedBindings = forkConversationBindings(
+                    updateConversationBindingsFromLegacySession(session),
+                    newHistoryId,
+                    now,
+                );
 
                 const runtime =
                     state.runtimes.find(
@@ -14496,6 +14522,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     isLoadingPersistedMessages: false,
                     activeWorkCycleId: null,
                     visibleWorkCycleId: null,
+                    conversationBindings: forkedBindings,
                 };
 
                 get().upsertSession(forkedSession, true);

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -186,6 +186,8 @@ import {
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
 import {
+    hasSameCanonicalSessionTopology,
+    projectCanonicalConversationContentUpdate,
     projectChatStoreToCanonical,
     projectSessionMapToConversations,
     resolveConversationId,
@@ -7056,11 +7058,44 @@ function getSetupStatusForRuntime(
 }
 
 function touchSessionOrder(sessionOrder: string[], sessionId: string) {
+    if (sessionOrder[0] === sessionId) {
+        return sessionOrder;
+    }
     if (!sessionOrder.includes(sessionId)) {
         return [sessionId, ...sessionOrder];
     }
 
     return [sessionId, ...sessionOrder.filter((id) => id !== sessionId)];
+}
+
+const _changedSessionIdsBySessionsMap = new WeakMap<
+    Record<string, AIChatSession>,
+    {
+        base: Record<string, AIChatSession>;
+        sessionIds: ReadonlySet<string>;
+    }
+>();
+
+function replaceSessionById(
+    sessionsById: Record<string, AIChatSession>,
+    sessionId: string,
+    nextSession: AIChatSession,
+) {
+    if (sessionsById[sessionId] === nextSession) return sessionsById;
+    const nextSessionsById = {
+        ...sessionsById,
+        [sessionId]: nextSession,
+    };
+    const pendingChanges = _changedSessionIdsBySessionsMap.get(sessionsById);
+    const changedSessionIds = new Set(
+        pendingChanges?.sessionIds,
+    );
+    changedSessionIds.add(sessionId);
+    _changedSessionIdsBySessionsMap.set(nextSessionsById, {
+        base: pendingChanges?.base ?? sessionsById,
+        sessionIds: changedSessionIds,
+    });
+    return nextSessionsById;
 }
 
 function updateSessionById(
@@ -7070,11 +7105,11 @@ function updateSessionById(
 ) {
     const session = state.sessionsById[sessionId];
     if (!session) return state.sessionsById;
-
-    return {
-        ...state.sessionsById,
-        [sessionId]: updater(session),
-    };
+    return replaceSessionById(
+        state.sessionsById,
+        sessionId,
+        updater(session),
+    );
 }
 
 function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
@@ -7708,10 +7743,11 @@ function flushDeltas() {
 
             if (nextSession === session) continue;
 
-            sessionsById = {
-                ...sessionsById,
-                [session_id]: nextSession,
-            };
+            sessionsById = replaceSessionById(
+                sessionsById,
+                session_id,
+                nextSession,
+            );
             changed = true;
         }
 
@@ -7738,10 +7774,11 @@ function flushDeltas() {
 
             if (!sessionChanged) continue;
 
-            sessionsById = {
-                ...sessionsById,
-                [sessionId]: nextSession,
-            };
+            sessionsById = replaceSessionById(
+                sessionsById,
+                sessionId,
+                nextSession,
+            );
             changed = true;
         }
 
@@ -8047,6 +8084,231 @@ function canonicalChatProjectionInputsEqual(
     );
 }
 
+function haveSameRecordKeys<T>(
+    previous: Readonly<Record<string, T>>,
+    next: Readonly<Record<string, T>>,
+) {
+    const previousKeys = Object.keys(previous);
+    const nextKeys = Object.keys(next);
+    return (
+        previousKeys.length === nextKeys.length &&
+        previousKeys.every((key) => Object.hasOwn(next, key))
+    );
+}
+
+function projectChangedSessionMapToConversations<T>(
+    previousValuesBySessionId: Readonly<Record<string, T>>,
+    nextValuesBySessionId: Readonly<Record<string, T>>,
+    previousValuesByConversationId: Record<string, T>,
+    projection: Pick<
+        ChatStore,
+        | "conversationIdBySessionRef"
+        | "conversationsById"
+        | "sessionIdByConversationId"
+    >,
+) {
+    if (previousValuesBySessionId === nextValuesBySessionId) {
+        return previousValuesByConversationId;
+    }
+
+    const affectedConversationIds = new Set<string>();
+    const sessionRefs = new Set([
+        ...Object.keys(previousValuesBySessionId),
+        ...Object.keys(nextValuesBySessionId),
+    ]);
+    for (const sessionRef of sessionRefs) {
+        if (
+            Object.hasOwn(previousValuesBySessionId, sessionRef) ===
+                Object.hasOwn(nextValuesBySessionId, sessionRef) &&
+            previousValuesBySessionId[sessionRef] ===
+                nextValuesBySessionId[sessionRef]
+        ) {
+            continue;
+        }
+        const conversationId = resolveConversationId(
+            projection,
+            sessionRef,
+        );
+        if (conversationId) affectedConversationIds.add(conversationId);
+    }
+
+    let projected = previousValuesByConversationId;
+    for (const conversationId of affectedConversationIds) {
+        const sessionId = projection.sessionIdByConversationId[conversationId];
+        let hasNextValue = false;
+        let nextValue: T | undefined;
+        if (sessionId && Object.hasOwn(nextValuesBySessionId, sessionId)) {
+            hasNextValue = true;
+            nextValue = nextValuesBySessionId[sessionId];
+        } else if (Object.hasOwn(nextValuesBySessionId, conversationId)) {
+            hasNextValue = true;
+            nextValue = nextValuesBySessionId[conversationId];
+        } else {
+            // Legacy callers may temporarily key a value by a native session
+            // or binding id. Prefer the elected local session above, but keep
+            // compatible aliases visible until structural migration runs.
+            for (const [sessionRef, value] of Object.entries(
+                nextValuesBySessionId,
+            )) {
+                if (
+                    resolveConversationId(projection, sessionRef) ===
+                    conversationId
+                ) {
+                    hasNextValue = true;
+                    nextValue = value;
+                }
+            }
+        }
+        const hadValue = Object.hasOwn(projected, conversationId);
+        if (!hasNextValue) {
+            if (!hadValue) continue;
+            if (projected === previousValuesByConversationId) {
+                projected = { ...previousValuesByConversationId };
+            }
+            delete projected[conversationId];
+            continue;
+        }
+        if (hadValue && projected[conversationId] === nextValue) continue;
+        if (projected === previousValuesByConversationId) {
+            projected = { ...previousValuesByConversationId };
+        }
+        projected[conversationId] = nextValue as T;
+    }
+
+    return projected;
+}
+
+function synchronizeCanonicalChatProjectionIncrementally(
+    previous: ChatStore,
+    next: ChatStore,
+): ChatStore | null {
+    const pendingChanges = _changedSessionIdsBySessionsMap.get(
+        next.sessionsById,
+    );
+    const changedSessionIds =
+        previous.sessionsById === next.sessionsById
+            ? new Set<string>()
+            : pendingChanges?.base === previous.sessionsById
+              ? pendingChanges.sessionIds
+              : undefined;
+    if (pendingChanges) {
+        // Hints belong to this Zustand transition only. Keeping them on the
+        // committed map would accumulate unrelated sessions across updates.
+        _changedSessionIdsBySessionsMap.delete(next.sessionsById);
+    }
+    if (
+        previous.sessionOrder !== next.sessionOrder ||
+        previous.activeSessionId !== next.activeSessionId ||
+        (!changedSessionIds &&
+            !haveSameRecordKeys(previous.sessionsById, next.sessionsById))
+    ) {
+        return null;
+    }
+
+    let conversationsById = next.conversationsById;
+    if (previous.sessionsById !== next.sessionsById) {
+        for (const sessionId of
+            changedSessionIds ?? Object.keys(next.sessionsById)) {
+            const previousSession = previous.sessionsById[sessionId];
+            const nextSession = next.sessionsById[sessionId];
+            if (previousSession === nextSession) continue;
+            if (
+                !previousSession ||
+                !nextSession ||
+                !hasSameCanonicalSessionTopology(
+                    previousSession,
+                    nextSession,
+                )
+            ) {
+                return null;
+            }
+
+            const conversationId = resolveConversationId(
+                next,
+                nextSession.sessionId,
+            );
+            if (!conversationId) return null;
+
+            // A stale compatibility session may share a durable conversation
+            // with the active session. Only the elected session owns content.
+            if (
+                next.sessionIdByConversationId[conversationId] !==
+                nextSession.sessionId
+            ) {
+                continue;
+            }
+
+            const previousConversation = conversationsById[conversationId];
+            if (!previousConversation) return null;
+            const nextConversation =
+                projectCanonicalConversationContentUpdate(
+                    previousConversation,
+                    nextSession,
+                );
+            if (nextConversation === previousConversation) continue;
+            if (conversationsById === next.conversationsById) {
+                conversationsById = { ...next.conversationsById };
+            }
+            conversationsById[conversationId] = nextConversation;
+        }
+    }
+
+    const projection = { ...next, conversationsById };
+    return {
+        ...next,
+        conversationsById,
+        composerPartsByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.composerPartsBySessionId,
+                next.composerPartsBySessionId,
+                next.composerPartsByConversationId,
+                projection,
+            ),
+        queuedMessagesByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.queuedMessagesBySessionId,
+                next.queuedMessagesBySessionId,
+                next.queuedMessagesByConversationId,
+                projection,
+            ),
+        queuedMessageEditByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.queuedMessageEditBySessionId,
+                next.queuedMessageEditBySessionId,
+                next.queuedMessageEditByConversationId,
+                projection,
+            ),
+        activeQueuedMessageByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.activeQueuedMessageBySessionId,
+                next.activeQueuedMessageBySessionId,
+                next.activeQueuedMessageByConversationId,
+                projection,
+            ),
+        pausedQueueByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.pausedQueueBySessionId,
+                next.pausedQueueBySessionId,
+                next.pausedQueueByConversationId,
+                projection,
+            ),
+        interruptedTurnStateByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.interruptedTurnStateBySessionId,
+                next.interruptedTurnStateBySessionId,
+                next.interruptedTurnStateByConversationId,
+                projection,
+            ),
+        tokenUsageByConversationId:
+            projectChangedSessionMapToConversations(
+                previous.tokenUsageBySessionId,
+                next.tokenUsageBySessionId,
+                next.tokenUsageByConversationId,
+                projection,
+            ),
+    };
+}
+
 function withCanonicalChatProjection(
     configure: StateCreator<ChatStore>,
 ): StateCreator<ChatStore> {
@@ -8059,10 +8321,21 @@ function withCanonicalChatProjection(
                 const nextState = replace
                     ? (patch as ChatStore)
                     : ({ ...state, ...patch } as ChatStore);
-                return !replace &&
+                if (
+                    !replace &&
                     canonicalChatProjectionInputsEqual(state, nextState)
-                    ? nextState
-                    : synchronizeCanonicalChatProjection(nextState);
+                ) {
+                    return nextState;
+                }
+                if (!replace) {
+                    const incremental =
+                        synchronizeCanonicalChatProjectionIncrementally(
+                            state,
+                            nextState,
+                        );
+                    if (incremental) return incremental;
+                }
+                return synchronizeCanonicalChatProjection(nextState);
             };
 
             if (replace) {
@@ -11096,14 +11369,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 // Don't create the message yet — it will be created lazily
                 // on the first delta so it appears in chronological order
                 // (after thinking and tool messages).
+                const streamingSession = {
+                    ...nextSession,
+                    status: "streaming" as const,
+                };
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: {
-                            ...nextSession,
-                            status: "streaming",
-                        },
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        streamingSession,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         session_id,
@@ -11127,10 +11402,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const nextSession = markSessionStreamingIfLive(session);
                 if (nextSession === session) return state;
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: nextSession,
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        nextSession,
+                    ),
                 };
             });
             bufferMessageDelta(session_id, message_id, delta, messageRole);
@@ -11162,10 +11438,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     );
                     if (nextSession === session) return state;
                     return {
-                        sessionsById: {
-                            ...state.sessionsById,
-                            [session_id]: nextSession,
-                        },
+                        sessionsById: replaceSessionById(
+                            state.sessionsById,
+                            session_id,
+                            nextSession,
+                        ),
                     };
                 });
                 persistCurrentSession(session_id);
@@ -11194,10 +11471,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: nextSession,
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        nextSession,
+                    ),
                     queuedMessagesBySessionId: activeQueuedMessage
                         ? cleanupQueuedMessagesBySessionId(
                               state.queuedMessagesBySessionId,
@@ -11244,26 +11522,28 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     nextSession.messageIndexById?.[message_id] != null;
                 if (exists) return state;
 
-                return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: appendSessionMessage(
-                            {
-                                ...nextSession,
-                                status: "streaming",
-                            },
-                            {
-                                id: message_id,
-                                role: "assistant",
-                                kind: "thinking",
-                                content: "",
-                                workCycleId: nextSession.activeWorkCycleId,
-                                title: "Thinking",
-                                timestamp: Date.now(),
-                                inProgress: true,
-                            },
-                        ),
+                const thinkingSession = appendSessionMessage(
+                    {
+                        ...nextSession,
+                        status: "streaming",
                     },
+                    {
+                        id: message_id,
+                        role: "assistant",
+                        kind: "thinking",
+                        content: "",
+                        workCycleId: nextSession.activeWorkCycleId,
+                        title: "Thinking",
+                        timestamp: Date.now(),
+                        inProgress: true,
+                    },
+                );
+                return {
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        thinkingSession,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         session_id,
@@ -11283,10 +11563,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const nextSession = markSessionStreamingIfLive(session);
                 if (nextSession === session) return state;
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: nextSession,
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        nextSession,
+                    ),
                 };
             });
             bufferThinkingDelta(session_id, message_id, delta);
@@ -11302,15 +11583,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const session = state.sessionsById[session_id];
                 if (!session) return state;
 
+                const nextSession = setMessageInProgressState(
+                    session,
+                    message_id,
+                    false,
+                );
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [session_id]: setMessageInProgressState(
-                            session,
-                            message_id,
-                            false,
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        session_id,
+                        nextSession,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         session_id,
@@ -11407,14 +11690,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     },
                 };
 
+                const activitySession = upsertSessionActivityMessage(
+                    consolidated,
+                    nextMessage,
+                );
+
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionActivityMessage(
-                            consolidated,
-                            nextMessage,
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        activitySession,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11473,14 +11759,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const session = state.sessionsById[payload.session_id];
                 if (!session) return state;
 
+                const nextSession = upsertSessionStatusMessage(
+                    session,
+                    payload,
+                );
+
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionStatusMessage(
-                            session,
-                            payload,
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        nextSession,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11509,19 +11798,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     ...createImageGenerationMessage(payload),
                     workCycleId: nextSession.activeWorkCycleId,
                 };
+                const sessionWithImage = upsertSessionMessage(
+                    nextSession,
+                    nextMessage,
+                    {
+                        preserveTimestamp: true,
+                        preserveWorkCycleId: true,
+                    },
+                );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionMessage(
-                            nextSession,
-                            nextMessage,
-                            {
-                                preserveTimestamp: true,
-                                preserveWorkCycleId: true,
-                            },
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        sessionWithImage,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11549,19 +11840,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     ...createPlanMessage(payload),
                     workCycleId: nextSession.activeWorkCycleId,
                 };
+                const sessionWithPlan = upsertSessionMessage(
+                    nextSession,
+                    nextMessage,
+                    {
+                        preserveTimestamp: true,
+                        preserveWorkCycleId: true,
+                    },
+                );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionMessage(
-                            nextSession,
-                            nextMessage,
-                            {
-                                preserveTimestamp: true,
-                                preserveWorkCycleId: true,
-                            },
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        sessionWithPlan,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11663,21 +11956,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         target: payload.target ?? null,
                     },
                 };
+                const sessionWithPermission = upsertSessionMessage(
+                    {
+                        ...sessionWithBuffer,
+                        status: "waiting_permission",
+                    },
+                    nextMessage,
+                    {
+                        preserveWorkCycleId: true,
+                    },
+                );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionMessage(
-                            {
-                                ...sessionWithBuffer,
-                                status: "waiting_permission",
-                            },
-                            nextMessage,
-                            {
-                                preserveWorkCycleId: true,
-                            },
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        sessionWithPermission,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11716,21 +12011,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         status: "pending",
                     },
                 };
+                const sessionWithUserInput = upsertSessionMessage(
+                    {
+                        ...nextSession,
+                        status: "waiting_user_input",
+                    },
+                    nextMessage,
+                    {
+                        preserveWorkCycleId: true,
+                    },
+                );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionMessage(
-                            {
-                                ...nextSession,
-                                status: "waiting_user_input",
-                            },
-                            nextMessage,
-                            {
-                                preserveWorkCycleId: true,
-                            },
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        sessionWithUserInput,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,
@@ -11754,26 +12051,28 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const status = payload.status ?? "pending";
 
                 if (status === "completed") {
+                    const completedSession =
+                        updateUrlElicitationMessageState(
+                            {
+                                ...nextSession,
+                                status:
+                                    nextSession.status ===
+                                    "waiting_user_input"
+                                        ? "streaming"
+                                        : nextSession.status,
+                            },
+                            payload.request_id,
+                            {
+                                status: "completed",
+                                completedByRuntime: true,
+                            },
+                        );
                     return {
-                        sessionsById: {
-                            ...state.sessionsById,
-                            [payload.session_id]:
-                                updateUrlElicitationMessageState(
-                                    {
-                                        ...nextSession,
-                                        status:
-                                            nextSession.status ===
-                                            "waiting_user_input"
-                                                ? "streaming"
-                                                : nextSession.status,
-                                    },
-                                    payload.request_id,
-                                    {
-                                        status: "completed",
-                                        completedByRuntime: true,
-                                    },
-                                ),
-                        },
+                        sessionsById: replaceSessionById(
+                            state.sessionsById,
+                            payload.session_id,
+                            completedSession,
+                        ),
                         sessionOrder: touchSessionOrder(
                             state.sessionOrder,
                             payload.session_id,
@@ -11799,21 +12098,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         toolCallId: payload.tool_call_id ?? null,
                     },
                 };
+                const sessionWithUrlRequest = upsertSessionMessage(
+                    {
+                        ...nextSession,
+                        status: "waiting_user_input",
+                    },
+                    nextMessage,
+                    {
+                        preserveWorkCycleId: true,
+                    },
+                );
 
                 return {
-                    sessionsById: {
-                        ...state.sessionsById,
-                        [payload.session_id]: upsertSessionMessage(
-                            {
-                                ...nextSession,
-                                status: "waiting_user_input",
-                            },
-                            nextMessage,
-                            {
-                                preserveWorkCycleId: true,
-                            },
-                        ),
-                    },
+                    sessionsById: replaceSessionById(
+                        state.sessionsById,
+                        payload.session_id,
+                        sessionWithUrlRequest,
+                    ),
                     sessionOrder: touchSessionOrder(
                         state.sessionOrder,
                         payload.session_id,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -12695,6 +12695,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         {
                             ...resumedSession,
                             historySessionId,
+                            conversationBindings:
+                                latestSession.conversationBindings,
                             parentSessionId:
                                 resumedSession.parentSessionId ??
                                 latestSession.parentSessionId ??

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2804,6 +2804,15 @@ function sanitizePersistedDisplayText(value?: string | null) {
         : value;
 }
 
+function sessionHasConversationHistory(session: AIChatSession) {
+    return (
+        Math.max(
+            getSessionTranscriptLength(session),
+            session.persistedMessageCount ?? 0,
+        ) > 0
+    );
+}
+
 function buildPromptWithContextHandoff(
     session: AIChatSession,
     prompt: string,
@@ -8838,6 +8847,14 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         const requestedRuntimeId = currentItem.runtimeId ?? session.runtimeId;
         const providerSwitchRequested =
             requestedRuntimeId !== session.runtimeId;
+        if (
+            providerSwitchRequested &&
+            sessionHasConversationHistory(session)
+        ) {
+            throw new Error(
+                "This conversation cannot switch ACP providers. Start a new chat to use another provider.",
+            );
+        }
         if (providerSwitchRequested) {
             const state = get();
             const conversationId =
@@ -9044,8 +9061,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 currentItem.prompt,
                 connected.targetBinding,
                 route.startReason,
-                route.providerChanged ||
-                    session.resumeContextPending === true,
+                session.resumeContextPending === true,
             );
             currentItem = {
                 ...currentItem,
@@ -12728,6 +12744,12 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             if (!sourceSession) {
                 return;
             }
+            if (
+                selection.runtimeId !== sourceSession.runtimeId &&
+                sessionHasConversationHistory(sourceSession)
+            ) {
+                return;
+            }
 
             _pendingTurnCatalogKeyByConversationId.set(
                 conversationId,
@@ -12867,23 +12889,25 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const activeBinding = conversation.activeBindingId
                     ? currentState.bindingsById[conversation.activeBindingId]
                     : null;
+                const activeRuntimeId =
+                    activeBinding?.runtimeId ?? session.runtimeId;
                 const providerChanged =
-                    activeBinding != null &&
-                    activeBinding.runtimeId !== selection.runtimeId;
+                    activeRuntimeId !== selection.runtimeId;
                 const setupStatus =
                     currentState.setupStatusByRuntimeId[selection.runtimeId];
                 if (
                     isClaudeTerminalRuntimeId(selection.runtimeId) ||
                     (providerChanged &&
-                        (getConversationSwitchBlocker(conversation, {
-                            hasQueuedMessages:
-                                (currentState.queuedMessagesBySessionId[
-                                    sessionId
-                                ]?.length ?? 0) > 0 ||
-                                currentState.activeQueuedMessageBySessionId[
-                                    sessionId
-                                ] != null,
-                        }) != null ||
+                        (sessionHasConversationHistory(session) ||
+                            getConversationSwitchBlocker(conversation, {
+                                hasQueuedMessages:
+                                    (currentState.queuedMessagesBySessionId[
+                                        sessionId
+                                    ]?.length ?? 0) > 0 ||
+                                    currentState.activeQueuedMessageBySessionId[
+                                        sessionId
+                                    ] != null,
+                            }) != null ||
                             (setupStatus != null &&
                                 !isRuntimeSetupReady(setupStatus))))
                 ) {
@@ -13174,10 +13198,14 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const activeBinding = conversation.activeBindingId
                 ? state.bindingsById[conversation.activeBindingId]
                 : null;
+            const activeRuntimeId =
+                activeBinding?.runtimeId ?? session.runtimeId;
             const providerChanged =
-                activeBinding != null &&
-                activeBinding.runtimeId !== selection.runtimeId;
+                activeRuntimeId !== selection.runtimeId;
             if (providerChanged) {
+                if (sessionHasConversationHistory(session)) {
+                    return;
+                }
                 const blocker = getConversationSwitchBlocker(conversation, {
                     hasQueuedMessages:
                         (state.queuedMessagesBySessionId[sessionId]?.length ??
@@ -13239,10 +13267,15 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const conversationId =
                 resolveConversationId(get(), resolvedSessionId) ??
                 session.historySessionId;
-            const selection =
+            const requestedSelection =
                 _pendingTurnSelectionByConversationId.get(conversationId) ??
                 updateConversationBindingsFromLegacySession(session)
                     .preferredSelection;
+            const selection =
+                requestedSelection.runtimeId !== session.runtimeId &&
+                sessionHasConversationHistory(session)
+                    ? getConversationSelection(session)
+                    : requestedSelection;
             const providerChanged = selection.runtimeId !== session.runtimeId;
 
             if (

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -175,6 +175,7 @@ import {
     planConversationTurnRoute,
     type ConversationTurnRoute,
 } from "../conversationTurnRouting";
+import type { PreparedConversationTurnCatalog } from "../conversationPickerModel";
 import {
     deserializeConversationBindings,
     forkConversationBindings,
@@ -1581,6 +1582,10 @@ interface ChatStore {
     runtimeConnectionByRuntimeId: Record<string, AIRuntimeConnectionState>;
     setupStatusByRuntimeId: Record<string, AIRuntimeSetupStatus>;
     runtimes: AIRuntimeDescriptor[];
+    preparedTurnCatalogByConversationId: Record<
+        string,
+        PreparedConversationTurnCatalog
+    >;
     /** Canonical chat authority. AIChatSession below is a compatibility view. */
     conversationsById: Record<string, AIConversation>;
     bindingsById: Record<string, AcpConversationBinding>;
@@ -1765,6 +1770,10 @@ interface ChatStore {
         conversationId: string,
         selection: ConversationSelection,
     ) => void;
+    prepareConversationTurnCatalog: (
+        conversationId: string,
+        selection: ConversationSelection,
+    ) => Promise<void>;
     startConversationTurn: (
         conversationId: string,
         selection: ConversationSelection,
@@ -7170,6 +7179,18 @@ const _pendingTurnSelectionByConversationId = new Map<
     string,
     ConversationSelection
 >();
+const _pendingTurnCatalogKeyByConversationId = new Map<string, string>();
+// Keep probe ids on globalThis so Vite HMR cannot forget them while an async
+// ACP probe is running. Session-created/list events must never project these
+// implementation-detail sessions as user-visible conversations.
+const turnCatalogProbeGlobal = globalThis as typeof globalThis & {
+    __neverwriteTurnCatalogProbeSessionIds?: Set<string>;
+};
+const _turnCatalogProbeSessionIds =
+    turnCatalogProbeGlobal.__neverwriteTurnCatalogProbeSessionIds ??
+    new Set<string>();
+turnCatalogProbeGlobal.__neverwriteTurnCatalogProbeSessionIds =
+    _turnCatalogProbeSessionIds;
 type PendingConversationTurnEventRoute = {
     sourceSessionId: string;
     token: string;
@@ -7184,6 +7205,14 @@ let _sessionPersistenceEpoch = 0;
 
 function getSessionPersistenceKey(session: AIChatSession) {
     return session.historySessionId || session.sessionId;
+}
+
+function getPreparedTurnCatalogKey(
+    selection: Pick<ConversationSelection, "runtimeId" | "modelId">,
+) {
+    // ACP options can change with the model, so a runtime-only cache key would
+    // incorrectly reuse reasoning or service-tier choices across models.
+    return `${selection.runtimeId}\u0000${selection.modelId}`;
 }
 
 async function persistSessionNow(session: AIChatSession) {
@@ -9487,6 +9516,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         runtimeConnectionByRuntimeId: {},
         setupStatusByRuntimeId: {},
         runtimes: [],
+        preparedTurnCatalogByConversationId: {},
         sessionsById: {},
         sessionOrder: [],
         pendingAvailableCommandsBySessionId: {},
@@ -9807,7 +9837,12 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 } else if (!get().historyStorageVaultPath) {
                     set({ historyStorageStatus: null });
                 }
-                const sessions = await aiListSessions(vaultPath);
+                // Initialization can overlap a probe during HMR. Filter it at
+                // inventory ingestion as well as at event ingestion below.
+                const sessions = (await aiListSessions(vaultPath)).filter(
+                    (session) =>
+                        !_turnCatalogProbeSessionIds.has(session.sessionId),
+                );
                 const hydratedRuntimes = hydrateRuntimesFromSessions(
                     runtimes,
                     sessions,
@@ -10420,6 +10455,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         },
 
         upsertSession: (session, activate = false, options = {}) => {
+            // Probe sessions exist only to obtain model-dependent config and
+            // must not enter the canonical conversation projection.
+            if (_turnCatalogProbeSessionIds.has(session.sessionId)) {
+                return;
+            }
             let shouldDrainQueue = false;
             let sessionToPersist: AIChatSession | null = null;
             set((state) => {
@@ -12647,6 +12687,153 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             });
         },
 
+        prepareConversationTurnCatalog: async (conversationId, selection) => {
+            const requestKey = getPreparedTurnCatalogKey(selection);
+            const prepared =
+                get().preparedTurnCatalogByConversationId[conversationId];
+            if (
+                (prepared &&
+                    getPreparedTurnCatalogKey(prepared) === requestKey) ||
+                _pendingTurnCatalogKeyByConversationId.get(conversationId) ===
+                    requestKey
+            ) {
+                return;
+            }
+
+            const state = get();
+            const runtime = state.runtimes.find(
+                (candidate) => candidate.runtime.id === selection.runtimeId,
+            );
+            if (
+                !runtime?.runtime.capabilities.includes("create_session")
+            ) {
+                return;
+            }
+            const sessionId =
+                state.sessionIdByConversationId[conversationId] ??
+                resolveLegacySessionId(state, conversationId);
+            const sourceSession = sessionId
+                ? state.sessionsById[sessionId]
+                : null;
+            if (!sourceSession) {
+                return;
+            }
+
+            _pendingTurnCatalogKeyByConversationId.set(
+                conversationId,
+                requestKey,
+            );
+            let probeSessionId: string | null = null;
+            try {
+                const vaultPath =
+                    sourceSession.vaultPath ??
+                    useVaultStore.getState().vaultPath ??
+                    null;
+                const probeSession = await aiCreateSession(
+                    selection.runtimeId,
+                    vaultPath,
+                    sourceSession.additionalRoots ?? [],
+                );
+                probeSessionId = probeSession.sessionId;
+                _turnCatalogProbeSessionIds.add(probeSessionId);
+                // Configure the probe exactly like the eventual turn. Several
+                // ACPs reveal reasoning and service-tier options only after the
+                // target model has been selected.
+                const configuredSession =
+                    await configureConversationTurnSession(
+                        probeSession,
+                        selection,
+                    );
+
+                if (
+                    _pendingTurnCatalogKeyByConversationId.get(
+                        conversationId,
+                    ) !== requestKey
+                ) {
+                    // A newer selection won the race; never publish stale
+                    // options from the superseded probe.
+                    return;
+                }
+                const currentConversation =
+                    get().conversationsById[conversationId];
+                if (
+                    !currentConversation ||
+                    getPreparedTurnCatalogKey(
+                        currentConversation.preferredSelection,
+                    ) !== requestKey
+                ) {
+                    return;
+                }
+
+                set((currentState) => ({
+                    preparedTurnCatalogByConversationId: {
+                        ...currentState.preparedTurnCatalogByConversationId,
+                        [conversationId]: {
+                            runtimeId: selection.runtimeId,
+                            modelId: selection.modelId,
+                            models: configuredSession.models,
+                            modes: configuredSession.modes,
+                            configOptions: configuredSession.configOptions,
+                            effortsByModel:
+                                configuredSession.effortsByModel ?? {},
+                        },
+                    },
+                }));
+            } catch (error) {
+                logWarn(
+                    "chat-store",
+                    `Failed to prepare turn catalog for ${selection.runtimeId}`,
+                    error,
+                );
+            } finally {
+                if (probeSessionId) {
+                    await aiDeleteRuntimeSession(probeSessionId).catch(
+                        () => {},
+                    );
+                    const sessionIdToRemove = probeSessionId;
+                    // The event bridge normally ignores probe sessions, but a
+                    // hot reload can race with creation. Remove any leaked
+                    // compatibility projection defensively after cleanup.
+                    set((currentState) => {
+                        if (!currentState.sessionsById[sessionIdToRemove]) {
+                            return currentState;
+                        }
+                        const sessionsById = {
+                            ...currentState.sessionsById,
+                        };
+                        delete sessionsById[sessionIdToRemove];
+                        return {
+                            sessionsById,
+                            sessionOrder: currentState.sessionOrder.filter(
+                                (sessionId) =>
+                                    sessionId !== sessionIdToRemove,
+                            ),
+                            activeSessionId:
+                                currentState.activeSessionId ===
+                                sessionIdToRemove
+                                    ? sourceSession.sessionId
+                                    : currentState.activeSessionId,
+                            lastFocusedSessionId:
+                                currentState.lastFocusedSessionId ===
+                                sessionIdToRemove
+                                    ? sourceSession.sessionId
+                                    : currentState.lastFocusedSessionId,
+                        };
+                    });
+                    _turnCatalogProbeSessionIds.delete(probeSessionId);
+                }
+                if (
+                    _pendingTurnCatalogKeyByConversationId.get(
+                        conversationId,
+                    ) === requestKey
+                ) {
+                    _pendingTurnCatalogKeyByConversationId.delete(
+                        conversationId,
+                    );
+                }
+            }
+        },
+
         setConversationTurnSelection: (conversationId, selection) => {
             const state = get();
             const sessionId =
@@ -12696,6 +12883,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const bindings =
                     updateConversationBindingsFromLegacySession(session);
                 const previous = bindings.preferredSelection;
+                const preparedCatalog =
+                    currentState.preparedTurnCatalogByConversationId[
+                        conversationId
+                    ];
+                const clearPreparedCatalog =
+                    preparedCatalog != null &&
+                    getPreparedTurnCatalogKey(preparedCatalog) !==
+                        getPreparedTurnCatalogKey(selection);
+                // Preserve the catalog when only effort/tier values change;
+                // invalidate it only when provider or model changes.
                 const optionKeys = new Set([
                     ...Object.keys(previous.options),
                     ...Object.keys(selection.options),
@@ -12728,6 +12925,15 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                             },
                         },
                     },
+                    ...(clearPreparedCatalog
+                        ? {
+                              preparedTurnCatalogByConversationId:
+                                  removeSessionMapEntry(
+                                      currentState.preparedTurnCatalogByConversationId,
+                                      conversationId,
+                                  ),
+                          }
+                        : {}),
                 };
             });
             if (changed) persistCurrentSession(sessionId);
@@ -15717,6 +15923,8 @@ export function resetChatStore() {
     _queueDrainLocks.clear();
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
+    _pendingTurnCatalogKeyByConversationId.clear();
+    _turnCatalogProbeSessionIds.clear();
     _pendingConversationTurnEventRouteBySessionId.clear();
     _pendingSessionPersistence.clear();
     _deltaBuffer.messageDelta.clear();
@@ -15735,6 +15943,7 @@ export function resetChatStore() {
         runtimeConnectionByRuntimeId: {},
         setupStatusByRuntimeId: {},
         runtimes: [],
+        preparedTurnCatalogByConversationId: {},
         sessionsById: {},
         sessionOrder: [],
         pendingAvailableCommandsBySessionId: {},
@@ -15790,6 +15999,8 @@ export function disposeChatStoreRuntime() {
     chatRuntimeInitialized = false;
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
+    _pendingTurnCatalogKeyByConversationId.clear();
+    _turnCatalogProbeSessionIds.clear();
     _pendingConversationTurnEventRouteBySessionId.clear();
     clearTrackedPersistedReconciliationTimers();
 }

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -159,6 +159,11 @@ import {
 } from "../types";
 import { isCancellableChatTurnStatus } from "../chatTurnStatus";
 import {
+    deserializeConversationBindings,
+    serializeConversationBindings,
+    updateConversationBindingsFromLegacySession,
+} from "../conversationModel";
+import {
     getLastTranscriptMessage,
     getSessionTranscriptLength,
     getSessionTranscriptMessages,
@@ -5912,6 +5917,11 @@ function applyPersistedHistoryMetadata(
             persistedPreview: sanitizePersistedDisplayText(history.preview),
             persistedMessageCount,
             loadedPersistedMessageStart,
+            conversationBindings: history.conversation_bindings
+                ? deserializeConversationBindings(
+                      history.conversation_bindings,
+                  )
+                : nextSession.conversationBindings,
         },
         persistedCatalog,
     );
@@ -6072,6 +6082,11 @@ function createPersistedSession(
                         )
                       : null,
             isLoadingPersistedMessages: false,
+            conversationBindings: history.conversation_bindings
+                ? deserializeConversationBindings(
+                      history.conversation_bindings,
+                  )
+                : undefined,
         },
         runtime,
     );
@@ -6649,6 +6664,18 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
             plan_entries: m.planEntries,
             plan_detail: m.planDetail,
             tool_action: m.toolAction,
+            turn_provenance: m.turnProvenance
+                ? {
+                      binding_id: m.turnProvenance.bindingId,
+                      runtime_id: m.turnProvenance.runtimeId,
+                      runtime_session_id:
+                          m.turnProvenance.runtimeSessionId,
+                      model_id: m.turnProvenance.modelId,
+                      mode_id: m.turnProvenance.modeId,
+                      options: m.turnProvenance.options,
+                      start_reason: m.turnProvenance.startReason,
+                  }
+                : undefined,
         }));
 
     const timestamps = messages.map((m) => m.timestamp);
@@ -6661,6 +6688,17 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
         timestamps.length > 0
             ? Math.max(session.persistedUpdatedAt ?? 0, ...timestamps)
             : (session.persistedUpdatedAt ?? Date.now());
+
+    const conversationBindings = updateConversationBindingsFromLegacySession({
+        ...session,
+        persistedMessageCount: messageCount,
+        persistedUpdatedAt: updatedAt,
+    });
+    conversationBindings.transcriptObservation = {
+        ...conversationBindings.transcriptObservation,
+        messageCount,
+        updatedAt,
+    };
 
     return {
         version: 1,
@@ -6720,6 +6758,8 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
         custom_title: session.customTitle ?? undefined,
         preview: getSessionPreview(session),
         messages,
+        conversation_bindings:
+            serializeConversationBindings(conversationBindings),
     };
 }
 
@@ -7360,6 +7400,18 @@ function restoreMessagesFromHistory(
                 planEntries: m.plan_entries,
                 planDetail: m.plan_detail,
                 toolAction: m.tool_action,
+                turnProvenance: m.turn_provenance
+                    ? {
+                          bindingId: m.turn_provenance.binding_id,
+                          runtimeId: m.turn_provenance.runtime_id,
+                          runtimeSessionId:
+                              m.turn_provenance.runtime_session_id,
+                          modelId: m.turn_provenance.model_id,
+                          modeId: m.turn_provenance.mode_id,
+                          options: m.turn_provenance.options,
+                          startReason: m.turn_provenance.start_reason,
+                      }
+                    : undefined,
             }),
         )
         .filter((message) => !isInternalRuntimeUserEchoMessage(message));

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -3448,6 +3448,17 @@ function migrateSessionLocalState(
     return true;
 }
 
+function normalizeResumedSessionWorkCycle(
+    session: AIChatSession,
+    visibleWorkCycleId: string | null | undefined,
+): AIChatSession {
+    return {
+        ...session,
+        activeWorkCycleId: null,
+        visibleWorkCycleId: visibleWorkCycleId ?? null,
+    };
+}
+
 function registerOpenEditorBaselines(sessionId: string) {
     const session = useChatStore.getState().sessionsById[sessionId];
     if (!session || !isLiveRuntimeSession(session)) {
@@ -12235,7 +12246,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     );
                 }
 
-                const migratedSession = startNewWorkCycle(
+                const migratedSession = normalizeResumedSessionWorkCycle(
                     replaceSessionTranscript(
                         {
                             ...resumedSession,
@@ -12285,6 +12296,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                                 !isTransientRecoveryStatusMessage(message),
                         ),
                     ),
+                    latestSession.visibleWorkCycleId,
                 );
 
                 migrateSessionLocalState(sessionId, migratedSession);

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -1761,6 +1761,10 @@ interface ChatStore {
         sessionId?: string,
     ) => Promise<void>;
     setComposerParts: (parts: AIComposerPart[], sessionId?: string) => void;
+    setConversationTurnSelection: (
+        conversationId: string,
+        selection: ConversationSelection,
+    ) => void;
     startConversationTurn: (
         conversationId: string,
         selection: ConversationSelection,
@@ -2929,6 +2933,9 @@ function commitAcceptedConversationTurn(input: {
         modeId: targetBinding.modeId,
         options: { ...targetBinding.options },
         startReason: input.route.startReason,
+        handoffTruncated: input.contextHandoff?.truncated ?? false,
+        handoffOmittedTurnCount:
+            input.contextHandoff?.omittedTurnCount ?? 0,
     };
     const attributedSource = replaceSessionMessage(
         input.sourceSession,
@@ -6886,6 +6893,19 @@ function toPersistedHistory(session: AIChatSession): PersistedSessionHistory {
                       mode_id: m.turnProvenance.modeId,
                       options: m.turnProvenance.options,
                       start_reason: m.turnProvenance.startReason,
+                      ...(m.turnProvenance.handoffTruncated !== undefined
+                          ? {
+                                handoff_truncated:
+                                    m.turnProvenance.handoffTruncated,
+                            }
+                          : {}),
+                      ...(m.turnProvenance.handoffOmittedTurnCount !== undefined
+                          ? {
+                                handoff_omitted_turn_count:
+                                    m.turnProvenance
+                                        .handoffOmittedTurnCount,
+                            }
+                          : {}),
                   }
                 : undefined,
         }));
@@ -7626,6 +7646,11 @@ function restoreMessagesFromHistory(
                           modeId: m.turn_provenance.mode_id,
                           options: m.turn_provenance.options,
                           startReason: m.turn_provenance.start_reason,
+                          handoffTruncated:
+                              m.turn_provenance.handoff_truncated,
+                          handoffOmittedTurnCount:
+                              m.turn_provenance
+                                  .handoff_omitted_turn_count,
                       }
                     : undefined,
             }),
@@ -12337,6 +12362,92 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         : {}),
                 };
             });
+        },
+
+        setConversationTurnSelection: (conversationId, selection) => {
+            const state = get();
+            const sessionId =
+                state.sessionIdByConversationId[conversationId] ??
+                resolveLegacySessionId(state, conversationId);
+            if (!sessionId) return;
+
+            let changed = false;
+            set((currentState) => {
+                const session = currentState.sessionsById[sessionId];
+                const conversation =
+                    currentState.conversationsById[conversationId];
+                const runtime = currentState.runtimes.find(
+                    (candidate) =>
+                        candidate.runtime.id === selection.runtimeId,
+                );
+                if (!session || !conversation || !runtime) {
+                    return currentState;
+                }
+
+                const activeBinding = conversation.activeBindingId
+                    ? currentState.bindingsById[conversation.activeBindingId]
+                    : null;
+                const providerChanged =
+                    activeBinding != null &&
+                    activeBinding.runtimeId !== selection.runtimeId;
+                const setupStatus =
+                    currentState.setupStatusByRuntimeId[selection.runtimeId];
+                if (
+                    isClaudeTerminalRuntimeId(selection.runtimeId) ||
+                    (providerChanged &&
+                        (getConversationSwitchBlocker(conversation, {
+                            hasQueuedMessages:
+                                (currentState.queuedMessagesBySessionId[
+                                    sessionId
+                                ]?.length ?? 0) > 0 ||
+                                currentState.activeQueuedMessageBySessionId[
+                                    sessionId
+                                ] != null,
+                        }) != null ||
+                            (setupStatus != null &&
+                                !isRuntimeSetupReady(setupStatus))))
+                ) {
+                    return currentState;
+                }
+
+                const bindings =
+                    updateConversationBindingsFromLegacySession(session);
+                const previous = bindings.preferredSelection;
+                const optionKeys = new Set([
+                    ...Object.keys(previous.options),
+                    ...Object.keys(selection.options),
+                ]);
+                if (
+                    previous.runtimeId === selection.runtimeId &&
+                    previous.modelId === selection.modelId &&
+                    previous.modeId === selection.modeId &&
+                    [...optionKeys].every(
+                        (key) =>
+                            previous.options[key] === selection.options[key],
+                    )
+                ) {
+                    return currentState;
+                }
+
+                changed = true;
+                return {
+                    sessionsById: {
+                        ...currentState.sessionsById,
+                        [sessionId]: {
+                            ...session,
+                            conversationBindings: {
+                                ...bindings,
+                                revision: bindings.revision + 1,
+                                preferredSelection: {
+                                    ...selection,
+                                    options: { ...selection.options },
+                                },
+                            },
+                        },
+                    },
+                };
+            });
+            if (changed) persistCurrentSession(sessionId);
         },
 
         enqueueMessage: (sessionId, item) =>

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -8922,6 +8922,9 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         selection: ConversationSelection,
     ) {
         let session = initialSession;
+        const initiallyAvailableOptionIds = new Set(
+            initialSession.configOptions.map((option) => option.id),
+        );
         if (
             selection.modelId &&
             selection.modelId !==
@@ -8947,8 +8950,29 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             session = await aiSetMode(session.sessionId, selection.modeId);
         }
 
+        const effectiveSelection = {
+            ...selection,
+            options: Object.fromEntries(
+                Object.entries(selection.options).filter(([optionId]) => {
+                    const isAvailable = session.configOptions.some(
+                        (option) => option.id === optionId,
+                    );
+                    // ACP option catalogs may change after selecting a model.
+                    // An option that was valid for the session's initial model
+                    // is no longer part of the requested selection when the
+                    // target model removes it. Truly unknown option ids remain
+                    // strict and are rejected by the validation below.
+                    return (
+                        isAvailable ||
+                        !initiallyAvailableOptionIds.has(optionId)
+                    );
+                }),
+            ),
+        };
         const modelOptionId = getModelConfigOption(session)?.id ?? null;
-        for (const [optionId, value] of Object.entries(selection.options)) {
+        for (const [optionId, value] of Object.entries(
+            effectiveSelection.options,
+        )) {
             const option = session.configOptions.find(
                 (candidate) => candidate.id === optionId,
             );
@@ -8968,21 +8992,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             );
         }
 
-        const appliedSelection = getConversationSelection(session);
-        if (appliedSelection.runtimeId !== selection.runtimeId) {
+        const actualSelection = getConversationSelection(session);
+        if (actualSelection.runtimeId !== effectiveSelection.runtimeId) {
             throw new Error("The selected ACP provider was not applied.");
         }
-        if (appliedSelection.modelId !== selection.modelId) {
+        if (actualSelection.modelId !== effectiveSelection.modelId) {
             throw new Error(
-                `The selected model is unavailable: ${selection.modelId}`,
+                `The selected model is unavailable: ${effectiveSelection.modelId}`,
             );
         }
-        if (appliedSelection.modeId !== selection.modeId) {
+        if (actualSelection.modeId !== effectiveSelection.modeId) {
             throw new Error(
-                `The selected mode is unavailable: ${selection.modeId}`,
+                `The selected mode is unavailable: ${effectiveSelection.modeId}`,
             );
         }
-        for (const [optionId, value] of Object.entries(selection.options)) {
+        for (const [optionId, value] of Object.entries(
+            effectiveSelection.options,
+        )) {
             const option = session.configOptions.find(
                 (candidate) => candidate.id === optionId,
             );
@@ -8997,7 +9023,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 );
             }
         }
-        return session;
+        return { session, selection: effectiveSelection };
     }
 
     function sessionCanApplyConversationSelection(
@@ -9044,21 +9070,47 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         runtime: AIRuntimeDescriptor,
         session: AIChatSession,
         requestedSelection: ConversationSelection,
+        sourceSession: AIChatSession,
     ) {
+        const targetOptionIds = new Set(
+            session.configOptions.map((option) => option.id),
+        );
+        const knownCatalogOptionIds = new Set([
+            ...runtime.configOptions.map((option) => option.id),
+            ...sourceSession.configOptions.map((option) => option.id),
+        ]);
+        const normalizedSelection = {
+            ...requestedSelection,
+            options: Object.fromEntries(
+                Object.entries(requestedSelection.options).filter(
+                    ([optionId]) =>
+                        targetOptionIds.has(optionId) ||
+                        !knownCatalogOptionIds.has(optionId),
+                ),
+            ),
+        };
         if (
             sessionCanApplyConversationSelection(
                 session,
-                requestedSelection,
+                normalizedSelection,
             )
         ) {
-            return requestedSelection;
+            return normalizedSelection;
         }
 
         const descriptorDefault = getDefaultConversationSelection({ runtime });
+        const liveDescriptorDefault = {
+            ...descriptorDefault,
+            options: Object.fromEntries(
+                Object.entries(descriptorDefault.options).filter(
+                    ([optionId]) => targetOptionIds.has(optionId),
+                ),
+            ),
+        };
         if (
             conversationSelectionsEqual(
-                requestedSelection,
-                descriptorDefault,
+                normalizedSelection,
+                liveDescriptorDefault,
             )
         ) {
             // Runtime descriptors are only bootstrap metadata. In particular,
@@ -9070,7 +9122,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
 
         // Explicit user selections remain strict. The normal configuration
         // path below will report which requested value is unavailable.
-        return requestedSelection;
+        return normalizedSelection;
     }
 
     async function connectCustomConversationBinding(
@@ -9201,19 +9253,22 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             created = true;
         }
 
-        const resolvedSelection = created
+        let resolvedSelection = created
             ? resolveDiscoveredConversationSelection(
                   runtime,
                   runtimeSession,
                   input.route.selection,
+                  input.sourceSession,
               )
             : input.route.selection;
 
         try {
-            runtimeSession = await configureConversationTurnSession(
+            const configured = await configureConversationTurnSession(
                 runtimeSession,
                 resolvedSelection,
             );
+            runtimeSession = configured.session;
+            resolvedSelection = configured.selection;
         } catch (error) {
             if (created) {
                 await aiDeleteRuntimeSession(runtimeSession.sessionId).catch(
@@ -13284,22 +13339,24 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 );
                 probeSessionId = probeSession.sessionId;
                 _turnCatalogProbeSessionIds.add(probeSessionId);
-                const resolvedSelection =
+                const discoveredSelection =
                     resolveDiscoveredConversationSelection(
                         runtime,
                         probeSession,
                         selection,
+                        sourceSession,
                     );
                 // Configure the probe exactly like the eventual turn. Several
                 // ACPs reveal reasoning and service-tier options only after the
                 // target model has been selected. Bootstrap descriptor values
                 // are resolved from the live catalog first, so a synthetic
                 // `auto` model cannot prevent discovery from completing.
-                const configuredSession =
-                    await configureConversationTurnSession(
-                        probeSession,
-                        resolvedSelection,
-                    );
+                const configured = await configureConversationTurnSession(
+                    probeSession,
+                    discoveredSelection,
+                );
+                const configuredSession = configured.session;
+                const resolvedSelection = configured.selection;
 
                 if (
                     _pendingTurnCatalogKeyByConversationId.get(

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -9493,14 +9493,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         currentItem,
                     )) ?? session;
                 if (!session) return;
-            } else if (!hasFullPersistedTranscriptLoaded(session)) {
+            }
+
+            const transcriptIsPersistedButUnloaded =
+                (session.persistedMessageCount ?? 0) > 0 &&
+                getSessionTranscriptMessages(session).length === 0;
+            if (
+                transcriptIsPersistedButUnloaded ||
+                (initialProviderChangeRequested &&
+                    !hasFullPersistedTranscriptLoaded(session))
+            ) {
                 const loaded = await loadPersistedTranscript(
                     activeSessionId,
                     "full",
                 );
                 if (!loaded) {
                     throw new Error(
-                        "Failed to load the canonical transcript before changing ACP provider.",
+                        "Failed to load the canonical transcript before routing the conversation turn.",
                     );
                 }
                 session = get().sessionsById[activeSessionId] ?? session;
@@ -9575,7 +9584,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 currentItem.prompt,
                 connected.targetBinding,
                 route.startReason,
-                session.resumeContextPending === true,
+                session.resumeContextPending === true ||
+                    route.startReason === "transcript_handoff",
             );
             currentItem = {
                 ...currentItem,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -20,6 +20,7 @@ import {
     aiListSessions,
     aiListRuntimes,
     aiResumeRuntimeSession,
+    aiLoadRuntimeSession,
     aiLoadSession,
     aiLoadSessionHistoryPage,
     aiLoadSessionHistories,
@@ -31,6 +32,7 @@ import {
     aiSaveSessionHistory,
     aiSendMessage,
     aiStartAuth,
+    aiStartConversationTurn,
     aiSetConfigOption,
     aiSetMode,
     aiSetModel,
@@ -159,6 +161,8 @@ import {
     type ManagedAttachmentId,
     type QueuedChatMessage,
     type QueuedChatMessageStatus,
+    type ConversationSelection,
+    type ConversationTurnProvenance,
 } from "../types";
 import {
     ACP_HANDOFF_PROMPT_HEADER,
@@ -168,8 +172,14 @@ import {
 } from "../contextHandoff";
 import { isCancellableChatTurnStatus } from "../chatTurnStatus";
 import {
+    planConversationTurnRoute,
+    type ConversationTurnRoute,
+} from "../conversationTurnRouting";
+import {
     deserializeConversationBindings,
     forkConversationBindings,
+    getConversationSelection,
+    getConversationSwitchBlocker,
     serializeConversationBindings,
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
@@ -1751,6 +1761,10 @@ interface ChatStore {
         sessionId?: string,
     ) => Promise<void>;
     setComposerParts: (parts: AIComposerPart[], sessionId?: string) => void;
+    startConversationTurn: (
+        conversationId: string,
+        selection: ConversationSelection,
+    ) => Promise<void>;
     sendMessage: (sessionId?: string) => Promise<void>;
     enqueueMessage: (sessionId: string, item: QueuedChatMessage) => void;
     removeQueuedMessage: (sessionId: string, messageId: string) => void;
@@ -2173,28 +2187,37 @@ function appendSessionMessage(session: AIChatSession, message: AIChatMessage) {
     const normalized = ensurePersistedTranscriptWindowAnchor(
         normalizeSessionTranscript(session),
     );
-    const nextMessages = [...normalized.messages, message];
+    const attributedMessage =
+        message.turnProvenance || !normalized.activeTurnProvenance
+            ? message
+            : {
+                  ...message,
+                  turnProvenance: normalized.activeTurnProvenance,
+              };
+    const nextMessages = [...normalized.messages, attributedMessage];
 
     return {
         ...normalized,
         messages: nextMessages,
-        messageOrder: [...normalized.messageOrder!, message.id],
+        messageOrder: [...normalized.messageOrder!, attributedMessage.id],
         messagesById: {
             ...normalized.messagesById!,
-            [message.id]: message,
+            [attributedMessage.id]: attributedMessage,
         },
         messageIndexById: {
             ...normalized.messageIndexById!,
-            [message.id]: nextMessages.length - 1,
+            [attributedMessage.id]: nextMessages.length - 1,
         },
-        lastAssistantMessageId: isAssistantTextMessage(message)
-            ? message.id
+        lastAssistantMessageId: isAssistantTextMessage(attributedMessage)
+            ? attributedMessage.id
             : (normalized.lastAssistantMessageId ?? null),
-        lastTurnStartedMessageId: isTurnStartedStatusMessage(message)
-            ? message.id
+        lastTurnStartedMessageId: isTurnStartedStatusMessage(
+            attributedMessage,
+        )
+            ? attributedMessage.id
             : (normalized.lastTurnStartedMessageId ?? null),
-        activePlanMessageId: isIncompletePlanMessage(message)
-            ? message.id
+        activePlanMessageId: isIncompletePlanMessage(attributedMessage)
+            ? attributedMessage.id
             : (normalized.activePlanMessageId ?? null),
     };
 }
@@ -2768,22 +2791,25 @@ function sanitizePersistedDisplayText(value?: string | null) {
         : value;
 }
 
-function buildPromptWithResumeContext(session: AIChatSession, prompt: string) {
-    if (!session.resumeContextPending) {
+function buildPromptWithContextHandoff(
+    session: AIChatSession,
+    prompt: string,
+    binding: AcpConversationBinding | null,
+    reason: ConversationTurnRoute["startReason"],
+    required: boolean,
+) {
+    if (!required) {
         return { prompt, contextHandoff: undefined };
     }
 
     const bindings = updateConversationBindingsFromLegacySession(session);
-    const activeBinding = bindings.providerBindings.find(
-        (binding) => binding.bindingId === bindings.activeBindingId,
-    );
     const result = buildAcpContextHandoff({
         messages: getSessionTranscriptMessages(session),
         newUserMessage: prompt,
-        bindingId: activeBinding?.bindingId ?? null,
-        contextCursor: activeBinding?.contextCursor ?? null,
+        bindingId: binding?.bindingId ?? null,
+        contextCursor: binding?.contextCursor ?? null,
         contextSummary: bindings.contextSummary,
-        reason: "transcript_handoff",
+        reason,
     });
 
     return {
@@ -2792,40 +2818,184 @@ function buildPromptWithResumeContext(session: AIChatSession, prompt: string) {
     };
 }
 
-function acceptContextHandoff(
-    session: AIChatSession,
-    contextHandoff: AcpContextHandoffMetadata | undefined,
+function createTurnBinding(
+    conversationId: string,
+    runtimeSession: AIChatSession,
+    existing: AcpConversationBinding | null,
+    capabilities: readonly string[],
 ) {
-    if (!contextHandoff?.nextCursor || !contextHandoff.bindingId) {
-        return { ...session, resumeContextPending: false };
-    }
-
-    const bindings = updateConversationBindingsFromLegacySession(session);
-    if (bindings.activeBindingId !== contextHandoff.bindingId) {
-        return session;
-    }
-
     const now = Date.now();
-    let didAdvanceCursor = false;
+    const selection = getConversationSelection(runtimeSession);
+    return {
+        bindingId:
+            existing?.bindingId ??
+            `binding:${encodeURIComponent(conversationId)}:${encodeURIComponent(runtimeSession.runtimeId)}:${crypto.randomUUID()}`,
+        conversationId,
+        runtimeId: runtimeSession.runtimeId,
+        runtimeDisplayName: runtimeSession.runtimeDisplayName ?? null,
+        runtimeRevision: runtimeSession.runtimeRevision ?? null,
+        runtimeLaunchFingerprint:
+            runtimeSession.runtimeLaunchFingerprint ?? null,
+        runtimeSessionId: runtimeSession.runtimeSessionId ?? null,
+        continuationStrategy: runtimeSession.continuationStrategy ?? null,
+        capabilities: [...capabilities],
+        modelId: selection.modelId,
+        modeId: selection.modeId,
+        options: { ...selection.options },
+        models: runtimeSession.models,
+        modes: runtimeSession.modes,
+        configOptions: runtimeSession.configOptions,
+        availableCommands: runtimeSession.availableCommands,
+        effortsByModel: runtimeSession.effortsByModel ?? {},
+        runtimeState: runtimeSession.runtimeState ?? "live",
+        contextCursor: existing?.contextCursor ?? null,
+        contextGeneration: existing?.contextGeneration ?? 0,
+        createdAt: existing?.createdAt ?? now,
+        updatedAt: now,
+    } satisfies AcpConversationBinding;
+}
+
+function commitAcceptedConversationTurn(input: {
+    sourceSession: AIChatSession;
+    acceptedRuntimeSession: AIChatSession;
+    route: ConversationTurnRoute;
+    targetBinding: AcpConversationBinding;
+    contextHandoff?: AcpContextHandoffMetadata;
+    userMessageId: string;
+}) {
+    const bindings = updateConversationBindingsFromLegacySession(
+        input.sourceSession,
+    );
+    const acceptedSelection = getConversationSelection(
+        input.acceptedRuntimeSession,
+    );
+    const contextCursor =
+        input.contextHandoff?.bindingId === input.targetBinding.bindingId
+            ? (input.contextHandoff.nextCursor ??
+              input.targetBinding.contextCursor)
+            : input.targetBinding.contextCursor;
+    const targetBinding: AcpConversationBinding = {
+        ...input.targetBinding,
+        runtimeDisplayName:
+            input.acceptedRuntimeSession.runtimeDisplayName ??
+            input.targetBinding.runtimeDisplayName,
+        runtimeRevision:
+            input.acceptedRuntimeSession.runtimeRevision ??
+            input.targetBinding.runtimeRevision,
+        runtimeLaunchFingerprint:
+            input.acceptedRuntimeSession.runtimeLaunchFingerprint ??
+            input.targetBinding.runtimeLaunchFingerprint,
+        runtimeSessionId:
+            input.acceptedRuntimeSession.runtimeSessionId ??
+            input.targetBinding.runtimeSessionId,
+        continuationStrategy:
+            input.acceptedRuntimeSession.continuationStrategy ??
+            input.targetBinding.continuationStrategy,
+        modelId: acceptedSelection.modelId,
+        modeId: acceptedSelection.modeId,
+        options: { ...acceptedSelection.options },
+        models: input.acceptedRuntimeSession.models,
+        modes: input.acceptedRuntimeSession.modes,
+        configOptions: input.acceptedRuntimeSession.configOptions,
+        availableCommands: input.acceptedRuntimeSession.availableCommands,
+        effortsByModel:
+            input.acceptedRuntimeSession.effortsByModel ??
+            input.targetBinding.effortsByModel,
+        runtimeState: "live",
+        contextCursor,
+        updatedAt: Date.now(),
+    };
+    const providerBindings = bindings.providerBindings.some(
+        (binding) => binding.bindingId === targetBinding.bindingId,
+    )
+        ? bindings.providerBindings.map((binding) =>
+              binding.bindingId === targetBinding.bindingId
+                  ? targetBinding
+                  : binding,
+          )
+        : [...bindings.providerBindings, targetBinding];
+    const conversationBindings = {
+        ...bindings,
+        revision: bindings.revision + 1,
+        preferredSelection: acceptedSelection,
+        activeBindingId: targetBinding.bindingId,
+        providerBindings,
+    };
+    const provenance: ConversationTurnProvenance = {
+        bindingId: targetBinding.bindingId,
+        runtimeId: targetBinding.runtimeId,
+        runtimeSessionId: targetBinding.runtimeSessionId,
+        modelId: targetBinding.modelId,
+        modeId: targetBinding.modeId,
+        options: { ...targetBinding.options },
+        startReason: input.route.startReason,
+    };
+    const attributedSource = replaceSessionMessage(
+        input.sourceSession,
+        input.userMessageId,
+        (message) => ({ ...message, turnProvenance: provenance }),
+    );
+
+    return replaceSessionTranscript(
+        {
+            ...attributedSource,
+            ...input.acceptedRuntimeSession,
+            historySessionId: attributedSource.historySessionId,
+            parentSessionId: attributedSource.parentSessionId ?? null,
+            vaultPath: attributedSource.vaultPath ?? null,
+            customTitle: attributedSource.customTitle ?? null,
+            persistedTitle: attributedSource.persistedTitle ?? null,
+            persistedPreview: attributedSource.persistedPreview ?? null,
+            persistedCreatedAt: attributedSource.persistedCreatedAt ?? null,
+            persistedUpdatedAt: attributedSource.persistedUpdatedAt ?? null,
+            persistedMessageCount:
+                attributedSource.persistedMessageCount ??
+                getSessionTranscriptLength(attributedSource),
+            loadedPersistedMessageStart:
+                attributedSource.loadedPersistedMessageStart ?? 0,
+            attachments: attributedSource.attachments,
+            activeWorkCycleId: attributedSource.activeWorkCycleId ?? null,
+            visibleWorkCycleId: attributedSource.visibleWorkCycleId ?? null,
+            actionLog: attributedSource.actionLog,
+            isPersistedSession: false,
+            isResumingSession: false,
+            resumeContextPending: false,
+            runtimeState: "live",
+            conversationBindings,
+            activeTurnProvenance: provenance,
+        },
+        getSessionTranscriptMessages(attributedSource),
+    );
+}
+
+function completeActiveBindingTurn(
+    session: AIChatSession,
+    messageId: string,
+) {
+    const bindings = updateConversationBindingsFromLegacySession(session);
+    const activeBindingId = bindings.activeBindingId;
+    if (!activeBindingId) {
+        return { ...session, activeTurnProvenance: null };
+    }
+    let changed = false;
     const providerBindings = bindings.providerBindings.map((binding) => {
         if (
-            binding.bindingId !== contextHandoff.bindingId ||
-            binding.contextCursor === contextHandoff.nextCursor
+            binding.bindingId !== activeBindingId ||
+            binding.contextCursor === messageId
         ) {
             return binding;
         }
-        didAdvanceCursor = true;
+        changed = true;
         return {
             ...binding,
-            contextCursor: contextHandoff.nextCursor,
-            updatedAt: now,
+            contextCursor: messageId,
+            updatedAt: Date.now(),
         };
     });
-
     return {
         ...session,
-        resumeContextPending: false,
-        conversationBindings: didAdvanceCursor
+        activeTurnProvenance: null,
+        conversationBindings: changed
             ? {
                   ...bindings,
                   revision: bindings.revision + 1,
@@ -3227,6 +3397,7 @@ function registerOpenEditorBaselines(sessionId: string) {
 function buildQueuedMessage(
     session: AIChatSession,
     composerParts: AIComposerPart[],
+    selection: ConversationSelection,
 ): QueuedChatMessage | null {
     const composerPartsSnapshot = cloneComposerParts(composerParts);
     const content = serializeComposerParts(composerParts).trim();
@@ -3275,21 +3446,18 @@ function buildQueuedMessage(
         return null;
     }
 
-    const preparedPrompt = buildPromptWithResumeContext(session, prompt);
     return {
         id: crypto.randomUUID(),
         content,
-        prompt: preparedPrompt.prompt,
+        prompt,
         composerParts: composerPartsSnapshot,
         attachments,
         createdAt: Date.now(),
         status: "queued",
-        modelId: session.modelId ?? null,
-        modeId: session.modeId ?? null,
-        optionsSnapshot: Object.fromEntries(
-            session.configOptions.map((option) => [option.id, option.value]),
-        ),
-        contextHandoff: preparedPrompt.contextHandoff,
+        runtimeId: selection.runtimeId,
+        modelId: selection.modelId ?? null,
+        modeId: selection.modeId ?? null,
+        optionsSnapshot: { ...selection.options },
     };
 }
 
@@ -6819,6 +6987,10 @@ const _composerPreflightOwnershipBySessionId = new Map<
 >();
 const _pendingStopBySessionId = new Map<string, Promise<void>>();
 const _pendingSessionPersistence = new Map<string, AIChatSession>();
+const _pendingTurnSelectionByConversationId = new Map<
+    string,
+    ConversationSelection
+>();
 let _sessionPersistenceFlushScheduled = false;
 let _sessionPersistenceEpoch = 0;
 
@@ -8156,6 +8328,214 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         return session;
     }
 
+    async function configureConversationTurnSession(
+        initialSession: AIChatSession,
+        selection: ConversationSelection,
+    ) {
+        let session = initialSession;
+        if (
+            selection.modelId &&
+            selection.modelId !==
+                (getModelConfigOption(session)?.value ?? session.modelId) &&
+            supportsModelSelection(session, selection.modelId)
+        ) {
+            const modelConfig = getModelConfigOption(session);
+            session = modelConfig
+                ? await aiSetConfigOption(
+                      session.sessionId,
+                      modelConfig.id,
+                      selection.modelId,
+                  )
+                : await aiSetModel(session.sessionId, selection.modelId);
+        }
+        if (
+            selection.modeId &&
+            selection.modeId !== session.modeId &&
+            session.modes.some(
+                (mode) => mode.id === selection.modeId && !mode.disabled,
+            )
+        ) {
+            session = await aiSetMode(session.sessionId, selection.modeId);
+        }
+
+        const modelOptionId = getModelConfigOption(session)?.id ?? null;
+        for (const [optionId, value] of Object.entries(selection.options)) {
+            const option = session.configOptions.find(
+                (candidate) => candidate.id === optionId,
+            );
+            if (
+                !option ||
+                option.category === "mode" ||
+                option.id === modelOptionId ||
+                option.value === value ||
+                !option.options.some((candidate) => candidate.value === value)
+            ) {
+                continue;
+            }
+            session = await aiSetConfigOption(
+                session.sessionId,
+                option.id,
+                value,
+            );
+        }
+        return session;
+    }
+
+    async function connectCustomConversationBinding(
+        binding: AcpConversationBinding,
+        vaultPath: string | null,
+        additionalRoots: string[],
+    ) {
+        const runtimeSessionId = binding.runtimeSessionId?.trim();
+        const launchFingerprint = binding.runtimeLaunchFingerprint?.trim();
+        const continuationStrategy = binding.continuationStrategy;
+        if (
+            !runtimeSessionId ||
+            !launchFingerprint ||
+            !continuationStrategy ||
+            continuationStrategy === "new_session_only"
+        ) {
+            throw new Error(
+                "The selected custom ACP binding cannot be continued.",
+            );
+        }
+
+        let confirmedLaunchFingerprint: string | null = null;
+        let result = await aiContinueCustomRuntimeSession({
+            runtimeId: binding.runtimeId,
+            runtimeSessionId,
+            runtimeLaunchFingerprint: launchFingerprint,
+            continuationStrategy,
+            confirmedLaunchFingerprint,
+            vaultPath,
+            additionalRoots,
+        });
+        while (result.status === "confirmation_required") {
+            const approved = await confirm(result.message, {
+                title: "Custom ACP runtime changed",
+                kind: "warning",
+                okLabel: "Continue",
+                cancelLabel: "Cancel",
+            });
+            if (!approved) {
+                const cancelled = new Error(
+                    "Conversation provider switch cancelled.",
+                );
+                cancelled.name = "ConversationTurnCancelledError";
+                throw cancelled;
+            }
+            confirmedLaunchFingerprint = result.launchFingerprint;
+            result = await aiContinueCustomRuntimeSession({
+                runtimeId: binding.runtimeId,
+                runtimeSessionId,
+                runtimeLaunchFingerprint: launchFingerprint,
+                continuationStrategy,
+                confirmedLaunchFingerprint,
+                vaultPath,
+                additionalRoots,
+            });
+        }
+        if (result.status !== "connected") {
+            throw new Error(result.message);
+        }
+        return result.session;
+    }
+
+    async function connectConversationTurn(input: {
+        sourceSession: AIChatSession;
+        route: ConversationTurnRoute;
+        attachments: AIChatAttachment[];
+    }) {
+        const runtime = get().runtimes.find(
+            (candidate) =>
+                candidate.runtime.id === input.route.selection.runtimeId,
+        );
+        if (!runtime) {
+            throw new Error("The selected ACP provider is unavailable.");
+        }
+        const vaultPath =
+            input.sourceSession.vaultPath ??
+            useVaultStore.getState().vaultPath;
+        const additionalRoots = Array.from(
+            new Set([
+                ...(input.sourceSession.additionalRoots ?? []),
+                ...collectExternalAdditionalRoots(
+                    input.attachments,
+                    vaultPath ?? null,
+                ),
+            ]),
+        );
+        let runtimeSession: AIChatSession;
+        let created = false;
+
+        if (input.route.strategy === "continue") {
+            runtimeSession = input.sourceSession;
+        } else if (
+            input.route.targetBinding?.runtimeId.startsWith("custom:") &&
+            (input.route.strategy === "load" ||
+                input.route.strategy === "resume")
+        ) {
+            runtimeSession = await connectCustomConversationBinding(
+                input.route.targetBinding,
+                vaultPath ?? null,
+                additionalRoots,
+            );
+        } else if (
+            input.route.strategy === "load" &&
+            input.route.targetBinding?.runtimeSessionId
+        ) {
+            runtimeSession = await aiLoadRuntimeSession(
+                input.route.selection.runtimeId,
+                input.route.targetBinding.runtimeSessionId,
+                vaultPath ?? null,
+                additionalRoots,
+            );
+        } else if (
+            input.route.strategy === "resume" &&
+            input.route.targetBinding?.runtimeSessionId
+        ) {
+            runtimeSession = await aiResumeRuntimeSession(
+                input.route.selection.runtimeId,
+                input.route.targetBinding.runtimeSessionId,
+                vaultPath ?? null,
+                additionalRoots,
+            );
+        } else {
+            runtimeSession = await aiCreateSession(
+                input.route.selection.runtimeId,
+                vaultPath ?? null,
+                additionalRoots,
+            );
+            created = true;
+        }
+
+        try {
+            runtimeSession = await configureConversationTurnSession(
+                runtimeSession,
+                input.route.selection,
+            );
+        } catch (error) {
+            if (created) {
+                await aiDeleteRuntimeSession(runtimeSession.sessionId).catch(
+                    () => {},
+                );
+            }
+            throw error;
+        }
+
+        const targetBinding = createTurnBinding(
+            updateConversationBindingsFromLegacySession(
+                input.sourceSession,
+            ).conversationId,
+            runtimeSession,
+            input.route.strategy === "create"
+                ? null
+                : input.route.targetBinding,
+            runtime.runtime.capabilities,
+        );
+        return { runtimeSession, targetBinding, created };
+    }
+
     async function ensureRuntimeVisibleAfterOnboarding(runtimeId: string) {
         const state = get();
         const activeRuntimeId = state.activeSessionId
@@ -8202,11 +8582,55 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         let optimisticMessageInserted = false;
         let optimisticMessageId: string | null = null;
         let shouldRecoverPromptForRetry = false;
+        let preparedTurn:
+            | {
+                  runtimeSession: AIChatSession;
+                  targetBinding: AcpConversationBinding;
+                  route: ConversationTurnRoute;
+                  created: boolean;
+              }
+            | null = null;
+        let turnAccepted = false;
         let preflightOwnership = options?.preflightOwnership ?? null;
         let session = get().sessionsById[activeSessionId];
         try {
         if (!session || session.isResumingSession) {
             return;
+        }
+
+        const requestedRuntimeId = currentItem.runtimeId ?? session.runtimeId;
+        const providerSwitchRequested =
+            requestedRuntimeId !== session.runtimeId;
+        if (providerSwitchRequested) {
+            const state = get();
+            const conversationId =
+                resolveConversationId(state, activeSessionId) ??
+                session.historySessionId;
+            const conversation = state.conversationsById[conversationId];
+            const blocker = conversation
+                ? getConversationSwitchBlocker(conversation, {
+                      hasQueuedMessages:
+                          (state.queuedMessagesBySessionId[activeSessionId]
+                              ?.length ?? 0) > 0 ||
+                          state.activeQueuedMessageBySessionId[
+                              activeSessionId
+                          ] != null,
+                  })
+                : "session_transition_pending";
+            const runtime = state.runtimes.find(
+                (candidate) =>
+                    candidate.runtime.id === requestedRuntimeId,
+            );
+            const setupStatus =
+                state.setupStatusByRuntimeId[requestedRuntimeId];
+            if (
+                blocker ||
+                !runtime ||
+                isClaudeTerminalRuntimeId(requestedRuntimeId) ||
+                (setupStatus != null && !isRuntimeSetupReady(setupStatus))
+            ) {
+                return;
+            }
         }
 
             if (!preflightOwnership) {
@@ -8228,7 +8652,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
 
         clearInterruptedTurnState(activeSessionId);
 
-        if (!isLiveRuntimeSession(session)) {
+        if (!providerSwitchRequested && !isLiveRuntimeSession(session)) {
                 const resumedSessionId =
                     await get().resumeSession(activeSessionId);
             if (!resumedSessionId) {
@@ -8290,7 +8714,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
 
         try {
-            if (source === "immediate") {
+            if (!providerSwitchRequested && source === "immediate") {
                 const replacementSessionId =
                     await replaceEmptySessionForAdditionalRoots(
                         activeSessionId,
@@ -8316,12 +8740,68 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 }
             }
 
-            session =
+            if (!providerSwitchRequested) {
+                session =
                     (await syncQueuedMessageConfig(
                         activeSessionId,
                         currentItem,
                     )) ?? session;
-            if (!session) return;
+                if (!session) return;
+            } else if (!hasFullPersistedTranscriptLoaded(session)) {
+                const loaded = await loadPersistedTranscript(
+                    activeSessionId,
+                    "full",
+                );
+                if (!loaded) {
+                    throw new Error(
+                        "Failed to load the canonical transcript before changing ACP provider.",
+                    );
+                }
+                session = get().sessionsById[activeSessionId] ?? session;
+            }
+
+            const bindings =
+                updateConversationBindingsFromLegacySession(session);
+            const selection: ConversationSelection = {
+                runtimeId: requestedRuntimeId,
+                modelId: currentItem.modelId ?? session.modelId,
+                modeId: currentItem.modeId ?? session.modeId,
+                options: { ...currentItem.optionsSnapshot },
+            };
+            let route = planConversationTurnRoute({
+                session,
+                bindings,
+                selection,
+                runtimeCapabilities:
+                    get().runtimes.find(
+                        (runtime) =>
+                            runtime.runtime.id === requestedRuntimeId,
+                    )?.runtime.capabilities ?? [],
+                hasTranscript:
+                    getSessionTranscriptMessages(session).length > 0,
+            });
+            if (session.resumeContextPending && !route.providerChanged) {
+                route = { ...route, startReason: "transcript_handoff" };
+            }
+            const connected = await connectConversationTurn({
+                sourceSession: session,
+                route,
+                attachments: currentItem.attachments,
+            });
+            preparedTurn = { ...connected, route };
+            const preparedPrompt = buildPromptWithContextHandoff(
+                session,
+                currentItem.prompt,
+                connected.targetBinding,
+                route.startReason,
+                route.providerChanged ||
+                    session.resumeContextPending === true,
+            );
+            currentItem = {
+                ...currentItem,
+                prompt: preparedPrompt.prompt,
+                contextHandoff: preparedPrompt.contextHandoff,
+            };
 
                 const promotedDrafts =
                     await promoteQueuedMessageDrafts(currentItem);
@@ -8422,12 +8902,12 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     return;
                 }
 
-                if (preflightOwnership) {
+                if (preflightOwnership && !route.providerChanged) {
                     const releasedOwnership =
                         releaseComposerPreflightOwnership(
-                        activeSessionId,
-                        preflightOwnership.token,
-                    );
+                            activeSessionId,
+                            preflightOwnership.token,
+                        );
                     if (releasedOwnership) {
                         preflightOwnership = null;
                     }
@@ -8436,44 +8916,85 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 cleanupPromotedDrafts(promotedDrafts.promotions);
 
             const afterSend = get().sessionsById[activeSessionId];
-            if (afterSend) {
+            if (afterSend && !route.providerChanged) {
                 void persistSession(afterSend);
             }
 
+            if (route.providerChanged) {
+                await aiStartConversationTurn({
+                    conversationId: bindings.conversationId,
+                    bindingId: connected.targetBinding.bindingId,
+                    runtimeId: connected.runtimeSession.runtimeId,
+                    sessionId: connected.runtimeSession.sessionId,
+                    selection: getConversationSelection(
+                        connected.runtimeSession,
+                    ),
+                });
+            }
             const nextSession = await aiSendMessage(
-                activeSessionId,
+                connected.runtimeSession.sessionId,
                 currentItem.prompt,
                 currentItem.attachments,
             );
-            set((state) => ({
-                sessionsById: updateSessionById(
-                    state,
-                    activeSessionId,
-                    (current) =>
-                        acceptContextHandoff(
-                            current,
-                            currentItem.contextHandoff,
-                        ),
-                ),
-            }));
-            const acceptedSession = get().sessionsById[activeSessionId];
-            get().upsertSession({
-                ...nextSession,
-                historySessionId: session.historySessionId,
-                resumeContextPending: false,
-                conversationBindings:
-                    acceptedSession?.conversationBindings ??
-                    nextSession.conversationBindings,
+            turnAccepted = true;
+            const sourceAfterSend =
+                get().sessionsById[activeSessionId] ?? session;
+            const acceptedBinding = createTurnBinding(
+                bindings.conversationId,
+                nextSession,
+                connected.targetBinding,
+                get().runtimes.find(
+                    (runtime) =>
+                        runtime.runtime.id === nextSession.runtimeId,
+                )?.runtime.capabilities ?? [],
+            );
+            const committedSession = commitAcceptedConversationTurn({
+                sourceSession: sourceAfterSend,
+                acceptedRuntimeSession: nextSession,
+                route,
+                targetBinding: acceptedBinding,
+                contextHandoff: currentItem.contextHandoff,
+                userMessageId,
             });
+            if (preflightOwnership) {
+                const releasedOwnership = releaseComposerPreflightOwnership(
+                    activeSessionId,
+                    preflightOwnership.token,
+                );
+                if (releasedOwnership) {
+                    preflightOwnership = null;
+                }
+            }
+            if (committedSession.sessionId === activeSessionId) {
+                set((state) => ({
+                    sessionsById: {
+                        ...state.sessionsById,
+                        [activeSessionId]: committedSession,
+                    },
+                }));
+            } else {
+                migrateSessionLocalState(activeSessionId, committedSession);
+                activeSessionId = committedSession.sessionId;
+            }
+            persistCurrentSession(activeSessionId);
         } catch (error) {
+            if (preparedTurn?.created && !turnAccepted) {
+                await aiDeleteRuntimeSession(
+                    preparedTurn.runtimeSession.sessionId,
+                ).catch(() => {});
+            }
+            const cancelled =
+                error instanceof Error &&
+                error.name === "ConversationTurnCancelledError";
             const message = getAiErrorMessage(
                 error,
                 "Failed to send the message.",
-                session.runtimeId,
+                currentItem.runtimeId ?? session.runtimeId,
             );
             shouldRecoverPromptForRetry =
                 source === "immediate" &&
-                isRuntimeSessionDisconnectedErrorMessage(message);
+                (providerSwitchRequested ||
+                    isRuntimeSessionDisconnectedErrorMessage(message));
             const failedOptimisticMessageId = shouldRecoverPromptForRetry
                 ? optimisticMessageId
                 : null;
@@ -8498,15 +9019,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     status: "failed",
                 }));
             }
-            get().applySessionError({
-                session_id: activeSessionId,
-                message,
-            });
+            if (!cancelled) {
+                get().applySessionError({
+                    session_id: activeSessionId,
+                    message,
+                });
+            }
             if (shouldRecoverPromptForRetry) {
                 persistCurrentSession(activeSessionId);
             }
-            if (isAuthenticationErrorMessage(message, session.runtimeId)) {
-                await get().refreshSetupStatus(session.runtimeId);
+            const failedRuntimeId = currentItem.runtimeId ?? session.runtimeId;
+            if (
+                !cancelled &&
+                isAuthenticationErrorMessage(message, failedRuntimeId)
+            ) {
+                await get().refreshSetupStatus(failedRuntimeId);
             }
         }
         } finally {
@@ -10232,7 +10759,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 if (!session) return state;
                 const activeQueuedMessage =
                     state.activeQueuedMessageBySessionId[session_id] ?? null;
-                const nextSession = finalizeActionLogForWorkCycle(
+                const finalizedSession = finalizeActionLogForWorkCycle(
                     stampElapsedOnTurnStartedSession(
                         {
                             ...markAllMessagesComplete(session),
@@ -10240,6 +10767,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         },
                         completedAt,
                     ),
+                );
+                const nextSession = completeActiveBindingTurn(
+                    { ...finalizedSession, activeWorkCycleId: null },
+                    message_id,
                 );
 
                 return {
@@ -12019,6 +12550,68 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             }
         },
 
+        startConversationTurn: async (conversationId, selection) => {
+            const state = get();
+            const sessionId =
+                state.sessionIdByConversationId[conversationId] ??
+                resolveLegacySessionId(state, conversationId);
+            const session = sessionId
+                ? state.sessionsById[sessionId]
+                : undefined;
+            const conversation = state.conversationsById[conversationId];
+            if (!sessionId || !session || !conversation) return;
+
+            const activeBinding = conversation.activeBindingId
+                ? state.bindingsById[conversation.activeBindingId]
+                : null;
+            const providerChanged =
+                activeBinding != null &&
+                activeBinding.runtimeId !== selection.runtimeId;
+            if (providerChanged) {
+                const blocker = getConversationSwitchBlocker(conversation, {
+                    hasQueuedMessages:
+                        (state.queuedMessagesBySessionId[sessionId]?.length ??
+                            0) > 0 ||
+                        state.activeQueuedMessageBySessionId[sessionId] != null,
+                });
+                const runtime = state.runtimes.find(
+                    (candidate) =>
+                        candidate.runtime.id === selection.runtimeId,
+                );
+                const setupStatus =
+                    state.setupStatusByRuntimeId[selection.runtimeId];
+                if (
+                    blocker ||
+                    !runtime ||
+                    isClaudeTerminalRuntimeId(selection.runtimeId) ||
+                    (setupStatus != null &&
+                        !isRuntimeSetupReady(setupStatus))
+                ) {
+                    return;
+                }
+            }
+
+            const pendingSelection = {
+                ...selection,
+                options: { ...selection.options },
+            };
+            _pendingTurnSelectionByConversationId.set(
+                conversationId,
+                pendingSelection,
+            );
+            try {
+                await get().sendMessage(sessionId);
+            } finally {
+                const pending =
+                    _pendingTurnSelectionByConversationId.get(conversationId);
+                if (pending === pendingSelection) {
+                    _pendingTurnSelectionByConversationId.delete(
+                        conversationId,
+                    );
+                }
+            }
+        },
+
         sendMessage: async (sessionId) => {
             let resolvedSessionId = sessionId ?? get().activeSessionId;
             if (!resolvedSessionId) return;
@@ -12033,9 +12626,18 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 return;
             }
 
+            const conversationId =
+                resolveConversationId(get(), resolvedSessionId) ??
+                session.historySessionId;
+            const selection =
+                _pendingTurnSelectionByConversationId.get(conversationId) ??
+                updateConversationBindingsFromLegacySession(session)
+                    .preferredSelection;
+            const providerChanged = selection.runtimeId !== session.runtimeId;
+
             if (
-                !isLiveRuntimeSession(session) ||
-                needsFullResumeContextTranscript(session)
+                (!providerChanged && !isLiveRuntimeSession(session)) ||
+                (!providerChanged && needsFullResumeContextTranscript(session))
             ) {
                 const preparedSessionId =
                     await prepareSessionForPromptBuild(resolvedSessionId);
@@ -12053,7 +12655,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const composerParts =
                 composerPartsBySessionId[resolvedSessionId] ??
                 createEmptyComposerParts();
-            const queuedItem = buildQueuedMessage(session, composerParts);
+            const queuedItem = buildQueuedMessage(
+                session,
+                composerParts,
+                selection,
+            );
             if (!queuedItem) return;
             const pendingStop = _pendingStopBySessionId.get(resolvedSessionId);
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -175,7 +175,10 @@ import {
     planConversationTurnRoute,
     type ConversationTurnRoute,
 } from "../conversationTurnRouting";
-import type { PreparedConversationTurnCatalog } from "../conversationPickerModel";
+import {
+    getDefaultConversationSelection,
+    type PreparedConversationTurnCatalog,
+} from "../conversationPickerModel";
 import {
     deserializeConversationBindings,
     forkConversationBindings,
@@ -7329,6 +7332,27 @@ function getPreparedTurnCatalogKey(
     return `${selection.runtimeId}\u0000${selection.modelId}`;
 }
 
+function conversationSelectionsEqual(
+    left: ConversationSelection,
+    right: ConversationSelection,
+) {
+    if (
+        left.runtimeId !== right.runtimeId ||
+        left.modelId !== right.modelId ||
+        left.modeId !== right.modeId
+    ) {
+        return false;
+    }
+
+    const optionIds = new Set([
+        ...Object.keys(left.options),
+        ...Object.keys(right.options),
+    ]);
+    return [...optionIds].every(
+        (optionId) => left.options[optionId] === right.options[optionId],
+    );
+}
+
 async function persistSessionNow(session: AIChatSession) {
     const vaultPath = getSessionVaultPath(session);
     if (!vaultPath) return;
@@ -8976,6 +9000,79 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         return session;
     }
 
+    function sessionCanApplyConversationSelection(
+        session: AIChatSession,
+        selection: ConversationSelection,
+    ) {
+        if (session.runtimeId !== selection.runtimeId) {
+            return false;
+        }
+        const selectedModelId =
+            getModelConfigOption(session)?.value ?? session.modelId;
+        if (
+            selection.modelId !== selectedModelId &&
+            !supportsModelSelection(session, selection.modelId)
+        ) {
+            return false;
+        }
+        if (
+            selection.modeId !== session.modeId &&
+            !session.modes.some(
+                (mode) => mode.id === selection.modeId && !mode.disabled,
+            )
+        ) {
+            return false;
+        }
+
+        return Object.entries(selection.options).every(
+            ([optionId, value]) => {
+                const option = session.configOptions.find(
+                    (candidate) => candidate.id === optionId,
+                );
+                return (
+                    option != null &&
+                    (option.value === value ||
+                        option.options.some(
+                            (candidate) => candidate.value === value,
+                        ))
+                );
+            },
+        );
+    }
+
+    function resolveDiscoveredConversationSelection(
+        runtime: AIRuntimeDescriptor,
+        session: AIChatSession,
+        requestedSelection: ConversationSelection,
+    ) {
+        if (
+            sessionCanApplyConversationSelection(
+                session,
+                requestedSelection,
+            )
+        ) {
+            return requestedSelection;
+        }
+
+        const descriptorDefault = getDefaultConversationSelection({ runtime });
+        if (
+            conversationSelectionsEqual(
+                requestedSelection,
+                descriptorDefault,
+            )
+        ) {
+            // Runtime descriptors are only bootstrap metadata. In particular,
+            // most built-ins advertise a synthetic `auto` model before their
+            // ACP has connected. Discovery must adopt the live session's real
+            // default instead of rejecting the catalog we just loaded.
+            return getConversationSelection(session);
+        }
+
+        // Explicit user selections remain strict. The normal configuration
+        // path below will report which requested value is unavailable.
+        return requestedSelection;
+    }
+
     async function connectCustomConversationBinding(
         binding: AcpConversationBinding,
         vaultPath: string | null,
@@ -9104,10 +9201,18 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             created = true;
         }
 
+        const resolvedSelection = created
+            ? resolveDiscoveredConversationSelection(
+                  runtime,
+                  runtimeSession,
+                  input.route.selection,
+              )
+            : input.route.selection;
+
         try {
             runtimeSession = await configureConversationTurnSession(
                 runtimeSession,
-                input.route.selection,
+                resolvedSelection,
             );
         } catch (error) {
             if (created) {
@@ -9128,7 +9233,12 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 : input.route.targetBinding,
             runtime.runtime.capabilities,
         );
-        return { runtimeSession, targetBinding, created };
+        return {
+            runtimeSession,
+            targetBinding,
+            created,
+            selection: resolvedSelection,
+        };
     }
 
     async function ensureRuntimeVisibleAfterOnboarding(runtimeId: string) {
@@ -9396,6 +9506,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 route,
                 attachments: currentItem.attachments,
             });
+            if (
+                !conversationSelectionsEqual(
+                    route.selection,
+                    connected.selection,
+                )
+            ) {
+                route = {
+                    ...route,
+                    selection: connected.selection,
+                };
+                get().setConversationTurnSelection(
+                    bindings.conversationId,
+                    connected.selection,
+                );
+            }
             preparedTurn = { ...connected, route };
             await aiStartConversationTurn({
                 conversationId: bindings.conversationId,
@@ -13159,13 +13284,21 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 );
                 probeSessionId = probeSession.sessionId;
                 _turnCatalogProbeSessionIds.add(probeSessionId);
+                const resolvedSelection =
+                    resolveDiscoveredConversationSelection(
+                        runtime,
+                        probeSession,
+                        selection,
+                    );
                 // Configure the probe exactly like the eventual turn. Several
                 // ACPs reveal reasoning and service-tier options only after the
-                // target model has been selected.
+                // target model has been selected. Bootstrap descriptor values
+                // are resolved from the live catalog first, so a synthetic
+                // `auto` model cannot prevent discovery from completing.
                 const configuredSession =
                     await configureConversationTurnSession(
                         probeSession,
-                        selection,
+                        resolvedSelection,
                     );
 
                 if (
@@ -13177,7 +13310,14 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     // options from the superseded probe.
                     return;
                 }
-                const currentConversation =
+                set((currentState) => ({
+                    runtimes: hydrateRuntimesFromSessions(
+                        currentState.runtimes,
+                        [configuredSession],
+                    ),
+                }));
+
+                let currentConversation =
                     get().conversationsById[conversationId];
                 if (
                     !currentConversation ||
@@ -13185,15 +13325,40 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         currentConversation.preferredSelection,
                     ) !== requestKey
                 ) {
+                    // Provider previews still warm the shared runtime catalog,
+                    // but must not change this conversation's staged choice.
                     return;
+                }
+
+                if (
+                    !conversationSelectionsEqual(
+                        selection,
+                        resolvedSelection,
+                    )
+                ) {
+                    get().setConversationTurnSelection(
+                        conversationId,
+                        resolvedSelection,
+                    );
+                    currentConversation =
+                        get().conversationsById[conversationId];
+                    if (
+                        !currentConversation ||
+                        !conversationSelectionsEqual(
+                            currentConversation.preferredSelection,
+                            resolvedSelection,
+                        )
+                    ) {
+                        return;
+                    }
                 }
 
                 set((currentState) => ({
                     preparedTurnCatalogByConversationId: {
                         ...currentState.preparedTurnCatalogByConversationId,
                         [conversationId]: {
-                            runtimeId: selection.runtimeId,
-                            modelId: selection.modelId,
+                            runtimeId: resolvedSelection.runtimeId,
+                            modelId: resolvedSelection.modelId,
                             models: configuredSession.models,
                             modes: configuredSession.modes,
                             configOptions: configuredSession.configOptions,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -9593,6 +9593,12 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 contextHandoff: currentItem.contextHandoff,
                 userMessageId,
             });
+            const replacedRuntimeSessionId =
+                route.initialProviderChanged &&
+                isLiveRuntimeSession(session) &&
+                committedSession.sessionId !== activeSessionId
+                    ? activeSessionId
+                    : null;
             if (preflightOwnership) {
                 const releasedOwnership = releaseComposerPreflightOwnership(
                     activeSessionId,
@@ -9619,6 +9625,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     pendingEventRoute.token,
                 );
                 pendingEventRoute = null;
+            }
+            if (replacedRuntimeSessionId) {
+                await aiDeleteRuntimeSession(replacedRuntimeSessionId).catch(
+                    () => {},
+                );
             }
             logCanonicalConversationDiagnostic(
                 "canonical conversation turn accepted",

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -186,6 +186,7 @@ import {
     updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
 import {
+    createConversationScopedValueResolver,
     hasSameCanonicalSessionTopology,
     projectCanonicalConversationContentUpdate,
     projectChatStoreToCanonical,
@@ -8133,34 +8134,14 @@ function projectChangedSessionMapToConversations<T>(
     }
 
     let projected = previousValuesByConversationId;
+    const resolveValue = createConversationScopedValueResolver(
+        nextValuesBySessionId,
+        projection,
+    );
     for (const conversationId of affectedConversationIds) {
-        const sessionId = projection.sessionIdByConversationId[conversationId];
-        let hasNextValue = false;
-        let nextValue: T | undefined;
-        if (sessionId && Object.hasOwn(nextValuesBySessionId, sessionId)) {
-            hasNextValue = true;
-            nextValue = nextValuesBySessionId[sessionId];
-        } else if (Object.hasOwn(nextValuesBySessionId, conversationId)) {
-            hasNextValue = true;
-            nextValue = nextValuesBySessionId[conversationId];
-        } else {
-            // Legacy callers may temporarily key a value by a native session
-            // or binding id. Prefer the elected local session above, but keep
-            // compatible aliases visible until structural migration runs.
-            for (const [sessionRef, value] of Object.entries(
-                nextValuesBySessionId,
-            )) {
-                if (
-                    resolveConversationId(projection, sessionRef) ===
-                    conversationId
-                ) {
-                    hasNextValue = true;
-                    nextValue = value;
-                }
-            }
-        }
+        const resolved = resolveValue(conversationId);
         const hadValue = Object.hasOwn(projected, conversationId);
-        if (!hasNextValue) {
+        if (!resolved.hasValue) {
             if (!hadValue) continue;
             if (projected === previousValuesByConversationId) {
                 projected = { ...previousValuesByConversationId };
@@ -8168,11 +8149,11 @@ function projectChangedSessionMapToConversations<T>(
             delete projected[conversationId];
             continue;
         }
-        if (hadValue && projected[conversationId] === nextValue) continue;
+        if (hadValue && projected[conversationId] === resolved.value) continue;
         if (projected === previousValuesByConversationId) {
             projected = { ...previousValuesByConversationId };
         }
-        projected[conversationId] = nextValue as T;
+        projected[conversationId] = resolved.value;
     }
 
     return projected;

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -6791,7 +6791,7 @@ function getSelectableDefaultRuntimeId(
     runtimes: AIRuntimeDescriptor[],
     setupStatusByRuntimeId?: Record<string, AIRuntimeSetupStatus>,
 ) {
-    if (!runtimeId) return null;
+    if (!runtimeId || isClaudeTerminalRuntimeId(runtimeId)) return null;
     if (!runtimes.some((runtime) => runtime.runtime.id === runtimeId)) {
         return null;
     }
@@ -9617,12 +9617,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         },
 
         setDefaultRuntime: (runtimeId) => {
+            const nextRuntimeId = isClaudeTerminalRuntimeId(runtimeId)
+                ? null
+                : runtimeId;
             _defaultRuntimePreferenceVersion += 1;
             set((state) => ({
-                defaultRuntimeId: runtimeId,
-                selectedRuntimeId: runtimeId ?? state.selectedRuntimeId,
+                defaultRuntimeId: nextRuntimeId,
+                selectedRuntimeId: nextRuntimeId ?? state.selectedRuntimeId,
             }));
-            saveAiPreferences({ defaultRuntimeId: runtimeId ?? undefined });
+            saveAiPreferences({
+                defaultRuntimeId: nextRuntimeId ?? undefined,
+            });
         },
 
         getDefaultNewChatRuntimeId: () => {
@@ -9784,11 +9789,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 // still available and ready. Otherwise stay on ACP runtimes;
                 // Claude Code remains available but is not promoted to the
                 // default just because the binary exists in PATH.
+                const persistedDefaultRuntimeId =
+                    loadAiPreferences().defaultRuntimeId;
                 const persistedRuntimeId = getSelectableDefaultRuntimeId(
-                        loadAiPreferences().defaultRuntimeId,
-                        runtimes,
-                        setupStatusByRuntimeId,
-                    );
+                    persistedDefaultRuntimeId,
+                    runtimes,
+                    setupStatusByRuntimeId,
+                );
+                if (isClaudeTerminalRuntimeId(persistedDefaultRuntimeId)) {
+                    saveAiPreferences({ defaultRuntimeId: undefined });
+                }
 
                 // Prefer in-memory changes made while this initialize() was in
                 // flight. "Automatic" is stored as null, so we need the version
@@ -14925,7 +14935,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     runtimes,
                     get().setupStatusByRuntimeId,
                 ) ??
-                getDefaultRuntimeId(runtimes, get().setupStatusByRuntimeId);
+                getImplicitDefaultAcpRuntimeId(
+                    runtimes,
+                    get().setupStatusByRuntimeId,
+                );
             if (!nextRuntimeId) return null;
 
             const markPendingSessionError = (message: string) => {
@@ -15276,7 +15289,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     state.runtimes,
                     state.setupStatusByRuntimeId,
                 ) ??
-                getDefaultRuntimeId(
+                getImplicitDefaultAcpRuntimeId(
                     state.runtimes,
                     state.setupStatusByRuntimeId,
                 );

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -8943,6 +8943,36 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 value,
             );
         }
+
+        const appliedSelection = getConversationSelection(session);
+        if (appliedSelection.runtimeId !== selection.runtimeId) {
+            throw new Error("The selected ACP provider was not applied.");
+        }
+        if (appliedSelection.modelId !== selection.modelId) {
+            throw new Error(
+                `The selected model is unavailable: ${selection.modelId}`,
+            );
+        }
+        if (appliedSelection.modeId !== selection.modeId) {
+            throw new Error(
+                `The selected mode is unavailable: ${selection.modeId}`,
+            );
+        }
+        for (const [optionId, value] of Object.entries(selection.options)) {
+            const option = session.configOptions.find(
+                (candidate) => candidate.id === optionId,
+            );
+            if (!option) {
+                throw new Error(
+                    `The selected ACP option is unavailable: ${optionId}`,
+                );
+            }
+            if (option.value !== value) {
+                throw new Error(
+                    `The selected ACP option was not applied: ${optionId}`,
+                );
+            }
+        }
         return session;
     }
 
@@ -9367,6 +9397,13 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 attachments: currentItem.attachments,
             });
             preparedTurn = { ...connected, route };
+            await aiStartConversationTurn({
+                conversationId: bindings.conversationId,
+                bindingId: connected.targetBinding.bindingId,
+                runtimeId: connected.runtimeSession.runtimeId,
+                sessionId: connected.runtimeSession.sessionId,
+                selection: route.selection,
+            });
             logCanonicalConversationDiagnostic(
                 "canonical conversation turn connected",
                 {
@@ -9528,17 +9565,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 };
             }
 
-            if (route.initialProviderChanged) {
-                await aiStartConversationTurn({
-                    conversationId: bindings.conversationId,
-                    bindingId: connected.targetBinding.bindingId,
-                    runtimeId: connected.runtimeSession.runtimeId,
-                    sessionId: connected.runtimeSession.sessionId,
-                    selection: getConversationSelection(
-                        connected.runtimeSession,
-                    ),
-                });
-            }
             const nextSession = await aiSendMessage(
                 connected.runtimeSession.sessionId,
                 currentItem.prompt,

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -721,6 +721,24 @@ function getRuntimeHistorySessionId(session: AIChatSession) {
     );
 }
 
+function getLiveRuntimeSessionId(session: AIChatSession) {
+    return session.runtimeSessionId?.trim() || session.sessionId;
+}
+
+function getRuntimeResumeSessionId(session: AIChatSession) {
+    const bindings = session.conversationBindings;
+    const activeBinding = bindings?.providerBindings.find(
+        (binding) => binding.bindingId === bindings.activeBindingId,
+    );
+    return (
+        (activeBinding?.runtimeId === session.runtimeId
+            ? activeBinding.runtimeSessionId?.trim()
+            : null) ||
+        session.runtimeSessionId?.trim() ||
+        getRuntimeHistorySessionId(session)
+    );
+}
+
 function isLiveRuntimeSession(session: AIChatSession) {
     return (
         session.runtimeState === "live" &&
@@ -2918,7 +2936,7 @@ function createTurnBinding(
         runtimeRevision: runtimeSession.runtimeRevision ?? null,
         runtimeLaunchFingerprint:
             runtimeSession.runtimeLaunchFingerprint ?? null,
-        runtimeSessionId: runtimeSession.runtimeSessionId ?? null,
+        runtimeSessionId: getLiveRuntimeSessionId(runtimeSession),
         continuationStrategy: runtimeSession.continuationStrategy ?? null,
         capabilities: [...capabilities],
         modelId: selection.modelId,
@@ -3015,6 +3033,9 @@ function commitAcceptedConversationTurn(input: {
             ...attributedSource,
             ...input.acceptedRuntimeSession,
             historySessionId: attributedSource.historySessionId,
+            runtimeSessionId: getLiveRuntimeSessionId(
+                input.acceptedRuntimeSession,
+            ),
             parentSessionId: attributedSource.parentSessionId ?? null,
             vaultPath: attributedSource.vaultPath ?? null,
             customTitle: attributedSource.customTitle ?? null,
@@ -12412,6 +12433,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     get().sessionsById[sessionId] ?? currentSession;
                 const historySessionId =
                     getRuntimeHistorySessionId(latestSession);
+                const runtimeResumeSessionId =
+                    getRuntimeResumeSessionId(latestSession);
                 let latestCatalog = getRuntimeCatalogSnapshot(latestSession);
                 logResumeRecovery("started", {
                     resume_strategy: resumeStrategy,
@@ -12435,9 +12458,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         latestSession.continuationStrategy;
                     const launchFingerprint =
                         latestSession.runtimeLaunchFingerprint?.trim();
-                    const runtimeSessionId =
-                        latestSession.runtimeSessionId?.trim() ||
-                        historySessionId;
+                    const runtimeSessionId = runtimeResumeSessionId;
                     if (!continuationStrategy || !launchFingerprint) {
                         set((state) => {
                             const current = state.sessionsById[sessionId];
@@ -12557,7 +12578,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     try {
                         resumedSession = await aiResumeRuntimeSession(
                             latestSession.runtimeId,
-                            historySessionId,
+                            runtimeResumeSessionId,
                             vaultPath,
                             latestSession.additionalRoots ?? null,
                         );

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2873,11 +2873,16 @@ function commitAcceptedConversationTurn(input: {
     const acceptedSelection = getConversationSelection(
         input.acceptedRuntimeSession,
     );
+    const completedEventCursor = findCompletedConversationTurnCursor(
+        input.sourceSession,
+        input.userMessageId,
+    );
     const contextCursor =
-        input.contextHandoff?.bindingId === input.targetBinding.bindingId
+        completedEventCursor ??
+        (input.contextHandoff?.bindingId === input.targetBinding.bindingId
             ? (input.contextHandoff.nextCursor ??
               input.targetBinding.contextCursor)
-            : input.targetBinding.contextCursor;
+            : input.targetBinding.contextCursor);
     const targetBinding: AcpConversationBinding = {
         ...input.targetBinding,
         runtimeDisplayName:
@@ -2925,22 +2930,15 @@ function commitAcceptedConversationTurn(input: {
         activeBindingId: targetBinding.bindingId,
         providerBindings,
     };
-    const provenance: ConversationTurnProvenance = {
-        bindingId: targetBinding.bindingId,
-        runtimeId: targetBinding.runtimeId,
-        runtimeSessionId: targetBinding.runtimeSessionId,
-        modelId: targetBinding.modelId,
-        modeId: targetBinding.modeId,
-        options: { ...targetBinding.options },
-        startReason: input.route.startReason,
-        handoffTruncated: input.contextHandoff?.truncated ?? false,
-        handoffOmittedTurnCount:
-            input.contextHandoff?.omittedTurnCount ?? 0,
-    };
-    const attributedSource = replaceSessionMessage(
+    const provenance = createConversationTurnProvenance(
+        targetBinding,
+        input.route,
+        input.contextHandoff,
+    );
+    const attributedSource = attributeConversationTurnMessages(
         input.sourceSession,
         input.userMessageId,
-        (message) => ({ ...message, turnProvenance: provenance }),
+        provenance,
     );
 
     return replaceSessionTranscript(
@@ -2968,11 +2966,84 @@ function commitAcceptedConversationTurn(input: {
             isResumingSession: false,
             resumeContextPending: false,
             runtimeState: "live",
+            status:
+                completedEventCursor != null
+                    ? "idle"
+                    : input.acceptedRuntimeSession.status,
             conversationBindings,
-            activeTurnProvenance: provenance,
+            activeTurnProvenance:
+                completedEventCursor != null ? null : provenance,
         },
         getSessionTranscriptMessages(attributedSource),
     );
+}
+
+function createConversationTurnProvenance(
+    binding: AcpConversationBinding,
+    route: ConversationTurnRoute,
+    contextHandoff?: AcpContextHandoffMetadata,
+): ConversationTurnProvenance {
+    return {
+        bindingId: binding.bindingId,
+        runtimeId: binding.runtimeId,
+        runtimeSessionId: binding.runtimeSessionId,
+        modelId: binding.modelId,
+        modeId: binding.modeId,
+        options: { ...binding.options },
+        startReason: route.startReason,
+        handoffTruncated: contextHandoff?.truncated ?? false,
+        handoffOmittedTurnCount: contextHandoff?.omittedTurnCount ?? 0,
+    };
+}
+
+function findCompletedConversationTurnCursor(
+    session: AIChatSession,
+    userMessageId: string,
+) {
+    const messages = getSessionTranscriptMessages(session);
+    const turnStartIndex = messages.findIndex(
+        (message) => message.id === userMessageId,
+    );
+    if (turnStartIndex < 0) return null;
+    return (
+        messages
+            .slice(turnStartIndex + 1)
+            .reverse()
+            .find(
+                (message) =>
+                    message.role === "assistant" &&
+                    message.kind === "text" &&
+                    message.inProgress === false,
+            )?.id ?? null
+    );
+}
+
+function attributeConversationTurnMessages(
+    session: AIChatSession,
+    userMessageId: string,
+    provenance: ConversationTurnProvenance,
+) {
+    let reachedTurn = false;
+    const messages = getSessionTranscriptMessages(session).map((message) => {
+        if (message.id === userMessageId) reachedTurn = true;
+        return reachedTurn && !message.turnProvenance
+            ? { ...message, turnProvenance: provenance }
+            : message;
+    });
+    return replaceSessionTranscript(session, messages);
+}
+
+function removeConversationTurnMessages(
+    session: AIChatSession,
+    userMessageId: string,
+) {
+    const messages = getSessionTranscriptMessages(session);
+    const turnStartIndex = messages.findIndex(
+        (message) => message.id === userMessageId,
+    );
+    return turnStartIndex < 0
+        ? session
+        : replaceSessionTranscript(session, messages.slice(0, turnStartIndex));
 }
 
 function completeActiveBindingTurn(
@@ -2980,7 +3051,8 @@ function completeActiveBindingTurn(
     messageId: string,
 ) {
     const bindings = updateConversationBindingsFromLegacySession(session);
-    const activeBindingId = bindings.activeBindingId;
+    const activeBindingId =
+        session.activeTurnProvenance?.bindingId ?? bindings.activeBindingId;
     if (!activeBindingId) {
         return { ...session, activeTurnProvenance: null };
     }
@@ -6754,17 +6826,93 @@ function logResumeRecovery(
     event: "started" | "succeeded" | "failed",
     payload: {
         resume_strategy: ResumeRecoveryStrategy;
-        history_session_id: string;
         runtime_id: string;
         persisted_message_count: number;
         loaded_persisted_message_start: number | null;
         resume_context_pending: boolean;
         runtime_state_before: string;
         runtime_state_after: string;
-        error_message?: string;
+        error_code?: CanonicalConversationErrorCode;
     },
 ) {
-    logDebug("chat-store", `saved chat recovery ${event}`, payload);
+    logCanonicalConversationDiagnostic(`saved chat recovery ${event}`, payload);
+}
+
+type CanonicalConversationErrorCode =
+    | "authentication_required"
+    | "provider_unavailable"
+    | "runtime_configuration_invalid"
+    | "runtime_disconnected"
+    | "transcript_unavailable"
+    | "turn_rejected"
+    | "unexpected";
+
+function getCanonicalConversationErrorCode(
+    message: string,
+    runtimeId?: string | null,
+): CanonicalConversationErrorCode {
+    if (isRuntimeSessionDisconnectedErrorMessage(message)) {
+        return "runtime_disconnected";
+    }
+    if (isAuthenticationErrorMessage(message, runtimeId)) {
+        return "authentication_required";
+    }
+    const normalized = message.toLowerCase();
+    if (normalized.includes("configuration is invalid")) {
+        return "runtime_configuration_invalid";
+    }
+    if (
+        normalized.includes("transcript") &&
+        (normalized.includes("failed to load") ||
+            normalized.includes("unavailable"))
+    ) {
+        return "transcript_unavailable";
+    }
+    if (
+        normalized.includes("provider is unavailable") ||
+        normalized.includes("runtime is no longer available")
+    ) {
+        return "provider_unavailable";
+    }
+    if (normalized.includes("rejected")) {
+        return "turn_rejected";
+    }
+    return "unexpected";
+}
+
+function logCanonicalConversationDiagnostic(
+    message: string,
+    detail: Record<string, unknown>,
+) {
+    _canonicalConversationLogSequence += 1;
+    logDebug("chat-store", message, detail, {
+        onceKey: `canonical-conversation:${_canonicalConversationLogSequence}`,
+    });
+}
+
+function registerPendingConversationTurnEventRoute(
+    sourceSessionId: string,
+    targetSessionId: string,
+) {
+    if (sourceSessionId === targetSessionId) return null;
+    const token = crypto.randomUUID();
+    _pendingConversationTurnEventRouteBySessionId.set(targetSessionId, {
+        sourceSessionId,
+        token,
+    });
+    return token;
+}
+
+function clearPendingConversationTurnEventRoute(
+    targetSessionId: string,
+    token: string,
+) {
+    if (
+        _pendingConversationTurnEventRouteBySessionId.get(targetSessionId)
+            ?.token === token
+    ) {
+        _pendingConversationTurnEventRouteBySessionId.delete(targetSessionId);
+    }
 }
 
 function getRuntimeReadyButDisabledMessage(
@@ -7011,6 +7159,15 @@ const _pendingTurnSelectionByConversationId = new Map<
     string,
     ConversationSelection
 >();
+type PendingConversationTurnEventRoute = {
+    sourceSessionId: string;
+    token: string;
+};
+const _pendingConversationTurnEventRouteBySessionId = new Map<
+    string,
+    PendingConversationTurnEventRoute
+>();
+let _canonicalConversationLogSequence = 0;
 let _sessionPersistenceFlushScheduled = false;
 let _sessionPersistenceEpoch = 0;
 
@@ -7841,9 +7998,20 @@ export function resolveChatSessionId(
         | "conversationIdBySessionRef"
         | "conversationsById"
         | "sessionIdByConversationId"
+        | "sessionsById"
     >,
     ref: string | null | undefined,
 ) {
+    if (ref) {
+        const pendingRoute =
+            _pendingConversationTurnEventRouteBySessionId.get(ref);
+        if (
+            pendingRoute &&
+            state.sessionsById[pendingRoute.sourceSessionId]
+        ) {
+            return pendingRoute.sourceSessionId;
+        }
+    }
     return resolveLegacySessionId(state, ref);
 }
 
@@ -8615,6 +8783,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                   created: boolean;
               }
             | null = null;
+        let plannedRoute: ConversationTurnRoute | null = null;
+        let pendingEventRoute:
+            | { targetSessionId: string; token: string }
+            | null = null;
         let turnAccepted = false;
         let preflightOwnership = options?.preflightOwnership ?? null;
         let session = get().sessionsById[activeSessionId];
@@ -8808,12 +8980,25 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             if (session.resumeContextPending && !route.providerChanged) {
                 route = { ...route, startReason: "transcript_handoff" };
             }
+            plannedRoute = route;
             const connected = await connectConversationTurn({
                 sourceSession: session,
                 route,
                 attachments: currentItem.attachments,
             });
             preparedTurn = { ...connected, route };
+            logCanonicalConversationDiagnostic(
+                "canonical conversation turn connected",
+                {
+                    strategy: route.strategy,
+                    start_reason: route.startReason,
+                    source_runtime_id: session.runtimeId,
+                    target_runtime_id: connected.runtimeSession.runtimeId,
+                    provider_changed: route.providerChanged,
+                    reused_binding: route.targetBinding != null,
+                    created_session: connected.created,
+                },
+            );
             const preparedPrompt = buildPromptWithContextHandoff(
                 session,
                 currentItem.prompt,
@@ -8841,6 +9026,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const userMessageId =
                 currentItem.optimisticMessageId ?? crypto.randomUUID();
             optimisticMessageId = userMessageId;
+            const turnProvenance = createConversationTurnProvenance(
+                connected.targetBinding,
+                route,
+                currentItem.contextHandoff,
+            );
             if (
                 source === "queue" &&
                 currentItem.optimisticMessageId !== userMessageId
@@ -8866,7 +9056,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const targetSession = state.sessionsById[activeSessionId];
                 if (!targetSession) return state;
                     didInsertOptimisticMessage = true;
-                const nextSession = startNewWorkCycle(targetSession);
+                const nextSession = startNewWorkCycle({
+                    ...targetSession,
+                    activeTurnProvenance: turnProvenance,
+                });
                 const userMessage: AIChatMessage = {
                     ...createTextMessage("user", currentItem.content),
                     id: userMessageId,
@@ -8945,6 +9138,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 void persistSession(afterSend);
             }
 
+            const eventRouteToken = registerPendingConversationTurnEventRoute(
+                activeSessionId,
+                connected.runtimeSession.sessionId,
+            );
+            if (eventRouteToken) {
+                pendingEventRoute = {
+                    targetSessionId: connected.runtimeSession.sessionId,
+                    token: eventRouteToken,
+                };
+            }
+
             if (route.providerChanged) {
                 await aiStartConversationTurn({
                     conversationId: bindings.conversationId,
@@ -8962,6 +9166,9 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 currentItem.attachments,
             );
             turnAccepted = true;
+            // Runtime deltas can arrive before the send IPC resolves. Materialize
+            // them on the source projection before its local session id migrates.
+            flushDeltasSync();
             const sourceAfterSend =
                 get().sessionsById[activeSessionId] ?? session;
             const acceptedBinding = createTurnBinding(
@@ -9001,8 +9208,38 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 migrateSessionLocalState(activeSessionId, committedSession);
                 activeSessionId = committedSession.sessionId;
             }
+            if (pendingEventRoute) {
+                clearPendingConversationTurnEventRoute(
+                    pendingEventRoute.targetSessionId,
+                    pendingEventRoute.token,
+                );
+                pendingEventRoute = null;
+            }
+            logCanonicalConversationDiagnostic(
+                "canonical conversation turn accepted",
+                {
+                    strategy: route.strategy,
+                    start_reason: route.startReason,
+                    source_runtime_id: session.runtimeId,
+                    target_runtime_id: committedSession.runtimeId,
+                    provider_changed: route.providerChanged,
+                    reused_binding: route.targetBinding != null,
+                    created_session: connected.created,
+                    handoff_truncated:
+                        currentItem.contextHandoff?.truncated ?? false,
+                    handoff_omitted_turn_count:
+                        currentItem.contextHandoff?.omittedTurnCount ?? 0,
+                },
+            );
             persistCurrentSession(activeSessionId);
         } catch (error) {
+            if (pendingEventRoute) {
+                clearPendingConversationTurnEventRoute(
+                    pendingEventRoute.targetSessionId,
+                    pendingEventRoute.token,
+                );
+                pendingEventRoute = null;
+            }
             if (preparedTurn?.created && !turnAccepted) {
                 await aiDeleteRuntimeSession(
                     preparedTurn.runtimeSession.sessionId,
@@ -9016,6 +9253,26 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 "Failed to send the message.",
                 currentItem.runtimeId ?? session.runtimeId,
             );
+            if (plannedRoute) {
+                logCanonicalConversationDiagnostic(
+                    "canonical conversation turn failed",
+                    {
+                        strategy: plannedRoute.strategy,
+                        start_reason: plannedRoute.startReason,
+                        source_runtime_id: session.runtimeId,
+                        target_runtime_id:
+                            plannedRoute.selection.runtimeId,
+                        provider_changed: plannedRoute.providerChanged,
+                        reused_binding:
+                            plannedRoute.targetBinding != null,
+                        created_session: preparedTurn?.created ?? false,
+                        error_code: getCanonicalConversationErrorCode(
+                            message,
+                            plannedRoute.selection.runtimeId,
+                        ),
+                    },
+                );
+            }
             shouldRecoverPromptForRetry =
                 source === "immediate" &&
                 (providerSwitchRequested ||
@@ -9023,17 +9280,29 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const failedOptimisticMessageId = shouldRecoverPromptForRetry
                 ? optimisticMessageId
                 : null;
-            if (failedOptimisticMessageId) {
+            if (failedOptimisticMessageId || preparedTurn) {
                 set((state) => {
                     const targetSession = state.sessionsById[activeSessionId];
                     if (!targetSession) return state;
+                    const recoveredSession = failedOptimisticMessageId
+                        ? removeConversationTurnMessages(
+                              targetSession,
+                              failedOptimisticMessageId,
+                          )
+                        : targetSession;
+                    const shouldClearProvenance =
+                        preparedTurn != null &&
+                        recoveredSession.activeTurnProvenance?.bindingId ===
+                            preparedTurn.targetBinding.bindingId;
                     return {
                         sessionsById: {
                             ...state.sessionsById,
-                            [activeSessionId]: removeSessionMessage(
-                                targetSession,
-                                failedOptimisticMessageId,
-                            ),
+                            [activeSessionId]: shouldClearProvenance
+                                ? {
+                                      ...recoveredSession,
+                                      activeTurnProvenance: null,
+                                  }
+                                : recoveredSession,
                         },
                     };
                 });
@@ -11738,7 +12007,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 let latestCatalog = getRuntimeCatalogSnapshot(latestSession);
                 logResumeRecovery("started", {
                     resume_strategy: resumeStrategy,
-                    history_session_id: historySessionId,
                     runtime_id: latestSession.runtimeId,
                     persisted_message_count:
                         getSessionPersistedMessageCount(latestSession),
@@ -11892,7 +12160,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         );
                         logResumeRecovery("failed", {
                             resume_strategy: "native_load_session",
-                            history_session_id: historySessionId,
                             runtime_id: latestSession.runtimeId,
                             persisted_message_count:
                                 getSessionPersistedMessageCount(latestSession),
@@ -11904,7 +12171,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                             runtime_state_before: runtimeStateBefore,
                             runtime_state_after:
                                 getSessionRuntimeStateForLog(latestSession),
-                            error_message: nativeResumeMessage,
+                            error_code: getCanonicalConversationErrorCode(
+                                nativeResumeMessage,
+                                latestSession.runtimeId,
+                            ),
                         });
 
                         const fullTranscriptLoaded =
@@ -11922,7 +12192,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         resumeStrategy = "transcript_prompt_injection";
                         logResumeRecovery("started", {
                             resume_strategy: resumeStrategy,
-                            history_session_id: historySessionId,
                             runtime_id: latestSession.runtimeId,
                             persisted_message_count:
                                 getSessionPersistedMessageCount(latestSession),
@@ -11934,7 +12203,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                             runtime_state_before: runtimeStateBefore,
                             runtime_state_after:
                                 getSessionRuntimeStateForLog(latestSession),
-                            error_message: nativeResumeMessage,
+                            error_code: getCanonicalConversationErrorCode(
+                                nativeResumeMessage,
+                                latestSession.runtimeId,
+                            ),
                         });
                         const fallback = await createTranscriptResumeSession(
                                 latestSession,
@@ -12018,7 +12290,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 migrateSessionLocalState(sessionId, migratedSession);
                 logResumeRecovery("succeeded", {
                     resume_strategy: resumeStrategy,
-                    history_session_id: historySessionId,
                     runtime_id: migratedSession.runtimeId,
                     persisted_message_count:
                         getSessionPersistedMessageCount(migratedSession),
@@ -12041,9 +12312,6 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const failedSession = get().sessionsById[sessionId] ?? session;
                 logResumeRecovery("failed", {
                     resume_strategy: resumeStrategy,
-                    history_session_id: getRuntimeHistorySessionId(
-                        failedSession,
-                    ),
                     runtime_id: failedSession.runtimeId,
                     persisted_message_count:
                         getSessionPersistedMessageCount(failedSession),
@@ -12054,7 +12322,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     runtime_state_before: getSessionRuntimeStateForLog(session),
                     runtime_state_after:
                         getSessionRuntimeStateForLog(failedSession),
-                    error_message: message,
+                    error_code: getCanonicalConversationErrorCode(
+                        message,
+                        failedSession.runtimeId,
+                    ),
                 });
                 set((state) => {
                     const current = state.sessionsById[sessionId];
@@ -15434,6 +15705,7 @@ export function resetChatStore() {
     _queueDrainLocks.clear();
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
+    _pendingConversationTurnEventRouteBySessionId.clear();
     _pendingSessionPersistence.clear();
     _deltaBuffer.messageDelta.clear();
     _deltaBuffer.thinkingDelta.clear();
@@ -15506,5 +15778,6 @@ export function disposeChatStoreRuntime() {
     chatRuntimeInitialized = false;
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
+    _pendingConversationTurnEventRouteBySessionId.clear();
     clearTrackedPersistedReconciliationTimers();
 }

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -165,6 +165,34 @@ describe("canonical chat store projection", () => {
         ).toEqual({ "conversation-1": "live draft" });
     });
 
+    it("does not reassign a native runtime session to another conversation", () => {
+        const source = createSession({
+            sessionId: "source-session",
+            historySessionId: "source-conversation",
+            runtimeSessionId: "shared-native-session",
+        });
+        const fork = createSession({
+            sessionId: "fork-session",
+            historySessionId: "fork-conversation",
+            runtimeSessionId: "shared-native-session",
+        });
+        const projection = projectChatStoreToCanonical({
+            sessionsById: {
+                [fork.sessionId]: fork,
+                [source.sessionId]: source,
+            },
+            sessionOrder: [fork.sessionId, source.sessionId],
+            activeSessionId: source.sessionId,
+        });
+
+        expect(
+            resolveConversationId(projection, "shared-native-session"),
+        ).toBe("source-conversation");
+        expect(resolveConversationId(projection, fork.sessionId)).toBe(
+            "fork-conversation",
+        );
+    });
+
     it("drops bindings from the retired multi-provider flow", () => {
         const session = createSession();
         const bindingState = createConversationBindingsFromLegacySession(session);

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { createConversationBindingsFromLegacySession } from "../conversationModel";
 import type { AIChatSession } from "../types";
 import {
+    hasSameCanonicalSessionTopology,
+    projectCanonicalConversationContentUpdate,
     projectChatStoreToCanonical,
     projectSessionMapToConversations,
     resolveConversationId,
@@ -44,6 +46,83 @@ function createSession(overrides: Partial<AIChatSession> = {}): AIChatSession {
 }
 
 describe("canonical chat store projection", () => {
+    it("updates content while preserving canonical routing state", () => {
+        const session = createSession();
+        const projection = projectChatStoreToCanonical({
+            sessionsById: { [session.sessionId]: session },
+            sessionOrder: [session.sessionId],
+            activeSessionId: session.sessionId,
+        });
+        const previous = projection.conversationsById["conversation-1"];
+        const stagedSelection = {
+            ...previous.preferredSelection,
+            modelId: "opus",
+        };
+        const stagedConversation = {
+            ...previous,
+            parentConversationId: "normalized-parent",
+            preferredSelection: stagedSelection,
+        };
+        const messages = [
+            {
+                id: "assistant-1",
+                role: "assistant" as const,
+                kind: "text" as const,
+                content: "Hello",
+                timestamp: 1,
+            },
+        ];
+
+        const updated = projectCanonicalConversationContentUpdate(
+            stagedConversation,
+            {
+                ...session,
+                status: "streaming",
+                messages,
+            },
+        );
+
+        expect(updated).not.toBe(stagedConversation);
+        expect(updated.messages).toBe(messages);
+        expect(updated.status).toBe("streaming");
+        expect(updated.parentConversationId).toBe("normalized-parent");
+        expect(updated.preferredSelection).toBe(stagedSelection);
+        expect(updated.activeBindingId).toBe(
+            stagedConversation.activeBindingId,
+        );
+        expect(
+            projectCanonicalConversationContentUpdate(updated, {
+                ...session,
+                status: "streaming",
+                messages,
+            }),
+        ).toBe(updated);
+    });
+
+    it("classifies routing and binding changes as structural", () => {
+        const session = createSession();
+
+        expect(
+            hasSameCanonicalSessionTopology(session, {
+                ...session,
+                status: "streaming",
+                messages: [],
+            }),
+        ).toBe(true);
+        expect(
+            hasSameCanonicalSessionTopology(session, {
+                ...session,
+                runtimeSessionId: "native-replaced",
+            }),
+        ).toBe(false);
+        expect(
+            hasSameCanonicalSessionTopology(session, {
+                ...session,
+                modelId: "opus",
+            }),
+        ).toBe(false);
+    });
+
     it("deduplicates local and native session replacements by conversation", () => {
         const stale = createSession({
             sessionId: "persisted:conversation-1",

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -140,4 +140,35 @@ describe("canonical chat store projection", () => {
             runtimeSessionId: "native-session",
         });
     });
+
+    it("keeps an active provider model staged for the next turn", () => {
+        const session = createSession();
+        const bindingState = createConversationBindingsFromLegacySession(session);
+        const withStagedModel: AIChatSession = {
+            ...session,
+            conversationBindings: {
+                ...bindingState,
+                preferredSelection: {
+                    ...bindingState.preferredSelection,
+                    modelId: "opus",
+                },
+            },
+        };
+
+        const projection = projectChatStoreToCanonical({
+            sessionsById: { [session.sessionId]: withStagedModel },
+            sessionOrder: [session.sessionId],
+            activeSessionId: session.sessionId,
+        });
+
+        expect(
+            projection.conversationsById["conversation-1"]?.preferredSelection,
+        ).toMatchObject({
+            runtimeId: "claude-acp",
+            modelId: "opus",
+        });
+        expect(
+            projection.bindingsById[bindingState.activeBindingId!]?.modelId,
+        ).toBe("sonnet");
+    });
 });

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -157,12 +157,21 @@ describe("canonical chat store projection", () => {
         expect(
             projectSessionMapToConversations(
                 {
-                    [stale.sessionId]: "stale draft",
                     [live.sessionId]: "live draft",
+                    [stale.sessionId]: "stale draft",
                 },
                 projection,
             ),
         ).toEqual({ "conversation-1": "live draft" });
+        expect(
+            projectSessionMapToConversations(
+                {
+                    [live.runtimeSessionId as string]: "live usage",
+                    [stale.runtimeSessionId as string]: "stale usage",
+                },
+                projection,
+            ),
+        ).toEqual({ "conversation-1": "live usage" });
     });
 
     it("does not reassign a native runtime session to another conversation", () => {

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+import { createConversationBindingsFromLegacySession } from "../conversationModel";
+import type { AIChatSession } from "../types";
+import {
+    projectChatStoreToCanonical,
+    projectSessionMapToConversations,
+    resolveConversationId,
+    resolveLegacySessionId,
+    selectLegacySessionForConversation,
+} from "./chatStoreConversationProjection";
+
+function createSession(overrides: Partial<AIChatSession> = {}): AIChatSession {
+    return {
+        sessionId: "local-session",
+        historySessionId: "conversation-1",
+        runtimeSessionId: "native-session",
+        vaultPath: "/vault",
+        status: "idle",
+        runtimeId: "claude-acp",
+        runtimeDisplayName: "Claude",
+        modelId: "sonnet",
+        modeId: "default",
+        models: [
+            {
+                id: "sonnet",
+                runtimeId: "claude-acp",
+                name: "Sonnet",
+                description: "",
+            },
+        ],
+        modes: [
+            {
+                id: "default",
+                runtimeId: "claude-acp",
+                name: "Default",
+                description: "",
+            },
+        ],
+        configOptions: [],
+        messages: [],
+        attachments: [],
+        runtimeState: "live",
+        ...overrides,
+    };
+}
+
+describe("canonical chat store projection", () => {
+    it("deduplicates local and native session replacements by conversation", () => {
+        const stale = createSession({
+            sessionId: "persisted:conversation-1",
+            runtimeSessionId: "native-old",
+            runtimeState: "persisted_only",
+        });
+        const live = createSession({
+            sessionId: "local-live",
+            runtimeSessionId: "native-live",
+        });
+        const projection = projectChatStoreToCanonical({
+            sessionsById: {
+                [stale.sessionId]: stale,
+                [live.sessionId]: live,
+            },
+            sessionOrder: [stale.sessionId, live.sessionId],
+            activeSessionId: live.sessionId,
+        });
+
+        expect(projection.conversationOrder).toEqual(["conversation-1"]);
+        expect(projection.activeConversationId).toBe("conversation-1");
+        expect(projection.sessionIdByConversationId["conversation-1"]).toBe(
+            "local-live",
+        );
+        expect(
+            resolveConversationId(projection, "native-live"),
+        ).toBe("conversation-1");
+        expect(
+            resolveLegacySessionId(projection, "native-old"),
+        ).toBe("local-live");
+
+        expect(
+            projectSessionMapToConversations(
+                {
+                    [stale.sessionId]: "stale draft",
+                    [live.sessionId]: "live draft",
+                },
+                projection,
+            ),
+        ).toEqual({ "conversation-1": "live draft" });
+    });
+
+    it("indexes every persisted binding and projects the active one for legacy UI", () => {
+        const session = createSession();
+        const bindingState = createConversationBindingsFromLegacySession(session);
+        const activeBinding = bindingState.providerBindings[0];
+        const previousBinding = {
+            ...activeBinding,
+            bindingId: "binding:codex",
+            runtimeId: "codex-acp",
+            runtimeSessionId: "codex-native",
+            modelId: "gpt-5",
+            models: [],
+            modes: [],
+            configOptions: [],
+        };
+        const withBindings: AIChatSession = {
+            ...session,
+            conversationBindings: {
+                ...bindingState,
+                revision: 2,
+                providerBindings: [previousBinding, activeBinding],
+            },
+        };
+        const projection = projectChatStoreToCanonical({
+            sessionsById: { [session.sessionId]: withBindings },
+            sessionOrder: [session.sessionId],
+            activeSessionId: session.sessionId,
+        });
+
+        expect(projection.bindingsById["binding:codex"]).toMatchObject({
+            runtimeId: "codex-acp",
+            runtimeSessionId: "codex-native",
+        });
+        expect(resolveConversationId(projection, "binding:codex")).toBe(
+            "conversation-1",
+        );
+        expect(resolveConversationId(projection, "codex-native")).toBe(
+            "conversation-1",
+        );
+
+        const legacy = selectLegacySessionForConversation(
+            {
+                ...projection,
+                sessionsById: { [session.sessionId]: withBindings },
+            },
+            "conversation-1",
+        );
+        expect(legacy).toMatchObject({
+            sessionId: "local-session",
+            historySessionId: "conversation-1",
+            runtimeId: "claude-acp",
+            runtimeSessionId: "native-session",
+        });
+    });
+});

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.test.ts
@@ -6,7 +6,6 @@ import {
     projectSessionMapToConversations,
     resolveConversationId,
     resolveLegacySessionId,
-    selectLegacySessionForConversation,
 } from "./chatStoreConversationProjection";
 
 function createSession(overrides: Partial<AIChatSession> = {}): AIChatSession {
@@ -87,7 +86,7 @@ describe("canonical chat store projection", () => {
         ).toEqual({ "conversation-1": "live draft" });
     });
 
-    it("indexes every persisted binding and projects the active one for legacy UI", () => {
+    it("drops bindings from the retired multi-provider flow", () => {
         const session = createSession();
         const bindingState = createConversationBindingsFromLegacySession(session);
         const activeBinding = bindingState.providerBindings[0];
@@ -115,30 +114,10 @@ describe("canonical chat store projection", () => {
             activeSessionId: session.sessionId,
         });
 
-        expect(projection.bindingsById["binding:codex"]).toMatchObject({
-            runtimeId: "codex-acp",
-            runtimeSessionId: "codex-native",
-        });
-        expect(resolveConversationId(projection, "binding:codex")).toBe(
-            "conversation-1",
-        );
-        expect(resolveConversationId(projection, "codex-native")).toBe(
-            "conversation-1",
-        );
-
-        const legacy = selectLegacySessionForConversation(
-            {
-                ...projection,
-                sessionsById: { [session.sessionId]: withBindings },
-            },
-            "conversation-1",
-        );
-        expect(legacy).toMatchObject({
-            sessionId: "local-session",
-            historySessionId: "conversation-1",
-            runtimeId: "claude-acp",
-            runtimeSessionId: "native-session",
-        });
+        expect(projection.bindingsById["binding:codex"]).toBeUndefined();
+        expect(resolveConversationId(projection, "binding:codex")).toBeNull();
+        expect(resolveConversationId(projection, "codex-native")).toBeNull();
+        expect(Object.values(projection.bindingsById)).toHaveLength(1);
     });
 
     it("keeps an active provider model staged for the next turn", () => {

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
@@ -1,5 +1,4 @@
 import {
-  projectCanonicalConversationToLegacy,
   projectLegacySessionToCanonical,
   updateConversationBindingsFromLegacySession,
 } from "../conversationModel";
@@ -205,21 +204,4 @@ export function projectSessionMapToConversations<T>(
     if (conversationId) valuesByConversationId[conversationId] = value;
   }
   return valuesByConversationId;
-}
-
-/** Returns the temporary AIChatSession view used by legacy UI consumers. */
-export function selectLegacySessionForConversation(
-  state: CanonicalChatStoreProjection & {
-    sessionsById: Record<string, AIChatSession>;
-  },
-  conversationId: string,
-) {
-  const conversation = state.conversationsById[conversationId];
-  const sessionId = state.sessionIdByConversationId[conversationId];
-  const template = sessionId ? state.sessionsById[sessionId] : null;
-  const binding = conversation?.activeBindingId
-    ? state.bindingsById[conversation.activeBindingId]
-    : null;
-  if (!conversation || !template || !binding) return null;
-  return projectCanonicalConversationToLegacy(conversation, binding, template);
 }

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
@@ -1,0 +1,225 @@
+import {
+  projectCanonicalConversationToLegacy,
+  projectLegacySessionToCanonical,
+  updateConversationBindingsFromLegacySession,
+} from "../conversationModel";
+import type {
+  AcpConversationBinding,
+  AIChatSession,
+  AIConversation,
+} from "../types";
+
+export interface CanonicalChatStoreProjection {
+  conversationsById: Record<string, AIConversation>;
+  bindingsById: Record<string, AcpConversationBinding>;
+  conversationOrder: string[];
+  activeConversationId: string | null;
+  conversationIdBySessionRef: Record<string, string>;
+  sessionIdByConversationId: Record<string, string>;
+}
+
+export interface LegacyChatProjectionSource {
+  sessionsById: Record<string, AIChatSession>;
+  sessionOrder: string[];
+  activeSessionId: string | null;
+}
+
+function addSessionRef(
+  refs: Record<string, string>,
+  ref: string | null | undefined,
+  conversationId: string,
+) {
+  const normalized = ref?.trim();
+  if (normalized) refs[normalized] = conversationId;
+}
+
+function orderedSessionIds(source: LegacyChatProjectionSource) {
+  const known = new Set<string>();
+  const ordered: string[] = [];
+  const add = (sessionId: string | null | undefined) => {
+    if (!sessionId || known.has(sessionId) || !source.sessionsById[sessionId]) {
+      return;
+    }
+    known.add(sessionId);
+    ordered.push(sessionId);
+  };
+
+  // The active local session is the compatibility projection that should win
+  // if a native resume briefly leaves both the old and new ids in memory.
+  add(source.activeSessionId);
+  source.sessionOrder.forEach(add);
+  Object.keys(source.sessionsById).forEach(add);
+    return ordered;
+}
+
+function isProjectableSession(session: AIChatSession) {
+    return (
+        typeof session.sessionId === "string" &&
+        typeof session.runtimeId === "string" &&
+        typeof session.modelId === "string" &&
+        typeof session.modeId === "string" &&
+        Array.isArray(session.models) &&
+        Array.isArray(session.modes) &&
+        Array.isArray(session.configOptions) &&
+        Array.isArray(session.messages) &&
+        Array.isArray(session.attachments)
+    );
+}
+
+/**
+ * Builds the canonical store projection from the transitional session store.
+ * One conversation is emitted per durable history id even if multiple local or
+ * native session ids temporarily refer to it.
+ */
+export function projectChatStoreToCanonical(
+  source: LegacyChatProjectionSource,
+): CanonicalChatStoreProjection {
+  const conversationsById: Record<string, AIConversation> = {};
+  const bindingsById: Record<string, AcpConversationBinding> = {};
+  const conversationIdBySessionRef: Record<string, string> = {};
+  const sessionIdByConversationId: Record<string, string> = {};
+  const conversationOrder: string[] = [];
+
+  for (const sessionId of orderedSessionIds(source)) {
+        const session = source.sessionsById[sessionId];
+        if (!session || !isProjectableSession(session)) continue;
+
+    const projected = projectLegacySessionToCanonical(session);
+    const bindingState = updateConversationBindingsFromLegacySession(session);
+    const conversationId = bindingState.conversationId;
+
+    addSessionRef(
+      conversationIdBySessionRef,
+      session.sessionId,
+      conversationId,
+    );
+    addSessionRef(
+      conversationIdBySessionRef,
+      session.historySessionId,
+      conversationId,
+    );
+    addSessionRef(
+      conversationIdBySessionRef,
+      session.runtimeSessionId,
+      conversationId,
+    );
+    addSessionRef(conversationIdBySessionRef, conversationId, conversationId);
+
+    for (const binding of bindingState.providerBindings) {
+      if (!bindingsById[binding.bindingId]) {
+        bindingsById[binding.bindingId] = binding;
+      }
+      addSessionRef(
+        conversationIdBySessionRef,
+        binding.bindingId,
+        conversationId,
+      );
+      addSessionRef(
+        conversationIdBySessionRef,
+        binding.runtimeSessionId,
+        conversationId,
+      );
+    }
+
+    if (conversationsById[conversationId]) continue;
+
+    conversationsById[conversationId] = {
+      ...projected.conversation,
+      conversationId,
+      preferredSelection: bindingState.preferredSelection,
+      activeBindingId: bindingState.activeBindingId,
+    };
+    sessionIdByConversationId[conversationId] = session.sessionId;
+    conversationOrder.push(conversationId);
+  }
+
+  // Parent refs from legacy payloads can be local, native, or durable ids.
+  // Normalize them only after every ref has been indexed.
+  for (const [conversationId, conversation] of Object.entries(
+    conversationsById,
+  )) {
+    const parentRef = conversation.parentConversationId;
+    if (!parentRef) continue;
+    const parentConversationId =
+      conversationIdBySessionRef[parentRef] ?? parentRef;
+    if (parentConversationId !== parentRef) {
+      conversationsById[conversationId] = {
+        ...conversation,
+        parentConversationId,
+      };
+    }
+  }
+
+  const activeConversationId = source.activeSessionId
+    ? (conversationIdBySessionRef[source.activeSessionId] ?? null)
+    : null;
+
+  return {
+    conversationsById,
+    bindingsById,
+    conversationOrder,
+    activeConversationId,
+    conversationIdBySessionRef,
+    sessionIdByConversationId,
+  };
+}
+
+export function resolveConversationId(
+  state: Pick<
+    CanonicalChatStoreProjection,
+    "conversationIdBySessionRef" | "conversationsById"
+  >,
+  ref: string | null | undefined,
+) {
+  if (!ref) return null;
+  const indexed = state.conversationIdBySessionRef[ref];
+  if (indexed) return indexed;
+  return state.conversationsById[ref] ? ref : null;
+}
+
+export function resolveLegacySessionId(
+  state: Pick<
+    CanonicalChatStoreProjection,
+    | "conversationIdBySessionRef"
+    | "conversationsById"
+    | "sessionIdByConversationId"
+  >,
+  ref: string | null | undefined,
+) {
+  const conversationId = resolveConversationId(state, ref);
+  return conversationId
+    ? (state.sessionIdByConversationId[conversationId] ?? null)
+    : null;
+}
+
+export function projectSessionMapToConversations<T>(
+  valuesBySessionId: Readonly<Record<string, T>>,
+  projection: Pick<
+    CanonicalChatStoreProjection,
+    "conversationIdBySessionRef" | "conversationsById"
+  >,
+): Record<string, T> {
+  const valuesByConversationId: Record<string, T> = {};
+  for (const [sessionRef, value] of Object.entries(valuesBySessionId)) {
+    const conversationId = resolveConversationId(projection, sessionRef);
+    if (conversationId) valuesByConversationId[conversationId] = value;
+  }
+  return valuesByConversationId;
+}
+
+/** Returns the temporary AIChatSession view used by legacy UI consumers. */
+export function selectLegacySessionForConversation(
+  state: CanonicalChatStoreProjection & {
+    sessionsById: Record<string, AIChatSession>;
+  },
+  conversationId: string,
+) {
+  const conversation = state.conversationsById[conversationId];
+  const sessionId = state.sessionIdByConversationId[conversationId];
+  const template = sessionId ? state.sessionsById[sessionId] : null;
+  const binding = conversation?.activeBindingId
+    ? state.bindingsById[conversation.activeBindingId]
+    : null;
+  if (!conversation || !template || !binding) return null;
+  return projectCanonicalConversationToLegacy(conversation, binding, template);
+}

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
@@ -66,6 +66,107 @@ function isProjectableSession(session: AIChatSession) {
 }
 
 /**
+ * Content-only session updates may be projected without rebuilding bindings
+ * or the session-ref indices. Any field that can change conversation identity,
+ * routing, or the provider binding belongs in this topology comparison.
+ */
+export function hasSameCanonicalSessionTopology(
+  previous: AIChatSession,
+  next: AIChatSession,
+) {
+  return (
+    previous.sessionId === next.sessionId &&
+    previous.historySessionId === next.historySessionId &&
+    previous.parentSessionId === next.parentSessionId &&
+    previous.vaultPath === next.vaultPath &&
+    previous.runtimeSessionId === next.runtimeSessionId &&
+    previous.runtimeId === next.runtimeId &&
+    previous.runtimeDisplayName === next.runtimeDisplayName &&
+    previous.runtimeRevision === next.runtimeRevision &&
+    previous.runtimeLaunchFingerprint === next.runtimeLaunchFingerprint &&
+    previous.continuationStrategy === next.continuationStrategy &&
+    previous.modelId === next.modelId &&
+    previous.modeId === next.modeId &&
+    previous.models === next.models &&
+    previous.modes === next.modes &&
+    previous.configOptions === next.configOptions &&
+    previous.availableCommands === next.availableCommands &&
+    previous.effortsByModel === next.effortsByModel &&
+    previous.runtimeState === next.runtimeState &&
+    previous.conversationBindings === next.conversationBindings
+  );
+}
+
+function hasSameCanonicalConversationContent(
+  previous: AIConversation,
+  next: AIConversation,
+) {
+  return (
+    previous.conversationId === next.conversationId &&
+    previous.parentConversationId === next.parentConversationId &&
+    previous.vaultPath === next.vaultPath &&
+    previous.closedAt === next.closedAt &&
+    previous.status === next.status &&
+    previous.activeWorkCycleId === next.activeWorkCycleId &&
+    previous.visibleWorkCycleId === next.visibleWorkCycleId &&
+    previous.actionLog === next.actionLog &&
+    previous.messages === next.messages &&
+    previous.attachments === next.attachments &&
+    previous.preferredSelection === next.preferredSelection &&
+    previous.activeBindingId === next.activeBindingId &&
+    previous.persistedCreatedAt === next.persistedCreatedAt &&
+    previous.persistedUpdatedAt === next.persistedUpdatedAt &&
+    previous.persistedTitle === next.persistedTitle &&
+    previous.customTitle === next.customTitle &&
+    previous.persistedPreview === next.persistedPreview &&
+    previous.persistedMessageCount === next.persistedMessageCount &&
+    previous.loadedPersistedMessageStart ===
+      next.loadedPersistedMessageStart &&
+    previous.isLoadingPersistedMessages ===
+      next.isLoadingPersistedMessages &&
+    previous.isPersistedSession === next.isPersistedSession &&
+    previous.isPendingSessionCreation === next.isPendingSessionCreation &&
+    previous.isResumingSession === next.isResumingSession
+  );
+}
+
+/**
+ * Refreshes the mutable conversation payload for one legacy session while
+ * preserving canonical identity, normalized parent refs, and staged routing.
+ */
+export function projectCanonicalConversationContentUpdate(
+  previous: AIConversation,
+  session: AIChatSession,
+) {
+  const next: AIConversation = {
+    ...previous,
+    closedAt: session.closedAt ?? null,
+    status: session.status,
+    activeWorkCycleId: session.activeWorkCycleId ?? null,
+    visibleWorkCycleId: session.visibleWorkCycleId ?? null,
+    actionLog: session.actionLog,
+    messages: session.messages,
+    attachments: session.attachments,
+    persistedCreatedAt: session.persistedCreatedAt ?? null,
+    persistedUpdatedAt: session.persistedUpdatedAt ?? null,
+    persistedTitle: session.persistedTitle ?? null,
+    customTitle: session.customTitle ?? null,
+    persistedPreview: session.persistedPreview ?? null,
+    persistedMessageCount: session.persistedMessageCount,
+    loadedPersistedMessageStart:
+      session.loadedPersistedMessageStart ?? null,
+    isLoadingPersistedMessages: session.isLoadingPersistedMessages,
+    isPersistedSession: session.isPersistedSession ?? false,
+    isPendingSessionCreation: session.isPendingSessionCreation ?? false,
+    isResumingSession: session.isResumingSession ?? false,
+  };
+
+  return hasSameCanonicalConversationContent(previous, next)
+    ? previous
+    : next;
+}
+
+/**
  * Builds the canonical store projection from the transitional session store.
  * One conversation is emitted per durable history id even if multiple local or
  * native session ids temporarily refer to it.

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
@@ -29,7 +29,15 @@ function addSessionRef(
   conversationId: string,
 ) {
   const normalized = ref?.trim();
-  if (normalized) refs[normalized] = conversationId;
+  if (!normalized) return;
+  const existingConversationId = refs[normalized];
+  if (
+    existingConversationId &&
+    existingConversationId !== conversationId
+  ) {
+    return;
+  }
+  refs[normalized] = conversationId;
 }
 
 function orderedSessionIds(source: LegacyChatProjectionSource) {

--- a/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
+++ b/apps/desktop/src/features/ai/store/chatStoreConversationProjection.ts
@@ -304,13 +304,77 @@ export function projectSessionMapToConversations<T>(
   valuesBySessionId: Readonly<Record<string, T>>,
   projection: Pick<
     CanonicalChatStoreProjection,
-    "conversationIdBySessionRef" | "conversationsById"
+    | "conversationIdBySessionRef"
+    | "conversationsById"
+    | "sessionIdByConversationId"
   >,
 ): Record<string, T> {
   const valuesByConversationId: Record<string, T> = {};
-  for (const [sessionRef, value] of Object.entries(valuesBySessionId)) {
-    const conversationId = resolveConversationId(projection, sessionRef);
-    if (conversationId) valuesByConversationId[conversationId] = value;
+  const resolveValue = createConversationScopedValueResolver(
+    valuesBySessionId,
+    projection,
+  );
+  for (const conversationId of Object.keys(projection.conversationsById)) {
+    const resolved = resolveValue(conversationId);
+    if (resolved.hasValue) {
+      valuesByConversationId[conversationId] = resolved.value;
+    }
   }
   return valuesByConversationId;
+}
+
+export function createConversationScopedValueResolver<T>(
+  valuesBySessionId: Readonly<Record<string, T>>,
+  projection: Pick<
+    CanonicalChatStoreProjection,
+    "conversationIdBySessionRef" | "sessionIdByConversationId"
+  >,
+): (
+  conversationId: string,
+) => { hasValue: false } | { hasValue: true; value: T } {
+  let aliasValuesByConversationId: Record<string, T> | null = null;
+
+  return (conversationId) => {
+    const canonicalSessionId =
+      projection.sessionIdByConversationId[conversationId];
+    if (
+      canonicalSessionId &&
+      Object.hasOwn(valuesBySessionId, canonicalSessionId)
+    ) {
+      return {
+        hasValue: true,
+        value: valuesBySessionId[canonicalSessionId],
+      };
+    }
+    if (Object.hasOwn(valuesBySessionId, conversationId)) {
+      return { hasValue: true, value: valuesBySessionId[conversationId] };
+    }
+
+    if (!aliasValuesByConversationId) {
+      aliasValuesByConversationId = {};
+      // Legacy values can still be keyed by a native session or binding id.
+      // Build fallbacks from the canonical ref index so precedence does not
+      // depend on insertion order in the session-scoped value map.
+      for (const [sessionRef, mappedConversationId] of Object.entries(
+        projection.conversationIdBySessionRef,
+      )) {
+        if (
+          !Object.hasOwn(
+            aliasValuesByConversationId,
+            mappedConversationId,
+          ) &&
+          Object.hasOwn(valuesBySessionId, sessionRef)
+        ) {
+          aliasValuesByConversationId[mappedConversationId] =
+            valuesBySessionId[sessionRef];
+        }
+      }
+    }
+    return Object.hasOwn(aliasValuesByConversationId, conversationId)
+      ? {
+          hasValue: true,
+          value: aliasValuesByConversationId[conversationId],
+        }
+      : { hasValue: false };
+  };
 }

--- a/apps/desktop/src/features/ai/store/chatTabsStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatTabsStore.test.ts
@@ -36,6 +36,28 @@ describe("chatTabsStore", () => {
         expect(useChatTabsStore.getState().activeTabId).toBe(firstTabId);
     });
 
+    it("keeps one tab when a conversation receives a new local session id", () => {
+        useChatTabsStore.getState().openSessionTab("persisted:history-a", {
+            historySessionId: "history-a",
+            runtimeId: "runtime-a",
+        });
+        const tabId = useChatTabsStore.getState().tabs[0]?.id;
+
+        useChatTabsStore.getState().openSessionTab("live-session-a", {
+            historySessionId: "history-a",
+            runtimeId: "runtime-a",
+        });
+
+        expect(useChatTabsStore.getState().tabs).toEqual([
+            expect.objectContaining({
+                id: tabId,
+                conversationId: "history-a",
+                sessionId: "live-session-a",
+                historySessionId: "history-a",
+            }),
+        ]);
+    });
+
     it("reorders tabs without changing the active tab id", () => {
         useChatTabsStore.getState().openSessionTab("session-a");
         useChatTabsStore.getState().openSessionTab("session-b");

--- a/apps/desktop/src/features/ai/store/chatTabsStore.ts
+++ b/apps/desktop/src/features/ai/store/chatTabsStore.ts
@@ -10,6 +10,8 @@ const CHAT_TABS_PERSIST_VERSION = 1;
 
 export interface ChatWorkspaceTab {
     id: string;
+    /** Stable canonical identity; optional only for persisted v1 compatibility. */
+    conversationId?: string;
     sessionId: string;
     historySessionId?: string;
     runtimeId?: string;
@@ -81,19 +83,21 @@ function normalizeTabs(
 ): ChatWorkspaceTab[] {
     const deduped: ChatWorkspaceTab[] = [];
     const indexesByTabId = new Map<string, number>();
-    const indexesBySessionId = new Map<string, number>();
+    const indexesByConversationId = new Map<string, number>();
 
     for (const tab of tabs) {
         if (!tab.id || !tab.sessionId) continue;
 
+        const conversationId = resolveTabConversationId(tab);
         const existingIndex =
-            indexesByTabId.get(tab.id) ?? indexesBySessionId.get(tab.sessionId);
+            indexesByTabId.get(tab.id) ??
+            indexesByConversationId.get(conversationId);
 
         if (existingIndex === undefined) {
             const nextIndex = deduped.length;
             deduped.push(tab);
             indexesByTabId.set(tab.id, nextIndex);
-            indexesBySessionId.set(tab.sessionId, nextIndex);
+            indexesByConversationId.set(conversationId, nextIndex);
             continue;
         }
 
@@ -108,9 +112,11 @@ function normalizeTabs(
             indexesByTabId.set(preferred.id, existingIndex);
         }
 
-        if (preferred.sessionId !== existing.sessionId) {
-            indexesBySessionId.delete(existing.sessionId);
-            indexesBySessionId.set(preferred.sessionId, existingIndex);
+        const existingConversationId = resolveTabConversationId(existing);
+        const preferredConversationId = resolveTabConversationId(preferred);
+        if (preferredConversationId !== existingConversationId) {
+            indexesByConversationId.delete(existingConversationId);
+            indexesByConversationId.set(preferredConversationId, existingIndex);
         }
     }
 
@@ -174,6 +180,7 @@ function normalizeParsedWorkspace(raw: unknown): PersistedChatWorkspace | null {
             if (!tab || typeof tab !== "object") return null;
             const current = tab as {
                 id?: unknown;
+                conversationId?: unknown;
                 sessionId?: unknown;
                 historySessionId?: unknown;
                 runtimeId?: unknown;
@@ -193,6 +200,13 @@ function normalizeParsedWorkspace(raw: unknown): PersistedChatWorkspace | null {
                 id: current.id,
                 sessionId: current.sessionId,
             };
+
+            if (
+                typeof current.conversationId === "string" &&
+                current.conversationId.length > 0
+            ) {
+                normalizedTab.conversationId = current.conversationId;
+            }
 
             if (
                 typeof current.historySessionId === "string" &&
@@ -231,6 +245,11 @@ function createTab(
 ): ChatWorkspaceTab {
     const tab: ChatWorkspaceTab = {
         id: crypto.randomUUID(),
+        conversationId:
+            historySessionId ??
+            (sessionId.startsWith("persisted:")
+                ? sessionId.slice("persisted:".length) || sessionId
+                : sessionId),
         sessionId,
     };
 
@@ -253,6 +272,12 @@ function resolveTabHistorySessionId(tab: ChatWorkspaceTab) {
     return null;
 }
 
+function resolveTabConversationId(tab: ChatWorkspaceTab) {
+    return (
+        tab.conversationId ?? resolveTabHistorySessionId(tab) ?? tab.sessionId
+    );
+}
+
 function syncTabMetadata(
     tab: ChatWorkspaceTab,
     historySessionId?: string | null,
@@ -260,16 +285,23 @@ function syncTabMetadata(
 ): ChatWorkspaceTab {
     const nextHistorySessionId = historySessionId ?? tab.historySessionId;
     const nextRuntimeId = runtimeId ?? tab.runtimeId;
+    const nextConversationId =
+        tab.conversationId ??
+        nextHistorySessionId ??
+        resolveTabHistorySessionId(tab) ??
+        tab.sessionId;
 
     if (
         nextHistorySessionId === tab.historySessionId &&
-        nextRuntimeId === tab.runtimeId
+        nextRuntimeId === tab.runtimeId &&
+        nextConversationId === tab.conversationId
     ) {
         return tab;
     }
 
     return {
         ...tab,
+        conversationId: nextConversationId,
         ...(nextHistorySessionId
             ? { historySessionId: nextHistorySessionId }
             : {}),
@@ -394,18 +426,30 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
         runtimeId = null,
     ) => {
         let ensuredTabId = "";
+        const requestedConversationId =
+            historySessionId ??
+            (sessionId.startsWith("persisted:")
+                ? sessionId.slice("persisted:".length) || sessionId
+                : sessionId);
 
         set((state) => {
             const existing = state.tabs.find(
-                (tab) => tab.sessionId === sessionId,
+                (tab) =>
+                    resolveTabConversationId(tab) === requestedConversationId,
             );
             if (existing) {
                 ensuredTabId = existing.id;
-                const nextTabs = state.tabs.map((tab) =>
-                    tab.id === existing.id
-                        ? syncTabMetadata(tab, historySessionId, runtimeId)
-                        : tab,
-                );
+                const nextTabs = state.tabs.map((tab) => {
+                    if (tab.id !== existing.id) return tab;
+                    const synced = syncTabMetadata(
+                        tab,
+                        historySessionId,
+                        runtimeId,
+                    );
+                    return synced.sessionId === sessionId
+                        ? synced
+                        : { ...synced, sessionId };
+                });
                 const tabsChanged = nextTabs.some(
                     (tab, index) => tab !== state.tabs[index],
                 );
@@ -459,14 +503,19 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
         set((state) => {
             const removedTabIndexes = state.tabs.reduce<number[]>(
                 (indexes, tab, index) =>
-                    tab.sessionId === sessionId ? [...indexes, index] : indexes,
+                    tab.sessionId === sessionId ||
+                    resolveTabConversationId(tab) === sessionId
+                        ? [...indexes, index]
+                        : indexes,
                 [],
             );
 
             if (!removedTabIndexes.length) return state;
 
             const tabs = state.tabs.filter(
-                (tab) => tab.sessionId !== sessionId,
+                (tab) =>
+                    tab.sessionId !== sessionId &&
+                    resolveTabConversationId(tab) !== sessionId,
             );
             const activeTabId =
                 state.tabs[removedTabIndexes[0]]?.id === state.activeTabId
@@ -483,10 +532,13 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
 
     pruneInvalidTabs: (validSessionIds) => {
         const validSessionIdSet = new Set(validSessionIds);
+        const isValid = (tab: ChatWorkspaceTab) =>
+            validSessionIdSet.has(tab.sessionId) ||
+            validSessionIdSet.has(resolveTabConversationId(tab));
 
         set((state) => {
             const removedTabIndex = state.tabs.findIndex(
-                (tab) => !validSessionIdSet.has(tab.sessionId),
+                (tab) => !isValid(tab),
             );
             if (removedTabIndex === -1) {
                 const tabs = normalizeTabs(state.tabs, state.activeTabId);
@@ -497,9 +549,7 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
             }
 
             const tabs = normalizeTabs(
-                state.tabs.filter((tab) =>
-                    validSessionIdSet.has(tab.sessionId),
-                ),
+                state.tabs.filter((tab) => isValid(tab)),
                 state.activeTabId,
             );
             const activeTabId =
@@ -529,10 +579,15 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
         );
         const sessionIdByHistoryId = new Map<string, string>();
         const historyIdBySessionId = new Map<string, string>();
+        const sessionIdByConversationId = new Map<string, string>();
         const runtimeIdBySessionId = new Map<string, string>();
         const runtimeIdByHistoryId = new Map<string, string>();
         for (const session of validSessions) {
             const historySessionId = session.historySessionId ?? null;
+            sessionIdByConversationId.set(
+                historySessionId ?? session.sessionId,
+                session.sessionId,
+            );
             if (!historySessionId) continue;
             sessionIdByHistoryId.set(historySessionId, session.sessionId);
             historyIdBySessionId.set(session.sessionId, historySessionId);
@@ -550,6 +605,23 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
         let tabs = normalizeTabs(
             (workspace?.tabs ?? [])
                 .map((tab): ChatWorkspaceTab | null => {
+                    const conversationId = resolveTabConversationId(tab);
+                    const canonicalSessionId =
+                        sessionIdByConversationId.get(conversationId);
+                    if (canonicalSessionId) {
+                        return syncTabMetadata(
+                            {
+                                ...tab,
+                                conversationId,
+                                sessionId: canonicalSessionId,
+                            },
+                            historyIdBySessionId.get(canonicalSessionId) ??
+                                resolveTabHistorySessionId(tab),
+                            runtimeIdBySessionId.get(canonicalSessionId) ??
+                                runtimeIdByHistoryId.get(conversationId) ??
+                                tab.runtimeId,
+                        );
+                    }
                     if (validSessionIdSet.has(tab.sessionId)) {
                         return syncTabMetadata(
                             tab,
@@ -572,6 +644,7 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
 
                     return {
                         ...tab,
+                        conversationId: historySessionId,
                         sessionId: resolvedSessionId,
                         historySessionId,
                         runtimeId:
@@ -625,6 +698,10 @@ export const useChatTabsStore = create<ChatTabsStore>((set, get) => ({
                     tab.sessionId === oldSessionId
                         ? {
                               ...tab,
+                              conversationId:
+                                  historySessionId ??
+                                  tab.conversationId ??
+                                  resolveTabConversationId(tab),
                               sessionId: newSessionId,
                               historySessionId:
                                   historySessionId ??
@@ -662,7 +739,7 @@ useChatTabsStore.subscribe((state) => {
     // Cheap fingerprint to skip expensive serialization when nothing relevant changed
     let sig = state.activeTabId ?? "";
     for (const t of state.tabs) {
-        sig += `|${t.id}|${t.sessionId ?? ""}|${t.historySessionId ?? ""}|${t.runtimeId ?? ""}|${t.pinned ? "1" : "0"}`;
+        sig += `|${t.id}|${t.conversationId ?? ""}|${t.sessionId ?? ""}|${t.historySessionId ?? ""}|${t.runtimeId ?? ""}|${t.pinned ? "1" : "0"}`;
     }
     if (sig === _lastChatTabsSig) return;
     _lastChatTabsSig = sig;

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -37,7 +37,6 @@ export interface ConversationSelection {
 
 export type ConversationTurnStartReason =
     | "normal"
-    | "provider_switch"
     | "native_resume"
     | "transcript_handoff";
 

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -345,6 +345,8 @@ export interface QueuedChatMessage {
     attachments: AIChatAttachment[];
     createdAt: number;
     status: QueuedChatMessageStatus;
+    /** Provider selected for this turn. Omitted only by legacy queue entries. */
+    runtimeId?: string | null;
     modelId: string | null;
     modeId: string | null;
     optionsSnapshot: Record<string, string>;
@@ -633,6 +635,8 @@ export interface AIChatSession {
     resumeContextPending?: boolean;
     resumeReconnectFailed?: boolean;
     runtimeState?: AIRuntimeSessionState;
+    /** Provenance applied to runtime events until the accepted turn completes. */
+    activeTurnProvenance?: ConversationTurnProvenance | null;
     /** Canonical provider bindings loaded from the versioned history sidecar. */
     conversationBindings?: ConversationBindingsState;
 }

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -60,6 +60,10 @@ export interface ConversationTurnProvenance {
     modeId: string;
     options: Record<string, string>;
     startReason: ConversationTurnStartReason;
+    /** Whether the bounded transcript handoff omitted context for this turn. */
+    handoffTruncated?: boolean;
+    /** Complete turns omitted from the handoff budget. */
+    handoffOmittedTurnCount?: number;
 }
 
 export type AIRuntimeConnectionStatus = "idle" | "loading" | "ready" | "error";
@@ -961,6 +965,8 @@ export interface PersistedMessage {
         mode_id: string;
         options: Record<string, string>;
         start_reason: ConversationTurnStartReason;
+        handoff_truncated?: boolean;
+        handoff_omitted_turn_count?: number;
     };
 }
 

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -510,6 +510,23 @@ export interface AcpConversationBinding {
     updatedAt: number | null;
 }
 
+export interface ConversationTranscriptObservation {
+    messageCount: number;
+    updatedAt: number;
+    transcriptFingerprint: string | null;
+}
+
+export interface ConversationBindingsState {
+    version: number;
+    revision: number;
+    conversationId: string;
+    preferredSelection: ConversationSelection;
+    activeBindingId: string | null;
+    providerBindings: AcpConversationBinding[];
+    contextSummary: string | null;
+    transcriptObservation: ConversationTranscriptObservation;
+}
+
 export interface AIConversation {
     conversationId: string;
     parentConversationId: string | null;
@@ -603,6 +620,8 @@ export interface AIChatSession {
     resumeContextPending?: boolean;
     resumeReconnectFailed?: boolean;
     runtimeState?: AIRuntimeSessionState;
+    /** Canonical provider bindings loaded from the versioned history sidecar. */
+    conversationBindings?: ConversationBindingsState;
 }
 
 export interface AIRuntimeDescriptor {
@@ -917,6 +936,57 @@ export interface PersistedMessage {
     plan_entries?: AIPlanEntry[];
     plan_detail?: string;
     tool_action?: AIToolActivityAction | null;
+    turn_provenance?: {
+        binding_id: string;
+        runtime_id: string;
+        runtime_session_id: string | null;
+        model_id: string;
+        mode_id: string;
+        options: Record<string, string>;
+        start_reason: ConversationTurnStartReason;
+    };
+}
+
+export interface PersistedConversationBindings {
+    version: number;
+    revision: number;
+    conversation_id: string;
+    preferred_selection: {
+        runtime_id: string;
+        model_id: string;
+        mode_id: string;
+        options: Record<string, string>;
+    };
+    active_binding_id: string | null;
+    provider_bindings: Array<{
+        binding_id: string;
+        conversation_id: string;
+        runtime_id: string;
+        runtime_display_name: string | null;
+        runtime_revision: number | null;
+        runtime_launch_fingerprint: string | null;
+        runtime_session_id: string | null;
+        continuation_strategy: AcpContinuationStrategy | null;
+        capabilities: string[];
+        model_id: string;
+        mode_id: string;
+        options: Record<string, string>;
+        models?: AIBackendRuntimeDescriptorPayload["models"];
+        modes?: AIBackendRuntimeDescriptorPayload["modes"];
+        config_options?: AIBackendSessionPayload["config_options"];
+        efforts_by_model?: Record<string, string[]>;
+        runtime_state: AIRuntimeSessionState;
+        context_cursor: string | null;
+        context_generation: number;
+        created_at: number | null;
+        updated_at: number | null;
+    }>;
+    context_summary: string | null;
+    transcript_observation: {
+        message_count: number;
+        updated_at: number;
+        transcript_fingerprint: string | null;
+    };
 }
 
 export interface PersistedSessionHistory {
@@ -944,6 +1014,7 @@ export interface PersistedSessionHistory {
     custom_title?: string | null;
     preview?: string;
     messages: PersistedMessage[];
+    conversation_bindings?: PersistedConversationBindings;
 }
 
 export interface PersistedSessionHistoryPage {

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -41,6 +41,17 @@ export type ConversationTurnStartReason =
     | "native_resume"
     | "transcript_handoff";
 
+export interface AcpContextHandoffMetadata {
+    bindingId: string | null;
+    fromCursor: string | null;
+    nextCursor: string | null;
+    cursorFound: boolean;
+    includedMessageIds: string[];
+    omittedTurnCount: number;
+    truncated: boolean;
+    reason: ConversationTurnStartReason;
+}
+
 export interface ConversationTurnProvenance {
     bindingId: string;
     runtimeId: string;
@@ -338,6 +349,8 @@ export interface QueuedChatMessage {
     modeId: string | null;
     optionsSnapshot: Record<string, string>;
     optimisticMessageId?: string;
+    /** Internal ACP payload metadata. Never rendered as a user message. */
+    contextHandoff?: AcpContextHandoffMetadata;
 }
 
 export type AIChatRole = "user" | "assistant" | "system";

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -280,7 +280,7 @@ export interface AIConfigSelectOption {
 export interface AIConfigOption {
     id: string;
     runtimeId: string;
-    category: "mode" | "model" | "reasoning" | "other";
+    category: "mode" | "model" | "reasoning" | "service_tier" | "other";
     label: string;
     description?: string;
     type: "select";
@@ -674,7 +674,12 @@ export interface AIBackendSessionPayload {
     config_options: Array<{
         id: string;
         runtime_id: string;
-        category: "mode" | "model" | "reasoning" | "other";
+        category:
+            | "mode"
+            | "model"
+            | "reasoning"
+            | "service_tier"
+            | "other";
         label: string;
         description?: string | null;
         type: "select";

--- a/apps/desktop/src/features/ai/types.ts
+++ b/apps/desktop/src/features/ai/types.ts
@@ -22,6 +22,35 @@ export type AIChatSessionStatus =
     | "review_required"
     | "error";
 
+export type AIRuntimeSessionState =
+    | "live"
+    | "persisted_only"
+    | "transcript_only"
+    | "detached";
+
+export interface ConversationSelection {
+    runtimeId: string;
+    modelId: string;
+    modeId: string;
+    options: Record<string, string>;
+}
+
+export type ConversationTurnStartReason =
+    | "normal"
+    | "provider_switch"
+    | "native_resume"
+    | "transcript_handoff";
+
+export interface ConversationTurnProvenance {
+    bindingId: string;
+    runtimeId: string;
+    runtimeSessionId: string | null;
+    modelId: string;
+    modeId: string;
+    options: Record<string, string>;
+    startReason: ConversationTurnStartReason;
+}
+
 export type AIRuntimeConnectionStatus = "idle" | "loading" | "ready" | "error";
 
 export type AIRuntimeBinarySource =
@@ -452,6 +481,59 @@ export interface AIChatMessage {
     planEntries?: AIPlanEntry[];
     planDetail?: string;
     toolAction?: AIToolActivityAction | null;
+    /** Runtime that executed this canonical turn. Persisted in phase A2. */
+    turnProvenance?: ConversationTurnProvenance;
+}
+
+export interface AcpConversationBinding {
+    bindingId: string;
+    conversationId: string;
+    runtimeId: string;
+    runtimeDisplayName: string | null;
+    runtimeRevision: number | null;
+    runtimeLaunchFingerprint: string | null;
+    runtimeSessionId: string | null;
+    continuationStrategy: AcpContinuationStrategy | null;
+    capabilities: string[];
+    modelId: string;
+    modeId: string;
+    options: Record<string, string>;
+    models: AIModelOption[];
+    modes: AIModeOption[];
+    configOptions: AIConfigOption[];
+    availableCommands?: AIAvailableCommand[];
+    effortsByModel: Record<string, string[]>;
+    runtimeState: AIRuntimeSessionState;
+    contextCursor: string | null;
+    contextGeneration: number;
+    createdAt: number | null;
+    updatedAt: number | null;
+}
+
+export interface AIConversation {
+    conversationId: string;
+    parentConversationId: string | null;
+    vaultPath: string | null;
+    closedAt: string | null;
+    status: AIChatSessionStatus;
+    activeWorkCycleId: string | null;
+    visibleWorkCycleId: string | null;
+    actionLog?: import("./diff/actionLogTypes").ActionLogState;
+    messages: AIChatMessage[];
+    attachments: AIChatAttachment[];
+    preferredSelection: ConversationSelection;
+    activeBindingId: string | null;
+    persistedCreatedAt: number | null;
+    persistedUpdatedAt: number | null;
+    persistedTitle: string | null;
+    customTitle: string | null;
+    persistedPreview: string | null;
+    persistedMessageCount?: number;
+    loadedPersistedMessageStart?: number | null;
+    isLoadingPersistedMessages?: boolean;
+    isPersistedSession: boolean;
+    isPendingSessionCreation: boolean;
+    isResumingSession: boolean;
 }
 
 export interface AIChatSession {
@@ -520,11 +602,7 @@ export interface AIChatSession {
     pendingSessionError?: string | null;
     resumeContextPending?: boolean;
     resumeReconnectFailed?: boolean;
-    runtimeState?:
-        | "live"
-        | "persisted_only"
-        | "transcript_only"
-        | "detached";
+    runtimeState?: AIRuntimeSessionState;
 }
 
 export interface AIRuntimeDescriptor {

--- a/apps/desktop/src/features/ai/useAiChatEventBridge.test.tsx
+++ b/apps/desktop/src/features/ai/useAiChatEventBridge.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AITokenUsagePayload } from "./types";
+import type { AIChatSession, AITokenUsagePayload } from "./types";
 
 const listeners = vi.hoisted(() => ({
     tokenUsage: undefined as
@@ -49,8 +49,24 @@ describe("useAiChatEventBridge", () => {
         unlisten.mockClear();
         noOpListener.mockClear();
         tokenUsageListener.mockClear();
+        const session: AIChatSession = {
+            sessionId: "session-1",
+            historySessionId: "conversation-1",
+            runtimeSessionId: "native-session-1",
+            status: "idle",
+            runtimeId: "test-runtime",
+            modelId: "test-model",
+            modeId: "default",
+            models: [],
+            modes: [],
+            configOptions: [],
+            messages: [],
+            attachments: [],
+        };
         useChatStore.setState({
-            sessionsById: { "session-1": {} as never },
+            sessionsById: { "session-1": session },
+            sessionOrder: ["session-1"],
+            activeSessionId: "session-1",
         });
     });
 
@@ -65,7 +81,7 @@ describe("useAiChatEventBridge", () => {
 
         act(() => {
             listeners.tokenUsage?.({
-                session_id: "session-1",
+                session_id: "native-session-1",
                 used: 136_000,
                 size: 272_000,
             });
@@ -77,6 +93,11 @@ describe("useAiChatEventBridge", () => {
                 used: 136_000,
                 size: 272_000,
         });
+        expect(
+            useChatStore.getState().tokenUsageByConversationId[
+                "conversation-1"
+            ],
+        ).toMatchObject({ used: 136_000, size: 272_000 });
 
         unmount();
         expect(unlisten).toHaveBeenCalledTimes(19);

--- a/apps/desktop/src/features/ai/useAiChatEventBridge.ts
+++ b/apps/desktop/src/features/ai/useAiChatEventBridge.ts
@@ -20,7 +20,30 @@ import {
     listenToAiUrlElicitationRequest,
     listenToAiUserInputRequest,
 } from "./api";
-import { useChatStore } from "./store/chatStore";
+import { resolveChatSessionId, useChatStore } from "./store/chatStore";
+
+function routeSessionEvent<T extends { session_id: string }>(payload: T): T {
+    const sessionId = resolveChatSessionId(
+        useChatStore.getState(),
+        payload.session_id,
+    );
+    return sessionId && sessionId !== payload.session_id
+        ? { ...payload, session_id: sessionId }
+        : payload;
+}
+
+function routeOptionalSessionEvent<T extends { session_id?: string | null }>(
+    payload: T,
+): T {
+    if (!payload.session_id) return payload;
+    const sessionId = resolveChatSessionId(
+        useChatStore.getState(),
+        payload.session_id,
+    );
+    return sessionId && sessionId !== payload.session_id
+        ? { ...payload, session_id: sessionId }
+        : payload;
+}
 
 export function useAiChatEventBridge(enabled = true) {
     const chatActions = useRef(useChatStore.getState()).current;
@@ -41,6 +64,20 @@ export function useAiChatEventBridge(enabled = true) {
         };
 
         const bind = async () => {
+            const applySessionEvent = <T extends { session_id: string }>(
+                apply: (payload: T) => void,
+            ) =>
+                (payload: T) => {
+                    if (!disposed) apply(routeSessionEvent(payload));
+                };
+            const applyOptionalSessionEvent = <
+                T extends { session_id?: string | null },
+            >(
+                apply: (payload: T) => void,
+            ) =>
+                (payload: T) => {
+                    if (!disposed) apply(routeOptionalSessionEvent(payload));
+                };
             const listeners = await Promise.all([
                 listenToAiSessionCreated((session) => {
                     if (!disposed) chatActions.upsertSession(session);
@@ -48,61 +85,59 @@ export function useAiChatEventBridge(enabled = true) {
                 listenToAiSessionUpdated((session) => {
                     if (!disposed) chatActions.upsertSession(session);
                 }),
-                listenToAiSessionError((payload) => {
-                    if (!disposed) chatActions.applySessionError(payload);
-                }),
-                listenToAiMessageStarted((payload) => {
-                    if (!disposed) chatActions.applyMessageStarted(payload);
-                }),
-                listenToAiMessageDelta((payload) => {
-                    if (!disposed) chatActions.applyMessageDelta(payload);
-                }),
-                listenToAiMessageCompleted((payload) => {
-                    if (!disposed) chatActions.applyMessageCompleted(payload);
-                }),
-                listenToAiThinkingStarted((payload) => {
-                    if (!disposed) chatActions.applyThinkingStarted(payload);
-                }),
-                listenToAiThinkingDelta((payload) => {
-                    if (!disposed) chatActions.applyThinkingDelta(payload);
-                }),
-                listenToAiThinkingCompleted((payload) => {
-                    if (!disposed) chatActions.applyThinkingCompleted(payload);
-                }),
-                listenToAiToolActivity((payload) => {
-                    if (!disposed) chatActions.applyToolActivity(payload);
-                }),
-                listenToAiStatusEvent((payload) => {
-                    if (!disposed) chatActions.applyStatusEvent(payload);
-                }),
-                listenToAiImageGeneration((payload) => {
-                    if (!disposed) chatActions.applyImageGeneration(payload);
-                }),
-                listenToAiPlanUpdated((payload) => {
-                    if (!disposed) chatActions.applyPlanUpdate(payload);
-                }),
-                listenToAiAvailableCommandsUpdated((payload) => {
-                    if (!disposed) {
-                        chatActions.applyAvailableCommandsUpdate(payload);
-                    }
-                }),
-                listenToAiPermissionRequest((payload) => {
-                    if (!disposed) chatActions.applyPermissionRequest(payload);
-                }),
-                listenToAiUserInputRequest((payload) => {
-                    if (!disposed) chatActions.applyUserInputRequest(payload);
-                }),
-                listenToAiUrlElicitationRequest((payload) => {
-                    if (!disposed) {
-                        chatActions.applyUrlElicitationRequest(payload);
-                    }
-                }),
-                listenToAiRuntimeConnection((payload) => {
-                    if (!disposed) chatActions.applyRuntimeConnection(payload);
-                }),
-                listenToAiTokenUsage((payload) => {
-                    if (!disposed) chatActions.applyTokenUsage(payload);
-                }),
+                listenToAiSessionError(
+                    applyOptionalSessionEvent(chatActions.applySessionError),
+                ),
+                listenToAiMessageStarted(
+                    applySessionEvent(chatActions.applyMessageStarted),
+                ),
+                listenToAiMessageDelta(
+                    applySessionEvent(chatActions.applyMessageDelta),
+                ),
+                listenToAiMessageCompleted(
+                    applySessionEvent(chatActions.applyMessageCompleted),
+                ),
+                listenToAiThinkingStarted(
+                    applySessionEvent(chatActions.applyThinkingStarted),
+                ),
+                listenToAiThinkingDelta(
+                    applySessionEvent(chatActions.applyThinkingDelta),
+                ),
+                listenToAiThinkingCompleted(
+                    applySessionEvent(chatActions.applyThinkingCompleted),
+                ),
+                listenToAiToolActivity(
+                    applySessionEvent(chatActions.applyToolActivity),
+                ),
+                listenToAiStatusEvent(
+                    applySessionEvent(chatActions.applyStatusEvent),
+                ),
+                listenToAiImageGeneration(
+                    applySessionEvent(chatActions.applyImageGeneration),
+                ),
+                listenToAiPlanUpdated(
+                    applySessionEvent(chatActions.applyPlanUpdate),
+                ),
+                listenToAiAvailableCommandsUpdated(
+                    applySessionEvent(chatActions.applyAvailableCommandsUpdate),
+                ),
+                listenToAiPermissionRequest(
+                    applySessionEvent(chatActions.applyPermissionRequest),
+                ),
+                listenToAiUserInputRequest(
+                    applySessionEvent(chatActions.applyUserInputRequest),
+                ),
+                listenToAiUrlElicitationRequest(
+                    applySessionEvent(chatActions.applyUrlElicitationRequest),
+                ),
+                listenToAiRuntimeConnection(
+                    applyOptionalSessionEvent(
+                        chatActions.applyRuntimeConnection,
+                    ),
+                ),
+                listenToAiTokenUsage(
+                    applySessionEvent(chatActions.applyTokenUsage),
+                ),
             ]);
 
             if (disposed) {

--- a/apps/desktop/src/features/editor/UnifiedBar.test.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.test.tsx
@@ -864,7 +864,7 @@ describe("UnifiedBar tab strip drop", () => {
         });
     });
 
-    it("opens the New Agent submenu and creates a chat for the selected provider", async () => {
+    it("creates a canonical agent directly from the new-tab menu", async () => {
         const user = userEvent.setup();
         type NewSessionFn = ReturnType<typeof useChatStore.getState>["newSession"];
         setEditorTabs([
@@ -919,8 +919,7 @@ describe("UnifiedBar tab strip drop", () => {
         const newAgentButton = await screen.findByRole("button", {
             name: "New Agent",
         });
-        fireEvent.mouseEnter(newAgentButton);
-        await user.click(await screen.findByRole("button", { name: "Claude" }));
+        await user.click(newAgentButton);
 
         await waitFor(() => {
             expect(
@@ -942,7 +941,7 @@ describe("UnifiedBar tab strip drop", () => {
             expect(
                 useChatStore.getState().sessionsById[chatSessionId.sessionId]
                     ?.runtimeId,
-            ).toBe("claude-acp");
+            ).toBe("codex-acp");
         }
     });
 

--- a/apps/desktop/src/features/editor/newTabMenuActions.test.ts
+++ b/apps/desktop/src/features/editor/newTabMenuActions.test.ts
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useSettingsStore } from "../../app/store/settingsStore";
 import type { ContextMenuEntry } from "../../components/context-menu/ContextMenu";
 import { resetChatStore, useChatStore } from "../ai/store/chatStore";
 import { CLAUDE_TERMINAL_RUNTIME_ID } from "../ai/utils/runtimeMetadata";
@@ -44,37 +45,52 @@ function seedRuntimes() {
             },
         ],
         selectedRuntimeId: "codex-acp",
+        setupStatusByRuntimeId: {
+            [CLAUDE_TERMINAL_RUNTIME_ID]: {
+                runtimeId: CLAUDE_TERMINAL_RUNTIME_ID,
+                binaryReady: true,
+                binarySource: "env",
+                authReady: true,
+                onboardingRequired: false,
+                authMethods: [],
+            },
+        },
     });
 }
 
-function isContextMenuItem(entry: ContextMenuEntry): entry is ContextMenuItem {
-    return "label" in entry;
-}
-
-function getNewAgentChild(label: string): ContextMenuItem {
-    const newAgent = buildNewTabContextMenuEntries({
-        paneId: "secondary",
-    }).find(
+function getEntry(label: string): ContextMenuItem | undefined {
+    return buildNewTabContextMenuEntries({ paneId: "secondary" }).find(
         (entry): entry is ContextMenuItem =>
-            isContextMenuItem(entry) && entry.label === "New Agent",
+            "label" in entry && entry.label === label,
     );
-    const child = newAgent?.children?.find(
-        (entry): entry is ContextMenuItem =>
-            isContextMenuItem(entry) && entry.label === label,
-    );
-    expect(child).toBeDefined();
-    return child!;
 }
 
 describe("newTabMenuActions", () => {
     beforeEach(() => {
         resetChatStore();
+        useSettingsStore.setState({ claudeCodeEnabled: false });
         vi.clearAllMocks();
         seedRuntimes();
     });
 
-    it("opens Claude Code agent entries as terminal sessions in the target pane", async () => {
-        getNewAgentChild("Claude Code").action?.();
+    it("creates a canonical agent directly without a provider submenu", async () => {
+        const newAgent = getEntry("New Agent");
+
+        expect(newAgent?.children).toBeUndefined();
+        newAgent?.action?.();
+
+        await waitFor(() => {
+            expect(
+                chatPaneMovementMock.createNewChatInWorkspace,
+            ).toHaveBeenCalledWith(undefined, { paneId: "secondary" });
+        });
+        expect(getEntry("Codex")).toBeUndefined();
+    });
+
+    it("adds Claude Code as a separate action when enabled for the vault", async () => {
+        useSettingsStore.setState({ claudeCodeEnabled: true });
+
+        getEntry("Claude Code")?.action?.();
 
         await waitFor(() => {
             expect(
@@ -84,37 +100,15 @@ describe("newTabMenuActions", () => {
         expect(
             chatPaneMovementMock.createNewChatInWorkspace,
         ).not.toHaveBeenCalled();
-        expect(useChatStore.getState().selectedRuntimeId).toBe(
-            CLAUDE_TERMINAL_RUNTIME_ID,
-        );
     });
 
-    it("keeps ACP agent entries on the normal chat creation path", async () => {
-        useChatStore.setState({
-            selectedRuntimeId: CLAUDE_TERMINAL_RUNTIME_ID,
-        });
-
-        getNewAgentChild("Codex").action?.();
-
-        await waitFor(() => {
-            expect(
-                chatPaneMovementMock.createNewChatInWorkspace,
-            ).toHaveBeenCalledWith("codex-acp", { paneId: "secondary" });
-        });
-        expect(
-            claudeCodeTerminalMock.openClaudeCodeTerminalWithContext,
-        ).not.toHaveBeenCalled();
-        expect(useChatStore.getState().selectedRuntimeId).toBe("codex-acp");
-    });
-
-    it("offers custom ACP runtimes and creates chats with their runtime ID", async () => {
-        const runtimeId = "custom:123e4567-e89b-12d3-a456-426614174000";
+    it("does not expose ACP runtimes as creation actions", () => {
         useChatStore.setState((state) => ({
             runtimes: [
                 ...state.runtimes,
                 {
                     runtime: {
-                        id: runtimeId,
+                        id: "custom:123e4567-e89b-12d3-a456-426614174000",
                         name: "Local reviewer",
                         description: "Custom ACP runtime.",
                         capabilities: ["create_session"],
@@ -126,13 +120,7 @@ describe("newTabMenuActions", () => {
             ],
         }));
 
-        getNewAgentChild("Local reviewer").action?.();
-
-        await waitFor(() => {
-            expect(
-                chatPaneMovementMock.createNewChatInWorkspace,
-            ).toHaveBeenCalledWith(runtimeId, { paneId: "secondary" });
-        });
-        expect(useChatStore.getState().selectedRuntimeId).toBe(runtimeId);
+        expect(getEntry("Local reviewer")).toBeUndefined();
+        expect(getEntry("New Agent")).toBeDefined();
     });
 });

--- a/apps/desktop/src/features/editor/newTabMenuActions.ts
+++ b/apps/desktop/src/features/editor/newTabMenuActions.ts
@@ -9,10 +9,11 @@ import {
     selectEditorWorkspaceTabs,
     useEditorStore,
 } from "../../app/store/editorStore";
-import { createNewChatInWorkspace } from "../ai/chatPaneMovement";
-import { useChatStore } from "../ai/store/chatStore";
-import { CLAUDE_TERMINAL_RUNTIME_ID } from "../ai/utils/runtimeMetadata";
-import { openClaudeCodeTerminalWithContext } from "../terminal/claudeCodeTerminal";
+import {
+    canCreateClaudeCodeAgent,
+    createCanonicalAgent,
+    createClaudeCodeAgent,
+} from "../ai/newAgentCreation";
 import {
     isSearchTab,
     SEARCH_NOTE_ID,
@@ -28,17 +29,9 @@ async function createNewNote(paneId?: string) {
     }
 }
 
-function getRuntimeMenuLabel(name: string) {
-    const trimmed = name.trim();
-    return trimmed.replace(/ ACP$/, "");
-}
-
-async function createNewChat(runtimeId?: string, paneId?: string) {
+async function createNewAgent(paneId?: string) {
     try {
-        await createNewChatInWorkspace(
-            runtimeId,
-            paneId ? { paneId } : undefined,
-        );
+        await createCanonicalAgent(paneId);
     } catch (error) {
         console.error("Failed to create a new chat from the tab menu:", error);
     }
@@ -88,14 +81,6 @@ export function buildNewTabContextMenuEntries(options?: {
     paneId?: string;
 }): ContextMenuEntry[] {
     const paneId = options?.paneId;
-    const chatState = useChatStore.getState();
-    const runtimes = [...chatState.runtimes];
-    const selectedRuntimeId = chatState.selectedRuntimeId;
-    runtimes.sort((left, right) => {
-        if (left.runtime.id === selectedRuntimeId) return -1;
-        if (right.runtime.id === selectedRuntimeId) return 1;
-        return left.runtime.name.localeCompare(right.runtime.name);
-    });
     const entries: ContextMenuEntry[] = [
         {
             label: "New Note",
@@ -109,43 +94,24 @@ export function buildNewTabContextMenuEntries(options?: {
         },
         {
             label: "New Agent",
-            disabled: runtimes.length === 0,
-            children:
-                runtimes.length > 0
-                    ? runtimes.map((runtime) => ({
-                          label: getRuntimeMenuLabel(runtime.runtime.name),
-                          action: () => {
-                              useChatStore
-                                  .getState()
-                                  .setSelectedRuntime(runtime.runtime.id);
-                              if (
-                                  runtime.runtime.id ===
-                                  CLAUDE_TERMINAL_RUNTIME_ID
-                              ) {
-                                  void openClaudeCodeTerminalWithContext(
-                                      undefined,
-                                      paneId,
-                                  );
-                              } else {
-                                  void createNewChat(
-                                      runtime.runtime.id,
-                                      paneId,
-                                  );
-                              }
-                          },
-                      }))
-                    : [
-                          {
-                              label: "No providers available",
-                              disabled: true,
-                          },
-                      ],
+            action: () => {
+                void createNewAgent(paneId);
+            },
         },
         {
             label: "Open Graph",
             action: () => openGraph(paneId),
         },
     ];
+
+    if (canCreateClaudeCodeAgent()) {
+        entries.splice(3, 0, {
+            label: "Claude Code",
+            action: () => {
+                void createClaudeCodeAgent(paneId);
+            },
+        });
+    }
 
     entries.push({
         label: "New Terminal",
@@ -159,6 +125,6 @@ export async function openNewNoteInPane(paneId?: string) {
     await createNewNote(paneId);
 }
 
-export async function openNewAgentInPane(paneId?: string, runtimeId?: string) {
-    await createNewChat(runtimeId, paneId);
+export async function openNewAgentInPane(paneId?: string) {
+    await createNewAgent(paneId);
 }

--- a/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../test/test-utils";
+import { useSettingsStore } from "../../app/store/settingsStore";
 import type {
     AIAuthTerminalSessionSnapshot,
     AIRuntimeDescriptor,
@@ -32,8 +33,12 @@ const apiMocks = vi.hoisted(() => ({
     listenToAiAuthTerminalExited: vi.fn(async () => vi.fn()),
     listenToAiAuthTerminalError: vi.fn(async () => vi.fn()),
 }));
+const terminalMocks = vi.hoisted(() => ({
+    checkClaudeCodeInstalled: vi.fn(async () => false),
+}));
 
 vi.mock("../ai/api", () => apiMocks);
+vi.mock("../terminal/claudeCodeTerminal", () => terminalMocks);
 
 function createRuntimeDescriptor(
     id: string,
@@ -296,7 +301,25 @@ async function openProvider(providerName: string) {
 describe("AIProvidersSettings", () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        terminalMocks.checkClaudeCodeInstalled.mockResolvedValue(false);
+        useSettingsStore.setState({ claudeCodeEnabled: false });
         mockProviders(createDefaultProviders());
+    });
+
+    it("enables Claude Code explicitly for the current vault", async () => {
+        terminalMocks.checkClaudeCodeInstalled.mockResolvedValue(true);
+
+        renderComponent(<AIProvidersSettings />);
+
+        const toggle = await screen.findByRole("switch", {
+            name: "Enable Claude Code for this vault",
+        });
+        expect(toggle).toHaveAttribute("aria-checked", "false");
+
+        fireEvent.click(toggle);
+
+        expect(useSettingsStore.getState().claudeCodeEnabled).toBe(true);
+        expect(toggle).toHaveAttribute("aria-checked", "true");
     });
 
     it("does not offer provider installs while runtime inventory is still loading", async () => {
@@ -342,7 +365,7 @@ describe("AIProvidersSettings", () => {
 
         renderComponent(<AIProvidersSettings />);
 
-        await screen.findByText("Default agent");
+        await screen.findByText("Default provider");
         expect(
             screen.queryByRole("option", { name: "Missing local" }),
         ).not.toBeInTheDocument();

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -2030,49 +2030,6 @@ export function AIProvidersSettings({
                                             )}
 
                                             {/* Expanded content — not shown for terminal runtime */}
-                                            {!isTerminalRuntime &&
-                                                isExpanded &&
-                                                provider.id === "claude-acp" && (
-                                                    <div
-                                                        style={{
-                                                            padding:
-                                                                "10px 14px",
-                                                            fontSize: 11,
-                                                            color: "var(--text-secondary)",
-                                                            borderTop:
-                                                                "1px solid var(--border)",
-                                                            lineHeight: 1.5,
-                                                        }}
-                                                    >
-                                                        <strong
-                                                            style={{
-                                                                color: "var(--text-primary)",
-                                                            }}
-                                                        >
-                                                            Claude subscription
-                                                        </strong>{" "}
-                                                        authentication only
-                                                        works with{" "}
-                                                        <strong
-                                                            style={{
-                                                                color: "var(--text-primary)",
-                                                            }}
-                                                        >
-                                                            Claude Code
-                                                        </strong>{" "}
-                                                        in the terminal. To use
-                                                        this provider, configure
-                                                        an{" "}
-                                                        <strong
-                                                            style={{
-                                                                color: "var(--text-primary)",
-                                                            }}
-                                                        >
-                                                            Anthropic API key
-                                                        </strong>{" "}
-                                                        below.
-                                                    </div>
-                                                )}
                                             {!isTerminalRuntime && isExpanded &&
                                                 (provider.setupStatus ? (
                                                     <ProviderExpandedPanel

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -1875,8 +1875,9 @@ export function AIProvidersSettings({
                                 <strong style={{ color: "var(--text-primary)" }}>
                                     Add to chat
                                 </strong>{" "}
-                                from the file tree. You can switch providers from
-                                inside the agent at any time.
+                                from the file tree. You can choose another
+                                provider until the new chat sends its first
+                                message.
                             </p>
                             <select
                                 value={defaultRuntimeId ?? ""}

--- a/apps/desktop/src/features/settings/AIProvidersSettings.tsx
+++ b/apps/desktop/src/features/settings/AIProvidersSettings.tsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { openUrl } from "@neverwrite/runtime";
 import { useVaultStore } from "../../app/store/vaultStore";
+import { useSettingsStore } from "../../app/store/settingsStore";
 import {
     aiGetEnvironmentDiagnostics,
     aiGetSetupStatus,
@@ -69,6 +70,57 @@ function getErrorMessage(error: unknown, fallback: string): string {
     if (error instanceof Error && error.message.trim()) return error.message;
     if (typeof error === "string" && error.trim()) return error;
     return fallback;
+}
+
+function SettingsToggle({
+    value,
+    onChange,
+    disabled = false,
+    label,
+}: {
+    value: boolean;
+    onChange: (value: boolean) => void;
+    disabled?: boolean;
+    label: string;
+}) {
+    return (
+        <button
+            type="button"
+            role="switch"
+            aria-label={label}
+            aria-checked={value}
+            disabled={disabled}
+            onClick={() => onChange(!value)}
+            className="nw-settings-toggle"
+            style={{
+                width: 36,
+                height: 20,
+                borderRadius: 10,
+                border: "none",
+                cursor: disabled ? "not-allowed" : "pointer",
+                backgroundColor: value
+                    ? "var(--accent)"
+                    : "var(--bg-tertiary)",
+                position: "relative",
+                flexShrink: 0,
+                opacity: disabled ? 0.4 : 1,
+            }}
+        >
+            <span
+                style={{
+                    position: "absolute",
+                    top: 2,
+                    left: value ? 18 : 2,
+                    width: 16,
+                    height: 16,
+                    borderRadius: "50%",
+                    backgroundColor: "#fff",
+                    boxShadow: "0 1px 3px rgba(0,0,0,0.2)",
+                    transition: "left 0.15s ease",
+                }}
+            />
+        </button>
+    );
 }
 
 function isApiKeyMethod(id?: string) {
@@ -1248,6 +1300,10 @@ export function AIProvidersSettings({
     const vaultPath = useVaultStore((s) => s.vaultPath);
     const defaultRuntimeId = useChatStore((s) => s.defaultRuntimeId);
     const setDefaultRuntime = useChatStore((s) => s.setDefaultRuntime);
+    const claudeCodeEnabled = useSettingsStore(
+        (s) => s.claudeCodeEnabled,
+    );
+    const setSetting = useSettingsStore((s) => s.setSetting);
     const refreshRuntimeCatalog = useChatStore(
         (s) => s.refreshRuntimeCatalog,
     );
@@ -1669,6 +1725,7 @@ export function AIProvidersSettings({
     // Providers available to be set as default and ready to start a session.
     const selectableProviders = runtimes
         .filter((runtime) =>
+            runtime.runtime.id !== CLAUDE_TERMINAL_RUNTIME_ID &&
             setupStatusMap[runtime.runtime.id]?.authReady === true &&
             !setupStatusMap[runtime.runtime.id]?.onboardingRequired,
         )
@@ -1681,12 +1738,22 @@ export function AIProvidersSettings({
         selectableProviders.length > 0 &&
         matchesSettingsSearch(
             searchQuery,
-            "Default agent",
+            "Default provider",
             "Default",
             "Agent",
             "Provider",
-            "Claude Code",
             ...selectableProviders.flatMap((p) => [p.name, p.id]),
+        );
+    const claudeCodeInstalled =
+        setupStatusMap[CLAUDE_TERMINAL_RUNTIME_ID]?.authReady === true;
+    const showClaudeCodeIntegration =
+        !isLoading &&
+        matchesSettingsSearch(
+            searchQuery,
+            "Claude Code integration",
+            "Enable Claude Code for this vault",
+            "Terminal",
+            "Agent menu",
         );
 
     const handleCustomCatalogChanged = useCallback(async () => {
@@ -1696,7 +1763,77 @@ export function AIProvidersSettings({
 
     return (
         <>
-            {/* ── Default agent ── */}
+            {showClaudeCodeIntegration && (
+                <>
+                    <div
+                        style={{
+                            fontSize: 10,
+                            fontWeight: 600,
+                            letterSpacing: "0.08em",
+                            textTransform: "uppercase",
+                            color: "var(--text-secondary)",
+                            paddingBottom: 6,
+                        }}
+                    >
+                        Claude Code integration
+                    </div>
+                    <div
+                        style={{
+                            border: "1px solid var(--border)",
+                            borderRadius: 10,
+                            overflow: "hidden",
+                            marginBottom: 24,
+                            backgroundColor: "var(--bg-secondary)",
+                        }}
+                    >
+                        <div
+                            style={{
+                                padding: 14,
+                                display: "flex",
+                                alignItems: "center",
+                                justifyContent: "space-between",
+                                gap: 16,
+                            }}
+                        >
+                            <div style={{ minWidth: 0 }}>
+                                <div
+                                    style={{
+                                        fontSize: 12,
+                                        fontWeight: 600,
+                                        color: "var(--text-primary)",
+                                    }}
+                                >
+                                    Enable Claude Code for this vault
+                                </div>
+                                <div
+                                    style={{
+                                        marginTop: 4,
+                                        fontSize: 11,
+                                        lineHeight: 1.45,
+                                        color: "var(--text-secondary)",
+                                    }}
+                                >
+                                    {claudeCodeInstalled
+                                        ? "Adds Claude Code as an explicit option when creating an agent."
+                                        : "Install Claude Code to enable this integration."}
+                                </div>
+                            </div>
+                            <SettingsToggle
+                                label="Enable Claude Code for this vault"
+                                value={claudeCodeEnabled}
+                                disabled={
+                                    !claudeCodeInstalled && !claudeCodeEnabled
+                                }
+                                onChange={(value) =>
+                                    setSetting("claudeCodeEnabled", value)
+                                }
+                            />
+                        </div>
+                    </div>
+                </>
+            )}
+
+            {/* ── Default provider ── */}
             {showDefaultSection && (
                 <>
                     <div
@@ -1709,7 +1846,7 @@ export function AIProvidersSettings({
                             paddingBottom: 6,
                         }}
                     >
-                        Default agent
+                        Default provider
                     </div>
                     <div
                         style={{
@@ -1733,17 +1870,13 @@ export function AIProvidersSettings({
                                     lineHeight: 1.5,
                                 }}
                             >
-                                The default agent opens when you start a new chat
-                                or use{" "}
+                                The default provider opens when you create a new
+                                agent or use{" "}
                                 <strong style={{ color: "var(--text-primary)" }}>
                                     Add to chat
                                 </strong>{" "}
-                                from the file tree. Select{" "}
-                                <strong style={{ color: "var(--text-primary)" }}>
-                                    Claude Code
-                                </strong>{" "}
-                                to route notes and files directly into a terminal
-                                session — no API key required.
+                                from the file tree. You can switch providers from
+                                inside the agent at any time.
                             </p>
                             <select
                                 value={defaultRuntimeId ?? ""}
@@ -1771,26 +1904,9 @@ export function AIProvidersSettings({
                                 {selectableProviders.map((p) => (
                                     <option key={p.id} value={p.id}>
                                         {p.name}
-                                        {p.id === CLAUDE_TERMINAL_RUNTIME_ID
-                                            ? " — terminal (no API key)"
-                                            : ""}
                                     </option>
                                 ))}
                             </select>
-                            {defaultRuntimeId === CLAUDE_TERMINAL_RUNTIME_ID && (
-                                <p
-                                    style={{
-                                        fontSize: 11,
-                                        color: "var(--text-secondary)",
-                                        margin: "8px 0 0",
-                                        lineHeight: 1.4,
-                                    }}
-                                >
-                                    Claude Code will open in a new terminal tab.
-                                    Attached files appear as @mentions in the
-                                    input — add your question and press Enter.
-                                </p>
-                            )}
                         </div>
                     </div>
                 </>

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1631,6 +1631,18 @@ body.dragging-tab * {
     backdrop-filter: blur(12px) saturate(120%);
 }
 
+/* Chat popovers use the same material as the composer dock. Keeping this in a
+   separate class lets portalled menus and controls outside the dock share the
+   tint without inheriting the dock's layout or shadow. */
+.nw-chat-glass-menu {
+    background-color: color-mix(
+        in srgb,
+        var(--bg-secondary) 80%,
+        transparent
+    );
+    backdrop-filter: blur(12px) saturate(120%);
+}
+
 /* The tight negative-spread shadow separates the compact dock without painting
    a false panel above it. The expanded surface already has pane edges. */
 .nw-chat-bottom-dock {
@@ -1639,13 +1651,15 @@ body.dragging-tab * {
 }
 
 @supports not (backdrop-filter: blur(1px)) {
-    .nw-chat-translucent-surface {
+    .nw-chat-translucent-surface,
+    .nw-chat-glass-menu {
         background-color: var(--bg-secondary);
     }
 }
 
 @media (prefers-reduced-transparency: reduce) {
-    .nw-chat-translucent-surface {
+    .nw-chat-translucent-surface,
+    .nw-chat-glass-menu {
         background-color: var(--bg-secondary);
         backdrop-filter: none;
     }

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -17,6 +17,7 @@ export default mergeConfig(
                 "src-electron/**/*.test.ts",
                 "src-electron/**/*.test.tsx",
                 "scripts/codex-v8-artifacts.test.mjs",
+                "scripts/electron-release-retry.test.mjs",
                 "scripts/packaged-sidecar-isolation.test.mjs",
                 "scripts/stage-electron-sidecar.test.mjs",
             ],

--- a/crates/ai/src/domain.rs
+++ b/crates/ai/src/domain.rs
@@ -25,6 +25,7 @@ pub enum AiConfigOptionCategory {
     Mode,
     Model,
     Reasoning,
+    ServiceTier,
     Other,
 }
 

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -12,6 +12,7 @@ use crate::{custom_runtimes::is_custom_acp_runtime_id, domain::AcpContinuationSt
 const SESSION_META_FILE: &str = "session-meta.json";
 const SESSION_INDEX_FILE: &str = "index.json";
 const SESSION_TRANSCRIPT_FILE: &str = "transcript.jsonl";
+const CONVERSATION_BINDINGS_FILE: &str = "conversation-bindings.json";
 const SESSION_COMPACTION_MARKER_FILE: &str = "compact-state.json";
 const FORMAT_VERSION: u32 = 1;
 const MB: u64 = 1024 * 1024;
@@ -27,6 +28,19 @@ const DEFAULT_TRANSCRIPT_COMPACTION_POLICY: TranscriptCompactionPolicy =
 /// or transaction safety decisions.
 pub fn is_incidental_filesystem_metadata(path: &Path, metadata: &fs::Metadata) -> bool {
     metadata.file_type().is_file() && path.file_name().is_some_and(|name| name == ".DS_Store")
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedTurnProvenance {
+    pub binding_id: String,
+    pub runtime_id: String,
+    #[serde(default)]
+    pub runtime_session_id: Option<String>,
+    pub model_id: String,
+    pub mode_id: String,
+    #[serde(default)]
+    pub options: BTreeMap<String, String>,
+    pub start_reason: String,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -66,6 +80,87 @@ pub struct PersistedMessage {
     pub plan_detail: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_action: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub turn_provenance: Option<PersistedTurnProvenance>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedConversationSelection {
+    pub runtime_id: String,
+    pub model_id: String,
+    pub mode_id: String,
+    #[serde(default)]
+    pub options: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedProviderBinding {
+    pub binding_id: String,
+    pub conversation_id: String,
+    pub runtime_id: String,
+    #[serde(default)]
+    pub runtime_display_name: Option<String>,
+    #[serde(default)]
+    pub runtime_revision: Option<u64>,
+    #[serde(default)]
+    pub runtime_launch_fingerprint: Option<String>,
+    #[serde(default)]
+    pub runtime_session_id: Option<String>,
+    #[serde(default)]
+    pub continuation_strategy: Option<AcpContinuationStrategy>,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    pub model_id: String,
+    pub mode_id: String,
+    #[serde(default)]
+    pub options: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub models: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub modes: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub config_options: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub efforts_by_model: BTreeMap<String, Vec<String>>,
+    pub runtime_state: String,
+    #[serde(default)]
+    pub context_cursor: Option<String>,
+    #[serde(default)]
+    pub context_generation: u64,
+    #[serde(default)]
+    pub created_at: Option<u64>,
+    #[serde(default)]
+    pub updated_at: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedTranscriptObservation {
+    pub message_count: usize,
+    pub updated_at: u64,
+    #[serde(default)]
+    pub transcript_fingerprint: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedConversationBindings {
+    pub version: u32,
+    pub revision: u64,
+    pub conversation_id: String,
+    pub preferred_selection: PersistedConversationSelection,
+    #[serde(default)]
+    pub active_binding_id: Option<String>,
+    #[serde(default)]
+    pub provider_bindings: Vec<PersistedProviderBinding>,
+    #[serde(default)]
+    pub context_summary: Option<String>,
+    pub transcript_observation: PersistedTranscriptObservation,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct PersistedSessionHistoryEnvelope {
+    #[serde(flatten)]
+    pub history: PersistedSessionHistory,
+    pub conversation_bindings: PersistedConversationBindings,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -641,6 +736,10 @@ fn session_transcript_path(session_dir: &Path) -> PathBuf {
     session_dir.join(SESSION_TRANSCRIPT_FILE)
 }
 
+fn conversation_bindings_path(session_dir: &Path) -> PathBuf {
+    session_dir.join(CONVERSATION_BINDINGS_FILE)
+}
+
 fn session_compaction_marker_path(session_dir: &Path) -> PathBuf {
     session_dir.join(SESSION_COMPACTION_MARKER_FILE)
 }
@@ -655,6 +754,10 @@ fn storage_session_index_file(storage_root: &Path, session_id: &str) -> PathBuf 
 
 fn storage_session_transcript_file(storage_root: &Path, session_id: &str) -> PathBuf {
     session_transcript_path(&storage_session_dir(storage_root, session_id))
+}
+
+fn storage_conversation_bindings_file(storage_root: &Path, session_id: &str) -> PathBuf {
+    conversation_bindings_path(&storage_session_dir(storage_root, session_id))
 }
 
 fn storage_session_is_complete(storage_root: &Path, session_id: &str) -> bool {
@@ -761,6 +864,11 @@ fn load_session_index(
 fn load_session_metadata_from_dir(session_dir: &Path) -> Result<PersistedSessionMetadata, String> {
     recover_incomplete_compaction(session_dir)?;
     read_json_file(&session_meta_path(session_dir))
+}
+
+fn load_session_index_from_dir(session_dir: &Path) -> Result<PersistedTranscriptIndex, String> {
+    recover_incomplete_compaction(session_dir)?;
+    read_json_file(&session_index_path(session_dir))
 }
 
 fn indexed_transcript_bytes(index: &PersistedTranscriptIndex) -> u64 {
@@ -1045,6 +1153,46 @@ fn persisted_history_content_fingerprint(
     Ok(digest_hex(&hasher.finalize().into()))
 }
 
+fn conversation_bindings_content_fingerprint(
+    bindings: &PersistedConversationBindings,
+) -> Result<String, String> {
+    let mut value = serde_json::to_value(bindings).map_err(|error| error.to_string())?;
+    if let Some(object) = value.as_object_mut() {
+        object.remove("revision");
+        object.remove("transcript_observation");
+        if let Some(provider_bindings) = object
+            .get_mut("provider_bindings")
+            .and_then(serde_json::Value::as_array_mut)
+        {
+            for binding in provider_bindings {
+                if let Some(binding) = binding.as_object_mut() {
+                    binding.remove("created_at");
+                    binding.remove("updated_at");
+                    binding.remove("runtime_state");
+                }
+            }
+        }
+    }
+    let mut hasher = Sha256::new();
+    hasher.update(b"neverwrite-conversation-bindings-content-v1");
+    update_canonical_json(&value, &mut hasher);
+    Ok(digest_hex(&hasher.finalize().into()))
+}
+
+fn combined_history_content_fingerprint(
+    history_fingerprint: &str,
+    bindings: &PersistedConversationBindings,
+) -> Result<String, String> {
+    let bindings_fingerprint = conversation_bindings_content_fingerprint(bindings)?;
+    let mut hasher = Sha256::new();
+    hasher.update(b"neverwrite-canonical-history-content-v1");
+    hasher.update((history_fingerprint.len() as u64).to_le_bytes());
+    hasher.update(history_fingerprint.as_bytes());
+    hasher.update((bindings_fingerprint.len() as u64).to_le_bytes());
+    hasher.update(bindings_fingerprint.as_bytes());
+    Ok(digest_hex(&hasher.finalize().into()))
+}
+
 fn inspect_compaction_state(
     storage_root: &Path,
     session_dir: &Path,
@@ -1195,6 +1343,7 @@ fn inspect_session_directory(
                 if name == SESSION_META_FILE
                     || name == SESSION_INDEX_FILE
                     || name == SESSION_TRANSCRIPT_FILE
+                    || name == CONVERSATION_BINDINGS_FILE
                     || compaction_entries.contains(&name)
                 {
                     continue;
@@ -1236,9 +1385,34 @@ fn inspect_session_directory(
     let metadata_path = session_meta_path(session_dir);
     let index_path = session_index_path(session_dir);
     let transcript_path = session_transcript_path(session_dir);
+    let bindings_path = conversation_bindings_path(session_dir);
     let metadata_bytes =
         read_expected_artifact(storage_root, &metadata_path, inventory, fingerprint);
     let index_bytes = read_expected_artifact(storage_root, &index_path, inventory, fingerprint);
+    let bindings_bytes = match fs::symlink_metadata(&bindings_path) {
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+        Err(error) => {
+            push_read_error(
+                inventory,
+                fingerprint,
+                relative_storage_path(storage_root, &bindings_path),
+                error.to_string(),
+            );
+            None
+        }
+        Ok(metadata) if metadata.file_type().is_file() => {
+            read_expected_artifact(storage_root, &bindings_path, inventory, fingerprint)
+        }
+        Ok(_) => {
+            push_corrupt_artifact(
+                inventory,
+                fingerprint,
+                relative_storage_path(storage_root, &bindings_path),
+                "Conversation bindings sidecar is not a regular file.",
+            );
+            None
+        }
+    };
     let transcript_relative_path = relative_storage_path(storage_root, &transcript_path);
     let transcript_artifact_fingerprint = match fs::symlink_metadata(&transcript_path) {
         Ok(metadata) if metadata.file_type().is_file() => {
@@ -1336,6 +1510,59 @@ fn inspect_session_directory(
         session_id: metadata.session_id.clone(),
         relative_path: relative_dir.clone(),
     });
+    let parsed_bindings = if let Some(artifact) = &bindings_bytes {
+        match serde_json::from_slice::<PersistedConversationBindings>(&artifact.bytes) {
+            Ok(bindings)
+                if bindings.version == FORMAT_VERSION
+                    && bindings.conversation_id == metadata.session_id =>
+            {
+                match validate_persisted_conversation_bindings(&bindings) {
+                    Ok(()) => Some(bindings),
+                    Err(error) => {
+                        push_corrupt_artifact(
+                            inventory,
+                            fingerprint,
+                            relative_storage_path(storage_root, &bindings_path),
+                            error,
+                        );
+                        None
+                    }
+                }
+            }
+            Ok(bindings) if bindings.version != FORMAT_VERSION => {
+                push_corrupt_artifact(
+                    inventory,
+                    fingerprint,
+                    relative_storage_path(storage_root, &bindings_path),
+                    format!(
+                        "Unsupported conversation bindings version: {}.",
+                        bindings.version
+                    ),
+                );
+                None
+            }
+            Ok(_) => {
+                push_corrupt_artifact(
+                    inventory,
+                    fingerprint,
+                    relative_storage_path(storage_root, &bindings_path),
+                    "Conversation bindings belong to another conversation.",
+                );
+                None
+            }
+            Err(error) => {
+                push_corrupt_artifact(
+                    inventory,
+                    fingerprint,
+                    relative_storage_path(storage_root, &bindings_path),
+                    format!("Invalid conversation bindings: {error}"),
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let (Some(index), Some(transcript_artifact_fingerprint)) =
         (index, transcript_artifact_fingerprint)
@@ -1373,16 +1600,35 @@ fn inspect_session_directory(
     else {
         return;
     };
+    let effective_bindings = parsed_bindings
+        .map(|bindings| reconcile_conversation_bindings(bindings, &metadata, &index))
+        .unwrap_or_else(|| synthesize_conversation_bindings(&metadata, &index));
+    let content_fingerprint = match combined_history_content_fingerprint(
+        &transcript_fingerprints.content,
+        &effective_bindings,
+    ) {
+        Ok(fingerprint) => fingerprint,
+        Err(error) => {
+            push_corrupt_artifact(inventory, fingerprint, relative_dir, error);
+            return;
+        }
+    };
     inventory.sessions.push(InspectedHistory {
         session_id: metadata.session_id,
         relative_path: relative_dir,
         format: InspectedHistoryFormat::Directory,
-        content_fingerprint: transcript_fingerprints.content,
-        artifact_fingerprint: combined_artifact_fingerprint(&[
-            metadata_artifact.fingerprint,
-            index_artifact.fingerprint,
-            transcript_fingerprints.artifact,
-        ]),
+        content_fingerprint,
+        artifact_fingerprint: {
+            let mut artifacts = vec![
+                metadata_artifact.fingerprint,
+                index_artifact.fingerprint,
+                transcript_fingerprints.artifact,
+            ];
+            if let Some(bindings_artifact) = bindings_bytes {
+                artifacts.push(bindings_artifact.fingerprint);
+            }
+            combined_artifact_fingerprint(&artifacts)
+        },
         managed_attachment_ids: transcript_fingerprints.managed_attachment_ids,
     });
 }
@@ -1471,7 +1717,7 @@ fn inspect_legacy_json_history(
             return;
         }
     };
-    let content_fingerprint = match persisted_history_content_fingerprint(&history) {
+    let history_fingerprint = match persisted_history_content_fingerprint(&history) {
         Ok(fingerprint) => fingerprint,
         Err(error) => {
             push_corrupt_artifact(
@@ -1483,6 +1729,33 @@ fn inspect_legacy_json_history(
             return;
         }
     };
+    let metadata = metadata_from_history(&history, history.messages.len());
+    let index = PersistedTranscriptIndex {
+        version: FORMAT_VERSION,
+        message_offsets: vec![],
+        message_lengths: vec![],
+        message_hashes: match history
+            .messages
+            .iter()
+            .map(hash_message)
+            .collect::<Result<Vec<_>, _>>()
+        {
+            Ok(hashes) => hashes,
+            Err(error) => {
+                push_corrupt_artifact(inventory, fingerprint, relative_path, error);
+                return;
+            }
+        },
+    };
+    let bindings = synthesize_conversation_bindings(&metadata, &index);
+    let content_fingerprint =
+        match combined_history_content_fingerprint(&history_fingerprint, &bindings) {
+            Ok(fingerprint) => fingerprint,
+            Err(error) => {
+                push_corrupt_artifact(inventory, fingerprint, relative_path, error);
+                return;
+            }
+        };
     inventory.sessions.push(InspectedHistory {
         session_id: history.session_id,
         relative_path,
@@ -1880,6 +2153,362 @@ fn load_history_from_session_dir(
         vec![]
     };
     Ok(history_from_metadata(metadata, messages))
+}
+
+enum ConversationBindingsFileState {
+    Missing,
+    Supported(PersistedConversationBindings),
+    Unusable,
+}
+
+fn legacy_binding_id(conversation_id: &str, runtime_id: &str) -> String {
+    format!("legacy:{conversation_id}:{runtime_id}")
+}
+
+fn config_option_values(config_options: &Option<serde_json::Value>) -> BTreeMap<String, String> {
+    config_options
+        .as_ref()
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(|option| {
+            Some((
+                option.get("id")?.as_str()?.to_string(),
+                option.get("value")?.as_str()?.to_string(),
+            ))
+        })
+        .collect()
+}
+
+fn transcript_fingerprint(index: &PersistedTranscriptIndex) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(b"neverwrite-canonical-transcript-v1");
+    for hash in &index.message_hashes {
+        hasher.update((hash.len() as u64).to_le_bytes());
+        hasher.update(hash.as_bytes());
+    }
+    digest_hex(&hasher.finalize().into())
+}
+
+fn binding_from_metadata(
+    metadata: &PersistedSessionMetadata,
+    binding_id: String,
+) -> PersistedProviderBinding {
+    let runtime_id = metadata.runtime_id.clone().unwrap_or_default();
+    PersistedProviderBinding {
+        binding_id,
+        conversation_id: metadata.session_id.clone(),
+        runtime_id,
+        runtime_display_name: metadata.runtime_display_name.clone(),
+        runtime_revision: metadata.runtime_revision,
+        runtime_launch_fingerprint: metadata.runtime_launch_fingerprint.clone(),
+        runtime_session_id: metadata.runtime_session_id.clone(),
+        continuation_strategy: metadata.continuation_strategy,
+        capabilities: vec![],
+        model_id: metadata.model_id.clone(),
+        mode_id: metadata.mode_id.clone(),
+        options: config_option_values(&metadata.config_options),
+        models: metadata.models.clone(),
+        modes: metadata.modes.clone(),
+        config_options: metadata.config_options.clone(),
+        efforts_by_model: BTreeMap::new(),
+        runtime_state: "persisted_only".to_string(),
+        context_cursor: None,
+        context_generation: 0,
+        created_at: Some(metadata.created_at),
+        updated_at: Some(metadata.updated_at),
+    }
+}
+
+fn synthesize_conversation_bindings(
+    metadata: &PersistedSessionMetadata,
+    index: &PersistedTranscriptIndex,
+) -> PersistedConversationBindings {
+    let runtime_id = metadata.runtime_id.clone().unwrap_or_default();
+    let binding_id = legacy_binding_id(&metadata.session_id, &runtime_id);
+    PersistedConversationBindings {
+        version: FORMAT_VERSION,
+        revision: 0,
+        conversation_id: metadata.session_id.clone(),
+        preferred_selection: PersistedConversationSelection {
+            runtime_id,
+            model_id: metadata.model_id.clone(),
+            mode_id: metadata.mode_id.clone(),
+            options: config_option_values(&metadata.config_options),
+        },
+        active_binding_id: Some(binding_id.clone()),
+        provider_bindings: vec![binding_from_metadata(metadata, binding_id)],
+        context_summary: None,
+        transcript_observation: PersistedTranscriptObservation {
+            message_count: metadata.message_count,
+            updated_at: metadata.updated_at,
+            transcript_fingerprint: Some(transcript_fingerprint(index)),
+        },
+    }
+}
+
+fn validate_persisted_conversation_bindings(
+    bindings: &PersistedConversationBindings,
+) -> Result<(), String> {
+    if bindings.version != FORMAT_VERSION {
+        return Err(format!(
+            "Unsupported conversation bindings version: {}.",
+            bindings.version
+        ));
+    }
+    if bindings.conversation_id.trim().is_empty() {
+        return Err("Conversation bindings contain an empty conversation ID.".to_string());
+    }
+    let mut ids = HashSet::new();
+    for binding in &bindings.provider_bindings {
+        if binding.binding_id.trim().is_empty() || !ids.insert(binding.binding_id.as_str()) {
+            return Err(
+                "Conversation bindings contain an invalid or duplicate binding ID.".to_string(),
+            );
+        }
+        if binding.conversation_id != bindings.conversation_id {
+            return Err("Provider binding belongs to another conversation.".to_string());
+        }
+    }
+    if bindings
+        .active_binding_id
+        .as_ref()
+        .is_some_and(|active_id| !ids.contains(active_id.as_str()))
+    {
+        return Err("Conversation bindings reference a missing active binding.".to_string());
+    }
+    Ok(())
+}
+
+fn read_conversation_bindings_file(session_dir: &Path) -> ConversationBindingsFileState {
+    let path = conversation_bindings_path(session_dir);
+    if !path.exists() {
+        return ConversationBindingsFileState::Missing;
+    }
+    let Ok(bindings) = read_json_file::<PersistedConversationBindings>(&path) else {
+        return ConversationBindingsFileState::Unusable;
+    };
+    if validate_persisted_conversation_bindings(&bindings).is_err() {
+        return ConversationBindingsFileState::Unusable;
+    }
+    ConversationBindingsFileState::Supported(bindings)
+}
+
+fn reconcile_conversation_bindings(
+    mut bindings: PersistedConversationBindings,
+    metadata: &PersistedSessionMetadata,
+    index: &PersistedTranscriptIndex,
+) -> PersistedConversationBindings {
+    if bindings.conversation_id != metadata.session_id
+        || bindings
+            .provider_bindings
+            .iter()
+            .any(|binding| binding.conversation_id != metadata.session_id)
+    {
+        return synthesize_conversation_bindings(metadata, index);
+    }
+
+    let current_fingerprint = transcript_fingerprint(index);
+    let legacy_changed = bindings.transcript_observation.message_count != metadata.message_count
+        || bindings.transcript_observation.updated_at < metadata.updated_at
+        || bindings
+            .transcript_observation
+            .transcript_fingerprint
+            .as_deref()
+            != Some(current_fingerprint.as_str());
+
+    if legacy_changed {
+        for binding in &mut bindings.provider_bindings {
+            binding.context_cursor = None;
+            binding.context_generation = binding.context_generation.saturating_add(1);
+        }
+        let runtime_id = metadata.runtime_id.clone().unwrap_or_default();
+        let position = bindings
+            .provider_bindings
+            .iter()
+            .position(|binding| binding.runtime_id == runtime_id);
+        let binding_id = position
+            .map(|index| bindings.provider_bindings[index].binding_id.clone())
+            .unwrap_or_else(|| legacy_binding_id(&metadata.session_id, &runtime_id));
+        let mut projected = binding_from_metadata(metadata, binding_id.clone());
+        if let Some(index) = position {
+            let previous = &bindings.provider_bindings[index];
+            projected.capabilities = previous.capabilities.clone();
+            projected.context_generation = previous.context_generation;
+            projected.created_at = previous.created_at.or(projected.created_at);
+            bindings.provider_bindings[index] = projected;
+        } else {
+            projected.context_generation = 1;
+            bindings.provider_bindings.push(projected);
+        }
+        bindings.active_binding_id = Some(binding_id);
+        bindings.preferred_selection = PersistedConversationSelection {
+            runtime_id,
+            model_id: metadata.model_id.clone(),
+            mode_id: metadata.mode_id.clone(),
+            options: config_option_values(&metadata.config_options),
+        };
+    }
+
+    bindings.transcript_observation = PersistedTranscriptObservation {
+        message_count: metadata.message_count,
+        updated_at: metadata.updated_at,
+        transcript_fingerprint: Some(current_fingerprint),
+    };
+    bindings
+}
+
+fn load_conversation_bindings_from_dir(
+    session_dir: &Path,
+) -> Result<PersistedConversationBindings, String> {
+    let metadata = load_session_metadata_from_dir(session_dir)?;
+    let index = load_session_index_from_dir(session_dir)?;
+    Ok(match read_conversation_bindings_file(session_dir) {
+        ConversationBindingsFileState::Supported(bindings) => {
+            reconcile_conversation_bindings(bindings, &metadata, &index)
+        }
+        ConversationBindingsFileState::Missing | ConversationBindingsFileState::Unusable => {
+            synthesize_conversation_bindings(&metadata, &index)
+        }
+    })
+}
+
+fn project_active_binding_to_history(
+    history: &mut PersistedSessionHistory,
+    bindings: &PersistedConversationBindings,
+) -> Result<(), String> {
+    if bindings.version != FORMAT_VERSION || bindings.conversation_id != history.session_id {
+        return Err("Invalid canonical conversation bindings payload.".to_string());
+    }
+    if bindings
+        .provider_bindings
+        .iter()
+        .any(|binding| binding.conversation_id != history.session_id)
+    {
+        return Err("Provider binding belongs to another conversation.".to_string());
+    }
+    validate_persisted_conversation_bindings(bindings)?;
+    let active = bindings
+        .active_binding_id
+        .as_ref()
+        .and_then(|active_id| {
+            bindings
+                .provider_bindings
+                .iter()
+                .find(|binding| &binding.binding_id == active_id)
+        })
+        .ok_or_else(|| "Canonical conversation has no active provider binding.".to_string())?;
+    history.runtime_id = Some(active.runtime_id.clone());
+    history.runtime_display_name = active.runtime_display_name.clone();
+    history.runtime_revision = active.runtime_revision;
+    history.runtime_launch_fingerprint = active.runtime_launch_fingerprint.clone();
+    history.runtime_session_id = active.runtime_session_id.clone();
+    history.continuation_strategy = active.continuation_strategy;
+    history.model_id = active.model_id.clone();
+    history.mode_id = active.mode_id.clone();
+    history.models = active.models.clone();
+    history.modes = active.modes.clone();
+    history.config_options = active.config_options.clone();
+    Ok(())
+}
+
+fn merge_conversation_bindings(
+    existing: Option<PersistedConversationBindings>,
+    mut incoming: PersistedConversationBindings,
+) -> PersistedConversationBindings {
+    if let Some(existing) = existing {
+        let mut merged = existing
+            .provider_bindings
+            .into_iter()
+            .map(|binding| (binding.binding_id.clone(), binding))
+            .collect::<BTreeMap<_, _>>();
+        for binding in incoming.provider_bindings {
+            merged.insert(binding.binding_id.clone(), binding);
+        }
+        incoming.provider_bindings = merged.into_values().collect();
+        incoming.context_summary = incoming.context_summary.or(existing.context_summary);
+        incoming.revision = incoming.revision.max(existing.revision).saturating_add(1);
+    } else {
+        incoming.revision = incoming.revision.saturating_add(1);
+    }
+    incoming
+}
+
+pub fn save_session_history_with_bindings(
+    storage_root: &Path,
+    history: &PersistedSessionHistory,
+    bindings: Option<PersistedConversationBindings>,
+) -> Result<(), String> {
+    let session_dir = storage_session_dir(storage_root, &history.session_id);
+    let disk_state = read_conversation_bindings_file(&session_dir);
+    if matches!(disk_state, ConversationBindingsFileState::Unusable) {
+        return save_session_history(storage_root, history);
+    }
+
+    let Some(bindings) = bindings else {
+        return save_session_history(storage_root, history);
+    };
+    validate_persisted_conversation_bindings(&bindings)?;
+    if bindings.conversation_id != history.session_id {
+        return Err("Canonical bindings do not match the persisted history.".to_string());
+    }
+    let existing = match disk_state {
+        ConversationBindingsFileState::Supported(existing) => Some(existing),
+        ConversationBindingsFileState::Missing => None,
+        ConversationBindingsFileState::Unusable => unreachable!(),
+    };
+    let mut bindings = merge_conversation_bindings(existing, bindings);
+    let mut projected_history = history.clone();
+    project_active_binding_to_history(&mut projected_history, &bindings)?;
+    save_session_history(storage_root, &projected_history)?;
+
+    let metadata = load_session_metadata(storage_root, &history.session_id)?;
+    let index = load_session_index(storage_root, &history.session_id)?;
+    bindings.transcript_observation = PersistedTranscriptObservation {
+        message_count: metadata.message_count,
+        updated_at: metadata.updated_at,
+        transcript_fingerprint: Some(transcript_fingerprint(&index)),
+    };
+    write_json_atomic(
+        &storage_conversation_bindings_file(storage_root, &history.session_id),
+        &bindings,
+    )
+}
+
+pub fn load_all_session_histories_with_bindings(
+    storage_root: &Path,
+    include_messages: bool,
+) -> Result<Vec<PersistedSessionHistoryEnvelope>, String> {
+    load_all_session_histories(storage_root, include_messages)?
+        .into_iter()
+        .map(|history| {
+            let session_dir = storage_session_dir(storage_root, &history.session_id);
+            let conversation_bindings =
+                if storage_session_is_complete(storage_root, &history.session_id) {
+                    load_conversation_bindings_from_dir(&session_dir)?
+                } else {
+                    let metadata = metadata_from_history(
+                        &history,
+                        history.message_count.unwrap_or(history.messages.len()),
+                    );
+                    let index = PersistedTranscriptIndex {
+                        version: FORMAT_VERSION,
+                        message_offsets: vec![],
+                        message_lengths: vec![],
+                        message_hashes: history
+                            .messages
+                            .iter()
+                            .map(hash_message)
+                            .collect::<Result<Vec<_>, _>>()?,
+                    };
+                    synthesize_conversation_bindings(&metadata, &index)
+                };
+            Ok(PersistedSessionHistoryEnvelope {
+                history,
+                conversation_bindings,
+            })
+        })
+        .collect()
 }
 
 fn legacy_session_priority(storage_root: &Path, path: &Path, session_id: &str) -> u8 {
@@ -2977,6 +3606,7 @@ pub fn fork_session_history(
     }
 
     let source_meta = load_session_metadata_from_dir(&source_dir)?;
+    let source_bindings = load_conversation_bindings_from_dir(&source_dir)?;
 
     let new_session_id = uuid::Uuid::new_v4().to_string();
     let now_ms = SystemTime::now()
@@ -3046,6 +3676,36 @@ pub fn fork_session_history(
     };
 
     write_json_atomic(&session_meta_path(&dest_dir), &new_metadata)?;
+
+    let mut forked_bindings = source_bindings;
+    let source_active_binding_id = forked_bindings.active_binding_id.clone();
+    let mut next_active_binding_id = None;
+    forked_bindings.conversation_id = new_session_id.clone();
+    forked_bindings.revision = forked_bindings.revision.saturating_add(1);
+    for (index, binding) in forked_bindings.provider_bindings.iter_mut().enumerate() {
+        let was_active = source_active_binding_id.as_deref() == Some(binding.binding_id.as_str());
+        binding.binding_id = format!("fork:{new_session_id}:{}:{index}", binding.runtime_id);
+        binding.conversation_id = new_session_id.clone();
+        if is_custom_acp_runtime_id(&binding.runtime_id) {
+            binding.runtime_session_id = None;
+            binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
+        }
+        binding.context_cursor = None;
+        binding.context_generation = binding.context_generation.saturating_add(1);
+        binding.created_at = Some(now_ms);
+        binding.updated_at = Some(now_ms);
+        if was_active {
+            next_active_binding_id = Some(binding.binding_id.clone());
+        }
+    }
+    forked_bindings.active_binding_id = next_active_binding_id;
+    let dest_index = load_session_index_from_dir(&dest_dir)?;
+    forked_bindings.transcript_observation = PersistedTranscriptObservation {
+        message_count: new_metadata.message_count,
+        updated_at: new_metadata.updated_at,
+        transcript_fingerprint: Some(transcript_fingerprint(&dest_index)),
+    };
+    write_json_atomic(&conversation_bindings_path(&dest_dir), &forked_bindings)?;
 
     Ok(new_session_id)
 }
@@ -3159,6 +3819,7 @@ mod tests {
                     plan_entries: None,
                     plan_detail: None,
                     tool_action: None,
+                    turn_provenance: None,
                 },
                 PersistedMessage {
                     id: "assistant:1".to_string(),
@@ -3181,6 +3842,7 @@ mod tests {
                     plan_entries: None,
                     plan_detail: None,
                     tool_action: None,
+                    turn_provenance: None,
                 },
             ],
         }
@@ -3980,6 +4642,15 @@ mod tests {
             forked.continuation_strategy,
             Some(AcpContinuationStrategy::NewSessionOnly)
         );
+        let forked_bindings =
+            load_conversation_bindings_from_dir(&storage_session_dir(&dir, &forked_session_id))
+                .expect("forked bindings should load");
+        assert_eq!(forked_bindings.conversation_id, forked_session_id);
+        assert!(forked_bindings.provider_bindings.iter().all(|binding| {
+            binding.conversation_id == forked_bindings.conversation_id
+                && binding.runtime_session_id.is_none()
+                && binding.context_cursor.is_none()
+        }));
 
         fs::remove_dir_all(dir).ok();
     }
@@ -4155,6 +4826,7 @@ mod tests {
                     plan_entries: None,
                     plan_detail: None,
                     tool_action: None,
+                    turn_provenance: None,
                 },
                 PersistedMessage {
                     id: "plan:1".to_string(),
@@ -4177,6 +4849,7 @@ mod tests {
                     plan_entries: None,
                     plan_detail: Some("Do the thing".to_string()),
                     tool_action: None,
+                    turn_provenance: None,
                 },
             ],
         };
@@ -4417,6 +5090,7 @@ mod tests {
             plan_entries: None,
             plan_detail: None,
             tool_action: None,
+            turn_provenance: None,
         };
         let permission = PersistedMessage {
             id: "permission:1".to_string(),
@@ -4467,6 +5141,7 @@ mod tests {
             plan_entries: None,
             plan_detail: None,
             tool_action: None,
+            turn_provenance: None,
         };
         let user_input = PersistedMessage {
             id: "input:1".to_string(),
@@ -4499,6 +5174,7 @@ mod tests {
             plan_entries: None,
             plan_detail: None,
             tool_action: None,
+            turn_provenance: None,
         };
         let plan = PersistedMessage {
             id: "plan:1".to_string(),
@@ -4531,6 +5207,15 @@ mod tests {
                 "session_id": "child-session",
                 "label": "Open child"
             })),
+            turn_provenance: Some(PersistedTurnProvenance {
+                binding_id: "binding-1".to_string(),
+                runtime_id: "codex-acp".to_string(),
+                runtime_session_id: Some("runtime-1".to_string()),
+                model_id: "test-model".to_string(),
+                mode_id: "default".to_string(),
+                options: BTreeMap::new(),
+                start_reason: "normal".to_string(),
+            }),
         };
 
         let expected_messages = vec![
@@ -4656,5 +5341,233 @@ mod tests {
         );
 
         fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn legacy_history_load_synthesizes_bindings_without_writing_the_sidecar() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        save_session_history(&dir, &history).expect("legacy-compatible history should persist");
+
+        let envelopes = load_all_session_histories_with_bindings(&dir, false)
+            .expect("canonical history summaries should load");
+
+        assert_eq!(envelopes.len(), 1);
+        assert_eq!(envelopes[0].conversation_bindings.revision, 0);
+        assert_eq!(
+            envelopes[0].conversation_bindings.conversation_id,
+            history.session_id
+        );
+        assert_eq!(
+            envelopes[0].conversation_bindings.provider_bindings[0].runtime_id,
+            "codex-acp"
+        );
+        assert!(!storage_conversation_bindings_file(&dir, &history.session_id).exists());
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn canonical_save_materializes_sidecar_and_keeps_legacy_projection() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        save_session_history(&dir, &history).expect("base history should persist");
+        let mut bindings =
+            load_conversation_bindings_from_dir(&storage_session_dir(&dir, &history.session_id))
+                .expect("legacy projection should synthesize");
+        let active = &mut bindings.provider_bindings[0];
+        active.runtime_id = "claude-acp".to_string();
+        active.model_id = "sonnet".to_string();
+        bindings.preferred_selection.runtime_id = "claude-acp".to_string();
+        bindings.preferred_selection.model_id = "sonnet".to_string();
+
+        save_session_history_with_bindings(&dir, &history, Some(bindings))
+            .expect("canonical history should persist");
+
+        let sidecar: PersistedConversationBindings = read_json_file(
+            &storage_conversation_bindings_file(&dir, &history.session_id),
+        )
+        .expect("sidecar should load");
+        let metadata =
+            load_session_metadata(&dir, &history.session_id).expect("legacy metadata should load");
+        assert_eq!(sidecar.revision, 1);
+        assert_eq!(metadata.runtime_id.as_deref(), Some("claude-acp"));
+        assert_eq!(metadata.model_id, "sonnet");
+        let inventory = inspect_history_storage(&dir);
+        assert!(inventory.histories.unknown_entries.is_empty());
+        assert!(inventory.histories.corrupt_artifacts.is_empty());
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn downgrade_write_reconciles_without_losing_existing_bindings() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        save_session_history(&dir, &history).expect("base history should persist");
+        let bindings =
+            load_conversation_bindings_from_dir(&storage_session_dir(&dir, &history.session_id))
+                .expect("legacy projection should synthesize");
+        save_session_history_with_bindings(&dir, &history, Some(bindings))
+            .expect("sidecar should materialize");
+
+        let mut legacy_write = history.clone();
+        legacy_write.runtime_id = Some("gemini-acp".to_string());
+        legacy_write.model_id = "gemini-pro".to_string();
+        legacy_write.updated_at = 30;
+        legacy_write.messages.push(PersistedMessage {
+            id: "assistant:legacy".to_string(),
+            role: "assistant".to_string(),
+            kind: "text".to_string(),
+            content: "Written after downgrade".to_string(),
+            timestamp: 30,
+            attachments: None,
+            title: None,
+            meta: None,
+            permission_request_id: None,
+            permission_options: None,
+            diffs: None,
+            review_diffs: None,
+            user_input_request_id: None,
+            user_input_questions: None,
+            url_elicitation_request_id: None,
+            url_elicitation_id: None,
+            url_elicitation_url: None,
+            plan_entries: None,
+            plan_detail: None,
+            tool_action: None,
+            turn_provenance: None,
+        });
+        legacy_write.message_count = Some(legacy_write.messages.len());
+        save_session_history(&dir, &legacy_write).expect("legacy write should remain supported");
+
+        let mut envelopes = load_all_session_histories_with_bindings(&dir, true)
+            .expect("upgraded history should reconcile");
+        let envelope = envelopes.pop().expect("history should exist");
+        assert_eq!(envelope.history.messages.len(), 3);
+        assert_eq!(
+            envelope
+                .conversation_bindings
+                .provider_bindings
+                .iter()
+                .map(|binding| binding.runtime_id.as_str())
+                .collect::<HashSet<_>>(),
+            HashSet::from(["codex-acp", "gemini-acp"])
+        );
+        assert!(envelope
+            .conversation_bindings
+            .provider_bindings
+            .iter()
+            .all(|binding| binding.context_cursor.is_none()));
+
+        save_session_history_with_bindings(
+            &dir,
+            &envelope.history,
+            Some(envelope.conversation_bindings),
+        )
+        .expect("reconciled state should persist");
+        let persisted: PersistedConversationBindings = read_json_file(
+            &storage_conversation_bindings_file(&dir, &history.session_id),
+        )
+        .expect("sidecar should load");
+        assert_eq!(persisted.revision, 2);
+        assert_eq!(persisted.provider_bindings.len(), 2);
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn future_sidecar_degrades_to_legacy_without_being_overwritten() {
+        let dir = make_temp_dir();
+        let mut history = sample_history();
+        save_session_history(&dir, &history).expect("base history should persist");
+        let synthesized =
+            load_conversation_bindings_from_dir(&storage_session_dir(&dir, &history.session_id))
+                .expect("bindings should synthesize");
+        let future = serde_json::json!({
+            "version": 99,
+            "future_payload": { "keep": true }
+        });
+        let sidecar_path = storage_conversation_bindings_file(&dir, &history.session_id);
+        write_json_atomic(&sidecar_path, &future).expect("future sidecar should persist");
+        let before = fs::read(&sidecar_path).expect("future sidecar should be readable");
+        history.updated_at = 30;
+
+        save_session_history_with_bindings(&dir, &history, Some(synthesized))
+            .expect("legacy projection should still save");
+
+        assert_eq!(
+            fs::read(&sidecar_path).expect("future sidecar should remain"),
+            before
+        );
+        let loaded = load_all_session_histories_with_bindings(&dir, false)
+            .expect("history should degrade to synthesized bindings");
+        assert_eq!(loaded[0].conversation_bindings.revision, 0);
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn corrupt_sidecar_degrades_to_legacy_without_blocking_history_load() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        save_session_history(&dir, &history).expect("base history should persist");
+        let sidecar_path = storage_conversation_bindings_file(&dir, &history.session_id);
+        fs::write(&sidecar_path, b"{not-json").expect("corrupt sidecar should persist");
+
+        let loaded = load_all_session_histories_with_bindings(&dir, true)
+            .expect("history should fall back to legacy projection");
+
+        assert_eq!(loaded[0].history.messages.len(), history.messages.len());
+        assert_eq!(loaded[0].conversation_bindings.revision, 0);
+        assert_eq!(
+            fs::read(&sidecar_path).expect("corrupt sidecar should remain"),
+            b"{not-json"
+        );
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn versioned_legacy_fixtures_upgrade_lazily_and_idempotently() {
+        for fixture in [
+            include_str!("../testdata/session-history/v0.7.1.json"),
+            include_str!("../testdata/session-history/minimum-v1.json"),
+        ] {
+            let dir = make_temp_dir();
+            let history: PersistedSessionHistory =
+                serde_json::from_str(fixture).expect("legacy fixture should deserialize");
+            save_session_history(&dir, &history).expect("legacy fixture should persist");
+            let sidecar_path = storage_conversation_bindings_file(&dir, &history.session_id);
+            assert!(!sidecar_path.exists());
+
+            let first = load_all_session_histories_with_bindings(&dir, true)
+                .expect("fixture should load")
+                .pop()
+                .expect("fixture history should exist");
+            assert!(!sidecar_path.exists());
+            save_session_history_with_bindings(
+                &dir,
+                &first.history,
+                Some(first.conversation_bindings),
+            )
+            .expect("fixture should upgrade");
+
+            let second = load_all_session_histories_with_bindings(&dir, true)
+                .expect("upgraded fixture should load")
+                .pop()
+                .expect("upgraded fixture history should exist");
+            save_session_history_with_bindings(
+                &dir,
+                &second.history,
+                Some(second.conversation_bindings),
+            )
+            .expect("repeated upgrade should remain valid");
+            let persisted: PersistedConversationBindings =
+                read_json_file(&sidecar_path).expect("materialized sidecar should remain readable");
+            assert_eq!(persisted.provider_bindings.len(), 1);
+
+            fs::remove_dir_all(dir).ok();
+        }
     }
 }

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -7,7 +7,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::{custom_runtimes::is_custom_acp_runtime_id, domain::AcpContinuationStrategy};
+use crate::domain::AcpContinuationStrategy;
 
 const SESSION_META_FILE: &str = "session-meta.json";
 const SESSION_INDEX_FILE: &str = "index.json";
@@ -344,6 +344,16 @@ struct PersistedSessionMetadata {
     preview: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     forked_from: Option<String>,
+}
+
+fn normalize_fork_runtime_identity(
+    mut metadata: PersistedSessionMetadata,
+) -> PersistedSessionMetadata {
+    if metadata.forked_from.is_some() {
+        metadata.runtime_session_id = None;
+        metadata.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
+    }
+    metadata
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -856,6 +866,7 @@ fn load_session_metadata(
     session_id: &str,
 ) -> Result<PersistedSessionMetadata, String> {
     read_json_file(&storage_session_meta_file(storage_root, session_id))
+        .map(normalize_fork_runtime_identity)
 }
 
 fn load_session_index(
@@ -867,7 +878,7 @@ fn load_session_index(
 
 fn load_session_metadata_from_dir(session_dir: &Path) -> Result<PersistedSessionMetadata, String> {
     recover_incomplete_compaction(session_dir)?;
-    read_json_file(&session_meta_path(session_dir))
+    read_json_file(&session_meta_path(session_dir)).map(normalize_fork_runtime_identity)
 }
 
 fn load_session_index_from_dir(session_dir: &Path) -> Result<PersistedTranscriptIndex, String> {
@@ -2253,6 +2264,24 @@ fn synthesize_conversation_bindings(
     }
 }
 
+fn bindings_identify_fork(bindings: &PersistedConversationBindings) -> bool {
+    let prefix = format!("fork:{}:", bindings.conversation_id);
+    bindings
+        .provider_bindings
+        .iter()
+        .any(|binding| binding.binding_id.starts_with(&prefix))
+}
+
+fn normalize_fork_binding_runtime_identity(
+    mut bindings: PersistedConversationBindings,
+) -> PersistedConversationBindings {
+    for binding in &mut bindings.provider_bindings {
+        binding.runtime_session_id = None;
+        binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
+    }
+    bindings
+}
+
 fn validate_persisted_conversation_bindings(
     bindings: &PersistedConversationBindings,
 ) -> Result<(), String> {
@@ -2399,14 +2428,18 @@ fn load_conversation_bindings_from_dir(
 ) -> Result<PersistedConversationBindings, String> {
     let metadata = load_session_metadata_from_dir(session_dir)?;
     let index = load_session_index_from_dir(session_dir)?;
-    Ok(match read_conversation_bindings_file(session_dir) {
+    let mut bindings = match read_conversation_bindings_file(session_dir) {
         ConversationBindingsFileState::Supported(bindings) => {
             reconcile_conversation_bindings(*bindings, &metadata, &index)
         }
         ConversationBindingsFileState::Missing | ConversationBindingsFileState::Unusable => {
             synthesize_conversation_bindings(&metadata, &index)
         }
-    })
+    };
+    if metadata.forked_from.is_some() || bindings_identify_fork(&bindings) {
+        bindings = normalize_fork_binding_runtime_identity(bindings);
+    }
+    Ok(bindings)
 }
 
 fn project_active_binding_to_history(
@@ -2508,7 +2541,7 @@ pub fn load_all_session_histories_with_bindings(
 ) -> Result<Vec<PersistedSessionHistoryEnvelope>, String> {
     load_all_session_histories(storage_root, include_messages)?
         .into_iter()
-        .map(|history| {
+        .map(|mut history| {
             let session_dir = storage_session_dir(storage_root, &history.session_id);
             let conversation_bindings =
                 if storage_session_is_complete(storage_root, &history.session_id) {
@@ -2530,6 +2563,10 @@ pub fn load_all_session_histories_with_bindings(
                     };
                     synthesize_conversation_bindings(&metadata, &index)
                 };
+            if bindings_identify_fork(&conversation_bindings) {
+                history.runtime_session_id = None;
+                history.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
+            }
             Ok(PersistedSessionHistoryEnvelope {
                 history,
                 conversation_bindings,
@@ -3660,11 +3697,6 @@ pub fn fork_session_history(
         .custom_title
         .or(source_meta.title)
         .map(|t| format!("{t} (fork)"));
-    let is_custom_acp_runtime = source_meta
-        .runtime_id
-        .as_deref()
-        .is_some_and(is_custom_acp_runtime_id);
-
     let new_metadata = PersistedSessionMetadata {
         version: source_meta.version,
         session_id: new_session_id.clone(),
@@ -3675,18 +3707,10 @@ pub fn fork_session_history(
         runtime_revision: source_meta.runtime_revision,
         runtime_launch_fingerprint: source_meta.runtime_launch_fingerprint,
         // A transcript fork must not reconnect to the source runtime session.
-        // Custom ACP does not offer a native fork operation, so its fork starts
-        // a fresh session and sends the copied transcript as resume context.
-        runtime_session_id: if is_custom_acp_runtime {
-            None
-        } else {
-            source_meta.runtime_session_id
-        },
-        continuation_strategy: if is_custom_acp_runtime {
-            Some(AcpContinuationStrategy::NewSessionOnly)
-        } else {
-            source_meta.continuation_strategy
-        },
+        // Its next turn starts a fresh native session and receives the copied
+        // transcript as bounded resume context.
+        runtime_session_id: None,
+        continuation_strategy: Some(AcpContinuationStrategy::NewSessionOnly),
         model_id: source_meta.model_id,
         mode_id: source_meta.mode_id,
         models: source_meta.models,
@@ -3713,10 +3737,8 @@ pub fn fork_session_history(
         .map(|binding| {
             binding.binding_id = format!("fork:{new_session_id}:{}", binding.runtime_id);
             binding.conversation_id = new_session_id.clone();
-            if is_custom_acp_runtime_id(&binding.runtime_id) {
-                binding.runtime_session_id = None;
-                binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
-            }
+            binding.runtime_session_id = None;
+            binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
             binding.context_cursor = None;
             binding.context_generation = binding.context_generation.saturating_add(1);
             binding.created_at = Some(now_ms);
@@ -4641,6 +4663,79 @@ mod tests {
             summaries[0].continuation_strategy,
             Some(AcpContinuationStrategy::Load)
         );
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn builtin_runtime_fork_discards_source_runtime_session_identity() {
+        let dir = make_temp_dir();
+        let mut history = sample_history();
+        history.runtime_session_id = Some("source-runtime-session".to_string());
+        history.continuation_strategy = Some(AcpContinuationStrategy::Resume);
+
+        save_session_history(&dir, &history).expect("history should persist");
+        let forked_session_id =
+            fork_session_history(&dir, &history.session_id).expect("history should fork");
+        let forked = load_all_session_histories(&dir, false)
+            .expect("forked history should load")
+            .into_iter()
+            .find(|candidate| candidate.session_id == forked_session_id)
+            .expect("forked history should be present");
+
+        assert_eq!(forked.runtime_session_id, None);
+        assert_eq!(
+            forked.continuation_strategy,
+            Some(AcpContinuationStrategy::NewSessionOnly)
+        );
+        let forked_bindings =
+            load_conversation_bindings_from_dir(&storage_session_dir(&dir, &forked_session_id))
+                .expect("forked bindings should load");
+        assert!(forked_bindings.provider_bindings.iter().all(|binding| {
+            binding.runtime_session_id.is_none()
+                && binding.continuation_strategy == Some(AcpContinuationStrategy::NewSessionOnly)
+        }));
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn legacy_fork_sidecar_isolated_when_loaded() {
+        let dir = make_temp_dir();
+        let mut history = sample_history();
+        history.runtime_session_id = Some("shared-runtime-session".to_string());
+        history.continuation_strategy = Some(AcpContinuationStrategy::Resume);
+        save_session_history(&dir, &history).expect("history should persist");
+
+        let session_dir = storage_session_dir(&dir, &history.session_id);
+        let mut bindings =
+            load_conversation_bindings_from_dir(&session_dir).expect("bindings should synthesize");
+        let fork_binding_id = format!("fork:{}:codex-acp", history.session_id);
+        bindings.active_binding_id = Some(fork_binding_id.clone());
+        bindings.provider_bindings[0].binding_id = fork_binding_id;
+        write_json_atomic(&conversation_bindings_path(&session_dir), &bindings)
+            .expect("legacy fork sidecar should persist");
+
+        let restored = load_all_session_histories_with_bindings(&dir, false)
+            .expect("legacy fork should load")
+            .into_iter()
+            .find(|candidate| candidate.history.session_id == history.session_id)
+            .expect("legacy fork should be present");
+        assert_eq!(restored.history.runtime_session_id, None);
+        assert_eq!(
+            restored.history.continuation_strategy,
+            Some(AcpContinuationStrategy::NewSessionOnly)
+        );
+
+        assert!(restored
+            .conversation_bindings
+            .provider_bindings
+            .iter()
+            .all(|binding| {
+                binding.runtime_session_id.is_none()
+                    && binding.continuation_strategy
+                        == Some(AcpContinuationStrategy::NewSessionOnly)
+            }));
 
         fs::remove_dir_all(dir).ok();
     }

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -41,6 +41,10 @@ pub struct PersistedTurnProvenance {
     #[serde(default)]
     pub options: BTreeMap<String, String>,
     pub start_reason: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_truncated: Option<bool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff_omitted_turn_count: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -5215,6 +5219,8 @@ mod tests {
                 mode_id: "default".to_string(),
                 options: BTreeMap::new(),
                 start_reason: "normal".to_string(),
+                handoff_truncated: Some(true),
+                handoff_omitted_turn_count: Some(3),
             }),
         };
 

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -1515,7 +1515,9 @@ fn inspect_session_directory(
         relative_path: relative_dir.clone(),
     });
     let parsed_bindings = if let Some(artifact) = &bindings_bytes {
-        match serde_json::from_slice::<PersistedConversationBindings>(&artifact.bytes) {
+        match serde_json::from_slice::<PersistedConversationBindings>(&artifact.bytes)
+            .map(normalize_single_provider_binding)
+        {
             Ok(bindings)
                 if bindings.version == FORMAT_VERSION
                     && bindings.conversation_id == metadata.session_id =>
@@ -2263,6 +2265,9 @@ fn validate_persisted_conversation_bindings(
     if bindings.conversation_id.trim().is_empty() {
         return Err("Conversation bindings contain an empty conversation ID.".to_string());
     }
+    if bindings.provider_bindings.len() > 1 {
+        return Err("A conversation cannot contain bindings for multiple providers.".to_string());
+    }
     let mut ids = HashSet::new();
     for binding in &bindings.provider_bindings {
         if binding.binding_id.trim().is_empty() || !ids.insert(binding.binding_id.as_str()) {
@@ -2284,12 +2289,45 @@ fn validate_persisted_conversation_bindings(
     Ok(())
 }
 
+fn normalize_single_provider_binding(
+    mut bindings: PersistedConversationBindings,
+) -> PersistedConversationBindings {
+    if bindings.provider_bindings.len() <= 1 {
+        return bindings;
+    }
+
+    let active_index = bindings
+        .active_binding_id
+        .as_ref()
+        .and_then(|active_id| {
+            bindings
+                .provider_bindings
+                .iter()
+                .position(|binding| &binding.binding_id == active_id)
+        })
+        .unwrap_or(0);
+    let active = bindings.provider_bindings.remove(active_index);
+    bindings.active_binding_id = Some(active.binding_id.clone());
+    if bindings.transcript_observation.message_count > 0 {
+        bindings.preferred_selection = PersistedConversationSelection {
+            runtime_id: active.runtime_id.clone(),
+            model_id: active.model_id.clone(),
+            mode_id: active.mode_id.clone(),
+            options: active.options.clone(),
+        };
+    }
+    bindings.provider_bindings = vec![active];
+    bindings
+}
+
 fn read_conversation_bindings_file(session_dir: &Path) -> ConversationBindingsFileState {
     let path = conversation_bindings_path(session_dir);
     if !path.exists() {
         return ConversationBindingsFileState::Missing;
     }
-    let Ok(bindings) = read_json_file::<PersistedConversationBindings>(&path) else {
+    let Ok(bindings) = read_json_file::<PersistedConversationBindings>(&path)
+        .map(normalize_single_provider_binding)
+    else {
         return ConversationBindingsFileState::Unusable;
     };
     if validate_persisted_conversation_bindings(&bindings).is_err() {
@@ -2322,29 +2360,23 @@ fn reconcile_conversation_bindings(
             != Some(current_fingerprint.as_str());
 
     if legacy_changed {
-        for binding in &mut bindings.provider_bindings {
-            binding.context_cursor = None;
-            binding.context_generation = binding.context_generation.saturating_add(1);
-        }
         let runtime_id = metadata.runtime_id.clone().unwrap_or_default();
-        let position = bindings
+        let previous = bindings
             .provider_bindings
             .iter()
-            .position(|binding| binding.runtime_id == runtime_id);
-        let binding_id = position
-            .map(|index| bindings.provider_bindings[index].binding_id.clone())
+            .find(|binding| binding.runtime_id == runtime_id);
+        let binding_id = previous
+            .map(|binding| binding.binding_id.clone())
             .unwrap_or_else(|| legacy_binding_id(&metadata.session_id, &runtime_id));
         let mut projected = binding_from_metadata(metadata, binding_id.clone());
-        if let Some(index) = position {
-            let previous = &bindings.provider_bindings[index];
+        if let Some(previous) = previous {
             projected.capabilities = previous.capabilities.clone();
-            projected.context_generation = previous.context_generation;
+            projected.context_generation = previous.context_generation.saturating_add(1);
             projected.created_at = previous.created_at.or(projected.created_at);
-            bindings.provider_bindings[index] = projected;
         } else {
             projected.context_generation = 1;
-            bindings.provider_bindings.push(projected);
         }
+        bindings.provider_bindings = vec![projected];
         bindings.active_binding_id = Some(binding_id);
         bindings.preferred_selection = PersistedConversationSelection {
             runtime_id,
@@ -2421,15 +2453,6 @@ fn merge_conversation_bindings(
     mut incoming: PersistedConversationBindings,
 ) -> PersistedConversationBindings {
     if let Some(existing) = existing {
-        let mut merged = existing
-            .provider_bindings
-            .into_iter()
-            .map(|binding| (binding.binding_id.clone(), binding))
-            .collect::<BTreeMap<_, _>>();
-        for binding in incoming.provider_bindings {
-            merged.insert(binding.binding_id.clone(), binding);
-        }
-        incoming.provider_bindings = merged.into_values().collect();
         incoming.context_summary = incoming.context_summary.or(existing.context_summary);
         incoming.revision = incoming.revision.max(existing.revision).saturating_add(1);
     } else {
@@ -3682,26 +3705,24 @@ pub fn fork_session_history(
     write_json_atomic(&session_meta_path(&dest_dir), &new_metadata)?;
 
     let mut forked_bindings = source_bindings;
-    let source_active_binding_id = forked_bindings.active_binding_id.clone();
-    let mut next_active_binding_id = None;
     forked_bindings.conversation_id = new_session_id.clone();
     forked_bindings.revision = forked_bindings.revision.saturating_add(1);
-    for (index, binding) in forked_bindings.provider_bindings.iter_mut().enumerate() {
-        let was_active = source_active_binding_id.as_deref() == Some(binding.binding_id.as_str());
-        binding.binding_id = format!("fork:{new_session_id}:{}:{index}", binding.runtime_id);
-        binding.conversation_id = new_session_id.clone();
-        if is_custom_acp_runtime_id(&binding.runtime_id) {
-            binding.runtime_session_id = None;
-            binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
-        }
-        binding.context_cursor = None;
-        binding.context_generation = binding.context_generation.saturating_add(1);
-        binding.created_at = Some(now_ms);
-        binding.updated_at = Some(now_ms);
-        if was_active {
-            next_active_binding_id = Some(binding.binding_id.clone());
-        }
-    }
+    let next_active_binding_id = forked_bindings
+        .provider_bindings
+        .first_mut()
+        .map(|binding| {
+            binding.binding_id = format!("fork:{new_session_id}:{}", binding.runtime_id);
+            binding.conversation_id = new_session_id.clone();
+            if is_custom_acp_runtime_id(&binding.runtime_id) {
+                binding.runtime_session_id = None;
+                binding.continuation_strategy = Some(AcpContinuationStrategy::NewSessionOnly);
+            }
+            binding.context_cursor = None;
+            binding.context_generation = binding.context_generation.saturating_add(1);
+            binding.created_at = Some(now_ms);
+            binding.updated_at = Some(now_ms);
+            binding.binding_id.clone()
+        });
     forked_bindings.active_binding_id = next_active_binding_id;
     let dest_index = load_session_index_from_dir(&dest_dir)?;
     forked_bindings.transcript_observation = PersistedTranscriptObservation {
@@ -5407,7 +5428,39 @@ mod tests {
     }
 
     #[test]
-    fn downgrade_write_reconciles_without_losing_existing_bindings() {
+    fn legacy_multi_provider_sidecar_normalizes_to_the_active_binding() {
+        let dir = make_temp_dir();
+        let history = sample_history();
+        save_session_history(&dir, &history).expect("base history should persist");
+        let session_dir = storage_session_dir(&dir, &history.session_id);
+        let mut bindings = load_conversation_bindings_from_dir(&session_dir)
+            .expect("legacy projection should synthesize");
+        let active_id = bindings.active_binding_id.clone().unwrap();
+        let mut stale = bindings.provider_bindings[0].clone();
+        stale.binding_id = "stale-provider-binding".to_string();
+        stale.runtime_id = "gemini-acp".to_string();
+        bindings.provider_bindings.push(stale);
+        write_json_atomic(&conversation_bindings_path(&session_dir), &bindings)
+            .expect("legacy sidecar should persist");
+
+        let normalized = load_conversation_bindings_from_dir(&session_dir)
+            .expect("legacy sidecar should normalize");
+        assert_eq!(
+            normalized.active_binding_id.as_deref(),
+            Some(active_id.as_str())
+        );
+        assert_eq!(normalized.provider_bindings.len(), 1);
+        assert_eq!(normalized.provider_bindings[0].binding_id, active_id);
+        assert!(inspect_history_storage(&dir)
+            .histories
+            .corrupt_artifacts
+            .is_empty());
+
+        fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    fn legacy_write_rebinds_the_conversation_to_one_provider() {
         let dir = make_temp_dir();
         let history = sample_history();
         save_session_history(&dir, &history).expect("base history should persist");
@@ -5458,7 +5511,7 @@ mod tests {
                 .iter()
                 .map(|binding| binding.runtime_id.as_str())
                 .collect::<HashSet<_>>(),
-            HashSet::from(["codex-acp", "gemini-acp"])
+            HashSet::from(["gemini-acp"])
         );
         assert!(envelope
             .conversation_bindings
@@ -5477,7 +5530,7 @@ mod tests {
         )
         .expect("sidecar should load");
         assert_eq!(persisted.revision, 2);
-        assert_eq!(persisted.provider_bindings.len(), 2);
+        assert_eq!(persisted.provider_bindings.len(), 1);
 
         fs::remove_dir_all(dir).ok();
     }

--- a/crates/ai/src/persistence.rs
+++ b/crates/ai/src/persistence.rs
@@ -2161,7 +2161,7 @@ fn load_history_from_session_dir(
 
 enum ConversationBindingsFileState {
     Missing,
-    Supported(PersistedConversationBindings),
+    Supported(Box<PersistedConversationBindings>),
     Unusable,
 }
 
@@ -2295,7 +2295,7 @@ fn read_conversation_bindings_file(session_dir: &Path) -> ConversationBindingsFi
     if validate_persisted_conversation_bindings(&bindings).is_err() {
         return ConversationBindingsFileState::Unusable;
     }
-    ConversationBindingsFileState::Supported(bindings)
+    ConversationBindingsFileState::Supported(Box::new(bindings))
 }
 
 fn reconcile_conversation_bindings(
@@ -2369,7 +2369,7 @@ fn load_conversation_bindings_from_dir(
     let index = load_session_index_from_dir(session_dir)?;
     Ok(match read_conversation_bindings_file(session_dir) {
         ConversationBindingsFileState::Supported(bindings) => {
-            reconcile_conversation_bindings(bindings, &metadata, &index)
+            reconcile_conversation_bindings(*bindings, &metadata, &index)
         }
         ConversationBindingsFileState::Missing | ConversationBindingsFileState::Unusable => {
             synthesize_conversation_bindings(&metadata, &index)
@@ -2457,7 +2457,7 @@ pub fn save_session_history_with_bindings(
         return Err("Canonical bindings do not match the persisted history.".to_string());
     }
     let existing = match disk_state {
-        ConversationBindingsFileState::Supported(existing) => Some(existing),
+        ConversationBindingsFileState::Supported(existing) => Some(*existing),
         ConversationBindingsFileState::Missing => None,
         ConversationBindingsFileState::Unusable => unreachable!(),
     };

--- a/crates/ai/testdata/session-history/minimum-v1.json
+++ b/crates/ai/testdata/session-history/minimum-v1.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "session_id": "fixture-minimum-v1",
+  "model_id": "legacy-model",
+  "mode_id": "default",
+  "created_at": 10,
+  "updated_at": 10,
+  "messages": [
+    {
+      "id": "user:legacy",
+      "role": "user",
+      "kind": "text",
+      "content": "Legacy chat",
+      "timestamp": 10
+    }
+  ]
+}

--- a/crates/ai/testdata/session-history/v0.7.1.json
+++ b/crates/ai/testdata/session-history/v0.7.1.json
@@ -1,0 +1,40 @@
+{
+  "version": 1,
+  "session_id": "fixture-v0.7.1",
+  "parent_session_id": null,
+  "closed_at": null,
+  "runtime_id": "codex-acp",
+  "runtime_display_name": "Codex",
+  "runtime_revision": 1,
+  "runtime_launch_fingerprint": "codex-v1",
+  "runtime_session_id": "runtime-v0.7.1",
+  "continuation_strategy": "resume",
+  "model_id": "gpt-5",
+  "mode_id": "default",
+  "models": [],
+  "modes": [],
+  "config_options": [],
+  "additional_roots": [],
+  "created_at": 100,
+  "updated_at": 200,
+  "start_index": 0,
+  "message_count": 2,
+  "title": "Release fixture",
+  "preview": "Ready",
+  "messages": [
+    {
+      "id": "user:fixture",
+      "role": "user",
+      "kind": "text",
+      "content": "Continue this chat",
+      "timestamp": 100
+    },
+    {
+      "id": "assistant:fixture",
+      "role": "assistant",
+      "kind": "text",
+      "content": "Ready",
+      "timestamp": 200
+    }
+  ]
+}

--- a/docs/ai-session-history.md
+++ b/docs/ai-session-history.md
@@ -30,6 +30,7 @@ Each modern session directory contains:
 - `session-meta.json`: session metadata such as runtime, model, mode, title, timestamps, parent session, and message count.
 - `index.json`: transcript offsets, lengths, and message hashes used for windowed transcript loading.
 - `transcript.jsonl`: newline-delimited JSON transcript entries.
+- `conversation-bindings.json`: optional versioned canonical conversation metadata for ACP provider bindings, continuation strategies, next-turn selection, and transcript cursors.
 
 The `.neverwrite` directory is NeverWrite's internal hidden-state directory.
 It is hidden by dotfile convention on macOS and Linux, and may be filtered by
@@ -97,6 +98,18 @@ closing the terminal ends the process and removes the row. It has no chat-tab
 Back/Forward history, saved chat view, or `Open in New Tab` action. Terminal tabs
 can be restored as workspace tabs, but their current metadata does not relaunch
 Claude Code or recreate the agent-sidebar projection after an app restart.
+
+## Canonical Conversation Rollout And Rollback
+
+Canonical ACP conversations are a normal data-model upgrade, not a Beta setting or runtime feature flag. A conversation keeps one durable transcript while each ACP provider has an independent binding; switching A -> B -> A can resume or load the previous binding when the provider supports it, and otherwise starts an isolated runtime session with a bounded transcript handoff.
+
+The compatibility window targets the last public release immediately before canonical conversations and the first releases that write `conversation-bindings.json`. Opening legacy history is lazy and does not create the sidecar until the upgraded app writes the conversation. The legacy projection in `session-meta.json` and the transcript remain readable by the previous release.
+
+For a rollback, close NeverWrite, install the immediately preceding public release, and reopen the same vault. Do not delete or edit the canonical sidecar. The older release ignores it and can continue writing the legacy transcript; a later re-upgrade reconciles those writes, preserves provider bindings, and invalidates stale context cursors so the next turn uses a safe transcript handoff.
+
+Rollback cannot reconnect a provider or model that the older release does not contain. A missing provider remains transcript-only, a custom ACP launch fingerprint change requires confirmation before continuation, and a `new_session_only` binding cannot regain native resume semantics. Forks receive independent canonical identities and do not reuse custom runtime session handles.
+
+Canonical routing diagnostics record only strategies, provider IDs, boolean outcomes, counts, runtime states, and bounded error codes. They never include prompt or transcript content, vault paths, attachment names, runtime command lines, environment values, or raw error messages.
 
 ## Recovery Flow
 


### PR DESCRIPTION
## Summary

This PR establishes a canonical lifecycle for ACP conversations. A conversation now has a stable durable identity and transcript, while provider-specific runtime state is stored in a versioned binding sidecar. The implementation keeps the existing session-based UI/store as a compatibility adapter during the migration, but makes canonical conversation state the source of truth for routing, persistence, reconnection, and conversation-scoped UI state.

The final product rule is intentionally conservative: users may select a different provider before the first message, but a conversation is bound to that provider once it has started. Changing provider after that point requires a new chat. Model, mode, and provider options remain validated against the selected runtime before each turn.

## User-visible behavior

- Adds a searchable, anchored provider/model picker with model-specific mode, reasoning, and service-tier controls.
- Allows choosing the provider for a new, empty conversation; provider changes are disabled once the conversation has transcript, queued work, or an in-flight transition.
- Preserves the selected provider, model, mode, and options across persistence and restoration.
- Restores a saved chat using native continuation when the runtime supports it; otherwise starts a fresh runtime and sends a bounded, sanitized transcript handoff with the next prompt.
- Keeps a conversation stable as it is opened in tabs, panes, the Agents sidebar, restored history, and workspace state.
- Improves Claude subscription setup detection and makes `codex-acp` the built-in Codex executable.

## Architecture and persistence

- Introduces canonical conversation, selection, binding, and routing models in the desktop store.
- Persists optional versioned `conversation-bindings.json` sidecars alongside the legacy transcript and metadata. The sidecar records the active provider binding, runtime identity, continuation strategy, capabilities, selection, context cursor, and transcript observation.
- Loads legacy histories without eagerly writing a sidecar, then reconciles legacy metadata and canonical bindings safely on later saves.
- Preserves canonical bindings during history migration, storage reconciliation, reconnect, and resume flows.
- Maintains the legacy `AIChatSession` projection while incrementally updating canonical conversation state during streaming, avoiding full-store reprojection on every runtime event.
- Migrates composer, queued messages, interrupted-turn state, and token usage to canonical conversation precedence so stale session aliases cannot win based on insertion order.

## Routing, safety, and lifecycle hardening

- Adds `ai_start_conversation_turn` to validate the requested provider, model, mode, options, conversation, and binding before a turn starts.
- Rejects unavailable or mismatched runtime configuration instead of silently falling back to runtime defaults.
- Keeps native runtime identity separate from durable history identity, including when a provider is selected before the first turn.
- Makes transcript forks independent: forks clear the source runtime session identity, reset the context cursor, force `new_session_only`, and start their next turn with copied transcript context.
- Releases a superseded ACP runtime session when the initial provider selection creates a replacement session.
- Adds temporary event routing around turn creation so early runtime events are applied to the intended conversation.
- Bounds and caches Claude authentication probes while using the effective runtime setup, preventing a stalled CLI check from blocking setup state indefinitely.

## Compatibility

- `conversation-bindings.json` is additive and versioned. The existing transcript and legacy metadata remain readable by the immediately preceding release.
- Rollbacks may ignore the sidecar and continue from the legacy transcript; a later upgrade reconciles those writes and safely invalidates stale context cursors.
- Forks and `new_session_only` bindings deliberately do not reuse a prior native runtime session; they continue through transcript handoff instead.

## Validation

All required GitHub Actions checks are passing, including Desktop, Rust, macOS Universal, Windows x64/arm64, Linux x64/ARM64, AI history recovery, static analysis, CodeQL, and validation.

Focused regression coverage includes:

- canonical binding serialization, migration, reconciliation, and rollback compatibility;
- provider selection and strict turn-start validation;
- native identity preservation across first-turn provider selection and reconnect;
- fork isolation for built-in and custom runtimes;
- canonical precedence for stale/live conversation-scoped state;
- streaming projection behavior, handoff construction, picker interactions, and Claude setup status.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added conversation-aware provider and model selection with searchable favorites and service-tier options.
  - Added provider switching, session continuation, context handoff, and preserved conversation history.
  - Added stable conversation tracking across tabs, reloads, resumes, and forks.
  - Added optional Claude Code integration settings and dedicated agent creation.
- **Bug Fixes**
  - Improved authentication recovery, runtime fallback, and chat menu positioning.
  - Improved release reliability with automatic build retries.
  - Standardized translucent chat menu styling.
- **Documentation**
  - Documented conversation bindings and history behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->