### PR TITLE
Restyle workspace tabs as floating capsules

### DIFF
--- a/apps/desktop/src/features/editor/EditorPaneBar.tsx
+++ b/apps/desktop/src/features/editor/EditorPaneBar.tsx
@@ -49,6 +49,13 @@ import {
     getChromeIconButtonStyle,
     getChromeNavigationButtonStyle,
 } from "./workspaceChromeControls";
+import {
+    getWorkspaceTabBarStyle,
+    getWorkspaceTabCloseButtonStyle,
+    getWorkspaceTabDragPreviewStyle,
+    getWorkspaceTabInsertionIndicatorStyle,
+    getWorkspaceTabStyle,
+} from "./workspaceTabChrome";
 
 function getTabLabel(
     tab: Tab,
@@ -447,13 +454,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
         <>
             <div
                 className="drag flex items-center shrink-0"
-                style={{
-                    height: 33,
-                    minHeight: 33,
-                    boxSizing: "border-box",
-                    borderBottom: "1px solid var(--border)",
-                    background: "var(--bg-secondary)",
-                }}
+                style={getWorkspaceTabBarStyle()}
                 data-pane-empty={hasTabs ? undefined : "true"}
             >
                 {showHistoryNavigationButtons && (
@@ -536,7 +537,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             data-pane-tab-overflowing={
                                 tabLayout.overflow || undefined
                             }
-                            className="relative flex min-w-0 shrink overflow-x-auto scrollbar-hidden items-end"
+                            className="relative flex min-w-0 shrink overflow-x-auto scrollbar-hidden items-center"
                             style={{
                                 gap: tabLayout.stripGap,
                                 padding: `0 ${tabLayout.stripPaddingX}px`,
@@ -647,45 +648,15 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                                     payload: { tabId: tab.id },
                                                 });
                                             }}
-                                            style={{
-                                                width: isPinned
-                                                    ? 34
-                                                    : tabLayout.tabWidth,
-                                                minWidth: isPinned
-                                                    ? 34
-                                                    : tabLayout.tabWidth,
-                                                maxWidth: isPinned ? 34 : 240,
-                                                height: 33,
-                                                flexShrink: 0,
-                                                justifyContent: isPinned
-                                                    ? "center"
-                                                    : undefined,
-                                                boxSizing: "border-box",
-                                                gap: isPinned
-                                                    ? 0
-                                                    : tabLayout.tabGap,
-                                                padding: isPinned
-                                                    ? 0
-                                                    : `0 ${tabLayout.tabPaddingX}px`,
-                                                borderRight:
-                                                    "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
-                                                background: isActive
-                                                    ? "var(--bg-primary)"
-                                                    : "transparent",
-                                                color: isActive
-                                                    ? "var(--text-primary)"
-                                                    : "var(--text-secondary)",
-                                                boxShadow: isActive
-                                                    ? "inset 0 -2px 0 0 var(--accent)"
-                                                    : "none",
-                                                zIndex: isActive ? 10 : 0,
-                                                opacity: isDragging ? 0.35 : 1,
-                                                cursor: isDragging
-                                                    ? "grabbing"
-                                                    : "pointer",
-                                                transition:
-                                                    "background 150ms, color 150ms",
-                                            }}
+                                            style={getWorkspaceTabStyle({
+                                                isActive,
+                                                isDragging,
+                                                isPinned,
+                                                tabWidth: tabLayout.tabWidth,
+                                                tabGap: tabLayout.tabGap,
+                                                tabPaddingX:
+                                                    tabLayout.tabPaddingX,
+                                            })}
                                         >
                                             {renderEditorTabLeadingIcon(
                                                 tab,
@@ -749,6 +720,9 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                                     style={{
                                                         fontSize:
                                                             tabLayout.titleFontSize,
+                                                        fontWeight: isActive
+                                                            ? 600
+                                                            : 500,
                                                     }}
                                                 >
                                                     {tabLabel}
@@ -764,19 +738,16 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                                                             tab.id,
                                                         );
                                                     }}
-                                                    className={`ml-0.5 inline-flex shrink-0 items-center justify-center rounded-md transition-[background-color,opacity,transform] duration-150 ease-out hover:bg-gray-500/30 active:bg-gray-500/55 active:scale-90 ${
+                                                    className={`ml-0.5 inline-flex shrink-0 items-center justify-center transition-[background-color,opacity,transform] duration-150 ease-out hover:bg-gray-500/25 active:bg-gray-500/50 active:scale-90 ${
                                                         isActive
                                                             ? "opacity-70 hover:opacity-100"
                                                             : "opacity-0 group-hover:opacity-65 hover:opacity-100"
                                                     }`}
-                                                    style={{
-                                                        width: 20,
-                                                        height: 20,
-                                                        color: "var(--text-secondary)",
-                                                        // Match UnifiedBar tab close: sit closer to the
-                                                        // right edge of the tab.
-                                                        marginRight: -6,
-                                                    }}
+                                                    style={getWorkspaceTabCloseButtonStyle(
+                                                        {
+                                                            size: tabLayout.closeButtonSize,
+                                                        },
+                                                    )}
                                                 >
                                                     <svg
                                                         width={13}
@@ -799,20 +770,7 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                             <div
                                 ref={insertionIndicatorRef}
                                 aria-hidden="true"
-                                className="rounded-full"
-                                style={{
-                                    position: "absolute",
-                                    top: "50%",
-                                    left: 0,
-                                    width: 3,
-                                    height: 20,
-                                    backgroundColor: "var(--accent)",
-                                    boxShadow:
-                                        "0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent)",
-                                    pointerEvents: "none",
-                                    zIndex: 20,
-                                    display: "none",
-                                }}
+                                style={getWorkspaceTabInsertionIndicatorStyle()}
                             />
                         </div>
                         )
@@ -1074,26 +1032,10 @@ export function EditorPaneBar({ paneId, isFocused }: EditorPaneBarProps) {
                       <div
                           ref={dragPreviewNodeRef}
                           data-pane-tab-drag-preview="true"
-                          style={{
-                              position: "fixed",
-                              left: 0,
-                              top: 0,
-                              display: "flex",
-                              alignItems: "center",
-                              gap: tabLayout.tabGap,
-                              maxWidth: 288,
-                              height: 33,
-                              padding: `0 ${tabLayout.tabPaddingX}px`,
-                              borderRadius: 4,
-                              border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
-                              background: "var(--bg-primary)",
-                              color: "var(--text-primary)",
-                              boxShadow:
-                                  "inset 0 -2px 0 0 var(--accent), 0 10px 24px rgba(15, 23, 42, 0.15)",
-                              pointerEvents: "none",
-                              zIndex: 9999,
-                              willChange: "transform",
-                          }}
+                          style={getWorkspaceTabDragPreviewStyle({
+                              tabGap: tabLayout.tabGap,
+                              tabPaddingX: tabLayout.tabPaddingX,
+                          })}
                       >
                           {renderEditorTabLeadingIcon(
                               draggedPreviewTab,

--- a/apps/desktop/src/features/editor/StackedPaneContent.tsx
+++ b/apps/desktop/src/features/editor/StackedPaneContent.tsx
@@ -33,6 +33,7 @@ import { renderEditorTabLeadingIcon } from "./editorTabIcons";
 import { useWorkspaceTabDrag } from "./useWorkspaceTabDrag";
 import { useDetachedTabWindowDrop } from "./useDetachedTabWindowDrop";
 import { createWorkspaceTabExternalDragHandlers } from "./tabDragAttachments";
+import { getWorkspaceTabDragPreviewStyle } from "./workspaceTabChrome";
 
 const LazyExcalidrawTabView = React.lazy(() =>
     import("../maps/ExcalidrawTabView").then((m) => ({
@@ -569,25 +570,11 @@ export function StackedPaneContent({
                       <div
                           ref={dragPreviewNodeRef}
                           data-pane-tab-drag-preview="true"
-                          style={{
-                              position: "fixed",
-                              left: 0,
-                              top: 0,
+                          style={getWorkspaceTabDragPreviewStyle({
+                              tabGap: 6,
+                              tabPaddingX: 10,
                               maxWidth: 240,
-                              height: 28,
-                              padding: "0 10px",
-                              display: "flex",
-                              alignItems: "center",
-                              borderRadius: 4,
-                              border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
-                              background: "var(--bg-primary)",
-                              color: "var(--text-primary)",
-                              boxShadow:
-                                  "inset 0 -2px 0 0 var(--accent), 0 10px 24px rgba(15, 23, 42, 0.15)",
-                              pointerEvents: "none",
-                              zIndex: 9999,
-                              willChange: "transform",
-                          }}
+                          })}
                       >
                           <span
                               style={{

--- a/apps/desktop/src/features/editor/UnifiedBar.tsx
+++ b/apps/desktop/src/features/editor/UnifiedBar.tsx
@@ -67,6 +67,11 @@ import {
     getChromeIconButtonStyle,
     getChromeNavigationButtonStyle,
 } from "./workspaceChromeControls";
+import {
+    getWorkspaceTabCloseButtonStyle,
+    getWorkspaceTabDragPreviewStyle,
+    getWorkspaceTabStyle,
+} from "./workspaceTabChrome";
 import { useWorkspaceTabDrag } from "./useWorkspaceTabDrag";
 import { useDetachedTabWindowDrop } from "./useDetachedTabWindowDrop";
 import { logError } from "../../app/utils/runtimeLog";
@@ -1139,7 +1144,7 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                         tabStripOverflowState.hasOverflow ||
                                         undefined
                                     }
-                                    className="no-drag relative flex min-w-0 shrink overflow-x-auto scrollbar-hidden items-end self-stretch"
+                                    className="no-drag relative flex min-w-0 shrink overflow-x-auto scrollbar-hidden items-center self-stretch"
                                     style={{
                                         gap: tabLayout.stripGap,
                                         padding: `0 ${tabLayout.stripPaddingX}px`,
@@ -1169,8 +1174,8 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                             aria-hidden="true"
                                             className="shrink-0 rounded-full"
                                             style={{
-                                                width: 3,
-                                                height: 22,
+                                                width: 2,
+                                                height: 18,
                                                 backgroundColor:
                                                     "var(--accent)",
                                                 boxShadow:
@@ -1272,40 +1277,30 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                                         isDragging || undefined
                                                     }
                                                     style={{
-                                                        width: tabLayout.tabWidth,
-                                                        minWidth:
-                                                            tabLayout.tabWidth,
-                                                        maxWidth: 240,
-                                                        height: 33,
-                                                        flexShrink: 0,
-                                                        boxSizing: "border-box",
-                                                        gap: tabLayout.tabGap,
-                                                        padding: `0 ${tabLayout.tabPaddingX}px`,
-                                                        borderRight:
-                                                            "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
-                                                        background: isActive
-                                                            ? "var(--bg-primary)"
-                                                            : "transparent",
-                                                        color: isActive
-                                                            ? "var(--text-primary)"
-                                                            : "var(--text-secondary)",
-                                                        boxShadow: isActive
-                                                            ? "inset 0 -2px 0 0 var(--accent)"
-                                                            : "none",
+                                                        ...getWorkspaceTabStyle(
+                                                            {
+                                                                isActive,
+                                                                isDragging,
+                                                                tabWidth:
+                                                                    tabLayout.tabWidth,
+                                                                tabGap: tabLayout.tabGap,
+                                                                tabPaddingX:
+                                                                    tabLayout.tabPaddingX,
+                                                                draggingOpacity:
+                                                                    DRAGGING_TAB_PLACEHOLDER_OPACITY,
+                                                            },
+                                                        ),
                                                         zIndex: isActive
                                                             ? 10
                                                             : isDragging
                                                               ? 20
                                                               : 0,
-                                                        opacity: isDragging
-                                                            ? DRAGGING_TAB_PLACEHOLDER_OPACITY
-                                                            : 1,
                                                         transform: isDragging
                                                             ? `translateX(${dragOffsetX}px)`
                                                             : undefined,
                                                         transition: isDragging
                                                             ? "none"
-                                                            : "transform 250ms cubic-bezier(0.2, 0.8, 0.2, 1), background 150ms ease, color 150ms ease, box-shadow 150ms ease",
+                                                            : "transform 250ms cubic-bezier(0.2, 0.8, 0.2, 1), background 160ms ease, color 160ms ease, border-color 160ms ease, box-shadow 160ms ease",
                                                         willChange: isDragging
                                                             ? "transform"
                                                             : undefined,
@@ -1324,6 +1319,9 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                                         style={{
                                                             fontSize:
                                                                 tabLayout.titleFontSize,
+                                                            fontWeight: isActive
+                                                                ? 600
+                                                                : 500,
                                                         }}
                                                     >
                                                         {isSearchTab(tab)
@@ -1351,19 +1349,16 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                                                 tab.id,
                                                             );
                                                         }}
-                                                        className={`no-drag shrink-0 rounded-md flex items-center justify-center transition-[background-color,opacity,transform] duration-150 ease-out hover:bg-gray-500/30 active:bg-gray-500/55 active:scale-90 ${
+                                                        className={`no-drag shrink-0 flex items-center justify-center transition-[background-color,opacity,transform] duration-150 ease-out hover:bg-gray-500/25 active:bg-gray-500/50 active:scale-90 ${
                                                             isActive
                                                                 ? "opacity-70 hover:opacity-100"
                                                                 : "opacity-0 group-hover:opacity-65 hover:opacity-100!"
                                                         }`}
-                                                        style={{
-                                                            width: tabLayout.closeButtonSize,
-                                                            height: tabLayout.closeButtonSize,
-                                                            // Eat into the tab's right padding so the
-                                                            // close button sits closer to the right edge
-                                                            // without losing its clickable area.
-                                                            marginRight: -6,
-                                                        }}
+                                                        style={getWorkspaceTabCloseButtonStyle(
+                                                            {
+                                                                size: tabLayout.closeButtonSize,
+                                                            },
+                                                        )}
                                                     >
                                                         <svg
                                                             width={
@@ -1389,8 +1384,8 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                                         aria-hidden="true"
                                                         className="shrink-0 rounded-full"
                                                         style={{
-                                                            width: 3,
-                                                            height: 22,
+                                                            width: 2,
+                                                            height: 18,
                                                             backgroundColor:
                                                                 "var(--accent)",
                                                             boxShadow:
@@ -1479,26 +1474,14 @@ export function UnifiedBar({ windowMode }: UnifiedBarProps) {
                                       ref={dragPreviewNodeRef}
                                       data-tab-drag-preview="true"
                                       style={{
-                                          position: "fixed",
-                                          left: 0,
-                                          top: 0,
+                                          ...getWorkspaceTabDragPreviewStyle({
+                                              tabGap: tabLayout.tabGap,
+                                              tabPaddingX:
+                                                  tabLayout.tabPaddingX,
+                                              maxWidth: tabLayout.tabWidth,
+                                          }),
                                           width: tabLayout.tabWidth,
                                           minWidth: tabLayout.tabWidth,
-                                          height: 30,
-                                          display: "flex",
-                                          alignItems: "center",
-                                          gap: tabLayout.tabGap,
-                                          padding: `0 ${tabLayout.tabPaddingX}px`,
-                                          borderRadius: 9,
-                                          border: "1px solid color-mix(in srgb, var(--accent) 16%, var(--border))",
-                                          background:
-                                              "color-mix(in srgb, var(--bg-primary) 94%, white 6%)",
-                                          color: "var(--text-primary)",
-                                          boxShadow:
-                                              "0 14px 32px rgba(15, 23, 42, 0.18)",
-                                          pointerEvents: "none",
-                                          zIndex: 9999,
-                                          willChange: "transform",
                                       }}
                                   >
                                       {renderEditorTabLeadingIcon(

--- a/apps/desktop/src/features/editor/editorTabStripLayout.ts
+++ b/apps/desktop/src/features/editor/editorTabStripLayout.ts
@@ -18,8 +18,8 @@ export interface EditorTabLayout {
 
 export const EDITOR_TAB_MAX_WIDTH = 160;
 export const EDITOR_TAB_MIN_WIDTH = 96;
-export const EDITOR_TAB_STRIP_GAP = 0;
-export const EDITOR_TAB_STRIP_PADDING_X = 0;
+export const EDITOR_TAB_STRIP_GAP = 3;
+export const EDITOR_TAB_STRIP_PADDING_X = 5;
 
 const COMFORTABLE_WIDTH = 144;
 const COMPACT_WIDTH = 118;

--- a/apps/desktop/src/features/editor/workspaceTabChrome.test.ts
+++ b/apps/desktop/src/features/editor/workspaceTabChrome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+    WORKSPACE_PINNED_TAB_SIZE,
+    WORKSPACE_TAB_HEIGHT,
+    WORKSPACE_TAB_RADIUS,
+    getWorkspaceTabStyle,
+} from "./workspaceTabChrome";
+
+describe("getWorkspaceTabStyle", () => {
+    it("renders idle tabs as floating capsules instead of flush chrome tabs", () => {
+        const style = getWorkspaceTabStyle({
+            isActive: false,
+            isDragging: false,
+            tabWidth: 144,
+            tabGap: 6,
+            tabPaddingX: 12,
+        });
+
+        expect(style.height).toBe(WORKSPACE_TAB_HEIGHT);
+        expect(style.borderRadius).toBe(WORKSPACE_TAB_RADIUS);
+        expect(style.background).toBe("transparent");
+        expect(style.border).toBe("1px solid transparent");
+        expect(style.boxShadow).toBe("none");
+    });
+
+    it("marks the active tab with a lifted surface", () => {
+        const style = getWorkspaceTabStyle({
+            isActive: true,
+            isDragging: false,
+            tabWidth: 144,
+            tabGap: 6,
+            tabPaddingX: 12,
+        });
+
+        expect(style.background).toContain("var(--accent)");
+        expect(style.boxShadow).not.toContain("inset 2px 0 0 0");
+        expect(style.border).toContain("var(--accent)");
+        expect(style.color).toBe("var(--text-primary)");
+    });
+
+    it("keeps pinned tabs as compact capsules", () => {
+        const style = getWorkspaceTabStyle({
+            isActive: false,
+            isDragging: false,
+            isPinned: true,
+            tabWidth: 144,
+            tabGap: 6,
+            tabPaddingX: 12,
+        });
+
+        expect(style.width).toBe(WORKSPACE_PINNED_TAB_SIZE);
+        expect(style.maxWidth).toBe(WORKSPACE_PINNED_TAB_SIZE);
+        expect(style.padding).toBe(0);
+        expect(style.justifyContent).toBe("center");
+    });
+});

--- a/apps/desktop/src/features/editor/workspaceTabChrome.ts
+++ b/apps/desktop/src/features/editor/workspaceTabChrome.ts
@@ -1,0 +1,132 @@
+import type { CSSProperties } from "react";
+
+export const WORKSPACE_TAB_BAR_HEIGHT = 33;
+export const WORKSPACE_TAB_HEIGHT = 26;
+export const WORKSPACE_TAB_RADIUS = 8;
+export const WORKSPACE_PINNED_TAB_SIZE = 28;
+
+const ACTIVE_TAB_BORDER =
+    "1px solid color-mix(in srgb, var(--accent) 34%, var(--border))";
+const IDLE_TAB_BORDER = "1px solid transparent";
+const ACTIVE_TAB_BACKGROUND =
+    "color-mix(in srgb, var(--bg-primary) 92%, var(--accent) 8%)";
+const ACTIVE_TAB_SHADOW = [
+    "inset 0 1px 0 color-mix(in srgb, var(--text-primary) 8%, transparent)",
+    "0 1px 2px rgba(0, 0, 0, 0.18)",
+].join(", ");
+
+export function getWorkspaceTabBarStyle(): CSSProperties {
+    return {
+        height: WORKSPACE_TAB_BAR_HEIGHT,
+        minHeight: WORKSPACE_TAB_BAR_HEIGHT,
+        boxSizing: "border-box",
+        borderBottom: "1px solid var(--border)",
+        background: "var(--bg-secondary)",
+    };
+}
+
+export function getWorkspaceTabStyle({
+    isActive,
+    isDragging,
+    isPinned = false,
+    tabWidth,
+    tabGap,
+    tabPaddingX,
+    draggingOpacity = 0.38,
+}: {
+    isActive: boolean;
+    isDragging: boolean;
+    isPinned?: boolean;
+    tabWidth: number;
+    tabGap: number;
+    tabPaddingX: number;
+    draggingOpacity?: number;
+}): CSSProperties {
+    const width = isPinned ? WORKSPACE_PINNED_TAB_SIZE : tabWidth;
+
+    return {
+        width,
+        minWidth: width,
+        maxWidth: isPinned ? WORKSPACE_PINNED_TAB_SIZE : 240,
+        height: WORKSPACE_TAB_HEIGHT,
+        flexShrink: 0,
+        alignSelf: "center",
+        justifyContent: isPinned ? "center" : undefined,
+        boxSizing: "border-box",
+        gap: isPinned ? 0 : tabGap,
+        padding: isPinned ? 0 : `0 ${tabPaddingX}px`,
+        borderRadius: WORKSPACE_TAB_RADIUS,
+        border: isActive ? ACTIVE_TAB_BORDER : IDLE_TAB_BORDER,
+        background: isActive ? ACTIVE_TAB_BACKGROUND : "transparent",
+        color: isActive ? "var(--text-primary)" : "var(--text-secondary)",
+        boxShadow: isActive ? ACTIVE_TAB_SHADOW : "none",
+        letterSpacing: "-0.012em",
+        zIndex: isActive ? 10 : 0,
+        opacity: isDragging ? draggingOpacity : 1,
+        cursor: isDragging ? "grabbing" : "pointer",
+        transition:
+            "background 160ms ease, color 160ms ease, border-color 160ms ease, box-shadow 160ms ease, opacity 120ms ease",
+    };
+}
+
+export function getWorkspaceTabCloseButtonStyle({
+    size,
+}: {
+    size: number;
+}): CSSProperties {
+    return {
+        width: size,
+        height: size,
+        borderRadius: 999,
+        color: "var(--text-secondary)",
+        marginRight: -2,
+    };
+}
+
+export function getWorkspaceTabDragPreviewStyle({
+    tabGap,
+    tabPaddingX,
+    maxWidth = 288,
+}: {
+    tabGap: number;
+    tabPaddingX: number;
+    maxWidth?: number;
+}): CSSProperties {
+    return {
+        position: "fixed",
+        left: 0,
+        top: 0,
+        display: "flex",
+        alignItems: "center",
+        gap: tabGap,
+        maxWidth,
+        height: WORKSPACE_TAB_HEIGHT,
+        padding: `0 ${tabPaddingX}px`,
+        borderRadius: WORKSPACE_TAB_RADIUS,
+        border: "1px solid var(--border)",
+        background: "var(--bg-secondary)",
+        color: "var(--text-primary)",
+        boxShadow: "0 8px 18px rgba(0, 0, 0, 0.28)",
+        letterSpacing: "-0.012em",
+        pointerEvents: "none",
+        zIndex: 9999,
+        willChange: "transform",
+    };
+}
+
+export function getWorkspaceTabInsertionIndicatorStyle(): CSSProperties {
+    return {
+        position: "absolute",
+        top: "50%",
+        left: 0,
+        width: 2,
+        height: 18,
+        borderRadius: 999,
+        backgroundColor: "var(--accent)",
+        boxShadow:
+            "0 0 0 1px color-mix(in srgb, var(--accent) 22%, transparent)",
+        pointerEvents: "none",
+        zIndex: 20,
+        display: "none",
+    };
+}

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -430,8 +430,13 @@ textarea,
    Excludes stacked-tab columns, which reuse data-pane-tab-id only for drop
    hit-testing and must not get the small-tab hover background. */
 [data-pane-tab-id]:not([aria-selected="true"]):not([data-stacked-column-id]):hover {
-    background: var(--bg-tertiary) !important;
+    background: color-mix(
+        in srgb,
+        var(--text-primary) 7%,
+        transparent
+    ) !important;
     color: var(--text-primary) !important;
+    border-color: color-mix(in srgb, var(--border) 58%, transparent) !important;
 }
 
 /* Native WebKit drag region: works at the OS level, not in JS. */
@@ -1920,11 +1925,11 @@ body.dragging-tab * {
 .ub-tab:not([data-active="true"]):hover {
     background-color: color-mix(
         in srgb,
-        var(--bg-primary) 62%,
+        var(--text-primary) 7%,
         transparent
     ) !important;
     color: var(--text-primary) !important;
-    border-color: color-mix(in srgb, var(--border) 66%, transparent) !important;
+    border-color: color-mix(in srgb, var(--border) 58%, transparent) !important;
 }
 
 .settings-range-slider {


### PR DESCRIPTION
## Summary
- Replace flush browser-style workspace tabs with compact floating capsules on pane bars and the unified bar.
- Centralize tab chrome (active, pinned, close, drag preview) so those surfaces no longer fork the same styles.
- Keep the active tab as a lifted chip without a left accent rail, and paint the drag preview on the tab-bar surface with a dry drop shadow instead of a light glow.

## Test plan
- [x] `apps/desktop` vitest: `workspaceTabChrome`, `editorTabStripLayout`, `EditorPaneBar`, `UnifiedBar`, `useWorkspaceTabDrag`, `MultiPaneWorkspace`, `workspaceContracts`
- [ ] Open multiple workspace tabs and confirm idle, hover, and active capsules.
- [ ] Pin a tab and confirm the compact capsule.
- [ ] Drag a tab in-pane and across panes; the ghost should match the tab bar and not flash white or glow.
- [ ] Check detached-window unified bar tabs for the same treatment.