### PR TITLE
Prepare 0.7.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,30 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.7.3] - 2026-08-16
+
+### Added
+
+- Added per-vault interface font selection for app controls and navigation, with support for system, sans, mono, rounded, and accessibility-focused font families.
+- Added configurable glass opacity for translucent interface surfaces, including the composer and menus.
+- Added document status filtering to the file tree, including filters for each known status and documents without a status.
+- Added a prompt history minimap to the chat transcript for quickly locating and navigating between prompts.
+
+### Changed
+
+- Refined chat glass surfaces across the composer, plan banner, menus, scroll controls, and other chat overlays, with clearer translucency, blur, borders, and spacing in compact and expanded layouts.
+- Consolidated compact composer mode, reasoning, service-tier, and other configuration controls into a dedicated options menu to preserve space in narrow chat panes.
+- Updated the embedded Claude ACP runtime to `0.68.0` and aligned its Claude Agent SDK dependencies with the upstream release.
+
+### Fixed
+
+- Fixed ACP mode and configuration synchronization after model changes so stale or unavailable selections are reconciled before a turn is sent.
+- Fixed chat pane minimum-width handling and expanded composer rounded margins so the composer and surrounding glass surfaces retain consistent geometry.
+
+### Security
+
+- Patched the Nano ID zero-size generator vulnerability by updating the Excalidraw-pinned `nanoid` dependency to `3.3.18`.
+
 ## [0.7.2] - 2026-08-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.7.2",
+    "version": "0.7.3",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.7.2",
+            "version": "0.7.3",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.7.2",
+    "version": "0.7.3",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.7.2",
+    "version": "0.7.3",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Align the desktop, native backend, Cargo lockfile, and Web Clipper versions at `0.7.3`.
- Add the `0.7.3` changelog entry covering the release changes since `0.7.2`.

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.7.3`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`

 