### PR TITLE
Allow removing unavailable vaults from Recents

### DIFF
--- a/apps/desktop/native-backend/src/ai_history/mod.rs
+++ b/apps/desktop/native-backend/src/ai_history/mod.rs
@@ -39,6 +39,8 @@ const COMMANDS: &[&str] = &[
 ];
 
 pub(crate) const AI_HISTORY_STORAGE_CHANGED_EVENT: &str = "ai_history_storage_changed";
+pub(crate) const ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR: &str =
+    "Switch to another vault before removing this one from Recents. Active AI sessions could recreate its device-local data.";
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(
@@ -237,15 +239,26 @@ impl AiHistoryStorageService {
         COMMANDS.contains(&command)
     }
 
-    pub(crate) fn forget_device_data(&self, vault_path: &Path) -> Result<(), String> {
+    pub(crate) fn forget_device_data(
+        &self,
+        vault_path: &Path,
+        active_vault_path: Option<&Path>,
+    ) -> Result<(), String> {
+        let target_identity = storage::resolve_known_vault_identity(vault_path)?;
+        if let Some(active_vault_path) = active_vault_path {
+            let active_identity = storage::resolve_known_vault_identity(active_vault_path)?;
+            if active_identity.normalized_path == target_identity.normalized_path {
+                return Err(ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR.to_string());
+            }
+        }
         if migration::has_pending(&self.app_data_root)? {
             return Err(
                 "AI history recovery must finish before local device data can be forgotten."
                     .to_string(),
             );
         }
-        let vault_key =
-            storage::remove_device_namespace_for_known_path(&self.app_data_root, vault_path)?;
+        storage::remove_device_namespace_for_known_identity(&self.app_data_root, &target_identity)?;
+        let vault_key = target_identity.vault_key;
         log_storage_event(&vault_key, None, "housekeeping", "forget_device_data");
         self.validated_scopes
             .lock()
@@ -1884,7 +1897,7 @@ mod tests {
         .unwrap();
         let layout = storage::resolve_layout(app_data.path(), vault.path()).unwrap();
 
-        service.forget_device_data(vault.path()).unwrap();
+        service.forget_device_data(vault.path(), None).unwrap();
 
         assert!(!layout.namespace.exists());
         assert_eq!(
@@ -1893,6 +1906,29 @@ mod tests {
                 .len(),
             1
         );
+    }
+
+    #[test]
+    fn forgetting_recents_data_succeeds_after_the_vault_path_disappears() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        fs::create_dir(&vault).unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        service
+            .invoke(
+                "ai_save_session_history",
+                &vault,
+                json!({ "history": text_history("device", "local") }),
+            )
+            .unwrap();
+        let layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        let known_path = vault.canonicalize().unwrap();
+        fs::remove_dir_all(&vault).unwrap();
+
+        service.forget_device_data(&known_path, None).unwrap();
+
+        assert!(!layout.namespace.exists());
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai_history/storage.rs
+++ b/apps/desktop/native-backend/src/ai_history/storage.rs
@@ -37,6 +37,12 @@ pub(super) struct ScopeLayout {
     pub managed: PathBuf,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct KnownVaultIdentity {
+    pub normalized_path: String,
+    pub vault_key: String,
+}
+
 impl ScopeLayout {
     pub(super) fn transaction_layout(&self) -> RootLayout {
         RootLayout {
@@ -496,11 +502,9 @@ pub(super) fn device_scope_for_key(
     })
 }
 
-pub(super) fn remove_device_namespace_for_known_path(
-    app_data_root: &Path,
+pub(super) fn resolve_known_vault_identity(
     vault_path: &Path,
-) -> Result<String, String> {
-    ensure_private_app_data_root(app_data_root)?;
+) -> Result<KnownVaultIdentity, String> {
     let known_path = match vault_path.canonicalize() {
         Ok(canonical) => canonical,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => vault_path.to_path_buf(),
@@ -516,14 +520,25 @@ pub(super) fn remove_device_namespace_for_known_path(
     {
         return Err("The stored vault path is not an absolute normalized path.".to_string());
     }
-    let vault_key = hex_sha256(normalized_vault_path(&known_path).as_bytes());
+    let normalized_path = normalized_vault_path(&known_path);
+    let vault_key = hex_sha256(normalized_path.as_bytes());
+    Ok(KnownVaultIdentity {
+        normalized_path,
+        vault_key,
+    })
+}
+
+pub(super) fn remove_device_namespace_for_known_identity(
+    app_data_root: &Path,
+    identity: &KnownVaultIdentity,
+) -> Result<(), String> {
+    ensure_private_app_data_root(app_data_root)?;
     let namespace = app_data_root
         .join("ai-history")
         .join("v1")
         .join("vaults")
-        .join(&vault_key);
-    remove_device_namespace_by_key(&namespace, &vault_key)?;
-    Ok(vault_key)
+        .join(&identity.vault_key);
+    remove_device_namespace_by_key(&namespace, &identity.vault_key)
 }
 
 fn remove_device_namespace_by_key(namespace: &Path, vault_key: &str) -> Result<(), String> {
@@ -950,10 +965,10 @@ mod tests {
         let known_path = vault.canonicalize().unwrap();
         fs::remove_dir_all(&vault).unwrap();
 
-        let removed_key =
-            remove_device_namespace_for_known_path(app_data.path(), &known_path).unwrap();
+        let identity = resolve_known_vault_identity(&known_path).unwrap();
+        remove_device_namespace_for_known_identity(app_data.path(), &identity).unwrap();
 
-        assert_eq!(removed_key, layout.vault_key);
+        assert_eq!(identity.vault_key, layout.vault_key);
         assert!(!layout.namespace.exists());
     }
 
@@ -975,10 +990,22 @@ mod tests {
         )
         .unwrap();
 
-        let removed_key = remove_device_namespace_for_known_path(app_data.path(), &alias).unwrap();
+        let identity = resolve_known_vault_identity(&alias).unwrap();
+        remove_device_namespace_for_known_identity(app_data.path(), &identity).unwrap();
 
-        assert_eq!(removed_key, layout.vault_key);
+        assert_eq!(identity.vault_key, layout.vault_key);
         assert!(!layout.namespace.exists());
+    }
+
+    #[test]
+    fn missing_known_vault_identity_rejects_relative_components() {
+        let error = resolve_known_vault_identity(Path::new("missing-vault"))
+            .expect_err("relative paths must not identify device-local data");
+
+        assert_eq!(
+            error,
+            "The stored vault path is not an absolute normalized path."
+        );
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -43,9 +43,6 @@ const DEFAULT_GRAPH_MAX_LINKS_GLOBAL: usize = 24_000;
 const DEFAULT_GRAPH_MAX_NODES_LOCAL: usize = 2_500;
 const DEFAULT_GRAPH_MAX_LINKS_LOCAL: usize = 12_000;
 const DEFAULT_LOCAL_GRAPH_HUB_NEIGHBOR_LIMIT: usize = 512;
-const ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR: &str =
-    "Switch to another vault before removing this one from Recents. Active AI sessions could recreate its device-local data.";
-
 #[derive(Debug, Deserialize)]
 struct RpcRequest {
     id: Value,
@@ -904,16 +901,11 @@ impl NativeBackend {
             "ai_register_file_baseline" => self.ai.register_file_baseline(&args),
             "forget_ai_history_device_data" => {
                 let vault_path = required_string(&args, &["vaultPath", "vault_path"])?;
-                let target_root = normalize_vault_path(&vault_path)?;
-                if let Some(active_vault_path) =
+                let active_vault_path =
                     optional_nullable_string(&args, &["activeVaultPath", "active_vault_path"])
-                {
-                    if normalize_vault_path(&active_vault_path)? == target_root {
-                        return Err(ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR.to_string());
-                    }
-                }
+                        .map(PathBuf::from);
                 self.ai_history
-                    .forget_device_data(Path::new(&target_root))?;
+                    .forget_device_data(Path::new(&vault_path), active_vault_path.as_deref())?;
                 Ok(json!(null))
             }
             command if AiHistoryStorageService::handles(command) => {
@@ -3424,7 +3416,49 @@ mod tests {
         )
         .unwrap_err();
 
-        assert_eq!(error, ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR);
+        assert_eq!(error, ai_history::ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR);
+    }
+
+    #[test]
+    fn forgets_recent_cleanup_after_the_vault_path_disappears() {
+        let (event_tx, _event_rx) = mpsc::channel::<RpcOutput>();
+        let backend = Arc::new(Mutex::new(NativeBackend::new(event_tx)));
+        let parent = tempfile::tempdir().unwrap();
+        let vault_path = parent.path().join("missing-vault");
+
+        let result = invoke(
+            &backend,
+            "forget_ai_history_device_data",
+            json!({
+                "vaultPath": vault_path,
+                "activeVaultPath": null,
+            }),
+        );
+
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn refuses_recent_cleanup_for_an_active_vault_after_its_path_disappears() {
+        let (event_tx, _event_rx) = mpsc::channel::<RpcOutput>();
+        let backend = Arc::new(Mutex::new(NativeBackend::new(event_tx)));
+        let parent = tempfile::tempdir().unwrap();
+        let vault_path = parent.path().join("vault");
+        fs::create_dir(&vault_path).unwrap();
+        let known_path = vault_path.canonicalize().unwrap();
+        fs::remove_dir_all(&vault_path).unwrap();
+
+        let error = invoke(
+            &backend,
+            "forget_ai_history_device_data",
+            json!({
+                "vaultPath": known_path,
+                "activeVaultPath": known_path,
+            }),
+        )
+        .unwrap_err();
+
+        assert_eq!(error, ai_history::ACTIVE_VAULT_DEVICE_DATA_FORGET_ERROR);
     }
 
     #[test]

--- a/apps/desktop/src/app/store/vaultStore.test.ts
+++ b/apps/desktop/src/app/store/vaultStore.test.ts
@@ -99,21 +99,49 @@ describe("vaultStore", () => {
         ]);
     });
 
-    it("forgets only device-local AI data when a vault is removed from Recents", async () => {
+    it("cleans per-vault state after device-local cleanup succeeds", async () => {
         const invoke = mockInvoke();
         invoke.mockResolvedValue(undefined);
         useVaultStore.setState({ vaultPath: null });
+        const perVaultKeys = [
+            "neverwrite.session.tabs:/missing-vault",
+            "neverwrite:theme:/missing-vault",
+            "neverwrite:settings:/missing-vault",
+            "neverwrite.chat.tabs:/missing-vault",
+            "neverwrite:bookmarks:/missing-vault",
+        ];
+        localStorage.setItem(
+            "neverwrite:recentVaults",
+            JSON.stringify([
+                { path: "/missing-vault", name: "Missing" },
+                { path: "/other-vault", name: "Other" },
+            ]),
+        );
+        localStorage.setItem("neverwrite:lastVaultPath", "/missing-vault");
+        for (const key of perVaultKeys) {
+            localStorage.setItem(key, "persisted");
+        }
 
-        await removeVaultFromList("/vault");
+        await removeVaultFromList("/missing-vault");
 
         expect(invoke).toHaveBeenCalledWith("forget_ai_history_device_data", {
-            vaultPath: "/vault",
+            vaultPath: "/missing-vault",
             activeVaultPath: null,
         });
         expect(invoke).not.toHaveBeenCalledWith(
             "ai_delete_all_session_histories",
             expect.anything(),
         );
+        expect(invoke).toHaveBeenCalledWith("delete_vault_snapshot", {
+            vaultPath: "/missing-vault",
+        });
+        expect(getRecentVaults()).toEqual([
+            { path: "/other-vault", name: "Other" },
+        ]);
+        expect(localStorage.getItem("neverwrite:lastVaultPath")).toBeNull();
+        for (const key of perVaultKeys) {
+            expect(localStorage.getItem(key)).toBeNull();
+        }
         vi.clearAllMocks();
 
         clearRecentVaults();

--- a/apps/desktop/src/features/settings/SettingsPanel.test.tsx
+++ b/apps/desktop/src/features/settings/SettingsPanel.test.tsx
@@ -444,6 +444,64 @@ describe("SettingsPanel", () => {
         );
     });
 
+    it("removes an unavailable vault after device-local cleanup succeeds", async () => {
+        const invoke = mockInvoke().mockResolvedValue(undefined);
+        localStorage.setItem(
+            "neverwrite:recentVaults",
+            JSON.stringify([
+                { path: "/missing-vault", name: "Missing Vault" },
+            ]),
+        );
+
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+        fireEvent.click(screen.getByRole("button", { name: "Vault" }));
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: "Remove Missing Vault from Recents",
+            }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+        await waitFor(() => {
+            expect(screen.queryByText("Missing Vault")).not.toBeInTheDocument();
+        });
+        expect(screen.getByText("No recent vaults.")).toBeInTheDocument();
+        expect(invoke).toHaveBeenCalledWith("forget_ai_history_device_data", {
+            vaultPath: "/missing-vault",
+            activeVaultPath: null,
+        });
+    });
+
+    it("keeps an unavailable vault visible when device-local cleanup fails", async () => {
+        mockInvoke().mockImplementation(async (command) => {
+            if (command === "forget_ai_history_device_data") {
+                throw new Error("cleanup blocked");
+            }
+            return undefined;
+        });
+        localStorage.setItem(
+            "neverwrite:recentVaults",
+            JSON.stringify([
+                { path: "/missing-vault", name: "Missing Vault" },
+            ]),
+        );
+
+        renderComponent(<SettingsPanel onClose={() => {}} />);
+        fireEvent.click(screen.getByRole("button", { name: "Vault" }));
+        fireEvent.click(
+            screen.getByRole("button", {
+                name: "Remove Missing Vault from Recents",
+            }),
+        );
+        fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+        expect(await screen.findByRole("alert")).toHaveTextContent(
+            "Could not delete device-local data. The vault remains in Recents so you can retry.",
+        );
+        expect(screen.getByText("Missing Vault")).toBeInTheDocument();
+        expect(screen.getByText("1/1")).toBeInTheDocument();
+    });
+
     it("searches settings by row content and switches to the matching panel", () => {
         renderComponent(<SettingsPanel onClose={() => {}} />);
 

--- a/docs/ai-session-history.md
+++ b/docs/ai-session-history.md
@@ -178,9 +178,7 @@ send a new message so NeverWrite can continue with the stored transcript.
 - `transcript.jsonl` is stored as local plaintext JSONL while retained.
 - Deleting a conversation from `Chat History` deletes its saved history and
   only managed blobs that no retained history references.
-- Removing a vault from Recents clears local registration, drafts, and
-  device-local history; it never deletes history or managed blobs inside the
-  vault.
+- Removing a vault from Recents clears local registration, drafts, and device-local history; it never deletes history or managed blobs inside the vault. The stored canonical path still identifies this device-local data when the original vault folder no longer exists.
 - If a recovered chat is missing, confirm you reopened the same vault and that the retention window did not prune the conversation.
 - Pasted screenshot drafts and managed blobs are plaintext local image files;
   review them before sharing app data or a vault archive.

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -157,9 +157,7 @@ days so a crash between promotion and history persistence does not create a
 broken message reference. Managed blobs referenced by retained histories are
 deleted only after their last retained reference is removed.
 
-Removing a vault from Recents clears local registration, drafts, and
-device-local AI history. It never deletes sessions or managed blobs stored
-inside the vault; deleting those requires the explicit Chat History action.
+Removing a vault from Recents clears local registration, drafts, and device-local AI history. It never deletes sessions or managed blobs stored inside the vault; deleting those requires the explicit Chat History action. If the vault folder no longer exists, its stored canonical path still identifies the device-local data that NeverWrite owns and removes.
 
 ## App Logs
 


### PR DESCRIPTION
## Summary

- allow device-local AI history cleanup to resolve a previously known vault path after its folder disappears
- centralize known-vault identity normalization so active-vault protection and namespace deletion use the same path-derived identity
- preserve fail-closed behavior for active vaults, relative paths, recovery state, permissions, and unsafe namespaces
- cover the native RPC, storage deletion, renderer success and failure flows, and document the retention behavior

## Why

Removing a vault from Settings > Vault > Recent Vaults first deletes NeverWrite-owned device-local AI data. The RPC previously required the target directory to exist before reaching storage code that already supported missing paths, so deleted or moved vault folders could never be removed from Recents.

This change distinguishes paths for live vault operations from stored paths used to forget local data. Missing paths remain valid only when they are absolute and normalized, while all other I/O and safety failures still block cleanup and keep the Recent entry visible for retry.

## Commits

1. `fix(vault): forget unavailable recent vaults`
2. `test(settings): cover recent vault cleanup outcomes`

## Testing

- `cargo test -p neverwrite-native-backend` (362 passed)
- `cargo clippy -p neverwrite-native-backend --all-targets -- -D warnings`
- `npm test -- src/app/store/vaultStore.test.ts src/features/settings/SettingsPanel.test.tsx` (56 passed)
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes

`cargo fmt --all -- --check` still reports pre-existing formatting differences in `crates/index/tests/integration.rs` and `crates/vault/tests/integration.rs`; this PR leaves those unrelated files untouched.
