### PR TITLE
Use theme accent for editor cursors

### DIFF
--- a/apps/desktop/src/features/editor/editorExtensions.ts
+++ b/apps/desktop/src/features/editor/editorExtensions.ts
@@ -76,7 +76,7 @@ export const baseTheme = EditorView.theme({
         minWidth: 0,
         boxSizing: "border-box",
         padding: `24px ${editorHorizontalInset} 120px`,
-        caretColor: "var(--text-primary)",
+        caretColor: "var(--accent)",
         lineHeight: "var(--text-input-line-height)",
         minHeight: "calc(100vh - 220px)",
     },
@@ -120,7 +120,7 @@ export const baseTheme = EditorView.theme({
             textDecoration: "none",
         },
     ".cm-cursor": {
-        borderLeftColor: "var(--text-primary)",
+        borderLeftColor: "var(--accent)",
         borderLeftWidth: "2px",
         marginLeft: "-1px",
         padding: "2px 0",

--- a/apps/desktop/src/features/editor/extensions/vimStatusBar.ts
+++ b/apps/desktop/src/features/editor/extensions/vimStatusBar.ts
@@ -69,7 +69,7 @@ const vimStatusBarTheme = EditorView.baseTheme({
     },
     ".cm-vim-panel input": {
         color: "var(--text-primary)",
-        caretColor: "var(--text-primary)",
+        caretColor: "var(--accent)",
     },
     // The block cursor inherits the font-size of the DOM node it sits on. On a
     // live-preview list line that node is the zero-`font-size` hidden marker,
@@ -77,7 +77,12 @@ const vimStatusBarTheme = EditorView.baseTheme({
     // to the editor font size so it stays visible regardless of the underlying
     // node's font-size.
     ".cm-vimMode .cm-fat-cursor": {
+        background: "var(--accent)",
         minWidth: "calc(var(--editor-font-size, 14px) * 0.5)",
+    },
+    "&.cm-vimMode:not(.cm-focused) .cm-fat-cursor": {
+        background: "none",
+        outline: "solid 1px var(--accent)",
     },
 });
 


### PR DESCRIPTION
## Summary

- use the active theme accent color for the standard CodeMirror caret
- apply the same accent color to Vim block cursors in focused and unfocused states
- keep the Vim command-line input caret consistent with the editor

## Why

Editor cursors previously used the primary text color, while Vim block cursors retained the dependency's fixed pink default. This made cursor styling inconsistent across editing modes and prevented it from reflecting the selected application theme.

## Impact

The editor caret now follows each theme's existing accent color in standard and Vim modes, including the unfocused Vim outline and the Vim command-line input.

## Validation

- `npx tsc -b --pretty false`
- `npx eslint src/features/editor/editorExtensions.ts src/features/editor/extensions/vimStatusBar.ts`
- `npm test -- --run src/features/editor/editorExtensions.vim.test.ts src/features/editor/Editor.test.tsx` (65 tests passed)
- `git diff --check`