### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ cargo test
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=jsgrrchg%2FNeverWrite&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#jsgrrchg/NeverWrite&type=date&legend=top-left">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=jsgrrchg/NeverWrite&type=date&theme=dark&legend=top-left" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=jsgrrchg/NeverWrite&type=date&legend=top-left" />
-    <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=jsgrrchg/NeverWrite&type=date&legend=top-left" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=jsgrrchg/NeverWrite&type=date&theme=dark&legend=top-left" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=jsgrrchg/NeverWrite&type=date&legend=top-left" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=jsgrrchg/NeverWrite&type=date&legend=top-left" />
   </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken because the upstream service depends on GitHub stargazer API restrictions that no longer work. This updates the chart to a working alternative so the stargazer graph displays correctly again.