### PR TITLE
Restore composer drop highlight

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.test.tsx
@@ -344,6 +344,50 @@ describe("AIChatComposer mention picker", () => {
         });
     });
 
+    it("exposes file-tree drag state to the visible composer surface", () => {
+        renderComposer();
+
+        const dropZone = document.querySelector(
+            '[data-ai-composer-drop-zone="true"]',
+        );
+        expect(dropZone).not.toHaveAttribute(
+            "data-ai-composer-drop-active",
+        );
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "start",
+                        x: 0,
+                        y: 0,
+                        notes: [],
+                    },
+                }),
+            );
+        });
+        expect(dropZone).toHaveAttribute(
+            "data-ai-composer-drop-active",
+            "true",
+        );
+
+        act(() => {
+            window.dispatchEvent(
+                new CustomEvent(FILE_TREE_NOTE_DRAG_EVENT, {
+                    detail: {
+                        phase: "cancel",
+                        x: 0,
+                        y: 0,
+                        notes: [],
+                    },
+                }),
+            );
+        });
+        expect(dropZone).not.toHaveAttribute(
+            "data-ai-composer-drop-active",
+        );
+    });
+
     it("reserves top spacing only when the context bar is present", () => {
         renderComposer({
             contextBar: <div data-testid="test-context-bar">Context</div>,

--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -1689,6 +1689,7 @@ export function AIChatComposer({
             ref={shellRef}
             data-ai-composer-drop-zone="true"
             data-ai-composer-session-id={sessionId}
+            data-ai-composer-drop-active={externalDragActive || undefined}
             className={
                 expanded
                     ? "flex h-full min-h-0 flex-1 flex-col"
@@ -1723,10 +1724,6 @@ export function AIChatComposer({
                     borderTop: "none",
                     borderRadius: 0,
                     backgroundColor: "transparent",
-                    boxShadow: externalDragActive
-                        ? "0 0 0 2px color-mix(in srgb, var(--accent) 20%, transparent)"
-                        : "none",
-                    transition: "box-shadow 0.15s ease",
                     maxHeight: "100%",
                     ...(expanded || customHeight == null
                         ? {}

--- a/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.test.tsx
@@ -508,15 +508,11 @@ describe("StackedPaneContent", () => {
         const composerDropZone = container.querySelector(
             '[data-ai-composer-drop-zone="true"]',
         ) as HTMLElement | null;
-        const composerShell = composerDropZone?.querySelector(
-            '[data-testid="chat-composer-shell"]',
-        ) as HTMLElement | null;
 
         expect(sourceColumn).not.toBeNull();
         expect(secondColumn).not.toBeNull();
         expect(sourceSpine).not.toBeNull();
         expect(composerDropZone).not.toBeNull();
-        expect(composerShell).not.toBeNull();
 
         vi.spyOn(tablist, "getBoundingClientRect").mockReturnValue(
             rect({ left: 100, top: 10, width: 600, height: 300 }),
@@ -578,7 +574,10 @@ describe("StackedPaneContent", () => {
         await waitFor(() => {
             expect(sourceColumn).toHaveStyle({ opacity: "0.5" });
         });
-        expect(composerShell!.style.boxShadow).toContain("color-mix");
+        expect(composerDropZone).toHaveAttribute(
+            "data-ai-composer-drop-active",
+            "true",
+        );
 
         await act(async () => {
             dispatchPointerEvent(window, "pointerup", {
@@ -671,15 +670,11 @@ describe("StackedPaneContent", () => {
         const composerDropZone = container.querySelector(
             '[data-ai-composer-drop-zone="true"]',
         ) as HTMLElement | null;
-        const composerShell = composerDropZone?.querySelector(
-            '[data-testid="chat-composer-shell"]',
-        ) as HTMLElement | null;
 
         expect(sourceColumn).not.toBeNull();
         expect(activeColumn).not.toBeNull();
         expect(rightColumn).not.toBeNull();
         expect(composerDropZone).not.toBeNull();
-        expect(composerShell).not.toBeNull();
 
         vi.spyOn(tablist, "getBoundingClientRect").mockReturnValue(
             rect({ left: 100, top: 10, width: 600, height: 300 }),
@@ -755,7 +750,10 @@ describe("StackedPaneContent", () => {
         await waitFor(() => {
             expect(sourceColumn).toHaveStyle({ opacity: "0.5" });
         });
-        expect(composerShell!.style.boxShadow).toContain("color-mix");
+        expect(composerDropZone).toHaveAttribute(
+            "data-ai-composer-drop-active",
+            "true",
+        );
 
         await act(async () => {
             dispatchPointerEvent(window, "pointerup", {

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -1653,12 +1653,31 @@ body.dragging-tab * {
     border: 1px solid var(--nw-glass-outline);
     border-radius: 20px;
     box-shadow: 0 14px 32px -22px color-mix(in srgb, black 52%, transparent);
+    transition:
+        border-color 150ms ease,
+        box-shadow 150ms ease;
 }
 
 .dark .nw-chat-floating-surface {
     box-shadow:
         inset 0 1px color-mix(in srgb, white 4%, transparent),
         0 18px 40px -26px color-mix(in srgb, black 82%, transparent);
+}
+
+/* The floating glass surface owns the composer's visible edge. Paint the drop
+   affordance here so its glow is not clipped by the surface's overflow mask. */
+.nw-chat-floating-surface:has(
+        [data-ai-composer-drop-active="true"]
+    ) {
+    border-color: color-mix(
+        in srgb,
+        var(--accent) 62%,
+        var(--nw-glass-outline)
+    );
+    box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--accent) 18%, transparent),
+        0 0 0 3px color-mix(in srgb, var(--accent) 14%, transparent),
+        0 16px 38px -22px color-mix(in srgb, var(--accent) 42%, transparent);
 }
 
 /* Portalled menus use a slightly denser recipe than the composer. The extra


### PR DESCRIPTION
## Summary

- expose the composer drag-over state to the visible floating glass surface
- render a theme-aware accent border and glow during vault and native file drags
- add regression coverage for activating and clearing the drop state

## Root cause

The composer modernization moved the visible border to an overflow-clipped glass container. The existing drop highlight remained on a transparent child, so its outer box shadow was clipped and no longer visible.

## Impact

Dragging notes, folders, or files over the composer once again provides a clear drop-target affordance. The effect uses semantic theme tokens, so it adapts to every light and dark theme.

## Validation

- `npm test -- --run src/features/ai/components/AIChatComposer.test.tsx`
- `npx eslint src/features/ai/components/AIChatComposer.tsx src/features/ai/components/AIChatComposer.test.tsx`
- `npm run build`
- `git diff --check`