### PR TITLE
Add per-vault UI font setting

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useLayoutEffect, useCallback, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
 import { getCurrentWindow } from "@neverwrite/runtime";
 import { listen } from "@neverwrite/runtime";
@@ -72,6 +72,7 @@ import {
 import { useVaultStore, type VaultNoteChange } from "./app/store/vaultStore";
 import { useLayoutStore } from "./app/store/layoutStore";
 import { useSettingsStore } from "./app/store/settingsStore";
+import { resolveFontFamily } from "./app/utils/fontFamily";
 import { formatShortcutAction } from "./app/shortcuts/format";
 import {
     matchesShortcutAction,
@@ -1145,6 +1146,7 @@ function useDynamicScrollbars() {
 }
 
 export default function App() {
+    const uiFontFamily = useSettingsStore((s) => s.uiFontFamily);
     const editorPaneSizes = useLayoutStore((s) => s.editorPaneSizes);
     const setEditorPaneSizes = useLayoutStore((s) => s.setEditorPaneSizes);
     const restoreVault = useVaultStore((s) => s.restoreVault);
@@ -1178,6 +1180,20 @@ export default function App() {
             vaultParam === null
         ),
     );
+
+    useLayoutEffect(() => {
+        const root = document.documentElement;
+        const previousFont = root.style.getPropertyValue("--font-ui");
+        root.style.setProperty("--font-ui", resolveFontFamily(uiFontFamily));
+
+        return () => {
+            if (previousFont) {
+                root.style.setProperty("--font-ui", previousFont);
+            } else {
+                root.style.removeProperty("--font-ui");
+            }
+        };
+    }, [uiFontFamily]);
     const pendingNoteReloadsRef = useRef<
         Map<string, ReturnType<typeof setTimeout>>
     >(new Map());

--- a/apps/desktop/src/app/store/settingsStore.test.ts
+++ b/apps/desktop/src/app/store/settingsStore.test.ts
@@ -28,6 +28,7 @@ describe("settingsStore", () => {
     });
 
     it("defaults app settings", () => {
+        expect(useSettingsStore.getState().uiFontFamily).toBe("system");
         expect(useSettingsStore.getState().terminalFontFamily).toBe("");
         expect(useSettingsStore.getState().terminalFontSize).toBe(13);
         expect(useSettingsStore.getState().claudeCodeEnabled).toBe(false);
@@ -148,6 +149,7 @@ describe("settingsStore", () => {
         useSettingsStore.getState().setSetting("fileTreeStickyFolders", false);
         useSettingsStore.getState().setSetting("agentsSidebarScale", 125);
         useSettingsStore.getState().setSetting("editorAutosaveDelayMs", 750);
+        useSettingsStore.getState().setSetting("uiFontFamily", "geist");
 
         expect(useSettingsStore.getState().aiReviewEnabled).toBe(false);
         expect(useSettingsStore.getState().inlineReviewEnabled).toBe(false);
@@ -155,6 +157,7 @@ describe("settingsStore", () => {
         expect(useSettingsStore.getState().fileTreeStickyFolders).toBe(false);
         expect(useSettingsStore.getState().agentsSidebarScale).toBe(125);
         expect(useSettingsStore.getState().editorAutosaveDelayMs).toBe(750);
+        expect(useSettingsStore.getState().uiFontFamily).toBe("geist");
         expect(
             JSON.parse(
                 localStorage.getItem("neverwrite:settings:/vaults/devtools") ?? "",
@@ -167,8 +170,22 @@ describe("settingsStore", () => {
                 fileTreeStickyFolders: false,
                 agentsSidebarScale: 125,
                 editorAutosaveDelayMs: 750,
+                uiFontFamily: "geist",
             },
         });
+    });
+
+    it("keeps the interface font per vault", () => {
+        useVaultStore.setState({ vaultPath: "/vaults/interface-one" });
+        useSettingsStore.getState().setSetting("uiFontFamily", "geist");
+
+        useVaultStore.setState({ vaultPath: "/vaults/interface-two" });
+        expect(useSettingsStore.getState().uiFontFamily).toBe("system");
+
+        useSettingsStore.getState().setSetting("uiFontFamily", "atkinson");
+
+        useVaultStore.setState({ vaultPath: "/vaults/interface-one" });
+        expect(useSettingsStore.getState().uiFontFamily).toBe("geist");
     });
 
     it("keeps AI change review enabled for older vault settings", () => {

--- a/apps/desktop/src/app/store/settingsStore.ts
+++ b/apps/desktop/src/app/store/settingsStore.ts
@@ -12,6 +12,9 @@ export interface Settings {
     // General
     openLastVaultOnLaunch: boolean;
 
+    // Appearance
+    uiFontFamily: EditorFontFamily;
+
     // Editor
     editorFontSize: number; // 10–24
     editorFontFamily: EditorFontFamily;
@@ -187,8 +190,23 @@ export const EDITOR_FONT_FAMILY_OPTIONS: {
     { value: "typewriter", label: "Typewriter", group: "Mono" },
 ];
 
+export const UI_FONT_FAMILY_OPTIONS: {
+    value: EditorFontFamily;
+    label: string;
+}[] = [
+    { value: "system", label: "System" },
+    { value: "sans", label: "Inter" },
+    { value: "geist", label: "Geist" },
+    { value: "geist-mono", label: "Geist Mono" },
+    { value: "jetbrains", label: "JetBrains Mono" },
+    { value: "ibm-plex-mono", label: "IBM Plex Mono" },
+    { value: "atkinson", label: "Atkinson Hyperlegible" },
+    { value: "rounded", label: "Rounded (SF Pro)" },
+];
+
 const defaults: Settings = {
     openLastVaultOnLaunch: true,
+    uiFontFamily: "system",
     editorFontSize: 14,
     editorFontFamily: "system",
     editorLineHeight: 175,
@@ -466,6 +484,7 @@ function extractSettingsFromStorage(raw: string | null): Settings | null {
             openLastVaultOnLaunch:
                 parsed.state.openLastVaultOnLaunch ??
                 defaults.openLastVaultOnLaunch,
+            uiFontFamily: normalizeEditorFontFamily(parsed.state.uiFontFamily),
             editorFontSize: normalizeIntInRange(
                 parsed.state.editorFontSize,
                 defaults.editorFontSize,
@@ -636,6 +655,7 @@ function hasStoredSpellcheckSettings(raw: string | null) {
 function pickSettings(state: SettingsStore): Settings {
     return {
         openLastVaultOnLaunch: state.openLastVaultOnLaunch,
+        uiFontFamily: state.uiFontFamily,
         editorFontSize: state.editorFontSize,
         editorFontFamily: state.editorFontFamily,
         editorLineHeight: state.editorLineHeight,

--- a/apps/desktop/src/app/utils/fontFamily.ts
+++ b/apps/desktop/src/app/utils/fontFamily.ts
@@ -1,0 +1,53 @@
+import type { EditorFontFamily } from "../store/settingsStore";
+
+export function resolveFontFamily(fontFamily: EditorFontFamily) {
+    switch (fontFamily) {
+        case "sans":
+            return '"Inter", "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif';
+        case "geist":
+            return '"Geist", "Inter", system-ui, sans-serif';
+        case "atkinson":
+            return '"Atkinson Hyperlegible", system-ui, sans-serif';
+        case "serif":
+            return '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif';
+        case "literata":
+            return '"Literata", Georgia, serif';
+        case "lora":
+            return '"Lora", "Palatino Linotype", Georgia, serif';
+        case "merriweather":
+            return '"Merriweather", Georgia, serif';
+        case "source-serif":
+            return '"Source Serif 4", Georgia, "Iowan Old Style", serif';
+        case "mono":
+            return '"JetBrains Mono", "SFMono-Regular", "Fira Code", Menlo, Monaco, Consolas, monospace';
+        case "jetbrains":
+            return '"JetBrains Mono", "Fira Code", Menlo, Monaco, Consolas, monospace';
+        case "fliege-mono":
+            return '"Fliege Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
+        case "geist-mono":
+            return '"Geist Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
+        case "ibm-plex-mono":
+            return '"IBM Plex Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
+        case "courier":
+            return '"Courier New", Courier, "Nimbus Mono PS", monospace';
+        case "reading":
+            return '"Charter", "Baskerville", "Georgia", serif';
+        case "rounded":
+            return '"SF Pro Rounded", "Nunito", "Avenir Next Rounded", "Hiragino Maru Gothic ProN", sans-serif';
+        case "humanist":
+            return '"Optima", "Gill Sans", "Trebuchet MS", "Segoe UI", sans-serif';
+        case "slab":
+            return '"Rockwell", "Clarendon Text", "Roboto Slab", "Courier Prime", serif';
+        case "typewriter":
+            return '"American Typewriter", "Courier Prime", "Courier New", "Nimbus Mono PS", monospace';
+        case "newspaper":
+            return '"Times New Roman", "Georgia", "Source Serif 4", "Iowan Old Style", serif';
+        case "condensed":
+            return '"Avenir Next Condensed", "Arial Narrow", "Roboto Condensed", "Helvetica Neue", sans-serif';
+        case "andale":
+            return '"Andale Mono", Menlo, Monaco, Consolas, monospace';
+        case "system":
+        default:
+            return 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
+    }
+}

--- a/apps/desktop/src/features/editor/editorExtensions.ts
+++ b/apps/desktop/src/features/editor/editorExtensions.ts
@@ -13,7 +13,6 @@ import { Compartment, RangeSetBuilder, type Extension } from "@codemirror/state"
 import { syntaxTree, syntaxHighlighting } from "@codemirror/language";
 import { buildSyntaxHighlightStyle } from "./extensions/syntaxTheme";
 import type {
-    EditorFontFamily,
     SpellcheckLanguage,
     SpellcheckSecondaryLanguage,
 } from "../../app/store/settingsStore";
@@ -25,6 +24,8 @@ import { vimStatusBarExtension } from "./extensions/vimStatusBar";
 import { resolveWikilink } from "./wikilinkResolution";
 import { navigateWikilink, getNoteLinkTarget } from "./wikilinkNavigation";
 import { resolveFrontendSpellcheckLanguage } from "../spellcheck/api";
+
+export { resolveFontFamily as getEditorFontFamily } from "../../app/utils/fontFamily";
 
 export type LinkContextMenuState = {
     x: number;
@@ -408,56 +409,4 @@ export function getSpellcheckExtension(
               }
             : {}),
     });
-}
-
-export function getEditorFontFamily(fontFamily: EditorFontFamily) {
-    switch (fontFamily) {
-        case "sans":
-            return '"Inter", "IBM Plex Sans", "Avenir Next", "Segoe UI", sans-serif';
-        case "geist":
-            return '"Geist", "Inter", system-ui, sans-serif';
-        case "atkinson":
-            return '"Atkinson Hyperlegible", system-ui, sans-serif';
-        case "serif":
-            return '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", Georgia, serif';
-        case "literata":
-            return '"Literata", Georgia, serif';
-        case "lora":
-            return '"Lora", "Palatino Linotype", Georgia, serif';
-        case "merriweather":
-            return '"Merriweather", Georgia, serif';
-        case "source-serif":
-            return '"Source Serif 4", Georgia, "Iowan Old Style", serif';
-        case "mono":
-            return '"JetBrains Mono", "SFMono-Regular", "Fira Code", Menlo, Monaco, Consolas, monospace';
-        case "jetbrains":
-            return '"JetBrains Mono", "Fira Code", Menlo, Monaco, Consolas, monospace';
-        case "fliege-mono":
-            return '"Fliege Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
-        case "geist-mono":
-            return '"Geist Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
-        case "ibm-plex-mono":
-            return '"IBM Plex Mono", "JetBrains Mono", Menlo, Monaco, Consolas, monospace';
-        case "courier":
-            return '"Courier New", Courier, "Nimbus Mono PS", monospace';
-        case "reading":
-            return '"Charter", "Baskerville", "Georgia", serif';
-        case "rounded":
-            return '"SF Pro Rounded", "Nunito", "Avenir Next Rounded", "Hiragino Maru Gothic ProN", sans-serif';
-        case "humanist":
-            return '"Optima", "Gill Sans", "Trebuchet MS", "Segoe UI", sans-serif';
-        case "slab":
-            return '"Rockwell", "Clarendon Text", "Roboto Slab", "Courier Prime", serif';
-        case "typewriter":
-            return '"American Typewriter", "Courier Prime", "Courier New", "Nimbus Mono PS", monospace';
-        case "newspaper":
-            return '"Times New Roman", "Georgia", "Source Serif 4", "Iowan Old Style", serif';
-        case "condensed":
-            return '"Avenir Next Condensed", "Arial Narrow", "Roboto Condensed", "Helvetica Neue", sans-serif';
-        case "andale":
-            return '"Andale Mono", Menlo, Monaco, Consolas, monospace';
-        case "system":
-        default:
-            return 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif';
-    }
 }

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -327,6 +327,40 @@ describe("SettingsPanel", () => {
         expect(useSettingsStore.getState().aiChatContentWidth).toBe(800);
     });
 
+    it("sets the interface font from Appearance", () => {
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+
+        fireEvent.click(screen.getByRole("button", { name: "Appearance" }));
+
+        const label = screen.getByText("Interface font");
+        const row = label.parentElement?.parentElement;
+        expect(row).not.toBeNull();
+
+        fireEvent.click(
+            within(row as HTMLElement).getByRole("button", {
+                name: "System",
+            }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Geist" }));
+
+        expect(useSettingsStore.getState().uiFontFamily).toBe("geist");
+
+        fireEvent.click(
+            within(row as HTMLElement).getByRole("button", {
+                name: "Geist",
+            }),
+        );
+        expect(
+            screen.getByRole("button", { name: "Geist Mono" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "JetBrains Mono" }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole("button", { name: "IBM Plex Mono" }),
+        ).toBeInTheDocument();
+    });
+
     it("filters recent vaults in a scrollable list", () => {
         localStorage.setItem(
             "neverwrite:recentVaults",

--- a/apps/desktop/src/features/settings/SettingsPanel.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import { openPath, openUrl, revealItemInDir } from "@neverwrite/runtime";
 import {
     EDITOR_FONT_FAMILY_OPTIONS,
     PDF_DEFAULT_ZOOM_STEPS,
+    UI_FONT_FAMILY_OPTIONS,
     useSettingsStore,
     type EditorFontFamily,
     type SpellcheckLanguage,
@@ -985,6 +986,7 @@ function AppearanceSettings({
         agentsSidebarScale,
         fileTreeStickyFolders,
         aiChatContentWidth,
+        uiFontFamily,
         setSetting,
     } = useSettingsStore();
     const [appZoomPercent, setAppZoomPercent] = useAppZoomPercent();
@@ -1028,6 +1030,20 @@ function AppearanceSettings({
             ],
         ],
     );
+    const showInterface = sectionHasSettingsSearchMatches(
+        searchQuery,
+        "Interface",
+        [
+            [
+                "Interface font",
+                "Font used for app controls and navigation. Editor, chat, composer, terminal, and code surfaces keep their own font settings.",
+                ...UI_FONT_FAMILY_OPTIONS.flatMap((option) => [
+                    option.value,
+                    option.label,
+                ]),
+            ],
+        ],
+    );
     const showZoom = sectionHasSettingsSearchMatches(searchQuery, "Zoom", [
         [
             "App zoom",
@@ -1042,7 +1058,14 @@ function AppearanceSettings({
         ],
     ]);
 
-    if (!showMode && !showTheme && !showNavigation && !showZoom && !showChat) {
+    if (
+        !showMode &&
+        !showTheme &&
+        !showInterface &&
+        !showNavigation &&
+        !showZoom &&
+        !showChat
+    ) {
         return <EmptyPanelSearchResult />;
     }
 
@@ -1074,6 +1097,30 @@ function AppearanceSettings({
                     <ThemePicker value={themeName} onChange={setThemeName} />
                 </>
             ) : null}
+
+            {showInterface ? <SectionLabel>Interface</SectionLabel> : null}
+            <SearchableRow
+                searchQuery={searchQuery}
+                section="Interface"
+                label="Interface font"
+                description="Font used for app controls and navigation. Editor, chat, composer, terminal, and code surfaces keep their own font settings."
+                keywords={UI_FONT_FAMILY_OPTIONS.flatMap((option) => [
+                    option.value,
+                    option.label,
+                ])}
+                control={
+                    <SelectField
+                        value={uiFontFamily}
+                        options={UI_FONT_FAMILY_OPTIONS}
+                        onChange={(value) =>
+                            setSetting(
+                                "uiFontFamily",
+                                value as EditorFontFamily,
+                            )
+                        }
+                    />
+                }
+            />
 
             {showNavigation ? <SectionLabel>Navigation</SectionLabel> : null}
             <SearchableRow

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -455,10 +455,7 @@ body,
 body {
     background-color: var(--bg-primary);
     color: var(--text-primary);
-    font-family:
-        system-ui,
-        -apple-system,
-        sans-serif;
+    font-family: var(--font-ui, system-ui, -apple-system, sans-serif);
     text-rendering: optimizeLegibility;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/docs/settings-scope.md
+++ b/docs/settings-scope.md
@@ -66,6 +66,7 @@ the same Settings stores.
 | General / Tabs | `tabOpenBehavior` | Per-vault | `history` | `neverwrite:settings:<vault-path>` | Valid values are `history` and `new_tab`. |
 | Appearance / Mode | `mode` | Per-vault, legacy global fallback | `system` | `neverwrite:theme:<vault-path>` | Valid values are `system`, `light`, and `dark`. |
 | Appearance / Mode | `themeName` | Per-vault, legacy global fallback | `default` | `neverwrite:theme:<vault-path>` | `isDark` is derived from `mode` plus OS preference. |
+| Appearance / Interface | `uiFontFamily` | Per-vault | `system` | `neverwrite:settings:<vault-path>` | Font used for app controls and navigation. Editor, chat, composer, terminal, and code surfaces keep their own font settings. |
 | Appearance / Navigation | `fileTreeScale` | Per-vault | `114` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `agentsSidebarScale` | Per-vault | `100` | `neverwrite:settings:<vault-path>` | Clamped to `90..140`. |
 | Appearance / Navigation | `fileTreeStickyFolders` | Per-vault | `true` | `neverwrite:settings:<vault-path>` | Controls sticky parent folders in the file tree. |


### PR DESCRIPTION
Adds a per-vault UI font preference with curated sans and monospace choices. Keeps editor, chat, terminal, code, and diff typography independent.

Checks: 2547 tests passing, lint, build.