### PR TITLE
Add movable Files and Agents sidebar views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added bidirectional placement for the Files and Agents sidebar views, with accessible context-menu and command-palette actions, persistent layout preferences, side-aware reveal and drag behavior, and adaptive right-sidebar sizing.
+
 ## [0.7.1] - 2026-08-09
 
 ### Fixed

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -9,8 +9,7 @@ import { resolveDeferredUnlisten } from "./app/utils/deferredUnlisten";
 import { vaultInvoke } from "./app/utils/vaultInvoke";
 import { AppLayout } from "./components/layout/AppLayout";
 import { SidebarShell } from "./components/layout/SidebarShell";
-import { LinksPanel } from "./features/notes/LinksPanel";
-import { OutlinePanel } from "./features/notes/OutlinePanel";
+import { RightSidebarShell } from "./components/layout/RightSidebarShell";
 import { AIChatWorkspaceHost } from "./features/ai/AIChatWorkspaceHost";
 import { AIChatDetachedWindowHost } from "./features/ai/AIChatDetachedWindowHost";
 import { listChatWorkspaceHistoryReferences } from "./features/ai/chatWorkspaceRestoration";
@@ -175,183 +174,6 @@ function resetAppToActualSize() {
     resetAppZoom();
 }
 
-type RightPanelTab = "outline" | "links";
-
-// The right panel lives outside the center column, so its tab bar starts at
-// Y=0 of the window. On Windows and Linux that zone is owned by the native
-// `titleBarOverlay` (34px tall caption strip anchored to the window's
-// top-right), which would otherwise paint min/max/close on top of the tab
-// bar. Reserve a matching 34px drag strip at the top of the panel — same
-// pattern as `EditorChromeBar` for the center column.
-const DESKTOP_PLATFORM = getDesktopPlatform();
-const USES_NATIVE_TITLEBAR_OVERLAY =
-    DESKTOP_PLATFORM === "windows" || DESKTOP_PLATFORM === "linux";
-
-const RIGHT_PANEL_TABS: Array<{
-    value: RightPanelTab;
-    label: string;
-    icon: React.ReactNode;
-}> = [
-    {
-        value: "outline",
-        label: "Outline",
-        icon: (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <path d="M3 3.5h10" />
-                <path d="M5.5 8h7.5" />
-                <path d="M8 12.5h5" />
-                <path d="M3 8h.01" />
-                <path d="M5.5 12.5h.01" />
-            </svg>
-        ),
-    },
-    {
-        value: "links",
-        label: "Links",
-        icon: (
-            <svg
-                width="12"
-                height="12"
-                viewBox="0 0 16 16"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="1.5"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-            >
-                <path d="M10 2h4v4M14 2l-6 6M6 4H3a1 1 0 0 0-1 1v8a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1v-3" />
-            </svg>
-        ),
-    },
-];
-
-function RightPanelTabBar({
-    view,
-    onSelect,
-    onCollapse,
-}: {
-    view: RightPanelTab;
-    onSelect: (view: RightPanelTab) => void;
-    onCollapse: () => void;
-}) {
-    return (
-        <div
-            className="flex items-center gap-1"
-            style={{ padding: "8px 8px 6px", flexShrink: 0 }}
-        >
-            {RIGHT_PANEL_TABS.map((tab) => {
-                const active = view === tab.value;
-                return (
-                    <button
-                        key={tab.value}
-                        type="button"
-                        onClick={() => onSelect(tab.value)}
-                        title={tab.label}
-                        data-active={active || undefined}
-                        className="ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
-                        style={{
-                            flex: 1,
-                            minWidth: 0,
-                            height: 26,
-                            padding: "0 6px",
-                            border: active
-                                ? "1px solid color-mix(in srgb, var(--accent) 22%, var(--border))"
-                                : "1px solid transparent",
-                            background: active
-                                ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
-                                : "transparent",
-                            color: active
-                                ? "var(--text-primary)"
-                                : "var(--text-secondary)",
-                            boxShadow: active
-                                ? "0 1px 2px rgb(0 0 0 / 0.12)"
-                                : "none",
-                            transition:
-                                "background-color 120ms ease, color 120ms ease, border-color 120ms ease, transform 120ms ease",
-                        }}
-                    >
-                        {tab.icon}
-                        <span className="truncate">{tab.label}</span>
-                    </button>
-                );
-            })}
-            <button
-                type="button"
-                onClick={onCollapse}
-                title="Hide right panel"
-                aria-label="Hide right panel"
-                className="ub-chrome-btn flex items-center justify-center shrink-0 rounded-md"
-                style={{
-                    width: 26,
-                    height: 26,
-                    border: "1px solid transparent",
-                    background: "transparent",
-                    color: "var(--text-secondary)",
-                    opacity: 0.82,
-                }}
-            >
-                <svg
-                    width="16"
-                    height="16"
-                    viewBox="0 0 16 16"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="1.4"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                >
-                    <rect x="2" y="2.5" width="12" height="11" rx="2.2" />
-                    <path d="M6 2.5v11" />
-                </svg>
-            </button>
-        </div>
-    );
-}
-
-function RightPanel() {
-    const rightPanelView = useLayoutStore(
-        (s) => s.activeSidebarView.right,
-    ) as RightPanelTab;
-    const activateSidebarView = useLayoutStore((s) => s.activateSidebarView);
-    const toggleRightPanel = useLayoutStore((s) => s.toggleRightPanel);
-    return (
-        <div className="flex h-full min-h-0 flex-col overflow-hidden">
-            {USES_NATIVE_TITLEBAR_OVERLAY && (
-                <div
-                    aria-hidden="true"
-                    data-right-panel-titlebar-inset
-                    style={
-                        {
-                            height: 34,
-                            flexShrink: 0,
-                            WebkitAppRegion: "drag",
-                            backgroundColor: "var(--sidebar-vibrancy-tint)",
-                        } as React.CSSProperties
-                    }
-                />
-            )}
-            <RightPanelTabBar
-                view={rightPanelView}
-                onSelect={(view) => activateSidebarView("right", view)}
-                onCollapse={toggleRightPanel}
-            />
-            <div className="min-h-0 flex-1 overflow-hidden">
-                {rightPanelView === "outline" && <OutlineRightPanel />}
-                {rightPanelView === "links" && <LinksPanel />}
-            </div>
-        </div>
-    );
-}
-
 const VAULT_OVERLAY_STRIP_LABEL: React.CSSProperties = {
     fontSize: "0.68em",
     letterSpacing: "0.12em",
@@ -507,42 +329,6 @@ function VaultOpeningOverlay() {
                 </div>
             </div>
         </div>
-    );
-}
-
-function OutlineRightPanel() {
-    const activeNoteId = useEditorStore((state) => {
-        const tab = selectFocusedEditorTab(state);
-        return tab && isNoteTab(tab) ? tab.noteId : null;
-    });
-    const activeContent = useEditorStore((state) => {
-        const tab = selectFocusedEditorTab(state);
-        return tab && isNoteTab(tab) ? tab.content : null;
-    });
-    const queueSelectionReveal = useEditorStore((s) => s.queueSelectionReveal);
-
-    if (!activeNoteId) {
-        return (
-            <div
-                className="flex items-center justify-center h-full text-xs"
-                style={{ color: "var(--text-secondary)" }}
-            >
-                No note open
-            </div>
-        );
-    }
-
-    return (
-        <OutlinePanel
-            content={activeContent}
-            onSelectHeading={(selection) =>
-                queueSelectionReveal({
-                    noteId: activeNoteId,
-                    anchor: selection.anchor,
-                    head: selection.head,
-                })
-            }
-        />
     );
 }
 
@@ -2343,7 +2129,7 @@ export default function App() {
                             </div>
                         </div>
                     }
-                    right={<RightPanel />}
+                    right={<RightSidebarShell />}
                 />
                 <VaultOpeningOverlay />
             </div>

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -318,8 +318,10 @@ function RightPanelTabBar({
 }
 
 function RightPanel() {
-    const rightPanelView = useLayoutStore((s) => s.rightPanelView);
-    const activateRightView = useLayoutStore((s) => s.activateRightView);
+    const rightPanelView = useLayoutStore(
+        (s) => s.activeSidebarView.right,
+    ) as RightPanelTab;
+    const activateSidebarView = useLayoutStore((s) => s.activateSidebarView);
     const toggleRightPanel = useLayoutStore((s) => s.toggleRightPanel);
     return (
         <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -339,7 +341,7 @@ function RightPanel() {
             )}
             <RightPanelTabBar
                 view={rightPanelView}
-                onSelect={activateRightView}
+                onSelect={(view) => activateSidebarView("right", view)}
                 onCollapse={toggleRightPanel}
             />
             <div className="min-h-0 flex-1 overflow-hidden">
@@ -558,8 +560,7 @@ function useRegisterCommands(
         const platform = getDesktopPlatform();
         const commandPaletteShortcut = getShortcutDefinition("command_palette");
         const quickSwitcherShortcut = getShortcutDefinition("quick_switcher");
-        const searchInVaultShortcut =
-            getShortcutDefinition("search_in_vault");
+        const searchInVaultShortcut = getShortcutDefinition("search_in_vault");
         const openVaultShortcut = getShortcutDefinition("open_vault");
         const newNoteShortcut = getShortcutDefinition("new_note");
         const newAgentShortcut = getShortcutDefinition("new_agent");
@@ -928,9 +929,7 @@ function useRegisterCommands(
             execute: () => {
                 const tab = activeTerminalTab();
                 if (!tab) return;
-                void useTerminalRuntimeStore
-                    .getState()
-                    .restart(tab.terminalId);
+                void useTerminalRuntimeStore.getState().restart(tab.terminalId);
             },
         });
 
@@ -1062,7 +1061,9 @@ function useGlobalShortcuts(
 
             if (matchesShortcutAction(e, "new_terminal", platform)) {
                 e.preventDefault();
-                useCommandStore.getState().execute("workspace:new-terminal-tab");
+                useCommandStore
+                    .getState()
+                    .execute("workspace:new-terminal-tab");
                 return;
             }
 
@@ -1496,11 +1497,7 @@ export default function App() {
         [],
     );
 
-    useRegisterCommands(
-        openSettings,
-        windowMode === "main",
-        shortcutOverrides,
-    );
+    useRegisterCommands(openSettings, windowMode === "main", shortcutOverrides);
     useGlobalShortcuts(
         openSettings,
         shortcutOverrides,
@@ -1768,8 +1765,9 @@ export default function App() {
             let restoredWorkspace = false;
 
             try {
-                const initialization =
-                    await useChatStore.getState().initialize();
+                const initialization = await useChatStore
+                    .getState()
+                    .initialize();
                 if (cancelled) return;
 
                 if (!initialization.sessionInventoryLoaded) {
@@ -1798,7 +1796,10 @@ export default function App() {
                     (workspace?.tabs ?? []).map((tab) => [tab.sessionId, tab]),
                 );
                 const restoredChatMetadataBySessionId = new Map(
-                    restoredChatWorkspace.tabs.map((tab) => [tab.sessionId, tab]),
+                    restoredChatWorkspace.tabs.map((tab) => [
+                        tab.sessionId,
+                        tab,
+                    ]),
                 );
                 const restoredChatMetadataByHistoryId = new Map(
                     restoredChatWorkspace.tabs.flatMap((tab) =>
@@ -1835,9 +1836,9 @@ export default function App() {
 
                 const initialChatHistoryReferences =
                     listChatWorkspaceHistoryReferences(
-                        selectEditorWorkspaceTabs(useEditorStore.getState()).filter(
-                            isChatTab,
-                        ),
+                        selectEditorWorkspaceTabs(
+                            useEditorStore.getState(),
+                        ).filter(isChatTab),
                     );
                 for (const entry of initialChatHistoryReferences) {
                     const resolvedHistorySessionId =
@@ -1853,17 +1854,20 @@ export default function App() {
                         sessionIdByHistoryId.get(resolvedHistorySessionId) ??
                         restoredChatMetadataByHistoryId.get(
                             resolvedHistorySessionId,
-                        )?.sessionId ?? entry.sessionId;
+                        )?.sessionId ??
+                        entry.sessionId;
 
                     if (
                         resolvedSessionId !== entry.sessionId ||
                         resolvedHistorySessionId !== entry.historySessionId
                     ) {
-                        useEditorStore.getState().replaceAiSessionId(
-                            entry.sessionId,
-                            resolvedSessionId,
-                            resolvedHistorySessionId,
-                        );
+                        useEditorStore
+                            .getState()
+                            .replaceAiSessionId(
+                                entry.sessionId,
+                                resolvedSessionId,
+                                resolvedHistorySessionId,
+                            );
                     }
                 }
 
@@ -1871,8 +1875,10 @@ export default function App() {
                 const focusedEditorTab = selectFocusedEditorTab(editorState);
                 const restoredChatHistoryReferences =
                     listChatWorkspaceHistoryReferences(
-                        selectEditorWorkspaceTabs(editorState).filter(isChatTab),
-                );
+                        selectEditorWorkspaceTabs(editorState).filter(
+                            isChatTab,
+                        ),
+                    );
                 await useChatStore.getState().reconcileRestoredWorkspaceTabs(
                     restoredChatHistoryReferences.map((entry) => {
                         const resolvedHistorySessionId =
@@ -1969,9 +1975,7 @@ export default function App() {
                     return;
 
                 const syncStrategy = getVaultChangeSyncStrategy(event.payload);
-                if (
-                    syncStrategy === "apply-note-change-and-refresh-entries"
-                ) {
+                if (syncStrategy === "apply-note-change-and-refresh-entries") {
                     applyVaultNoteChange(event.payload);
                     void refreshEntries();
                 } else if (syncStrategy === "refresh-entries") {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -699,6 +699,30 @@ function useRegisterCommands(
             execute: () => useLayoutStore.getState().toggleRightPanel(),
         });
 
+        for (const view of ["files", "agents"] as const) {
+            const label = view === "files" ? "Files" : "Agents";
+            register({
+                id: `layout:move-${view}-right`,
+                label: `Move ${label} to Right Sidebar`,
+                category: "Layout",
+                when: () =>
+                    useLayoutStore.getState().movableSidebarPlacement[view] ===
+                    "left",
+                execute: () =>
+                    useLayoutStore.getState().moveSidebarView(view, "right"),
+            });
+            register({
+                id: `layout:move-${view}-left`,
+                label: `Move ${label} to Left Sidebar`,
+                category: "Layout",
+                when: () =>
+                    useLayoutStore.getState().movableSidebarPlacement[view] ===
+                    "right",
+                execute: () =>
+                    useLayoutStore.getState().moveSidebarView(view, "left"),
+            });
+        }
+
         register({
             id: "app:open-settings",
             label: openSettingsShortcut.label,

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -228,7 +228,7 @@ describe("App web clipper routing", () => {
         await waitFor(() => {
             expect(
                 useCommandStore.getState().commands.has(
-                    "layout:move-files-right",
+                    "layout:move-files-left",
                 ),
             ).toBe(true);
         });
@@ -238,14 +238,14 @@ describe("App web clipper routing", () => {
                 .getState()
                 .search("")
                 .map((command) => command.label),
-        ).toContain("Move Files to Right Sidebar");
-        useCommandStore.getState().execute("layout:move-files-right");
+        ).toContain("Move Files to Left Sidebar");
+        useCommandStore.getState().execute("layout:move-files-left");
         expect(
             useCommandStore
                 .getState()
                 .search("")
                 .map((command) => command.label),
-        ).toContain("Move Files to Left Sidebar");
+        ).toContain("Move Files to Right Sidebar");
     });
 
     it("keeps the persisted chat workspace when chat initialization fails during cold start", async () => {

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -50,6 +50,10 @@ vi.mock("./components/layout/SidebarShell", () => ({
     SidebarShell: () => <div data-testid="sidebar-shell" />,
 }));
 
+vi.mock("./components/layout/RightSidebarShell", () => ({
+    RightSidebarShell: () => <div data-testid="right-sidebar-shell" />,
+}));
+
 vi.mock("./features/notes/LinksPanel", () => ({
     LinksPanel: () => <div data-testid="links-panel" />,
 }));

--- a/apps/desktop/src/App.webClipper.test.tsx
+++ b/apps/desktop/src/App.webClipper.test.tsx
@@ -223,6 +223,31 @@ describe("App web clipper routing", () => {
         });
     });
 
+    it("registers conditional sidebar movement commands", async () => {
+        renderComponent(<App />);
+        await waitFor(() => {
+            expect(
+                useCommandStore.getState().commands.has(
+                    "layout:move-files-right",
+                ),
+            ).toBe(true);
+        });
+
+        expect(
+            useCommandStore
+                .getState()
+                .search("")
+                .map((command) => command.label),
+        ).toContain("Move Files to Right Sidebar");
+        useCommandStore.getState().execute("layout:move-files-right");
+        expect(
+            useCommandStore
+                .getState()
+                .search("")
+                .map((command) => command.label),
+        ).toContain("Move Files to Left Sidebar");
+    });
+
     it("keeps the persisted chat workspace when chat initialization fails during cold start", async () => {
         const persistedWorkspace = {
             version: 1 as const,

--- a/apps/desktop/src/app/store/layoutStore.test.ts
+++ b/apps/desktop/src/app/store/layoutStore.test.ts
@@ -17,6 +17,7 @@ describe("layoutStore", () => {
     });
 
     it("moves an active view atomically and opens its destination", () => {
+        useLayoutStore.getState().moveSidebarView("files", "left");
         useLayoutStore.setState({
             rightPanelCollapsed: true,
             rightPanelWidth: 200,
@@ -36,13 +37,12 @@ describe("layoutStore", () => {
     it("moves an inactive view without changing the source selection", () => {
         useLayoutStore.getState().moveSidebarView("agents", "right");
         expect(useLayoutStore.getState().activeSidebarView).toEqual({
-            left: "files",
+            left: "tags",
             right: "agents",
         });
     });
 
     it("shows a view on its current side", () => {
-        useLayoutStore.getState().moveSidebarView("files", "right");
         useLayoutStore.setState({
             rightPanelCollapsed: true,
             activeSidebarView: { left: "tags", right: "outline" },
@@ -55,22 +55,25 @@ describe("layoutStore", () => {
     });
 
     it("uses the active right view minimum while preserving broad expansion", () => {
+        useLayoutStore.getState().activateSidebarView("right", "outline");
         useLayoutStore.getState().showRightPanelAtWidth(200);
         expect(useLayoutStore.getState().rightPanelWidth).toBe(200);
-        useLayoutStore.getState().moveSidebarView("files", "right");
+        useLayoutStore.getState().activateSidebarView("right", "files");
         useLayoutStore.getState().showRightPanelAtWidth(220);
         expect(useLayoutStore.getState().rightPanelWidth).toBe(280);
         useLayoutStore.getState().showRightPanelAtWidth(1600);
         expect(useLayoutStore.getState().rightPanelWidth).toBe(1600);
     });
 
-    it("hydrates placement and migrates compatible legacy selections", () => {
+    it("hydrates persisted placement and active selections", () => {
         localStorage.setItem(
             "neverwrite.sidebar.movable-placement.v1",
             JSON.stringify({ files: "right" }),
         );
-        localStorage.setItem("neverwrite.sidebar.view", "agents");
-        localStorage.setItem("neverwrite.rightpanel.view", "files");
+        localStorage.setItem(
+            "neverwrite.sidebar.active-views.v1",
+            JSON.stringify({ left: "agents", right: "files" }),
+        );
         expect(readHydratedLayoutSnapshot()).toMatchObject({
             movableSidebarPlacement: { files: "right", agents: "left" },
             activeSidebarView: { left: "agents", right: "files" },
@@ -84,8 +87,17 @@ describe("layoutStore", () => {
             JSON.stringify({ left: "outline", right: "maps" }),
         );
         expect(readHydratedLayoutSnapshot()).toMatchObject({
-            movableSidebarPlacement: { files: "left", agents: "left" },
-            activeSidebarView: { left: "files", right: "outline" },
+            movableSidebarPlacement: { files: "right", agents: "left" },
+            activeSidebarView: { left: "agents", right: "outline" },
+        });
+    });
+
+    it("uses the new layout for users without placement preferences", () => {
+        localStorage.setItem("neverwrite.sidebar.view", "files");
+        localStorage.setItem("neverwrite.rightpanel.view", "outline");
+        expect(readHydratedLayoutSnapshot()).toMatchObject({
+            movableSidebarPlacement: { files: "right", agents: "left" },
+            activeSidebarView: { left: "agents", right: "files" },
         });
     });
 

--- a/apps/desktop/src/app/store/layoutStore.test.ts
+++ b/apps/desktop/src/app/store/layoutStore.test.ts
@@ -54,6 +54,16 @@ describe("layoutStore", () => {
         });
     });
 
+    it("uses the active right view minimum while preserving broad expansion", () => {
+        useLayoutStore.getState().showRightPanelAtWidth(200);
+        expect(useLayoutStore.getState().rightPanelWidth).toBe(200);
+        useLayoutStore.getState().moveSidebarView("files", "right");
+        useLayoutStore.getState().showRightPanelAtWidth(220);
+        expect(useLayoutStore.getState().rightPanelWidth).toBe(280);
+        useLayoutStore.getState().showRightPanelAtWidth(1600);
+        expect(useLayoutStore.getState().rightPanelWidth).toBe(1600);
+    });
+
     it("hydrates placement and migrates compatible legacy selections", () => {
         localStorage.setItem(
             "neverwrite.sidebar.movable-placement.v1",

--- a/apps/desktop/src/app/store/layoutStore.test.ts
+++ b/apps/desktop/src/app/store/layoutStore.test.ts
@@ -1,10 +1,81 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { MIN_SIDEBAR_WIDTH, useLayoutStore } from "./layoutStore";
+import {
+    createDefaultLayoutState,
+    MIN_SIDEBAR_WIDTH,
+    readHydratedLayoutSnapshot,
+    useLayoutStore,
+} from "./layoutStore";
 
 describe("layoutStore", () => {
     beforeEach(() => {
+        localStorage.clear();
         useLayoutStore.setState({
+            ...createDefaultLayoutState(),
+            rightPanelExpanded: false,
             editorPaneSizes: [1],
+        });
+    });
+
+    it("moves an active view atomically and opens its destination", () => {
+        useLayoutStore.setState({
+            rightPanelCollapsed: true,
+            rightPanelWidth: 200,
+        });
+        useLayoutStore.getState().moveSidebarView("files", "right");
+
+        const state = useLayoutStore.getState();
+        expect(state.movableSidebarPlacement.files).toBe("right");
+        expect(state.activeSidebarView).toEqual({
+            left: "agents",
+            right: "files",
+        });
+        expect(state.rightPanelCollapsed).toBe(false);
+        expect(state.rightPanelWidth).toBe(280);
+    });
+
+    it("moves an inactive view without changing the source selection", () => {
+        useLayoutStore.getState().moveSidebarView("agents", "right");
+        expect(useLayoutStore.getState().activeSidebarView).toEqual({
+            left: "files",
+            right: "agents",
+        });
+    });
+
+    it("shows a view on its current side", () => {
+        useLayoutStore.getState().moveSidebarView("files", "right");
+        useLayoutStore.setState({
+            rightPanelCollapsed: true,
+            activeSidebarView: { left: "tags", right: "outline" },
+        });
+        useLayoutStore.getState().showSidebarView("files");
+        expect(useLayoutStore.getState()).toMatchObject({
+            rightPanelCollapsed: false,
+            activeSidebarView: { left: "tags", right: "files" },
+        });
+    });
+
+    it("hydrates placement and migrates compatible legacy selections", () => {
+        localStorage.setItem(
+            "neverwrite.sidebar.movable-placement.v1",
+            JSON.stringify({ files: "right" }),
+        );
+        localStorage.setItem("neverwrite.sidebar.view", "agents");
+        localStorage.setItem("neverwrite.rightpanel.view", "files");
+        expect(readHydratedLayoutSnapshot()).toMatchObject({
+            movableSidebarPlacement: { files: "right", agents: "left" },
+            activeSidebarView: { left: "agents", right: "files" },
+        });
+    });
+
+    it("falls back safely for invalid persisted JSON and incompatible views", () => {
+        localStorage.setItem("neverwrite.sidebar.movable-placement.v1", "{");
+        localStorage.setItem(
+            "neverwrite.sidebar.active-views.v1",
+            JSON.stringify({ left: "outline", right: "maps" }),
+        );
+        expect(readHydratedLayoutSnapshot()).toMatchObject({
+            movableSidebarPlacement: { files: "left", agents: "left" },
+            activeSidebarView: { left: "files", right: "outline" },
         });
     });
 

--- a/apps/desktop/src/app/store/layoutStore.ts
+++ b/apps/desktop/src/app/store/layoutStore.ts
@@ -1,67 +1,59 @@
 import { create } from "zustand";
+import {
+    DEFAULT_MOVABLE_SIDEBAR_PLACEMENT,
+    getSidebarFallbackView,
+    getSidebarViewMinimumWidth,
+    getSidebarViewSide,
+    isMovableSidebarView,
+    isViewAvailableOnSide,
+    normalizeActiveSidebarView,
+    normalizeMovableSidebarPlacement,
+    type MovableSidebarPlacement,
+    type MovableSidebarView,
+    type SidebarSide,
+    type SidebarView,
+} from "../../components/layout/sidebarViews";
 import { safeStorageGetItem, safeStorageSetItem } from "../utils/safeStorage";
 import { logWarn } from "../utils/runtimeLog";
 
-// Canonical list of left-sidebar views. Lives in the layout store (instead
-// of an obsolete component file) so renderer components can import the type
-// without coupling to a specific shell implementation.
-export type SidebarView =
-    | "files"
-    | "tags"
-    | "bookmarks"
-    | "maps"
-    | "agents";
+export type {
+    SidebarSide,
+    SidebarView,
+    MovableSidebarView,
+} from "../../components/layout/sidebarViews";
 
 const SIDEBAR_WIDTH_KEY = "neverwrite.sidebar.width";
 const SIDEBAR_COLLAPSED_KEY = "neverwrite.sidebar.collapsed";
-const SIDEBAR_VIEW_KEY = "neverwrite.sidebar.view";
+const LEGACY_SIDEBAR_VIEW_KEY = "neverwrite.sidebar.view";
+const RIGHT_PANEL_WIDTH_KEY = "neverwrite.rightpanel.width";
+const RIGHT_PANEL_COLLAPSED_KEY = "neverwrite.rightpanel.collapsed";
+const LEGACY_RIGHT_PANEL_VIEW_KEY = "neverwrite.rightpanel.view";
+const ACTIVE_SIDEBAR_VIEWS_KEY = "neverwrite.sidebar.active-views.v1";
+const MOVABLE_SIDEBAR_PLACEMENT_KEY = "neverwrite.sidebar.movable-placement.v1";
+const EDITOR_PANE_SIZES_KEY = "neverwrite.editor-pane.sizes";
+
 export const DEFAULT_SIDEBAR_WIDTH = 280;
 export const MIN_SIDEBAR_WIDTH = 280;
 export const MAX_SIDEBAR_WIDTH = 2000;
-
-const RIGHT_PANEL_WIDTH_KEY = "neverwrite.rightpanel.width";
-const RIGHT_PANEL_COLLAPSED_KEY = "neverwrite.rightpanel.collapsed";
-const RIGHT_PANEL_VIEW_KEY = "neverwrite.rightpanel.view";
 export const DEFAULT_RIGHT_PANEL_WIDTH = 280;
 export const MIN_RIGHT_PANEL_WIDTH = 200;
 export const MAX_RIGHT_PANEL_WIDTH = 2000;
 
-const EDITOR_PANE_SIZES_KEY = "neverwrite.editor-pane.sizes";
-
-const SIDEBAR_VIEWS: SidebarView[] = [
-    "files",
-    "tags",
-    "bookmarks",
-    "maps",
-    "agents",
-];
-const RIGHT_PANEL_VIEWS = ["links", "outline"] as const;
-
-type RightPanelView = (typeof RIGHT_PANEL_VIEWS)[number];
-
 const DEFAULT_EDITOR_PANE_SIZES = [1];
 
-function normalizeEditorPaneSizesForCount(count: number, sizes?: number[]) {
-    const normalizedCount = Math.max(1, Math.floor(count) || 1);
-    const incoming = (sizes ?? []).filter(
-        (value) => Number.isFinite(value) && value > 0,
-    );
-
-    if (incoming.length === normalizedCount) {
-        const total = incoming.reduce((sum, value) => sum + value, 0);
-        if (total > 0) {
-            return incoming.map((value) => value / total);
-        }
-    }
-
-    return Array.from({ length: normalizedCount }, () => 1 / normalizedCount);
+export interface ActiveSidebarViews {
+    left: SidebarView;
+    right: SidebarView;
 }
 
 interface LayoutStore {
     sidebarCollapsed: boolean;
     sidebarWidth: number;
-    sidebarView: SidebarView;
-    setSidebarView: (view: SidebarView) => void;
+    activeSidebarView: ActiveSidebarViews;
+    movableSidebarPlacement: MovableSidebarPlacement;
+    activateSidebarView: (side: SidebarSide, view: SidebarView) => void;
+    showSidebarView: (view: SidebarView) => void;
+    moveSidebarView: (view: MovableSidebarView, target: SidebarSide) => void;
     toggleSidebar: () => void;
     collapseSidebar: () => void;
     expandSidebar: () => void;
@@ -71,11 +63,9 @@ interface LayoutStore {
     rightPanelCollapsed: boolean;
     rightPanelExpanded: boolean;
     rightPanelWidth: number;
-    rightPanelView: RightPanelView;
     toggleRightPanel: () => void;
     setRightPanelExpanded: (expanded: boolean) => void;
     toggleRightPanelExpanded: () => void;
-    activateRightView: (view: RightPanelView) => void;
     showRightPanelAtWidth: (width: number) => void;
     collapseRightPanelToWidth: (width: number) => void;
     editorPaneSizes: number[];
@@ -93,22 +83,49 @@ type LayoutSnapshot = Pick<
     LayoutStore,
     | "sidebarCollapsed"
     | "sidebarWidth"
-    | "sidebarView"
+    | "activeSidebarView"
+    | "movableSidebarPlacement"
     | "rightPanelCollapsed"
     | "rightPanelWidth"
-    | "rightPanelView"
     | "editorPaneSizes"
 >;
 
-function clampSidebarWidth(width: number) {
-    return Math.max(MIN_SIDEBAR_WIDTH, Math.min(MAX_SIDEBAR_WIDTH, width));
+function normalizeEditorPaneSizesForCount(count: number, sizes?: number[]) {
+    const normalizedCount = Math.max(1, Math.floor(count) || 1);
+    const incoming = (sizes ?? []).filter(
+        (value) => Number.isFinite(value) && value > 0,
+    );
+    if (incoming.length === normalizedCount) {
+        const total = incoming.reduce((sum, value) => sum + value, 0);
+        if (total > 0) return incoming.map((value) => value / total);
+    }
+    return Array.from({ length: normalizedCount }, () => 1 / normalizedCount);
 }
 
-function clampRightPanelWidth(width: number) {
-    return Math.max(
-        MIN_RIGHT_PANEL_WIDTH,
-        Math.min(MAX_RIGHT_PANEL_WIDTH, width),
+function clampWidth(width: number, minimum: number, maximum: number) {
+    return Math.max(minimum, Math.min(maximum, width));
+}
+
+function clampSidebarWidth(width: number) {
+    return clampWidth(width, MIN_SIDEBAR_WIDTH, MAX_SIDEBAR_WIDTH);
+}
+
+function clampRightPanelWidth(width: number, activeView: SidebarView) {
+    return clampWidth(
+        width,
+        getSidebarViewMinimumWidth(activeView),
+        MAX_RIGHT_PANEL_WIDTH,
     );
+}
+
+function parseStoredJson(key: string): unknown {
+    const raw = safeStorageGetItem(key);
+    if (!raw) return undefined;
+    try {
+        return JSON.parse(raw);
+    } catch {
+        return undefined;
+    }
 }
 
 function parseStoredNumber(
@@ -118,15 +135,24 @@ function parseStoredNumber(
 ) {
     const raw = safeStorageGetItem(key);
     if (!raw) return fallback;
-
     const parsed = Number(raw);
     return Number.isFinite(parsed) ? clamp(parsed) : fallback;
 }
 
-function readHydratedLayoutSnapshot(): LayoutSnapshot {
-    const sidebarViewRaw = safeStorageGetItem(SIDEBAR_VIEW_KEY);
-    const rightPanelViewRaw = safeStorageGetItem(RIGHT_PANEL_VIEW_KEY);
-
+export function readHydratedLayoutSnapshot(): LayoutSnapshot {
+    const placement = normalizeMovableSidebarPlacement(
+        parseStoredJson(MOVABLE_SIDEBAR_PLACEMENT_KEY),
+    );
+    const storedActive = parseStoredJson(ACTIVE_SIDEBAR_VIEWS_KEY) as
+        Partial<Record<SidebarSide, unknown>> | undefined;
+    const leftCandidate =
+        storedActive?.left ?? safeStorageGetItem(LEGACY_SIDEBAR_VIEW_KEY);
+    const rightCandidate =
+        storedActive?.right ?? safeStorageGetItem(LEGACY_RIGHT_PANEL_VIEW_KEY);
+    const activeSidebarView: ActiveSidebarViews = {
+        left: normalizeActiveSidebarView("left", leftCandidate, placement),
+        right: normalizeActiveSidebarView("right", rightCandidate, placement),
+    };
     return {
         sidebarCollapsed: safeStorageGetItem(SIDEBAR_COLLAPSED_KEY) === "true",
         sidebarWidth: parseStoredNumber(
@@ -134,32 +160,20 @@ function readHydratedLayoutSnapshot(): LayoutSnapshot {
             DEFAULT_SIDEBAR_WIDTH,
             clampSidebarWidth,
         ),
-        sidebarView: SIDEBAR_VIEWS.includes(sidebarViewRaw as SidebarView)
-            ? (sidebarViewRaw as SidebarView)
-            : "files",
+        activeSidebarView,
+        movableSidebarPlacement: placement,
         rightPanelCollapsed:
             safeStorageGetItem(RIGHT_PANEL_COLLAPSED_KEY) === "true",
         rightPanelWidth: parseStoredNumber(
             RIGHT_PANEL_WIDTH_KEY,
             DEFAULT_RIGHT_PANEL_WIDTH,
-            clampRightPanelWidth,
+            (width) => clampRightPanelWidth(width, activeSidebarView.right),
         ),
-        rightPanelView: RIGHT_PANEL_VIEWS.includes(
-            rightPanelViewRaw as RightPanelView,
-        )
-            ? (rightPanelViewRaw as RightPanelView)
-            : "outline",
         editorPaneSizes: (() => {
-            try {
-                const raw = safeStorageGetItem(EDITOR_PANE_SIZES_KEY);
-                if (!raw) return DEFAULT_EDITOR_PANE_SIZES;
-                const parsed = JSON.parse(raw);
-                return Array.isArray(parsed)
-                    ? normalizeEditorPaneSizesForCount(parsed.length, parsed)
-                    : DEFAULT_EDITOR_PANE_SIZES;
-            } catch {
-                return DEFAULT_EDITOR_PANE_SIZES;
-            }
+            const parsed = parseStoredJson(EDITOR_PANE_SIZES_KEY);
+            return Array.isArray(parsed)
+                ? normalizeEditorPaneSizesForCount(parsed.length, parsed)
+                : DEFAULT_EDITOR_PANE_SIZES;
         })(),
     };
 }
@@ -167,39 +181,140 @@ function readHydratedLayoutSnapshot(): LayoutSnapshot {
 function persistBoolean(key: string, value: boolean) {
     safeStorageSetItem(key, String(value));
 }
-
 function persistNumber(key: string, value: number) {
     safeStorageSetItem(key, String(value));
 }
-
-function persistEditorPaneSizes(value: number[]) {
-    safeStorageSetItem(EDITOR_PANE_SIZES_KEY, JSON.stringify(value));
+function persistJson(key: string, value: unknown) {
+    safeStorageSetItem(key, JSON.stringify(value));
 }
-
+function persistEditorPaneSizes(value: number[]) {
+    persistJson(EDITOR_PANE_SIZES_KEY, value);
+}
 function getFileTreeScrollKey(vaultPath: string | null | undefined) {
     return vaultPath || "__no_vault__";
 }
 
-function createDefaultState(): LayoutSnapshot {
+export function createDefaultLayoutState(): LayoutSnapshot {
     return {
         sidebarCollapsed: false,
         sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
-        sidebarView: "files",
+        activeSidebarView: { left: "files", right: "outline" },
+        movableSidebarPlacement: { ...DEFAULT_MOVABLE_SIDEBAR_PLACEMENT },
         rightPanelCollapsed: false,
         rightPanelWidth: DEFAULT_RIGHT_PANEL_WIDTH,
-        rightPanelView: "outline",
         editorPaneSizes: DEFAULT_EDITOR_PANE_SIZES,
     };
 }
 
 export const useLayoutStore = create<LayoutStore>((set, get) => ({
-    ...createDefaultState(),
+    ...createDefaultLayoutState(),
     rightPanelExpanded: false,
     fileTreeScrollTopByVault: {},
-    setSidebarView: (view) => {
-        safeStorageSetItem(SIDEBAR_VIEW_KEY, view);
-        set({ sidebarView: view });
-    },
+    activateSidebarView: (side, view) =>
+        set((state) => {
+            if (
+                !isViewAvailableOnSide(
+                    view,
+                    side,
+                    state.movableSidebarPlacement,
+                )
+            ) {
+                return state;
+            }
+            const activeSidebarView = {
+                ...state.activeSidebarView,
+                [side]: view,
+            };
+            persistJson(ACTIVE_SIDEBAR_VIEWS_KEY, activeSidebarView);
+            const rightPanelWidth =
+                side === "right"
+                    ? clampRightPanelWidth(state.rightPanelWidth, view)
+                    : state.rightPanelWidth;
+            if (rightPanelWidth !== state.rightPanelWidth) {
+                persistNumber(RIGHT_PANEL_WIDTH_KEY, rightPanelWidth);
+            }
+            return {
+                activeSidebarView,
+                rightPanelWidth,
+                rightPanelExpanded: false,
+            };
+        }),
+    showSidebarView: (view) =>
+        set((state) => {
+            const side = getSidebarViewSide(
+                view,
+                state.movableSidebarPlacement,
+            );
+            const activeSidebarView = {
+                ...state.activeSidebarView,
+                [side]: view,
+            };
+            persistJson(ACTIVE_SIDEBAR_VIEWS_KEY, activeSidebarView);
+            if (side === "left") {
+                const sidebarWidth = clampSidebarWidth(state.sidebarWidth);
+                persistNumber(SIDEBAR_WIDTH_KEY, sidebarWidth);
+                persistBoolean(SIDEBAR_COLLAPSED_KEY, false);
+                return {
+                    activeSidebarView,
+                    sidebarWidth,
+                    sidebarCollapsed: false,
+                };
+            }
+            const rightPanelWidth = clampRightPanelWidth(
+                state.rightPanelWidth,
+                view,
+            );
+            persistNumber(RIGHT_PANEL_WIDTH_KEY, rightPanelWidth);
+            persistBoolean(RIGHT_PANEL_COLLAPSED_KEY, false);
+            return {
+                activeSidebarView,
+                rightPanelWidth,
+                rightPanelCollapsed: false,
+                rightPanelExpanded: false,
+            };
+        }),
+    moveSidebarView: (view, target) =>
+        set((state) => {
+            if (!isMovableSidebarView(view)) return state;
+            const source = state.movableSidebarPlacement[view];
+            if (source === target) return state;
+            const movableSidebarPlacement = {
+                ...state.movableSidebarPlacement,
+                [view]: target,
+            };
+            const activeSidebarView = {
+                ...state.activeSidebarView,
+                [target]: view,
+            };
+            if (state.activeSidebarView[source] === view) {
+                activeSidebarView[source] = getSidebarFallbackView(
+                    source,
+                    movableSidebarPlacement,
+                );
+            }
+            const rightPanelWidth =
+                target === "right"
+                    ? clampRightPanelWidth(state.rightPanelWidth, view)
+                    : state.rightPanelWidth;
+            persistJson(MOVABLE_SIDEBAR_PLACEMENT_KEY, movableSidebarPlacement);
+            persistJson(ACTIVE_SIDEBAR_VIEWS_KEY, activeSidebarView);
+            if (target === "right") {
+                persistNumber(RIGHT_PANEL_WIDTH_KEY, rightPanelWidth);
+                persistBoolean(RIGHT_PANEL_COLLAPSED_KEY, false);
+            } else {
+                persistBoolean(SIDEBAR_COLLAPSED_KEY, false);
+            }
+            return {
+                movableSidebarPlacement,
+                activeSidebarView,
+                sidebarCollapsed:
+                    target === "left" ? false : state.sidebarCollapsed,
+                rightPanelCollapsed:
+                    target === "right" ? false : state.rightPanelCollapsed,
+                rightPanelExpanded: false,
+                rightPanelWidth,
+            };
+        }),
     toggleSidebar: () =>
         set((state) => {
             const collapsed = !state.sidebarCollapsed;
@@ -215,21 +330,21 @@ export const useLayoutStore = create<LayoutStore>((set, get) => ({
         set({ sidebarCollapsed: false });
     },
     setSidebarWidth: (width) => {
-        const nextWidth = clampSidebarWidth(width);
-        persistNumber(SIDEBAR_WIDTH_KEY, nextWidth);
-        set({ sidebarWidth: nextWidth });
+        const next = clampSidebarWidth(width);
+        persistNumber(SIDEBAR_WIDTH_KEY, next);
+        set({ sidebarWidth: next });
     },
     showSidebarAtWidth: (width) => {
-        const nextWidth = clampSidebarWidth(width);
-        persistNumber(SIDEBAR_WIDTH_KEY, nextWidth);
+        const next = clampSidebarWidth(width);
+        persistNumber(SIDEBAR_WIDTH_KEY, next);
         persistBoolean(SIDEBAR_COLLAPSED_KEY, false);
-        set({ sidebarWidth: nextWidth, sidebarCollapsed: false });
+        set({ sidebarWidth: next, sidebarCollapsed: false });
     },
     collapseSidebarToWidth: (width) => {
-        const nextWidth = clampSidebarWidth(width);
-        persistNumber(SIDEBAR_WIDTH_KEY, nextWidth);
+        const next = clampSidebarWidth(width);
+        persistNumber(SIDEBAR_WIDTH_KEY, next);
         persistBoolean(SIDEBAR_COLLAPSED_KEY, true);
-        set({ sidebarWidth: nextWidth, sidebarCollapsed: true });
+        set({ sidebarWidth: next, sidebarCollapsed: true });
     },
     toggleRightPanel: () =>
         set((state) => {
@@ -252,89 +367,71 @@ export const useLayoutStore = create<LayoutStore>((set, get) => ({
                 ? state.rightPanelCollapsed
                 : false,
         })),
-    activateRightView: (view) =>
-        set((state) => {
-            // Tab clicks only update which view is shown — they never change
-            // docked/collapsed state. While the panel is hidden (incl. during
-            // an Arc peek), switching views keeps the peek flow intact; while
-            // docked, picking another tab just swaps the body. Docking is an
-            // explicit action (toggle button or shortcut).
-            if (state.rightPanelView === view) return state;
-            safeStorageSetItem(RIGHT_PANEL_VIEW_KEY, view);
-            return {
-                rightPanelView: view,
-                rightPanelExpanded: false,
-            };
-        }),
     showRightPanelAtWidth: (width) => {
-        const nextWidth = clampRightPanelWidth(width);
-        persistNumber(RIGHT_PANEL_WIDTH_KEY, nextWidth);
+        const state = get();
+        const next = clampRightPanelWidth(width, state.activeSidebarView.right);
+        persistNumber(RIGHT_PANEL_WIDTH_KEY, next);
         persistBoolean(RIGHT_PANEL_COLLAPSED_KEY, false);
         set({
-            rightPanelWidth: nextWidth,
+            rightPanelWidth: next,
             rightPanelCollapsed: false,
             rightPanelExpanded: false,
         });
     },
     collapseRightPanelToWidth: (width) => {
-        const nextWidth = clampRightPanelWidth(width);
-        persistNumber(RIGHT_PANEL_WIDTH_KEY, nextWidth);
+        const state = get();
+        const next = clampRightPanelWidth(width, state.activeSidebarView.right);
+        persistNumber(RIGHT_PANEL_WIDTH_KEY, next);
         persistBoolean(RIGHT_PANEL_COLLAPSED_KEY, true);
         set({
-            rightPanelWidth: nextWidth,
+            rightPanelWidth: next,
             rightPanelCollapsed: true,
             rightPanelExpanded: false,
         });
     },
     ensureEditorPaneSizeCount: (count) =>
         set((state) => {
-            const nextSizes = normalizeEditorPaneSizesForCount(
+            const next = normalizeEditorPaneSizesForCount(
                 count,
                 state.editorPaneSizes,
             );
-            const unchanged =
-                nextSizes.length === state.editorPaneSizes.length &&
-                nextSizes.every(
+            if (
+                next.length === state.editorPaneSizes.length &&
+                next.every(
                     (value, index) => value === state.editorPaneSizes[index],
-                );
-            if (unchanged) {
+                )
+            )
                 return state;
-            }
-            persistEditorPaneSizes(nextSizes);
-            return { editorPaneSizes: nextSizes };
+            persistEditorPaneSizes(next);
+            return { editorPaneSizes: next };
         }),
     setEditorPaneSizes: (count, sizes) => {
-        const nextSizes = normalizeEditorPaneSizesForCount(count, sizes);
-        persistEditorPaneSizes(nextSizes);
-        set({ editorPaneSizes: nextSizes });
+        const next = normalizeEditorPaneSizesForCount(count, sizes);
+        persistEditorPaneSizes(next);
+        set({ editorPaneSizes: next });
     },
-    getFileTreeScrollTop: (vaultPath) => {
-        const key = getFileTreeScrollKey(vaultPath);
-        return get().fileTreeScrollTopByVault[key] ?? 0;
-    },
+    getFileTreeScrollTop: (vaultPath) =>
+        get().fileTreeScrollTopByVault[getFileTreeScrollKey(vaultPath)] ?? 0,
     setFileTreeScrollTop: (vaultPath, scrollTop) => {
         const key = getFileTreeScrollKey(vaultPath);
-        const nextScrollTop = Math.max(0, Math.round(scrollTop));
-        set((state) => {
-            if (state.fileTreeScrollTopByVault[key] === nextScrollTop) {
-                return state;
-            }
-            return {
-                fileTreeScrollTopByVault: {
-                    ...state.fileTreeScrollTopByVault,
-                    [key]: nextScrollTop,
-                },
-            };
-        });
+        const next = Math.max(0, Math.round(scrollTop));
+        set((state) =>
+            state.fileTreeScrollTopByVault[key] === next
+                ? state
+                : {
+                      fileTreeScrollTopByVault: {
+                          ...state.fileTreeScrollTopByVault,
+                          [key]: next,
+                      },
+                  },
+        );
     },
 }));
 
 let layoutHydrated = false;
-
 export function hydrateLayoutStore() {
     if (layoutHydrated) return;
     layoutHydrated = true;
-
     try {
         useLayoutStore.setState(readHydratedLayoutSnapshot());
     } catch (error) {

--- a/apps/desktop/src/app/store/layoutStore.ts
+++ b/apps/desktop/src/app/store/layoutStore.ts
@@ -24,10 +24,8 @@ export type {
 
 const SIDEBAR_WIDTH_KEY = "neverwrite.sidebar.width";
 const SIDEBAR_COLLAPSED_KEY = "neverwrite.sidebar.collapsed";
-const LEGACY_SIDEBAR_VIEW_KEY = "neverwrite.sidebar.view";
 const RIGHT_PANEL_WIDTH_KEY = "neverwrite.rightpanel.width";
 const RIGHT_PANEL_COLLAPSED_KEY = "neverwrite.rightpanel.collapsed";
-const LEGACY_RIGHT_PANEL_VIEW_KEY = "neverwrite.rightpanel.view";
 const ACTIVE_SIDEBAR_VIEWS_KEY = "neverwrite.sidebar.active-views.v1";
 const MOVABLE_SIDEBAR_PLACEMENT_KEY = "neverwrite.sidebar.movable-placement.v1";
 const EDITOR_PANE_SIZES_KEY = "neverwrite.editor-pane.sizes";
@@ -145,10 +143,8 @@ export function readHydratedLayoutSnapshot(): LayoutSnapshot {
     );
     const storedActive = parseStoredJson(ACTIVE_SIDEBAR_VIEWS_KEY) as
         Partial<Record<SidebarSide, unknown>> | undefined;
-    const leftCandidate =
-        storedActive?.left ?? safeStorageGetItem(LEGACY_SIDEBAR_VIEW_KEY);
-    const rightCandidate =
-        storedActive?.right ?? safeStorageGetItem(LEGACY_RIGHT_PANEL_VIEW_KEY);
+    const leftCandidate = storedActive?.left ?? "agents";
+    const rightCandidate = storedActive?.right ?? "files";
     const activeSidebarView: ActiveSidebarViews = {
         left: normalizeActiveSidebarView("left", leftCandidate, placement),
         right: normalizeActiveSidebarView("right", rightCandidate, placement),
@@ -198,7 +194,7 @@ export function createDefaultLayoutState(): LayoutSnapshot {
     return {
         sidebarCollapsed: false,
         sidebarWidth: DEFAULT_SIDEBAR_WIDTH,
-        activeSidebarView: { left: "files", right: "outline" },
+        activeSidebarView: { left: "agents", right: "files" },
         movableSidebarPlacement: { ...DEFAULT_MOVABLE_SIDEBAR_PLACEMENT },
         rightPanelCollapsed: false,
         rightPanelWidth: DEFAULT_RIGHT_PANEL_WIDTH,

--- a/apps/desktop/src/app/store/workspaceContracts.test.ts
+++ b/apps/desktop/src/app/store/workspaceContracts.test.ts
@@ -22,6 +22,9 @@ describe("workspaceContracts Phase 0 inventory", () => {
         expect(inventoryIds.has("detached-window-drop-infrastructure")).toBe(
             true,
         );
+        expect(
+            inventoryIds.has("app-global-shortcuts-and-sidebar-shells"),
+        ).toBe(true);
         expect(inventoryIds.has("ai-chat-panel-sidebar-primary-surface")).toBe(
             true,
         );

--- a/apps/desktop/src/app/store/workspaceContracts.ts
+++ b/apps/desktop/src/app/store/workspaceContracts.ts
@@ -288,11 +288,12 @@ export const WORKSPACE_PHASE0_INVENTORY = [
             "Phase 5 keeps ghost previews and multi-window routing here, while the workspace drag hook stays responsible only for target resolution and commit intent.",
     },
     {
-        id: "app-global-shortcuts-and-sidebar-chat-host",
+        id: "app-global-shortcuts-and-sidebar-shells",
         role: "chat-sidebar-bridge",
         file: "apps/desktop/src/App.tsx",
         symbols: [
-            "RightPanel",
+            "SidebarShell",
+            "RightSidebarShell",
             "cycleEditorTabs",
             "tabs",
             "activeTabId",
@@ -300,9 +301,9 @@ export const WORKSPACE_PHASE0_INVENTORY = [
         reads: ["tabs", "activeTabId", "panes", "focusedPaneId"],
         writes: [],
         summary:
-            "The app shell no longer hosts the chat sidebar — that moved to the left SidebarShell. The right panel only exposes Outline/Links as contextual support.",
+            "The app shell composes side-aware shells. Files and Agents are movable auxiliary views, while Tags/Bookmarks/Maps remain left-only and Outline/Links remain right-only.",
         migrationIntent:
-            "Phase 2c keeps the right panel contextual and leaves future shortcut cleanup to focused-pane-aware commands.",
+            "Sidebar placement belongs to layout state; primary workspace ownership and future focused-pane shortcut cleanup remain separate concerns.",
     },
     {
         id: "ai-chat-panel-sidebar-primary-surface",
@@ -317,7 +318,7 @@ export const WORKSPACE_PHASE0_INVENTORY = [
         reads: [],
         writes: [],
         summary:
-            "AgentsSidebarPanel acts as a Comando-style launcher for workspace-owned chat sessions inside the left sidebar, without rendering the primary composer surface itself.",
+            "AgentsSidebarPanel acts as a Comando-style launcher for workspace-owned chat sessions from either sidebar, without rendering the primary composer surface itself.",
         migrationIntent:
             "Keep this panel auxiliary and resist reintroducing a second primary chat surface here.",
     },

--- a/apps/desktop/src/app/utils/navigation.test.ts
+++ b/apps/desktop/src/app/utils/navigation.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDefaultLayoutState, useLayoutStore } from "../store/layoutStore";
+import { REVEAL_NOTE_IN_TREE_EVENT, revealNoteInTree } from "./navigation";
+
+describe("revealNoteInTree", () => {
+    beforeEach(() => {
+        useLayoutStore.setState({
+            ...createDefaultLayoutState(),
+            rightPanelExpanded: false,
+        });
+    });
+
+    it("opens Files on its current side before dispatching the reveal", () => {
+        const frames: FrameRequestCallback[] = [];
+        vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+            (callback) => {
+                frames.push(callback);
+                return frames.length;
+            },
+        );
+        useLayoutStore.getState().moveSidebarView("files", "right");
+        useLayoutStore.setState({
+            rightPanelCollapsed: true,
+            activeSidebarView: { left: "tags", right: "outline" },
+        });
+        const listener = vi.fn();
+        window.addEventListener(REVEAL_NOTE_IN_TREE_EVENT, listener);
+
+        revealNoteInTree("note-1");
+        expect(useLayoutStore.getState()).toMatchObject({
+            rightPanelCollapsed: false,
+            activeSidebarView: { left: "tags", right: "files" },
+        });
+        expect(listener).not.toHaveBeenCalled();
+        frames[0](0);
+        expect(listener).toHaveBeenCalledTimes(1);
+        expect((listener.mock.calls[0][0] as CustomEvent).detail).toEqual({
+            noteId: "note-1",
+        });
+        window.removeEventListener(REVEAL_NOTE_IN_TREE_EVENT, listener);
+    });
+});

--- a/apps/desktop/src/app/utils/navigation.ts
+++ b/apps/desktop/src/app/utils/navigation.ts
@@ -3,13 +3,17 @@ export const CLEAR_FILE_TREE_SELECTION_EVENT =
     "neverwrite:clear-file-tree-selection";
 
 export function revealNoteInTree(noteId: string) {
-    window.dispatchEvent(
-        new CustomEvent(REVEAL_NOTE_IN_TREE_EVENT, {
-            detail: { noteId },
-        }),
-    );
+    useLayoutStore.getState().showSidebarView("files");
+    window.requestAnimationFrame(() => {
+        window.dispatchEvent(
+            new CustomEvent(REVEAL_NOTE_IN_TREE_EVENT, {
+                detail: { noteId },
+            }),
+        );
+    });
 }
 
 export function clearFileTreeSelection() {
     window.dispatchEvent(new CustomEvent(CLEAR_FILE_TREE_SELECTION_EVENT));
 }
+import { useLayoutStore } from "../store/layoutStore";

--- a/apps/desktop/src/components/layout/AppLayout.test.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.test.tsx
@@ -128,7 +128,7 @@ describe("AppLayout", () => {
             rightPanelCollapsed: false,
             rightPanelExpanded: false,
             rightPanelWidth: 280,
-            rightPanelView: "outline",
+            activeSidebarView: { left: "files", right: "outline" },
         });
     });
 

--- a/apps/desktop/src/components/layout/AppLayout.test.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.test.tsx
@@ -441,55 +441,62 @@ describe("AppLayout", () => {
     });
 
     it.each([
-        [FILE_TREE_NOTE_DRAG_EVENT, { notes: [] }],
+        [FILE_TREE_NOTE_DRAG_EVENT, "files", { notes: [] }],
         [
             AGENT_SIDEBAR_DRAG_EVENT,
+            "agents",
             { sessionId: "session-1", title: "Dragged agent" },
         ],
-    ])("keeps the right peek mounted for %s drags", (eventName, payload) => {
-        vi.useFakeTimers();
-        useLayoutStore.setState({ rightPanelCollapsed: true });
-        render(
-            <AppLayout
-                left={<div>Left</div>}
-                center={<div>Center</div>}
-                right={<div>Right</div>}
-            />,
-        );
-        fireEvent.mouseEnter(screen.getByTestId("right-peek-hotspot"));
-        const overlay = screen.getByTestId("right-peek-overlay");
-        act(() => {
-            window.dispatchEvent(
-                new CustomEvent(eventName, {
-                    detail: {
-                        phase: "start",
-                        x: window.innerWidth - 40,
-                        y: 40,
-                        ...payload,
-                    },
-                }),
+    ] as const)(
+        "keeps the right peek mounted for %s drags that cross the edge before starting",
+        (eventName, sourceView, payload) => {
+            vi.useFakeTimers();
+            useLayoutStore.getState().moveSidebarView(sourceView, "right");
+            useLayoutStore.setState({ rightPanelCollapsed: true });
+            render(
+                <AppLayout
+                    left={<div>Left</div>}
+                    center={<div>Center</div>}
+                    right={<div>Right</div>}
+                />,
             );
-        });
-        fireEvent.mouseLeave(overlay);
-        act(() => vi.advanceTimersByTime(400));
-        expect(screen.getByTestId("right-peek-overlay")).toBeInTheDocument();
-        act(() => {
-            window.dispatchEvent(
-                new CustomEvent(eventName, {
-                    detail: {
-                        phase: "cancel",
-                        x: 400,
-                        y: 400,
-                        ...payload,
-                    },
-                }),
-            );
-            vi.advanceTimersByTime(400);
-        });
-        expect(
-            screen.queryByTestId("right-peek-overlay"),
-        ).not.toBeInTheDocument();
-    });
+            fireEvent.mouseEnter(screen.getByTestId("right-peek-hotspot"));
+            const overlay = screen.getByTestId("right-peek-overlay");
+            act(() => {
+                window.dispatchEvent(
+                    new CustomEvent(eventName, {
+                        detail: {
+                            phase: "start",
+                            x: 400,
+                            y: 400,
+                            ...payload,
+                        },
+                    }),
+                );
+            });
+            fireEvent.mouseLeave(overlay);
+            act(() => vi.advanceTimersByTime(400));
+            expect(
+                screen.getByTestId("right-peek-overlay"),
+            ).toBeInTheDocument();
+            act(() => {
+                window.dispatchEvent(
+                    new CustomEvent(eventName, {
+                        detail: {
+                            phase: "cancel",
+                            x: 400,
+                            y: 400,
+                            ...payload,
+                        },
+                    }),
+                );
+                vi.advanceTimersByTime(400);
+            });
+            expect(
+                screen.queryByTestId("right-peek-overlay"),
+            ).not.toBeInTheDocument();
+        },
+    );
 
     it("mounts right content only once while the collapsed peek is visible", () => {
         useLayoutStore.setState({ rightPanelCollapsed: true });

--- a/apps/desktop/src/components/layout/AppLayout.test.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.test.tsx
@@ -440,6 +440,57 @@ describe("AppLayout", () => {
         ).not.toBeInTheDocument();
     });
 
+    it.each([
+        [FILE_TREE_NOTE_DRAG_EVENT, { notes: [] }],
+        [
+            AGENT_SIDEBAR_DRAG_EVENT,
+            { sessionId: "session-1", title: "Dragged agent" },
+        ],
+    ])("keeps the right peek mounted for %s drags", (eventName, payload) => {
+        vi.useFakeTimers();
+        useLayoutStore.setState({ rightPanelCollapsed: true });
+        render(
+            <AppLayout
+                left={<div>Left</div>}
+                center={<div>Center</div>}
+                right={<div>Right</div>}
+            />,
+        );
+        fireEvent.mouseEnter(screen.getByTestId("right-peek-hotspot"));
+        const overlay = screen.getByTestId("right-peek-overlay");
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(eventName, {
+                    detail: {
+                        phase: "start",
+                        x: window.innerWidth - 40,
+                        y: 40,
+                        ...payload,
+                    },
+                }),
+            );
+        });
+        fireEvent.mouseLeave(overlay);
+        act(() => vi.advanceTimersByTime(400));
+        expect(screen.getByTestId("right-peek-overlay")).toBeInTheDocument();
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(eventName, {
+                    detail: {
+                        phase: "cancel",
+                        x: 400,
+                        y: 400,
+                        ...payload,
+                    },
+                }),
+            );
+            vi.advanceTimersByTime(400);
+        });
+        expect(
+            screen.queryByTestId("right-peek-overlay"),
+        ).not.toBeInTheDocument();
+    });
+
     it("keeps the collapsed sidebar peek open inside the edge safe zone", () => {
         vi.useFakeTimers();
         useLayoutStore.setState({ sidebarCollapsed: true });

--- a/apps/desktop/src/components/layout/AppLayout.test.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.test.tsx
@@ -491,6 +491,21 @@ describe("AppLayout", () => {
         ).not.toBeInTheDocument();
     });
 
+    it("mounts right content only once while the collapsed peek is visible", () => {
+        useLayoutStore.setState({ rightPanelCollapsed: true });
+        render(
+            <AppLayout
+                left={<div>Left</div>}
+                center={<div>Center</div>}
+                right={<div>Right</div>}
+            />,
+        );
+
+        expect(screen.queryByText("Right")).not.toBeInTheDocument();
+        fireEvent.mouseEnter(screen.getByTestId("right-peek-hotspot"));
+        expect(screen.getAllByText("Right")).toHaveLength(1);
+    });
+
     it("keeps the collapsed sidebar peek open inside the edge safe zone", () => {
         vi.useFakeTimers();
         useLayoutStore.setState({ sidebarCollapsed: true });

--- a/apps/desktop/src/components/layout/AppLayout.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.tsx
@@ -27,7 +27,11 @@ import {
     AGENT_SIDEBAR_DRAG_EVENT,
     type AgentSidebarDragDetail,
 } from "../../features/ai/agentSidebarDragEvents";
-import { getSidebarViewMinimumWidth, type SidebarSide } from "./sidebarViews";
+import {
+    getSidebarViewMinimumWidth,
+    type MovableSidebarView,
+    type SidebarSide,
+} from "./sidebarViews";
 
 // Both macOS (native "sidebar" vibrancy) and Windows 11 (native acrylic
 // backgroundMaterial) paint a translucent window material beneath the
@@ -416,32 +420,9 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     ]);
 
     useEffect(() => {
-        const pointInside = (
-            element: HTMLElement | null,
-            x: number,
-            y: number,
-        ) => {
-            if (!element) return false;
-            const rect = element.getBoundingClientRect();
-            if (rect.width === 0 && rect.height === 0) {
-                const width = Number.parseFloat(element.style.width);
-                if (!Number.isFinite(width)) return false;
-                if (element.dataset.edgePeekOverlay === "left") {
-                    return x >= 0 && x <= width;
-                }
-                if (element.dataset.edgePeekOverlay === "right") {
-                    return x >= window.innerWidth - width;
-                }
-            }
-            return (
-                x >= rect.left &&
-                x <= rect.right &&
-                y >= rect.top &&
-                y <= rect.bottom
-            );
-        };
         const handleSidebarOriginDrag = (
             detail: FileTreeNoteDragDetail | AgentSidebarDragDetail,
+            sourceView: MovableSidebarView,
         ) => {
             if (!detail) return;
             if (Number.isFinite(detail.x) && Number.isFinite(detail.y)) {
@@ -456,28 +437,14 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
                     if (
                         "origin" in detail &&
                         detail.origin?.kind === "workspace-tab"
-                    )
+                    ) {
+                        sidebarDragOriginRef.current = null;
                         return;
+                    }
                     sidebarDragOriginRef.current =
-                        pointInside(
-                            sidebarOverlayRef.current,
-                            detail.x,
-                            detail.y,
-                        ) ||
-                        pointInside(leftPanelRef.current, detail.x, detail.y)
-                            ? "left"
-                            : pointInside(
-                                    rightOverlayRef.current,
-                                    detail.x,
-                                    detail.y,
-                                ) ||
-                                pointInside(
-                                    rightPanelRef.current,
-                                    detail.x,
-                                    detail.y,
-                                )
-                              ? "right"
-                              : null;
+                        useLayoutStore.getState().movableSidebarPlacement[
+                            sourceView
+                        ];
                 }
                 if (
                     sidebarDragOriginRef.current === "left" &&
@@ -514,12 +481,14 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
         const handleFileTreeDrag = (event: Event) => {
             handleSidebarOriginDrag(
                 (event as CustomEvent<FileTreeNoteDragDetail>).detail,
+                "files",
             );
         };
 
         const handleAgentSidebarDrag = (event: Event) => {
             handleSidebarOriginDrag(
                 (event as CustomEvent<AgentSidebarDragDetail>).detail,
+                "agents",
             );
         };
 

--- a/apps/desktop/src/components/layout/AppLayout.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.tsx
@@ -1149,7 +1149,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
                                 : "width 160ms cubic-bezier(0.22, 1, 0.36, 1)",
                         }}
                     >
-                        {right}
+                        {!rightPanelCollapsed && right}
                     </div>
                 )}
             </div>

--- a/apps/desktop/src/components/layout/AppLayout.tsx
+++ b/apps/desktop/src/components/layout/AppLayout.tsx
@@ -12,7 +12,6 @@ import { getCurrentWindow } from "@neverwrite/runtime";
 import {
     DEFAULT_RIGHT_PANEL_WIDTH,
     DEFAULT_SIDEBAR_WIDTH,
-    MIN_RIGHT_PANEL_WIDTH,
     MIN_SIDEBAR_WIDTH,
     useLayoutStore,
 } from "../../app/store/layoutStore";
@@ -28,6 +27,7 @@ import {
     AGENT_SIDEBAR_DRAG_EVENT,
     type AgentSidebarDragDetail,
 } from "../../features/ai/agentSidebarDragEvents";
+import { getSidebarViewMinimumWidth, type SidebarSide } from "./sidebarViews";
 
 // Both macOS (native "sidebar" vibrancy) and Windows 11 (native acrylic
 // backgroundMaterial) paint a translucent window material beneath the
@@ -113,6 +113,8 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     const rightPanelCollapsed = useLayoutStore((s) => s.rightPanelCollapsed);
     const rightPanelExpanded = useLayoutStore((s) => s.rightPanelExpanded);
     const rightPanelWidth = useLayoutStore((s) => s.rightPanelWidth);
+    const activeRightView = useLayoutStore((s) => s.activeSidebarView.right);
+    const rightMinimumWidth = getSidebarViewMinimumWidth(activeRightView);
     const collapseRightPanelToWidth = useLayoutStore(
         (s) => s.collapseRightPanelToWidth,
     );
@@ -132,9 +134,8 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     const sidebarDockFrameRef = useRef<number | null>(null);
     const sidebarDockUnmountTimerRef = useRef<number | null>(null);
     const previousSidebarCollapsedRef = useRef(sidebarCollapsed);
-    const [renderDockedSidebar, setRenderDockedSidebar] = useState(
-        !sidebarCollapsed,
-    );
+    const [renderDockedSidebar, setRenderDockedSidebar] =
+        useState(!sidebarCollapsed);
     const [dockedSidebarWidth, setDockedSidebarWidth] = useState(() =>
         sidebarCollapsed ? 0 : sidebarWidth,
     );
@@ -157,7 +158,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     const sidebarOverlayRef = useRef<HTMLDivElement>(null);
     const overlayDismissTimerRef = useRef<number | null>(null);
     const sidebarPointerRef = useRef<PointerPosition | null>(null);
-    const sidebarDragActiveRef = useRef(false);
+    const sidebarDragOriginRef = useRef<SidebarSide | null>(null);
 
     // Demote the inner wrapper once its own slide finishes. Guard on the
     // event target so transitions bubbling up from sidebar descendants don't
@@ -214,12 +215,12 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     );
 
     const scheduleHideSidebarOverlay = useCallback(() => {
-        if (sidebarDragActiveRef.current) return;
+        if (sidebarDragOriginRef.current === "left") return;
         if (overlayDismissTimerRef.current !== null) return;
         overlayDismissTimerRef.current = window.setTimeout(() => {
             overlayDismissTimerRef.current = null;
             if (
-                sidebarDragActiveRef.current ||
+                sidebarDragOriginRef.current === "left" ||
                 isSidebarPointerInSafeZone()
             ) {
                 return;
@@ -339,6 +340,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     // a drop target for note drags, so the simple hover flow is enough.
     const [rightOverlayVisible, setRightOverlayVisible] = useState(false);
     const rightOverlayRef = useRef<HTMLDivElement>(null);
+    const rightPanelRef = useRef<HTMLDivElement>(null);
     const rightOverlayDismissTimerRef = useRef<number | null>(null);
     const rightPointerRef = useRef<PointerPosition | null>(null);
 
@@ -375,9 +377,11 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     );
 
     const scheduleHideRightOverlay = useCallback(() => {
+        if (sidebarDragOriginRef.current === "right") return;
         if (rightOverlayDismissTimerRef.current !== null) return;
         rightOverlayDismissTimerRef.current = window.setTimeout(() => {
             rightOverlayDismissTimerRef.current = null;
+            if (sidebarDragOriginRef.current === "right") return;
             if (isRightPointerInSafeZone()) return;
             setRightOverlayVisible(false);
         }, EDGE_PEEK_DISMISS_DELAY_MS);
@@ -412,10 +416,32 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     ]);
 
     useEffect(() => {
+        const pointInside = (
+            element: HTMLElement | null,
+            x: number,
+            y: number,
+        ) => {
+            if (!element) return false;
+            const rect = element.getBoundingClientRect();
+            if (rect.width === 0 && rect.height === 0) {
+                const width = Number.parseFloat(element.style.width);
+                if (!Number.isFinite(width)) return false;
+                if (element.dataset.edgePeekOverlay === "left") {
+                    return x >= 0 && x <= width;
+                }
+                if (element.dataset.edgePeekOverlay === "right") {
+                    return x >= window.innerWidth - width;
+                }
+            }
+            return (
+                x >= rect.left &&
+                x <= rect.right &&
+                y >= rect.top &&
+                y <= rect.bottom
+            );
+        };
         const handleSidebarOriginDrag = (
-            detail:
-                | FileTreeNoteDragDetail
-                | AgentSidebarDragDetail,
+            detail: FileTreeNoteDragDetail | AgentSidebarDragDetail,
         ) => {
             if (!detail) return;
             if (Number.isFinite(detail.x) && Number.isFinite(detail.y)) {
@@ -426,28 +452,44 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
             }
 
             if (detail.phase === "start" || detail.phase === "move") {
-                const rootRect = rootRef.current?.getBoundingClientRect();
-                const overlayLeft = rootRect?.left ?? 0;
-                const startedInsideSidebarOverlay =
-                    detail.phase === "start" &&
-                    sidebarCollapsed &&
-                    sidebarOverlayVisible &&
-                    ("origin" in detail
-                        ? detail.origin?.kind !== "workspace-tab"
-                        : true) &&
-                    detail.x >= overlayLeft &&
-                    detail.x <= overlayLeft + sidebarWidth;
-
-                if (
-                    !sidebarDragActiveRef.current &&
-                    !startedInsideSidebarOverlay
-                ) {
-                    return;
+                if (detail.phase === "start") {
+                    if (
+                        "origin" in detail &&
+                        detail.origin?.kind === "workspace-tab"
+                    )
+                        return;
+                    sidebarDragOriginRef.current =
+                        pointInside(
+                            sidebarOverlayRef.current,
+                            detail.x,
+                            detail.y,
+                        ) ||
+                        pointInside(leftPanelRef.current, detail.x, detail.y)
+                            ? "left"
+                            : pointInside(
+                                    rightOverlayRef.current,
+                                    detail.x,
+                                    detail.y,
+                                ) ||
+                                pointInside(
+                                    rightPanelRef.current,
+                                    detail.x,
+                                    detail.y,
+                                )
+                              ? "right"
+                              : null;
                 }
-
-                sidebarDragActiveRef.current = true;
-                if (sidebarCollapsed) {
+                if (
+                    sidebarDragOriginRef.current === "left" &&
+                    sidebarCollapsed
+                ) {
                     showSidebarOverlay();
+                }
+                if (
+                    sidebarDragOriginRef.current === "right" &&
+                    rightPanelCollapsed
+                ) {
+                    showRightOverlay();
                 }
                 return;
             }
@@ -457,10 +499,14 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
                 detail.phase === "cancel" ||
                 detail.phase === "attach"
             ) {
-                if (!sidebarDragActiveRef.current) return;
-                sidebarDragActiveRef.current = false;
-                if (sidebarCollapsed) {
+                const origin = sidebarDragOriginRef.current;
+                if (!origin) return;
+                sidebarDragOriginRef.current = null;
+                if (origin === "left" && sidebarCollapsed) {
                     scheduleHideSidebarOverlay();
+                }
+                if (origin === "right" && rightPanelCollapsed) {
+                    scheduleHideRightOverlay();
                 }
             }
         };
@@ -483,7 +529,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
             handleAgentSidebarDrag,
         );
         return () => {
-            sidebarDragActiveRef.current = false;
+            sidebarDragOriginRef.current = null;
             window.removeEventListener(
                 FILE_TREE_NOTE_DRAG_EVENT,
                 handleFileTreeDrag,
@@ -495,10 +541,11 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
         };
     }, [
         scheduleHideSidebarOverlay,
+        scheduleHideRightOverlay,
         showSidebarOverlay,
+        showRightOverlay,
+        rightPanelCollapsed,
         sidebarCollapsed,
-        sidebarOverlayVisible,
-        sidebarWidth,
     ]);
 
     // Tear down the timer on unmount; also retract the overlay as soon as the
@@ -585,7 +632,6 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
     // --- Right panel ---
     const [isResizingRight, setIsResizingRight] = useState(false);
     const [collapsePreviewRight, setCollapsePreviewRight] = useState(false);
-    const rightPanelRef = useRef<HTMLDivElement>(null);
     const rightResizerRef = useRef<HTMLDivElement>(null);
     const rightSessionRef = useRef<HorizontalResizeSession | null>(null);
     const rightFrameRef = useRef<number | null>(null);
@@ -597,7 +643,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
         layoutWidth - effectiveRightForLeftCalc - MIN_CENTER_PEEK_WIDTH,
     );
     const maxRightWidthForLayout = Math.max(
-        MIN_RIGHT_PANEL_WIDTH,
+        rightMinimumWidth,
         layoutWidth - effectiveLeft - MIN_CENTER_PEEK_WIDTH,
     );
     const effectiveRight = rightPanelCollapsed
@@ -777,11 +823,11 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
             setIsResizingRight(false);
 
             if (s.pendingWidth < RIGHT_COLLAPSE_TRIGGER_WIDTH) {
-                collapseRightPanelToWidth(MIN_RIGHT_PANEL_WIDTH);
+                collapseRightPanelToWidth(rightMinimumWidth);
                 return;
             }
             const clamped = Math.max(
-                MIN_RIGHT_PANEL_WIDTH,
+                rightMinimumWidth,
                 Math.min(maxRightWidthForLayout, s.pendingWidth),
             );
             const snapped =
@@ -794,6 +840,7 @@ export function AppLayout({ left, center, right }: AppLayoutProps) {
             applyRightWidth,
             collapseRightPanelToWidth,
             maxRightWidthForLayout,
+            rightMinimumWidth,
             showRightPanelAtWidth,
             syncRightPreview,
         ],

--- a/apps/desktop/src/components/layout/RightSidebarShell.tsx
+++ b/apps/desktop/src/components/layout/RightSidebarShell.tsx
@@ -15,6 +15,7 @@ export function RightSidebarShell() {
     const activateSidebarView = useLayoutStore(
         (state) => state.activateSidebarView,
     );
+    const moveSidebarView = useLayoutStore((state) => state.moveSidebarView);
     const toggleRightPanel = useLayoutStore((state) => state.toggleRightPanel);
     const views = getSidebarViews("right", placement);
     const compactContextualViews = views.some(
@@ -55,6 +56,7 @@ export function RightSidebarShell() {
                     activeView={activeView}
                     compactContextualViews={compactContextualViews}
                     onSelect={selectView}
+                    onMove={moveSidebarView}
                 />
                 <button
                     type="button"

--- a/apps/desktop/src/components/layout/RightSidebarShell.tsx
+++ b/apps/desktop/src/components/layout/RightSidebarShell.tsx
@@ -1,0 +1,94 @@
+import { useCallback } from "react";
+import { useLayoutStore } from "../../app/store/layoutStore";
+import { getDesktopPlatform } from "../../app/utils/platform";
+import { SidebarTabs } from "./SidebarTabs";
+import { SidebarViewContent } from "./SidebarViewContent";
+import { getSidebarViews, type SidebarView } from "./sidebarViews";
+
+const PLATFORM = getDesktopPlatform();
+const USES_NATIVE_TITLEBAR_OVERLAY =
+    PLATFORM === "windows" || PLATFORM === "linux";
+
+export function RightSidebarShell() {
+    const activeView = useLayoutStore((state) => state.activeSidebarView.right);
+    const placement = useLayoutStore((state) => state.movableSidebarPlacement);
+    const activateSidebarView = useLayoutStore(
+        (state) => state.activateSidebarView,
+    );
+    const toggleRightPanel = useLayoutStore((state) => state.toggleRightPanel);
+    const views = getSidebarViews("right", placement);
+    const compactContextualViews = views.some(
+        (view) => view === "files" || view === "agents",
+    );
+    const selectView = useCallback(
+        (view: SidebarView) => activateSidebarView("right", view),
+        [activateSidebarView],
+    );
+
+    return (
+        <div
+            className="flex h-full min-h-0 flex-col overflow-hidden"
+            data-testid="right-sidebar-shell"
+            data-sidebar-side="right"
+        >
+            {USES_NATIVE_TITLEBAR_OVERLAY && (
+                <div
+                    aria-hidden="true"
+                    data-right-panel-titlebar-inset
+                    style={
+                        {
+                            height: 34,
+                            flexShrink: 0,
+                            WebkitAppRegion: "drag",
+                            backgroundColor: "var(--sidebar-vibrancy-tint)",
+                        } as React.CSSProperties
+                    }
+                />
+            )}
+            <div
+                className="flex items-center gap-1"
+                style={{ padding: "8px 8px 6px", flexShrink: 0 }}
+            >
+                <SidebarTabs
+                    side="right"
+                    views={views}
+                    activeView={activeView}
+                    compactContextualViews={compactContextualViews}
+                    onSelect={selectView}
+                />
+                <button
+                    type="button"
+                    onClick={toggleRightPanel}
+                    title="Hide right panel"
+                    aria-label="Hide right panel"
+                    className="ub-chrome-btn flex items-center justify-center shrink-0 rounded-md"
+                    style={{
+                        width: 26,
+                        height: 26,
+                        border: "1px solid transparent",
+                        background: "transparent",
+                        color: "var(--text-secondary)",
+                        opacity: 0.82,
+                    }}
+                >
+                    <svg
+                        width="16"
+                        height="16"
+                        viewBox="0 0 16 16"
+                        fill="none"
+                        stroke="currentColor"
+                        strokeWidth="1.4"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                    >
+                        <rect x="2" y="2.5" width="12" height="11" rx="2.2" />
+                        <path d="M6 2.5v11" />
+                    </svg>
+                </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden">
+                <SidebarViewContent view={activeView} />
+            </div>
+        </div>
+    );
+}

--- a/apps/desktop/src/components/layout/SidebarShell.test.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+    createDefaultLayoutState,
+    useLayoutStore,
+} from "../../app/store/layoutStore";
+import { RightSidebarShell } from "./RightSidebarShell";
+import { SidebarShell } from "./SidebarShell";
+
+vi.mock("../../features/vault/FileTree", () => ({
+    FileTree: () => <div data-testid="files-content" />,
+}));
+vi.mock("../../features/ai/AgentsSidebarPanel", () => ({
+    AgentsSidebarPanel: () => <div data-testid="agents-content" />,
+}));
+vi.mock("../../features/tags/TagsPanel", () => ({
+    TagsPanel: () => <div data-testid="tags-content" />,
+}));
+vi.mock("../../features/bookmarks/BookmarksPanel", () => ({
+    BookmarksPanel: () => <div data-testid="bookmarks-content" />,
+}));
+vi.mock("../../features/maps/MapsPanel", () => ({
+    MapsPanel: () => <div data-testid="maps-content" />,
+}));
+vi.mock("../../features/notes/OutlinePanel", () => ({
+    OutlinePanel: () => <div data-testid="outline-content" />,
+}));
+vi.mock("../../features/notes/LinksPanel", () => ({
+    LinksPanel: () => <div data-testid="links-content" />,
+}));
+vi.mock("../../features/vault/VaultSwitcher", () => ({
+    VaultSwitcher: () => <div data-testid="vault-switcher" />,
+}));
+vi.mock("../../features/updates/store", () => ({
+    useAppUpdateStore: (selector: (state: { status: null }) => unknown) =>
+        selector({ status: null }),
+}));
+describe("sidebar shells", () => {
+    beforeEach(() => {
+        useLayoutStore.setState({
+            ...createDefaultLayoutState(),
+            rightPanelExpanded: false,
+        });
+    });
+
+    it("renders the default views on their canonical sides", () => {
+        render(
+            <>
+                <SidebarShell onOpenSettings={vi.fn()} />
+                <RightSidebarShell />
+            </>,
+        );
+        const left = screen.getByTestId("sidebar-shell");
+        const right = screen.getByTestId("right-sidebar-shell");
+        expect(
+            within(left).getAllByRole("button", {
+                name: /Files|Agents|Tags|Bookmarks|Maps/,
+            }),
+        ).toHaveLength(5);
+        expect(
+            within(right).getAllByRole("button", { name: /Outline|Links/ }),
+        ).toHaveLength(2);
+        expect(screen.getAllByTestId("files-content")).toHaveLength(1);
+        expect(within(right).getByText("No note open")).toBeInTheDocument();
+        expect(screen.getByTestId("vault-switcher")).toBeInTheDocument();
+    });
+
+    it("mounts moved content only in its owning shell and compacts contextual tabs", () => {
+        useLayoutStore.getState().moveSidebarView("files", "right");
+        render(
+            <>
+                <SidebarShell onOpenSettings={vi.fn()} />
+                <RightSidebarShell />
+            </>,
+        );
+        const right = screen.getByTestId("right-sidebar-shell");
+        expect(within(right).getByTestId("files-content")).toBeInTheDocument();
+        expect(screen.getAllByTestId("files-content")).toHaveLength(1);
+        expect(
+            within(right).getByRole("button", { name: "Outline" }),
+        ).not.toHaveTextContent("Outline");
+        expect(
+            within(right).getByRole("button", { name: "Links" }),
+        ).not.toHaveTextContent("Links");
+    });
+
+    it("switches one body per side and hides the left footer for Maps", () => {
+        render(<SidebarShell onOpenSettings={vi.fn()} />);
+        fireEvent.click(screen.getByRole("button", { name: "Maps" }));
+        expect(screen.getByTestId("maps-content")).toBeInTheDocument();
+        expect(screen.queryByTestId("files-content")).not.toBeInTheDocument();
+        expect(screen.queryByTestId("vault-switcher")).not.toBeInTheDocument();
+    });
+});

--- a/apps/desktop/src/components/layout/SidebarShell.test.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.test.tsx
@@ -1,4 +1,10 @@
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import {
+    fireEvent,
+    render,
+    screen,
+    waitFor,
+    within,
+} from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
     createDefaultLayoutState,
@@ -90,5 +96,36 @@ describe("sidebar shells", () => {
         expect(screen.getByTestId("maps-content")).toBeInTheDocument();
         expect(screen.queryByTestId("files-content")).not.toBeInTheDocument();
         expect(screen.queryByTestId("vault-switcher")).not.toBeInTheDocument();
+    });
+
+    it("moves Files from its context menu and supports keyboard invocation", async () => {
+        render(
+            <>
+                <SidebarShell onOpenSettings={vi.fn()} />
+                <RightSidebarShell />
+            </>,
+        );
+        const files = screen.getByRole("button", { name: "Files" });
+        fireEvent.keyDown(files, { key: "F10", shiftKey: true });
+        fireEvent.click(await screen.findByText("Move to Right Sidebar"));
+        await waitFor(() =>
+            expect(
+                useLayoutStore.getState().movableSidebarPlacement.files,
+            ).toBe("right"),
+        );
+        expect(
+            within(screen.getByTestId("right-sidebar-shell")).getByRole(
+                "button",
+                { name: "Files" },
+            ),
+        ).toBeInTheDocument();
+    });
+
+    it("does not offer movement for fixed views", () => {
+        render(<SidebarShell onOpenSettings={vi.fn()} />);
+        fireEvent.contextMenu(screen.getByRole("button", { name: "Tags" }));
+        expect(
+            screen.queryByText(/Move to (Left|Right) Sidebar/),
+        ).not.toBeInTheDocument();
     });
 });

--- a/apps/desktop/src/components/layout/SidebarShell.test.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.test.tsx
@@ -62,16 +62,19 @@ describe("sidebar shells", () => {
             within(left).getAllByRole("button", {
                 name: /Files|Agents|Tags|Bookmarks|Maps/,
             }),
-        ).toHaveLength(5);
+        ).toHaveLength(4);
         expect(
-            within(right).getAllByRole("button", { name: /Outline|Links/ }),
-        ).toHaveLength(2);
+            within(right).getAllByRole("button", {
+                name: /Files|Outline|Links/,
+            }),
+        ).toHaveLength(3);
         expect(screen.getAllByTestId("files-content")).toHaveLength(1);
-        expect(within(right).getByText("No note open")).toBeInTheDocument();
+        expect(screen.getAllByTestId("agents-content")).toHaveLength(1);
         expect(screen.getByTestId("vault-switcher")).toBeInTheDocument();
     });
 
     it("mounts moved content only in its owning shell and compacts contextual tabs", () => {
+        useLayoutStore.getState().moveSidebarView("files", "left");
         useLayoutStore.getState().moveSidebarView("files", "right");
         render(
             <>
@@ -107,14 +110,14 @@ describe("sidebar shells", () => {
         );
         const files = screen.getByRole("button", { name: "Files" });
         fireEvent.keyDown(files, { key: "F10", shiftKey: true });
-        fireEvent.click(await screen.findByText("Move to Right Sidebar"));
+        fireEvent.click(await screen.findByText("Move to Left Sidebar"));
         await waitFor(() =>
             expect(
                 useLayoutStore.getState().movableSidebarPlacement.files,
-            ).toBe("right"),
+            ).toBe("left"),
         );
         expect(
-            within(screen.getByTestId("right-sidebar-shell")).getByRole(
+            within(screen.getByTestId("sidebar-shell")).getByRole(
                 "button",
                 { name: "Files" },
             ),

--- a/apps/desktop/src/components/layout/SidebarShell.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.tsx
@@ -35,6 +35,7 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
     const activateSidebarView = useLayoutStore(
         (state) => state.activateSidebarView,
     );
+    const moveSidebarView = useLayoutStore((state) => state.moveSidebarView);
     const toggleSidebar = useLayoutStore((state) => state.toggleSidebar);
     const updateAvailable = useAppUpdateStore(
         (state) => !!state.status?.update,
@@ -107,6 +108,7 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
                     views={views}
                     activeView={activeView}
                     onSelect={selectView}
+                    onMove={moveSidebarView}
                 />
             </div>
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">

--- a/apps/desktop/src/components/layout/SidebarShell.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.tsx
@@ -4,33 +4,18 @@ import {
     type MouseEvent as ReactMouseEvent,
 } from "react";
 import { getCurrentWindow } from "@neverwrite/runtime";
-import { useLayoutStore, type SidebarView } from "../../app/store/layoutStore";
+import { useLayoutStore } from "../../app/store/layoutStore";
 import {
     getDesktopPlatform,
     getTrafficLightSpacerWidth,
 } from "../../app/utils/platform";
 import { useAppUpdateStore } from "../../features/updates/store";
-import { FileTree } from "../../features/vault/FileTree";
-import { TagsPanel } from "../../features/tags/TagsPanel";
-import { BookmarksPanel } from "../../features/bookmarks/BookmarksPanel";
-import { MapsPanel } from "../../features/maps/MapsPanel";
-import { AgentsSidebarPanel } from "../../features/ai/AgentsSidebarPanel";
 import { VaultSwitcher } from "../../features/vault/VaultSwitcher";
-import { SIDEBAR_VIEW_CATALOG } from "./sidebarViews";
-
-// A single unified translucent left pane that replaces both the horizontal
-// chrome bar's sidebar toggle and the vertical ActivityBar rail. It renders
-// four regions top-to-bottom: drag header with collapse button, tab row,
-// view body, and the VaultSwitcher footer (which hosts Settings entry).
-// macOS vibrancy shows through via the already-transparent ancestors
-// (see AppLayout + index.css).
+import { SidebarTabs } from "./SidebarTabs";
+import { SidebarViewContent } from "./SidebarViewContent";
+import { getSidebarViews, type SidebarView } from "./sidebarViews";
 
 const IS_MACOS = getDesktopPlatform() === "macos";
-
-// Primary tabs are labeled; secondary ones stay compact (icon-only) so all
-// fit on a single row without truncation at default sidebar width.
-const PRIMARY_TABS: SidebarView[] = ["files", "agents"];
-const SECONDARY_TABS: SidebarView[] = ["tags", "bookmarks", "maps"];
 
 function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
     if (event.button !== 0) return;
@@ -40,146 +25,35 @@ function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
         .catch(() => {});
 }
 
-function SidebarTabIcon({ view }: { view: SidebarView }) {
-    const common = {
-        width: 14,
-        height: 14,
-        viewBox: "0 0 24 24",
-        fill: "none",
-        stroke: "currentColor",
-        strokeWidth: 1.6,
-        strokeLinecap: "round" as const,
-        strokeLinejoin: "round" as const,
-    };
-    switch (view) {
-        case "files":
-            return (
-                <svg {...common}>
-                    <path d="M4 4h6l2 2h8a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Z" />
-                </svg>
-            );
-        case "tags":
-            return (
-                <svg {...common}>
-                    <path d="M4 9h16M4 15h16M10 3 8 21M16 3l-2 18" />
-                </svg>
-            );
-        case "bookmarks":
-            return (
-                <svg {...common}>
-                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-                </svg>
-            );
-        case "maps":
-            return (
-                <svg {...common}>
-                    <circle cx="7" cy="12" r="2.5" />
-                    <circle cx="17" cy="7" r="2.5" />
-                    <circle cx="17" cy="17" r="2.5" />
-                    <path d="M9.5 12L14.5 7.5M9.5 12L14.5 16.5" />
-                </svg>
-            );
-        case "agents":
-            return (
-                <svg {...common}>
-                    <path d="M12 3v2" />
-                    <rect x="5" y="7" width="14" height="11" rx="3" />
-                    <circle cx="9.5" cy="12" r="1" />
-                    <circle cx="14.5" cy="12" r="1" />
-                    <path d="M9 18v2M15 18v2M3 12h2M19 12h2" />
-                </svg>
-            );
-    }
-}
-
-function SidebarTabButton({
-    view,
-    active,
-    onSelect,
-    compact = false,
-}: {
-    view: SidebarView;
-    active: boolean;
-    onSelect: (view: SidebarView) => void;
-    compact?: boolean;
-}) {
-    return (
-        <button
-            type="button"
-            onMouseDown={(event) => event.stopPropagation()}
-            onClick={() => onSelect(view)}
-            title={SIDEBAR_VIEW_CATALOG[view].label}
-            data-active={active || undefined}
-            data-sidebar-tab={view}
-            className="no-drag ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
-            style={{
-                flex: compact ? "0 0 auto" : 1,
-                minWidth: 0,
-                height: 28,
-                padding: compact ? "0 8px" : "0 6px",
-                border: active
-                    ? "1px solid color-mix(in srgb, var(--accent) 22%, var(--border))"
-                    : "1px solid transparent",
-                background: active
-                    ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
-                    : "transparent",
-                color: active ? "var(--text-primary)" : "var(--text-secondary)",
-                boxShadow: active ? "0 1px 2px rgb(0 0 0 / 0.12)" : "none",
-                transition:
-                    "background-color 140ms ease-out, color 140ms ease-out, border-color 140ms ease-out, transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 140ms ease-out",
-            }}
-        >
-            <SidebarTabIcon view={view} />
-            {!compact && (
-                <span className="truncate">
-                    {SIDEBAR_VIEW_CATALOG[view].label}
-                </span>
-            )}
-        </button>
-    );
-}
-
 export interface SidebarShellProps {
     onOpenSettings: (section?: string) => void;
 }
 
 export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
-    const sidebarView = useLayoutStore((s) => s.activeSidebarView.left);
-    const activateSidebarView = useLayoutStore((s) => s.activateSidebarView);
-    const toggleSidebar = useLayoutStore((s) => s.toggleSidebar);
-
+    const activeView = useLayoutStore((state) => state.activeSidebarView.left);
+    const placement = useLayoutStore((state) => state.movableSidebarPlacement);
+    const activateSidebarView = useLayoutStore(
+        (state) => state.activateSidebarView,
+    );
+    const toggleSidebar = useLayoutStore((state) => state.toggleSidebar);
     const updateAvailable = useAppUpdateStore(
         (state) => !!state.status?.update,
     );
-
+    const views = getSidebarViews("left", placement);
     const trafficLightInsetHeight = IS_MACOS
         ? Math.max(28, getTrafficLightSpacerWidth() / 2 + 12)
         : 0;
-
-    // Tab clicks only switch the view; they never change the docked/peek
-    // state. Docking is an explicit action (toggle button or shortcut), so
-    // browsing views inside the Arc peek overlay keeps the sidebar hidden.
-    const handleSelectView = useCallback(
-        (view: SidebarView) => {
-            activateSidebarView("left", view);
-        },
+    const selectView = useCallback(
+        (view: SidebarView) => activateSidebarView("left", view),
         [activateSidebarView],
     );
-
-    const currentView = sidebarView;
 
     return (
         <div
             className="flex h-full flex-col overflow-hidden"
             data-testid="sidebar-shell"
+            data-sidebar-side="left"
         >
-            {/* Traffic-light drag inset (macOS only). Keeps the window
-                draggable from the top of the sidebar when the horizontal
-                chrome bar is gone. */}
-            {/* Top row: sits alongside the macOS traffic-light cut-out and
-                hosts an oversized collapse button on the right. The empty
-                space is a drag region so the window is still draggable from
-                the top of the sidebar. */}
             <div
                 data-sidebar-drag-inset
                 onMouseDown={startWindowDrag}
@@ -224,51 +98,21 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
                     </svg>
                 </button>
             </div>
-
-            {/* Tab row: primary views carry a label, secondary views stay
-                compact (icon-only) so all five fit on one line. */}
             <div
                 className="flex items-center gap-1"
                 style={{ padding: "0 8px 8px", flexShrink: 0 }}
             >
-                {PRIMARY_TABS.map((view) => (
-                    <SidebarTabButton
-                        key={view}
-                        view={view}
-                        active={currentView === view}
-                        onSelect={handleSelectView}
-                    />
-                ))}
-                {SECONDARY_TABS.map((view) => (
-                    <SidebarTabButton
-                        key={view}
-                        view={view}
-                        active={currentView === view}
-                        onSelect={handleSelectView}
-                        compact
-                    />
-                ))}
+                <SidebarTabs
+                    side="left"
+                    views={views}
+                    activeView={activeView}
+                    onSelect={selectView}
+                />
             </div>
-
-            {/* View body. Fills remaining space above the footer. */}
             <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-                {currentView === "files" ? (
-                    <FileTree />
-                ) : currentView === "tags" ? (
-                    <TagsPanel />
-                ) : currentView === "bookmarks" ? (
-                    <BookmarksPanel />
-                ) : currentView === "agents" ? (
-                    <AgentsSidebarPanel />
-                ) : (
-                    <MapsPanel />
-                )}
+                <SidebarViewContent view={activeView} />
             </div>
-
-            {/* Footer: vault switcher hosts the Settings entry and its
-                update badge via its dropdown. Maps hides the switcher
-                because it runs its own multi-context chrome. */}
-            {currentView !== "maps" && (
+            {activeView !== "maps" && (
                 <VaultSwitcher
                     onOpenSettings={onOpenSettings}
                     updateAvailable={updateAvailable}

--- a/apps/desktop/src/components/layout/SidebarShell.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.tsx
@@ -74,10 +74,11 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
                     onClick={toggleSidebar}
                     title="Hide sidebar"
                     aria-label="Hide sidebar"
-                    className="no-drag ub-chrome-btn flex items-center justify-center rounded-md"
+                    className="no-drag ub-chrome-btn flex shrink-0 items-center justify-center rounded-md"
                     style={{
-                        width: 32,
-                        height: 32,
+                        width: 26,
+                        height: 26,
+                        transform: "translateY(-3px)",
                         border: "1px solid transparent",
                         background: "transparent",
                         color: "var(--text-secondary)",
@@ -85,8 +86,8 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
                     }}
                 >
                     <svg
-                        width="20"
-                        height="20"
+                        width="16"
+                        height="16"
                         viewBox="0 0 16 16"
                         fill="none"
                         stroke="currentColor"

--- a/apps/desktop/src/components/layout/SidebarShell.tsx
+++ b/apps/desktop/src/components/layout/SidebarShell.tsx
@@ -16,6 +16,7 @@ import { BookmarksPanel } from "../../features/bookmarks/BookmarksPanel";
 import { MapsPanel } from "../../features/maps/MapsPanel";
 import { AgentsSidebarPanel } from "../../features/ai/AgentsSidebarPanel";
 import { VaultSwitcher } from "../../features/vault/VaultSwitcher";
+import { SIDEBAR_VIEW_CATALOG } from "./sidebarViews";
 
 // A single unified translucent left pane that replaces both the horizontal
 // chrome bar's sidebar toggle and the vertical ActivityBar rail. It renders
@@ -30,14 +31,6 @@ const IS_MACOS = getDesktopPlatform() === "macos";
 // fit on a single row without truncation at default sidebar width.
 const PRIMARY_TABS: SidebarView[] = ["files", "agents"];
 const SECONDARY_TABS: SidebarView[] = ["tags", "bookmarks", "maps"];
-
-const TAB_LABELS: Record<SidebarView, string> = {
-    files: "Files",
-    tags: "Tags",
-    bookmarks: "Bookmarks",
-    maps: "Maps",
-    agents: "Agents",
-};
 
 function startWindowDrag(event: ReactMouseEvent<HTMLElement>) {
     if (event.button !== 0) return;
@@ -115,7 +108,7 @@ function SidebarTabButton({
             type="button"
             onMouseDown={(event) => event.stopPropagation()}
             onClick={() => onSelect(view)}
-            title={TAB_LABELS[view]}
+            title={SIDEBAR_VIEW_CATALOG[view].label}
             data-active={active || undefined}
             data-sidebar-tab={view}
             className="no-drag ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
@@ -130,19 +123,17 @@ function SidebarTabButton({
                 background: active
                     ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
                     : "transparent",
-                color: active
-                    ? "var(--text-primary)"
-                    : "var(--text-secondary)",
-                boxShadow: active
-                    ? "0 1px 2px rgb(0 0 0 / 0.12)"
-                    : "none",
+                color: active ? "var(--text-primary)" : "var(--text-secondary)",
+                boxShadow: active ? "0 1px 2px rgb(0 0 0 / 0.12)" : "none",
                 transition:
                     "background-color 140ms ease-out, color 140ms ease-out, border-color 140ms ease-out, transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 140ms ease-out",
             }}
         >
             <SidebarTabIcon view={view} />
             {!compact && (
-                <span className="truncate">{TAB_LABELS[view]}</span>
+                <span className="truncate">
+                    {SIDEBAR_VIEW_CATALOG[view].label}
+                </span>
             )}
         </button>
     );
@@ -153,11 +144,13 @@ export interface SidebarShellProps {
 }
 
 export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
-    const sidebarView = useLayoutStore((s) => s.sidebarView);
-    const setSidebarView = useLayoutStore((s) => s.setSidebarView);
+    const sidebarView = useLayoutStore((s) => s.activeSidebarView.left);
+    const activateSidebarView = useLayoutStore((s) => s.activateSidebarView);
     const toggleSidebar = useLayoutStore((s) => s.toggleSidebar);
 
-    const updateAvailable = useAppUpdateStore((state) => !!state.status?.update);
+    const updateAvailable = useAppUpdateStore(
+        (state) => !!state.status?.update,
+    );
 
     const trafficLightInsetHeight = IS_MACOS
         ? Math.max(28, getTrafficLightSpacerWidth() / 2 + 12)
@@ -168,9 +161,9 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
     // browsing views inside the Arc peek overlay keeps the sidebar hidden.
     const handleSelectView = useCallback(
         (view: SidebarView) => {
-            setSidebarView(view);
+            activateSidebarView("left", view);
         },
-        [setSidebarView],
+        [activateSidebarView],
     );
 
     const currentView = sidebarView;
@@ -191,12 +184,14 @@ export function SidebarShell({ onOpenSettings }: SidebarShellProps) {
                 data-sidebar-drag-inset
                 onMouseDown={startWindowDrag}
                 className="flex items-center justify-end"
-                style={{
-                    height: Math.max(trafficLightInsetHeight, 38),
-                    padding: "0 8px",
-                    flexShrink: 0,
-                    WebkitAppRegion: "drag",
-                } as CSSProperties}
+                style={
+                    {
+                        height: Math.max(trafficLightInsetHeight, 38),
+                        padding: "0 8px",
+                        flexShrink: 0,
+                        WebkitAppRegion: "drag",
+                    } as CSSProperties
+                }
             >
                 <button
                     type="button"

--- a/apps/desktop/src/components/layout/SidebarTabs.tsx
+++ b/apps/desktop/src/components/layout/SidebarTabs.tsx
@@ -1,6 +1,14 @@
-import type { KeyboardEvent, MouseEvent } from "react";
+import { useState, type KeyboardEvent, type MouseEvent } from "react";
+import {
+    ContextMenu,
+    type ContextMenuState,
+} from "../context-menu/ContextMenu";
 import type { SidebarSide, SidebarView } from "./sidebarViews";
-import { SIDEBAR_VIEW_CATALOG } from "./sidebarViews";
+import {
+    isMovableSidebarView,
+    SIDEBAR_VIEW_CATALOG,
+    type MovableSidebarView,
+} from "./sidebarViews";
 
 export function SidebarViewIcon({ view }: { view: SidebarView }) {
     const common = {
@@ -72,10 +80,7 @@ interface SidebarTabsProps {
     activeView: SidebarView;
     compactContextualViews?: boolean;
     onSelect: (view: SidebarView) => void;
-    onRequestContextMenu?: (
-        view: SidebarView,
-        event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
-    ) => void;
+    onMove?: (view: MovableSidebarView, target: SidebarSide) => void;
 }
 
 export function SidebarTabs({
@@ -84,70 +89,111 @@ export function SidebarTabs({
     activeView,
     compactContextualViews = false,
     onSelect,
-    onRequestContextMenu,
+    onMove,
 }: SidebarTabsProps) {
+    const [menu, setMenu] =
+        useState<ContextMenuState<MovableSidebarView> | null>(null);
+    const requestContextMenu = (
+        view: SidebarView,
+        event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+    ) => {
+        if (!onMove || !isMovableSidebarView(view)) return;
+        event.preventDefault();
+        event.stopPropagation();
+        const rect = event.currentTarget.getBoundingClientRect();
+        const pointer = "clientX" in event && event.clientX > 0;
+        setMenu({
+            payload: view,
+            x: pointer ? event.clientX : rect.left,
+            y: pointer ? event.clientY : rect.bottom,
+        });
+    };
+
     return (
-        <div
-            className="flex min-w-0 flex-1 items-center gap-1"
-            data-sidebar-tabs={side}
-        >
-            {views.map((view) => {
-                const definition = SIDEBAR_VIEW_CATALOG[view];
-                const compact =
-                    definition.compact ||
-                    (compactContextualViews &&
-                        (view === "outline" || view === "links"));
-                const active = activeView === view;
-                return (
-                    <button
-                        key={view}
-                        type="button"
-                        onMouseDown={(event) => event.stopPropagation()}
-                        onClick={() => onSelect(view)}
-                        onContextMenu={(event) =>
-                            onRequestContextMenu?.(view, event)
-                        }
-                        onKeyDown={(event) => {
-                            if (
-                                event.key === "ContextMenu" ||
-                                (event.shiftKey && event.key === "F10")
-                            ) {
-                                onRequestContextMenu?.(view, event);
+        <>
+            <div
+                className="flex min-w-0 flex-1 items-center gap-1"
+                data-sidebar-tabs={side}
+            >
+                {views.map((view) => {
+                    const definition = SIDEBAR_VIEW_CATALOG[view];
+                    const compact =
+                        definition.compact ||
+                        (compactContextualViews &&
+                            (view === "outline" || view === "links"));
+                    const active = activeView === view;
+                    return (
+                        <button
+                            key={view}
+                            type="button"
+                            onMouseDown={(event) => event.stopPropagation()}
+                            onClick={() => onSelect(view)}
+                            onContextMenu={(event) =>
+                                requestContextMenu(view, event)
                             }
-                        }}
-                        title={definition.label}
-                        aria-label={definition.label}
-                        data-active={active || undefined}
-                        data-sidebar-tab={view}
-                        className="no-drag ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
-                        style={{
-                            flex: compact ? "0 0 auto" : 1,
-                            minWidth: 0,
-                            height: side === "left" ? 28 : 26,
-                            padding: compact ? "0 8px" : "0 6px",
-                            border: active
-                                ? "1px solid color-mix(in srgb, var(--accent) 22%, var(--border))"
-                                : "1px solid transparent",
-                            background: active
-                                ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
-                                : "transparent",
-                            color: active
-                                ? "var(--text-primary)"
-                                : "var(--text-secondary)",
-                            boxShadow: active
-                                ? "0 1px 2px rgb(0 0 0 / 0.12)"
-                                : "none",
-                            transition:
-                                "background-color 140ms ease-out, color 140ms ease-out, border-color 140ms ease-out, transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 140ms ease-out",
-                        }}
-                    >
-                        <SidebarViewIcon view={view} />
-                        {!compact && (
-                            <span className="truncate">{definition.label}</span>
-                        )}
-                    </button>
-                );
-            })}
-        </div>
+                            onKeyDown={(event) => {
+                                if (
+                                    event.key === "ContextMenu" ||
+                                    (event.shiftKey && event.key === "F10")
+                                ) {
+                                    requestContextMenu(view, event);
+                                }
+                            }}
+                            title={definition.label}
+                            aria-label={definition.label}
+                            data-active={active || undefined}
+                            data-sidebar-tab={view}
+                            className="no-drag ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
+                            style={{
+                                flex: compact ? "0 0 auto" : 1,
+                                minWidth: 0,
+                                height: side === "left" ? 28 : 26,
+                                padding: compact ? "0 8px" : "0 6px",
+                                border: active
+                                    ? "1px solid color-mix(in srgb, var(--accent) 22%, var(--border))"
+                                    : "1px solid transparent",
+                                background: active
+                                    ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
+                                    : "transparent",
+                                color: active
+                                    ? "var(--text-primary)"
+                                    : "var(--text-secondary)",
+                                boxShadow: active
+                                    ? "0 1px 2px rgb(0 0 0 / 0.12)"
+                                    : "none",
+                                transition:
+                                    "background-color 140ms ease-out, color 140ms ease-out, border-color 140ms ease-out, transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 140ms ease-out",
+                            }}
+                        >
+                            <SidebarViewIcon view={view} />
+                            {!compact && (
+                                <span className="truncate">
+                                    {definition.label}
+                                </span>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
+            {menu && (
+                <ContextMenu
+                    menu={menu}
+                    entries={[
+                        {
+                            label:
+                                side === "left"
+                                    ? "Move to Right Sidebar"
+                                    : "Move to Left Sidebar",
+                            action: () =>
+                                onMove?.(
+                                    menu.payload,
+                                    side === "left" ? "right" : "left",
+                                ),
+                        },
+                    ]}
+                    onClose={() => setMenu(null)}
+                />
+            )}
+        </>
     );
 }

--- a/apps/desktop/src/components/layout/SidebarTabs.tsx
+++ b/apps/desktop/src/components/layout/SidebarTabs.tsx
@@ -1,0 +1,153 @@
+import type { KeyboardEvent, MouseEvent } from "react";
+import type { SidebarSide, SidebarView } from "./sidebarViews";
+import { SIDEBAR_VIEW_CATALOG } from "./sidebarViews";
+
+export function SidebarViewIcon({ view }: { view: SidebarView }) {
+    const common = {
+        width: 14,
+        height: 14,
+        viewBox: "0 0 24 24",
+        fill: "none",
+        stroke: "currentColor",
+        strokeWidth: 1.6,
+        strokeLinecap: "round" as const,
+        strokeLinejoin: "round" as const,
+    };
+    switch (view) {
+        case "files":
+            return (
+                <svg {...common}>
+                    <path d="M4 4h6l2 2h8a1 1 0 0 1 1 1v10a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1V5a1 1 0 0 1 1-1Z" />
+                </svg>
+            );
+        case "tags":
+            return (
+                <svg {...common}>
+                    <path d="M4 9h16M4 15h16M10 3 8 21M16 3l-2 18" />
+                </svg>
+            );
+        case "bookmarks":
+            return (
+                <svg {...common}>
+                    <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+                </svg>
+            );
+        case "maps":
+            return (
+                <svg {...common}>
+                    <circle cx="7" cy="12" r="2.5" />
+                    <circle cx="17" cy="7" r="2.5" />
+                    <circle cx="17" cy="17" r="2.5" />
+                    <path d="M9.5 12L14.5 7.5M9.5 12L14.5 16.5" />
+                </svg>
+            );
+        case "agents":
+            return (
+                <svg {...common}>
+                    <path d="M12 3v2" />
+                    <rect x="5" y="7" width="14" height="11" rx="3" />
+                    <circle cx="9.5" cy="12" r="1" />
+                    <circle cx="14.5" cy="12" r="1" />
+                    <path d="M9 18v2M15 18v2M3 12h2M19 12h2" />
+                </svg>
+            );
+        case "outline":
+            return (
+                <svg {...common}>
+                    <path d="M4 5h16M7 12h13M10 19h10M4 12h.01M7 19h.01" />
+                </svg>
+            );
+        case "links":
+            return (
+                <svg {...common}>
+                    <path d="M14 4h6v6M20 4l-9 9M10 6H5a2 2 0 0 0-2 2v11a2 2 0 0 0 2 2h11a2 2 0 0 0 2-2v-5" />
+                </svg>
+            );
+    }
+}
+
+interface SidebarTabsProps {
+    side: SidebarSide;
+    views: SidebarView[];
+    activeView: SidebarView;
+    compactContextualViews?: boolean;
+    onSelect: (view: SidebarView) => void;
+    onRequestContextMenu?: (
+        view: SidebarView,
+        event: MouseEvent<HTMLButtonElement> | KeyboardEvent<HTMLButtonElement>,
+    ) => void;
+}
+
+export function SidebarTabs({
+    side,
+    views,
+    activeView,
+    compactContextualViews = false,
+    onSelect,
+    onRequestContextMenu,
+}: SidebarTabsProps) {
+    return (
+        <div
+            className="flex min-w-0 flex-1 items-center gap-1"
+            data-sidebar-tabs={side}
+        >
+            {views.map((view) => {
+                const definition = SIDEBAR_VIEW_CATALOG[view];
+                const compact =
+                    definition.compact ||
+                    (compactContextualViews &&
+                        (view === "outline" || view === "links"));
+                const active = activeView === view;
+                return (
+                    <button
+                        key={view}
+                        type="button"
+                        onMouseDown={(event) => event.stopPropagation()}
+                        onClick={() => onSelect(view)}
+                        onContextMenu={(event) =>
+                            onRequestContextMenu?.(view, event)
+                        }
+                        onKeyDown={(event) => {
+                            if (
+                                event.key === "ContextMenu" ||
+                                (event.shiftKey && event.key === "F10")
+                            ) {
+                                onRequestContextMenu?.(view, event);
+                            }
+                        }}
+                        title={definition.label}
+                        aria-label={definition.label}
+                        data-active={active || undefined}
+                        data-sidebar-tab={view}
+                        className="no-drag ub-sidebar-tab flex items-center justify-center gap-1.5 text-[11px] font-medium rounded-md"
+                        style={{
+                            flex: compact ? "0 0 auto" : 1,
+                            minWidth: 0,
+                            height: side === "left" ? 28 : 26,
+                            padding: compact ? "0 8px" : "0 6px",
+                            border: active
+                                ? "1px solid color-mix(in srgb, var(--accent) 22%, var(--border))"
+                                : "1px solid transparent",
+                            background: active
+                                ? "color-mix(in srgb, var(--bg-primary) 60%, transparent)"
+                                : "transparent",
+                            color: active
+                                ? "var(--text-primary)"
+                                : "var(--text-secondary)",
+                            boxShadow: active
+                                ? "0 1px 2px rgb(0 0 0 / 0.12)"
+                                : "none",
+                            transition:
+                                "background-color 140ms ease-out, color 140ms ease-out, border-color 140ms ease-out, transform 140ms cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 140ms ease-out",
+                        }}
+                    >
+                        <SidebarViewIcon view={view} />
+                        {!compact && (
+                            <span className="truncate">{definition.label}</span>
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}

--- a/apps/desktop/src/components/layout/SidebarViewContent.tsx
+++ b/apps/desktop/src/components/layout/SidebarViewContent.tsx
@@ -1,0 +1,68 @@
+import {
+    useEditorStore,
+    isNoteTab,
+    selectFocusedEditorTab,
+} from "../../app/store/editorStore";
+import { AgentsSidebarPanel } from "../../features/ai/AgentsSidebarPanel";
+import { BookmarksPanel } from "../../features/bookmarks/BookmarksPanel";
+import { MapsPanel } from "../../features/maps/MapsPanel";
+import { LinksPanel } from "../../features/notes/LinksPanel";
+import { OutlinePanel } from "../../features/notes/OutlinePanel";
+import { TagsPanel } from "../../features/tags/TagsPanel";
+import { FileTree } from "../../features/vault/FileTree";
+import type { SidebarView } from "./sidebarViews";
+
+function OutlineSidebarContent() {
+    const activeNoteId = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
+        return tab && isNoteTab(tab) ? tab.noteId : null;
+    });
+    const activeContent = useEditorStore((state) => {
+        const tab = selectFocusedEditorTab(state);
+        return tab && isNoteTab(tab) ? tab.content : null;
+    });
+    const queueSelectionReveal = useEditorStore(
+        (state) => state.queueSelectionReveal,
+    );
+    if (!activeNoteId) {
+        return (
+            <div
+                className="flex items-center justify-center h-full text-xs"
+                style={{ color: "var(--text-secondary)" }}
+            >
+                No note open
+            </div>
+        );
+    }
+    return (
+        <OutlinePanel
+            content={activeContent}
+            onSelectHeading={(selection) =>
+                queueSelectionReveal({
+                    noteId: activeNoteId,
+                    anchor: selection.anchor,
+                    head: selection.head,
+                })
+            }
+        />
+    );
+}
+
+export function SidebarViewContent({ view }: { view: SidebarView }) {
+    switch (view) {
+        case "files":
+            return <FileTree />;
+        case "agents":
+            return <AgentsSidebarPanel />;
+        case "tags":
+            return <TagsPanel />;
+        case "bookmarks":
+            return <BookmarksPanel />;
+        case "maps":
+            return <MapsPanel />;
+        case "outline":
+            return <OutlineSidebarContent />;
+        case "links":
+            return <LinksPanel />;
+    }
+}

--- a/apps/desktop/src/components/layout/sidebarViews.test.ts
+++ b/apps/desktop/src/components/layout/sidebarViews.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+    getSidebarFallbackView,
+    getSidebarViews,
+    normalizeActiveSidebarView,
+    normalizeMovableSidebarPlacement,
+} from "./sidebarViews";
+
+describe("sidebarViews", () => {
+    it("returns the canonical default order", () => {
+        const placement = { files: "left", agents: "left" } as const;
+        expect(getSidebarViews("left", placement)).toEqual([
+            "files",
+            "agents",
+            "tags",
+            "bookmarks",
+            "maps",
+        ]);
+        expect(getSidebarViews("right", placement)).toEqual([
+            "outline",
+            "links",
+        ]);
+    });
+
+    it.each([
+        ["left", "left"],
+        ["left", "right"],
+        ["right", "left"],
+        ["right", "right"],
+    ] as const)(
+        "places every view exactly once for files=%s agents=%s",
+        (files, agents) => {
+            const placement = { files, agents };
+            const all = [
+                ...getSidebarViews("left", placement),
+                ...getSidebarViews("right", placement),
+            ];
+            expect(all).toHaveLength(7);
+            expect(new Set(all).size).toBe(7);
+        },
+    );
+
+    it("normalizes corrupt and partial placements", () => {
+        expect(normalizeMovableSidebarPlacement(undefined)).toEqual({
+            files: "left",
+            agents: "left",
+        });
+        expect(
+            normalizeMovableSidebarPlacement({
+                files: "right",
+                agents: "elsewhere",
+            }),
+        ).toEqual({ files: "right", agents: "left" });
+    });
+
+    it("uses deterministic side fallbacks", () => {
+        const placement = { files: "right", agents: "left" } as const;
+        expect(getSidebarFallbackView("left", placement)).toBe("agents");
+        expect(getSidebarFallbackView("right", placement)).toBe("outline");
+        expect(normalizeActiveSidebarView("left", "files", placement)).toBe(
+            "agents",
+        );
+    });
+});

--- a/apps/desktop/src/components/layout/sidebarViews.test.ts
+++ b/apps/desktop/src/components/layout/sidebarViews.test.ts
@@ -8,15 +8,15 @@ import {
 
 describe("sidebarViews", () => {
     it("returns the canonical default order", () => {
-        const placement = { files: "left", agents: "left" } as const;
+        const placement = { files: "right", agents: "left" } as const;
         expect(getSidebarViews("left", placement)).toEqual([
-            "files",
             "agents",
             "tags",
             "bookmarks",
             "maps",
         ]);
         expect(getSidebarViews("right", placement)).toEqual([
+            "files",
             "outline",
             "links",
         ]);
@@ -42,7 +42,7 @@ describe("sidebarViews", () => {
 
     it("normalizes corrupt and partial placements", () => {
         expect(normalizeMovableSidebarPlacement(undefined)).toEqual({
-            files: "left",
+            files: "right",
             agents: "left",
         });
         expect(

--- a/apps/desktop/src/components/layout/sidebarViews.ts
+++ b/apps/desktop/src/components/layout/sidebarViews.ts
@@ -1,0 +1,163 @@
+export type SidebarSide = "left" | "right";
+
+export type SidebarView =
+    "files" | "agents" | "tags" | "bookmarks" | "maps" | "outline" | "links";
+
+export type MovableSidebarView = "files" | "agents";
+export type MovableSidebarPlacement = Record<MovableSidebarView, SidebarSide>;
+
+interface SidebarViewDefinition {
+    label: string;
+    defaultSide: SidebarSide;
+    allowedSides: readonly SidebarSide[];
+    order: Record<SidebarSide, number>;
+    compact: boolean;
+    minimumWidth: number;
+}
+
+export const DEFAULT_MOVABLE_SIDEBAR_PLACEMENT: MovableSidebarPlacement = {
+    files: "left",
+    agents: "left",
+};
+
+export const SIDEBAR_VIEW_CATALOG: Record<SidebarView, SidebarViewDefinition> =
+    {
+        files: {
+            label: "Files",
+            defaultSide: "left",
+            allowedSides: ["left", "right"],
+            order: { left: 0, right: 0 },
+            compact: false,
+            minimumWidth: 280,
+        },
+        agents: {
+            label: "Agents",
+            defaultSide: "left",
+            allowedSides: ["left", "right"],
+            order: { left: 1, right: 1 },
+            compact: false,
+            minimumWidth: 280,
+        },
+        tags: {
+            label: "Tags",
+            defaultSide: "left",
+            allowedSides: ["left"],
+            order: { left: 2, right: 99 },
+            compact: true,
+            minimumWidth: 280,
+        },
+        bookmarks: {
+            label: "Bookmarks",
+            defaultSide: "left",
+            allowedSides: ["left"],
+            order: { left: 3, right: 99 },
+            compact: true,
+            minimumWidth: 280,
+        },
+        maps: {
+            label: "Maps",
+            defaultSide: "left",
+            allowedSides: ["left"],
+            order: { left: 4, right: 99 },
+            compact: true,
+            minimumWidth: 280,
+        },
+        outline: {
+            label: "Outline",
+            defaultSide: "right",
+            allowedSides: ["right"],
+            order: { left: 99, right: 2 },
+            compact: false,
+            minimumWidth: 200,
+        },
+        links: {
+            label: "Links",
+            defaultSide: "right",
+            allowedSides: ["right"],
+            order: { left: 99, right: 3 },
+            compact: false,
+            minimumWidth: 200,
+        },
+    };
+
+export const MOVABLE_SIDEBAR_VIEWS: readonly MovableSidebarView[] = [
+    "files",
+    "agents",
+];
+
+export function isMovableSidebarView(
+    view: SidebarView,
+): view is MovableSidebarView {
+    return MOVABLE_SIDEBAR_VIEWS.includes(view as MovableSidebarView);
+}
+
+export function getSidebarViewSide(
+    view: SidebarView,
+    placement: MovableSidebarPlacement,
+): SidebarSide {
+    return isMovableSidebarView(view)
+        ? placement[view]
+        : SIDEBAR_VIEW_CATALOG[view].defaultSide;
+}
+
+export function isViewAvailableOnSide(
+    view: SidebarView,
+    side: SidebarSide,
+    placement: MovableSidebarPlacement,
+) {
+    return getSidebarViewSide(view, placement) === side;
+}
+
+export function getSidebarViews(
+    side: SidebarSide,
+    placement: MovableSidebarPlacement,
+): SidebarView[] {
+    return (Object.keys(SIDEBAR_VIEW_CATALOG) as SidebarView[])
+        .filter((view) => isViewAvailableOnSide(view, side, placement))
+        .sort(
+            (left, right) =>
+                SIDEBAR_VIEW_CATALOG[left].order[side] -
+                SIDEBAR_VIEW_CATALOG[right].order[side],
+        );
+}
+
+export function getSidebarFallbackView(
+    side: SidebarSide,
+    placement: MovableSidebarPlacement,
+): SidebarView {
+    const available = getSidebarViews(side, placement);
+    if (side === "right" && available.includes("outline")) return "outline";
+    return available[0];
+}
+
+export function normalizeActiveSidebarView(
+    side: SidebarSide,
+    view: unknown,
+    placement: MovableSidebarPlacement,
+): SidebarView {
+    if (
+        typeof view === "string" &&
+        view in SIDEBAR_VIEW_CATALOG &&
+        isViewAvailableOnSide(view as SidebarView, side, placement)
+    ) {
+        return view as SidebarView;
+    }
+    return getSidebarFallbackView(side, placement);
+}
+
+export function getSidebarViewMinimumWidth(view: SidebarView) {
+    return SIDEBAR_VIEW_CATALOG[view].minimumWidth;
+}
+
+export function normalizeMovableSidebarPlacement(
+    value: unknown,
+): MovableSidebarPlacement {
+    const record =
+        value && typeof value === "object"
+            ? (value as Record<string, unknown>)
+            : {};
+    return {
+        files: record.files === "right" ? "right" : "left",
+        agents: record.agents === "right" ? "right" : "left",
+    };
+}

--- a/apps/desktop/src/components/layout/sidebarViews.ts
+++ b/apps/desktop/src/components/layout/sidebarViews.ts
@@ -16,7 +16,7 @@ interface SidebarViewDefinition {
 }
 
 export const DEFAULT_MOVABLE_SIDEBAR_PLACEMENT: MovableSidebarPlacement = {
-    files: "left",
+    files: "right",
     agents: "left",
 };
 
@@ -157,7 +157,7 @@ export function normalizeMovableSidebarPlacement(
             ? (value as Record<string, unknown>)
             : {};
     return {
-        files: record.files === "right" ? "right" : "left",
+        files: record.files === "left" ? "left" : "right",
         agents: record.agents === "right" ? "right" : "left",
     };
 }

--- a/docs/project-architecture.md
+++ b/docs/project-architecture.md
@@ -327,4 +327,12 @@ and Electron smoke tests when possible.
   [`apps/web-clipper/src/lib/desktop-api.ts`](../apps/web-clipper/src/lib/desktop-api.ts),
   and [`apps/desktop/src-electron/main/webClipper.ts`](../apps/desktop/src-electron/main/webClipper.ts).
 
-Last updated: June 1, 2026.
+## Sidebar layout ownership
+
+The renderer models sidebar content independently from sidebar geometry. `sidebarViews.ts` owns the canonical view catalog, fixed-side policy, movable placement for Files and Agents, ordering, fallbacks, and minimum widths. `layoutStore.ts` owns persistent placement, one active view per side, collapse state, and dimensions.
+
+`SidebarShell` and `RightSidebarShell` retain platform-specific chrome and render only the active view available on their side through the shared tab strip and content mapping. Files and Agents are auxiliary launchers that can move between sides; they do not own editor tabs, agent sessions, chat content, or workspace panes. Tags, Bookmarks, and Maps remain fixed to the left, while Outline and Links remain fixed to the right.
+
+Reveal and drag flows resolve the current side at runtime. `Reveal in File Tree` activates and mounts Files before emitting its selection intent, and `AppLayout` pins only the peek overlay where a file or agent drag began. Right-side geometry keeps a 200 px minimum for Outline and Links and a 280 px minimum for Files and Agents, with the same 2000 px nominal maximum as the left sidebar.
+
+Last updated: August 14, 2026.


### PR DESCRIPTION
## Summary

- add a canonical sidebar view catalog with persistent, validated placement for Files and Agents
- share sidebar tabs and content rendering while preserving side-specific chrome and fixed views
- expose bidirectional movement through accessible context menus and conditional command palette actions
- make file-tree reveal, drag-origin tracking, Arc peeks, and right-panel minimum widths side-aware
- update workspace contracts, architecture documentation, and the changelog

## Behavior

Files and Agents can move independently between the left and right sidebars and return to their original side. Moving a view activates and opens the destination, chooses a deterministic fallback in the source, and persists the resulting layout. Tags, Bookmarks, and Maps remain left-only; Outline and Links remain right-only.

The right sidebar keeps a 200 px minimum for Outline and Links and uses a 280 px minimum for Files and Agents, while retaining the existing expansion range. Reveal in File Tree now mounts Files on its current side before dispatching the reveal event, and file or agent drags pin only the peek overlay where the drag began.

## Validation

- npm run lint
- npm test — 208 files passed, 2543 tests passed, 2 todo
- npm run build

## Out of scope

- dragging tabs physically between sidebars
- free tab reordering
- moving Tags, Bookmarks, Maps, Outline, or Links