### PR TITLE
Add copy path action to note tabs

### DIFF
--- a/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.test.tsx
@@ -192,6 +192,38 @@ describe("EditorPaneBar", () => {
         ).not.toBeNull();
     });
 
+    it("copies the full note path from the tab context menu", async () => {
+        const user = userEvent.setup();
+        const writeText = vi
+            .spyOn(navigator.clipboard, "writeText")
+            .mockResolvedValue(undefined);
+        useVaultStore.setState({
+            vaultPath: "/vault",
+            notes: [
+                {
+                    id: "notes/a",
+                    path: "/vault/notes/a.md",
+                    title: "Alpha",
+                    modified_at: 1,
+                    created_at: 1,
+                },
+            ],
+        });
+
+        renderComponent(<EditorPaneBar paneId="primary" isFocused />);
+
+        const tabButton = document.querySelector(
+            '[data-pane-tab-id="tab-a"]',
+        ) as HTMLElement | null;
+        expect(tabButton).not.toBeNull();
+        fireEvent.contextMenu(tabButton!);
+        await user.click(
+            await screen.findByRole("button", { name: "Copy Path" }),
+        );
+
+        expect(writeText).toHaveBeenCalledWith("/vault/notes/a.md");
+    });
+
     it("shows pane history navigation buttons when open behavior uses history", () => {
         useSettingsStore.getState().setSetting("tabOpenBehavior", "history");
 

--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -139,6 +139,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
     );
     const tabOpenBehavior = useSettingsStore((state) => state.tabOpenBehavior);
     const vaultPath = useVaultStore((state) => state.vaultPath);
+    const notes = useVaultStore((state) => state.notes);
     const [tabContextMenu, setTabContextMenu] = useState<ContextMenuState<{
         tabId: string;
     }> | null>(null);
@@ -925,6 +926,12 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                         const targetTabIndex = pane.tabs.findIndex(
                             (candidate) => candidate.id === targetTab.id,
                         );
+                        const targetNotePath =
+                            isNoteTab(targetTab) && !isSearchTab(targetTab)
+                                ? (notes.find(
+                                      (note) => note.id === targetTab.noteId,
+                                  )?.path ?? null)
+                                : null;
 
                         const entries: ContextMenuEntry[] = [
                             {
@@ -932,6 +939,17 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                 action: () =>
                                     togglePaneTabPinned(paneId, targetTab.id),
                             },
+                            ...(targetNotePath
+                                ? [
+                                      {
+                                          label: "Copy Path",
+                                          action: () =>
+                                              void navigator.clipboard.writeText(
+                                                  targetNotePath,
+                                              ),
+                                      },
+                                  ]
+                                : []),
                             {
                                 label: "Close",
                                 action: () =>


### PR DESCRIPTION
## Summary

- add a `Copy Path` action to note tab context menus
- copy the note's full absolute path, including the `.md` extension
- keep the action unavailable for search and non-note tabs
- add focused test coverage for clipboard behavior

## Why

Power users need a direct way to copy a note's filesystem path without locating it in the file tree first.

## Validation

- `npm test -- --run src/features/editor/EditorPaneBar.test.tsx` (27 tests passed)
- `npx eslint src/features/editor/EditorPaneBar.tsx src/features/editor/EditorPaneBar.test.tsx`
- `git diff --check`