### PR TITLE
Reveal user message metadata on hover

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.test.tsx
@@ -412,7 +412,7 @@ describe("AIChatMessageItem user image attachments", () => {
         );
     });
 
-    it("shows sent time and copies the user message", async () => {
+    it("reveals reserved user metadata on hover or focus and copies the message", async () => {
         const timestamp = Date.parse("2026-07-11T15:42:00Z");
         const view = renderMessage({
             id: "user:copy",
@@ -422,6 +422,17 @@ describe("AIChatMessageItem user image attachments", () => {
             timestamp,
         });
 
+        expect(view.container.querySelector("[data-user-message]")).toHaveClass(
+            "group",
+        );
+        expect(
+            view.container.querySelector("[data-user-message-metadata]"),
+        ).toHaveClass(
+            "min-h-5",
+            "opacity-0",
+            "group-hover:opacity-[0.72]",
+            "group-has-[:focus-visible]:opacity-[0.72]",
+        );
         expect(
             view.container.querySelector("[data-user-message-metadata] time"),
         ).toHaveAttribute("dateTime", new Date(timestamp).toISOString());

--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -529,7 +529,7 @@ function UserTextMessage({
 
     return (
         <div
-            className="min-w-0 w-full max-w-full"
+            className="group min-w-0 w-full max-w-full"
             data-user-message="true"
         >
             <div
@@ -561,12 +561,11 @@ function UserTextMessage({
                 <UserMessageAttachments attachments={message.attachments} />
             </div>
             <div
-                className="mt-1 flex min-h-5 items-center justify-end gap-1.5 px-0.5 text-text-secondary"
+                className="mt-1 flex min-h-5 items-center justify-end gap-1.5 px-0.5 text-text-secondary opacity-0 transition-opacity group-hover:opacity-[0.72] group-has-[:focus-visible]:opacity-[0.72]"
                 data-user-message-metadata="true"
                 style={{
                     fontFamily: "var(--font-mono), ui-monospace, monospace",
                     fontSize: "10px",
-                    opacity: 0.72,
                 }}
             >
                 {formattedTime ? (


### PR DESCRIPTION
## Summary

- hide user message timestamps and copy controls until the message row is hovered
- preserve the metadata row height to avoid layout shifts
- keep the controls visible for keyboard users through `:focus-visible`

## Why

User message metadata was always visible, adding visual noise to the chat transcript. The metadata should remain available on demand without changing the message layout.

The initial focus treatment used `focus-within`, which caused the metadata to remain visible after clicking Copy because the button retained focus. Restricting the focus behavior to `:focus-visible` preserves keyboard accessibility without making mouse clicks sticky.

## Validation

- `npm test -- --run src/features/ai/components/AIChatMessageItem.test.tsx`
- `npm run build`
- `git diff --check`