### PR TITLE
Fix nanoid zero-size generator vulnerability

### DIFF
--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1616,9 +1616,9 @@
             }
         },
         "node_modules/@excalidraw/excalidraw/node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -115,7 +115,7 @@
             "lodash-es": "4.18.1"
         },
         "@excalidraw/excalidraw": {
-            "nanoid": "3.3.17"
+            "nanoid": "3.3.18"
         },
         "@excalidraw/mermaid-to-excalidraw": {
             "nanoid": "5.1.16"


### PR DESCRIPTION
## Summary

- Update the Excalidraw nanoid override from 3.3.17 to 3.3.18.
- Refresh the locked package version and integrity hash.

## Impact

This removes the vulnerable transitive nanoid version associated with GHSA-2v37-7h3g-55p8 / CVE-2026-67213, which can hang a calling thread when custom generators receive a zero size.

## Validation

- `npm ls nanoid --all --package-lock-only` resolves Excalidraw to 3.3.18.
- `npm audit` no longer reports a nanoid vulnerability.
- `npm run build` passes; existing CSS warnings about `::highlight` remain unchanged.