### PR TITLE
Fix expanded composer rounded margins

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -723,17 +723,15 @@ describe("AIChatSessionView", () => {
         );
         expect(expandedRegion).toHaveClass(
             "absolute",
-            "inset-0",
+            "inset-2",
         );
         expect(expandedRegion).not.toHaveClass(
             "nw-chat-translucent-surface",
         );
         expect(screen.getByTestId("chat-glass-surface")).toHaveClass(
             "nw-chat-translucent-surface",
-            "flex-1",
-        );
-        expect(screen.getByTestId("chat-glass-surface")).not.toHaveClass(
             "nw-chat-floating-surface",
+            "flex-1",
         );
         expect(screen.getByTestId("chat-message-list")).toBeInTheDocument();
         expect(screen.getByTestId("chat-transcript-region")).toHaveAttribute(

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -1238,17 +1238,17 @@ export function AIChatSessionView({ paneId, tabId }: AIChatSessionViewProps) {
                             ? "chat-expanded-composer-region"
                             : "chat-bottom-dock"
                     }
-                    className={
-                        composerExpanded
-                            ? "absolute inset-0 z-20 flex min-h-0 flex-col"
-                            : "nw-chat-bottom-dock absolute inset-x-0 bottom-0 z-20 flex max-h-full flex-col px-2 pb-2"
-                    }
+                        className={
+                            composerExpanded
+                                ? "absolute inset-2 z-20 flex min-h-0 flex-col"
+                                : "nw-chat-bottom-dock absolute inset-x-0 bottom-0 z-20 flex max-h-full flex-col px-2 pb-2"
+                        }
                 >
                     <div
                         data-testid="chat-glass-surface"
                         className={
                             composerExpanded
-                                ? "nw-chat-translucent-surface flex min-h-0 flex-1 flex-col"
+                                ? "nw-chat-translucent-surface nw-chat-floating-surface flex min-h-0 flex-1 flex-col"
                                 : "nw-chat-translucent-surface nw-chat-floating-surface flex min-h-0 max-h-full flex-col"
                         }
                         style={


### PR DESCRIPTION
Keeps the expanded composer rounded and inset from the viewport.

Tests: `npm test -- AIChatSessionView.test.tsx`