### PR TITLE
Use theme-aware stop button color

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -2141,7 +2141,7 @@ export function AIChatComposer({
                                 : "var(--text-secondary)",
                             backgroundColor: canRunPrimaryAction
                                 ? primaryAction === "stop"
-                                    ? "#b91c1c"
+                                    ? "var(--diff-remove)"
                                     : "var(--accent)"
                                 : "transparent",
                             border: "none",


### PR DESCRIPTION
## Summary

Use the existing `--diff-remove` token for the inference stop button while preserving its shape and behavior.

## Why

The stop color was hardcoded, so dark mode could not use its brighter danger color.

## Validation

- `npm test -- --run src/features/ai/components/AIChatComposer.test.tsx`