### PR TITLE
Prepare 0.7.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,11 +34,28 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
-## [Unreleased]
+## [0.7.2] - 2026-08-14
 
 ### Added
 
+- Added canonical AI conversations with durable conversation identities and persisted provider bindings, allowing chat state, transcripts, and provider configuration to survive reloads, reconnects, and history migration.
+- Added a unified ACP provider and model picker with provider-specific model catalogs, model-aware reasoning and service-tier controls, staged selections, and setup and availability feedback.
+- Added Claude subscription authentication to AI provider setup.
 - Added bidirectional placement for the Files and Agents sidebar views, with accessible context-menu and command-palette actions, persistent layout preferences, side-aware reveal and drag behavior, and adaptive right-sidebar sizing.
+
+### Changed
+
+- Updated the embedded Codex ACP runtime to `0.147.0`, including the `codex-acp` executable as the default Codex runtime and improved support for subagent lifecycle events.
+- Changed ACP conversation routing to select the appropriate continuation strategy, including bounded transcript handoff when a runtime cannot continue a native session, while preserving canonical conversation and provider state across turns.
+- Locked provider changes after a conversation begins and kept staged model and configuration choices scoped to the active conversation.
+- Refined AI provider and model controls with anchored popovers, clearer model labels, and improved keyboard and focus behavior.
+
+### Fixed
+
+- Fixed restored and migrated AI sessions losing provider bindings, model or configuration selections, and canonical conversation identity.
+- Fixed AI activity and change-review event handling across runtime upgrades, reconnects, persisted sessions, and subagent lifecycle changes.
+- Fixed subagent activity being duplicated or attached to stale child sessions, and preserved authoritative activity timestamps across restored sessions.
+- Fixed Claude subscription authentication status handling when OAuth sessions expire or status probes stall.
 
 ## [0.7.1] - 2026-08-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.7.1",
+    "version": "0.7.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.7.1",
+            "version": "0.7.2",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.7.1",
+    "version": "0.7.2",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.7.1",
+    "version": "0.7.2",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Align the desktop app, native backend, Web Clipper, and lockfiles at version 0.7.2.
- Promote the completed 0.7.2 changelog entry from Unreleased.
- Keep release metadata consistent for the tag-driven desktop release workflow.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.7.2`
- `node --test scripts/release-metadata.test.mjs`
- `cargo check -p neverwrite-native-backend`
- `cargo check --locked -p neverwrite-native-backend`
- `git diff --check`

All checks passed locally.