### PR TITLE
Recover AI history after vault filesystem identity changes

### DIFF
--- a/apps/desktop/native-backend/src/ai_history/mod.rs
+++ b/apps/desktop/native-backend/src/ai_history/mod.rs
@@ -35,6 +35,7 @@ const COMMANDS: &[&str] = &[
     "ai_get_history_recovery_diagnostic",
     "ai_reveal_history_recovery_root",
     "ai_retry_history_recovery",
+    "ai_adopt_history_storage_identity",
     "reconcile_ai_history_storage",
 ];
 
@@ -482,18 +483,8 @@ impl AiHistoryStorageService {
         layout: &storage::VaultStorageLayout,
         state: storage::CanonicalState,
     ) -> Result<CanonicalResolution, String> {
-        let operation_pending = storage::read_operation(layout)?.is_some()
-            || migration::has_pending(&self.app_data_root)?;
-        let validation = match &state.kind {
-            storage::CanonicalStateKind::Ready { scope } => {
-                migration::inspect_layout(&layout.scope(*scope).transaction_layout()).map(|_| ())
-            }
-            storage::CanonicalStateKind::RecoveryRequired => {
-                migration::inspect_layout(&layout.device.transaction_layout())
-                    .and_then(|_| migration::inspect_layout(&layout.vault.transaction_layout()))
-                    .map(|_| ())
-            }
-        };
+        let operation_pending = self.identity_change_operation_pending(layout)?;
+        let validation = Self::validate_identity_change_storage(layout, &state);
         let (reason, message, can_adopt_identity) = if operation_pending {
             (
                 "filesystem_identity_changed_during_operation".to_string(),
@@ -529,6 +520,30 @@ impl AiHistoryStorageService {
             },
             Some(RecoveryPlan::FilesystemIdentityChange { state }),
         ))
+    }
+
+    fn validate_identity_change_storage(
+        layout: &storage::VaultStorageLayout,
+        state: &storage::CanonicalState,
+    ) -> Result<(), String> {
+        match &state.kind {
+            storage::CanonicalStateKind::Ready { scope } => {
+                migration::inspect_layout(&layout.scope(*scope).transaction_layout()).map(|_| ())
+            }
+            storage::CanonicalStateKind::RecoveryRequired => {
+                migration::inspect_layout(&layout.device.transaction_layout())
+                    .and_then(|_| migration::inspect_layout(&layout.vault.transaction_layout()))
+                    .map(|_| ())
+            }
+        }
+    }
+
+    fn identity_change_operation_pending(
+        &self,
+        layout: &storage::VaultStorageLayout,
+    ) -> Result<bool, String> {
+        Ok(storage::read_operation(layout)?.is_some()
+            || migration::has_pending(&self.app_data_root)?)
     }
 
     fn initialize_missing_state(
@@ -1006,6 +1021,117 @@ impl AiHistoryStorageService {
         Ok(status)
     }
 
+    fn adopt_filesystem_identity(
+        &self,
+        vault_root: &Path,
+        expected_previous_identity: &str,
+        expected_current_identity: &str,
+    ) -> Result<StorageStatusSnapshot, String> {
+        let initial_layout = storage::resolve_layout(&self.app_data_root, vault_root)?;
+        log_storage_event(
+            &initial_layout.vault_key,
+            None,
+            "identity_adoption",
+            "started",
+        );
+        let result = (|| {
+            let storage::StateRead::FilesystemIdentityChanged(initial_state) =
+                storage::read_state(&initial_layout)
+            else {
+                return Err(
+                    "AI history does not have a filesystem identity change to restore.".to_string(),
+                );
+            };
+            if initial_state.filesystem_identity != expected_previous_identity
+                || initial_layout.filesystem_identity != expected_current_identity
+            {
+                return Err(
+                    "The vault folder identity changed again. Refresh recovery details and retry."
+                        .to_string(),
+                );
+            }
+            if self.identity_change_operation_pending(&initial_layout)? {
+                return Err(
+                    "AI history identity cannot be restored while a storage transaction is pending."
+                        .to_string(),
+                );
+            }
+            Self::validate_identity_change_storage(&initial_layout, &initial_state)?;
+
+            // Resolve and validate again immediately before the state commit so
+            // the confirmation cannot approve a stale cloud rematerialization.
+            let verified_layout = storage::resolve_layout(&self.app_data_root, vault_root)?;
+            if verified_layout.vault_key != initial_layout.vault_key
+                || verified_layout.canonical_vault_path != initial_layout.canonical_vault_path
+                || verified_layout.filesystem_identity != expected_current_identity
+            {
+                return Err(
+                    "The vault folder identity changed again. Refresh recovery details and retry."
+                        .to_string(),
+                );
+            }
+            let storage::StateRead::FilesystemIdentityChanged(verified_state) =
+                storage::read_state(&verified_layout)
+            else {
+                return Err(
+                    "AI history recovery state changed. Refresh recovery details and retry."
+                        .to_string(),
+                );
+            };
+            if verified_state != initial_state
+                || verified_state.filesystem_identity != expected_previous_identity
+            {
+                return Err(
+                    "AI history recovery state changed. Refresh recovery details and retry."
+                        .to_string(),
+                );
+            }
+            if self.identity_change_operation_pending(&verified_layout)? {
+                return Err(
+                    "AI history identity cannot be restored while a storage transaction is pending."
+                        .to_string(),
+                );
+            }
+            Self::validate_identity_change_storage(&verified_layout, &verified_state)?;
+
+            let target_state = verified_state.adopt_filesystem_identity(&verified_layout)?;
+            let target_kind = target_state.kind.clone();
+            self.validated_scopes
+                .lock()
+                .map_err(|error| format!("AI history validation state error: {error}"))?
+                .remove(&verified_layout.vault_key);
+            storage::write_state(&verified_layout, &target_state)?;
+
+            let resolution = match target_kind {
+                storage::CanonicalStateKind::Ready { scope } => {
+                    self.validate_active_scope_once(&verified_layout, scope)?;
+                    CanonicalResolution::Ready(scope)
+                }
+                storage::CanonicalStateKind::RecoveryRequired => {
+                    self.inspect_recovery_state(&verified_layout)?
+                }
+            };
+            let status = self.snapshot_for_resolution(&verified_layout, resolution)?;
+            self.emit_snapshot(&status);
+            Ok(status)
+        })();
+        let outcome = match &result {
+            Ok(_) => "completed",
+            Err(error) if error.contains("changed again") || error.contains("state changed") => {
+                "stale"
+            }
+            Err(error) if error.contains("transaction is pending") => "blocked",
+            Err(_) => "failed",
+        };
+        log_storage_event(
+            &initial_layout.vault_key,
+            None,
+            "identity_adoption",
+            outcome,
+        );
+        result
+    }
+
     fn reconcile_storage(
         &self,
         layout: &storage::VaultStorageLayout,
@@ -1163,6 +1289,28 @@ impl AiHistoryStorageService {
         if command == "ai_retry_history_recovery" {
             return serde_json::to_value(self.retry_recovery(&layout)?)
                 .map_err(|error| error.to_string());
+        }
+        if command == "ai_adopt_history_storage_identity" {
+            let previous_identity = required_string(
+                &args,
+                &[
+                    "expectedPreviousFilesystemIdentity",
+                    "expected_previous_filesystem_identity",
+                ],
+            )?;
+            let current_identity = required_string(
+                &args,
+                &[
+                    "expectedCurrentFilesystemIdentity",
+                    "expected_current_filesystem_identity",
+                ],
+            )?;
+            return serde_json::to_value(self.adopt_filesystem_identity(
+                vault_root,
+                &previous_identity,
+                &current_identity,
+            )?)
+            .map_err(|error| error.to_string());
         }
         if command == "reconcile_ai_history_storage" {
             let target: storage::AIStorageScope = serde_json::from_value(
@@ -2244,6 +2392,49 @@ mod tests {
         );
         assert_eq!(diagnostic["roots"][0]["id"], "device");
         assert_eq!(diagnostic["roots"][0]["hasData"], true);
+
+        let previous_identity = diagnostic["identityChange"]["previousFilesystemIdentity"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        let current_identity = diagnostic["identityChange"]["currentFilesystemIdentity"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert!(service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": "stale-identity",
+                    "expectedCurrentFilesystemIdentity": current_identity,
+                }),
+            )
+            .is_err());
+
+        let adopted = service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": previous_identity,
+                    "expectedCurrentFilesystemIdentity": current_identity,
+                }),
+            )
+            .unwrap();
+        assert_eq!(adopted["status"], "ready");
+        assert_eq!(adopted["scope"], "device");
+        let histories = service
+            .invoke("ai_load_session_histories", &vault, json!({}))
+            .unwrap();
+        assert_eq!(histories[0]["session_id"], "original");
+        let storage::StateRead::Valid(adopted_state) = storage::read_state(&current_layout) else {
+            panic!("expected the adopted state to be valid");
+        };
+        assert_eq!(
+            adopted_state.filesystem_identity,
+            current_layout.filesystem_identity
+        );
     }
 
     #[test]
@@ -2295,6 +2486,170 @@ mod tests {
         );
         assert_eq!(fs::read(&layout.state_file).unwrap(), state_before);
         assert_eq!(fs::read(&layout.operation_file).unwrap(), operation_before);
+        let storage::StateRead::FilesystemIdentityChanged(state) = storage::read_state(&layout)
+        else {
+            panic!("expected identity recovery to remain pending");
+        };
+        assert!(service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": state.filesystem_identity,
+                    "expectedCurrentFilesystemIdentity": layout.filesystem_identity,
+                }),
+            )
+            .is_err());
+        assert_eq!(fs::read(&layout.state_file).unwrap(), state_before);
+        assert_eq!(fs::read(&layout.operation_file).unwrap(), operation_before);
+    }
+
+    #[test]
+    fn adopting_a_rematerialized_vault_scope_preserves_its_canonical_scope() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        let replacement = parent.path().join("replacement");
+        fs::create_dir(&vault).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        service
+            .invoke(
+                "ai_save_session_history",
+                &vault,
+                json!({ "history": text_history("vault-session", "vault history") }),
+            )
+            .unwrap();
+        service
+            .invoke(
+                "reconcile_ai_history_storage",
+                &vault,
+                json!({ "targetScope": "vault" }),
+            )
+            .unwrap();
+
+        fs::rename(vault.join(".neverwrite"), replacement.join(".neverwrite")).unwrap();
+        fs::remove_dir_all(&vault).unwrap();
+        fs::rename(&replacement, &vault).unwrap();
+
+        let diagnostic = service
+            .invoke("ai_get_history_recovery_diagnostic", &vault, json!({}))
+            .unwrap();
+        assert_eq!(diagnostic["identityChange"]["scope"], "vault");
+        let adopted = service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": diagnostic["identityChange"]["previousFilesystemIdentity"],
+                    "expectedCurrentFilesystemIdentity": diagnostic["identityChange"]["currentFilesystemIdentity"],
+                }),
+            )
+            .unwrap();
+        assert_eq!(adopted["status"], "ready");
+        assert_eq!(adopted["scope"], "vault");
+        let histories = service
+            .invoke("ai_load_session_histories", &vault, json!({}))
+            .unwrap();
+        assert_eq!(histories[0]["session_id"], "vault-session");
+    }
+
+    #[test]
+    fn identity_adoption_preserves_an_existing_recovery_required_state() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        let replacement = parent.path().join("replacement");
+        fs::create_dir(&vault).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        service
+            .invoke(
+                "ai_save_session_history",
+                &vault,
+                json!({ "history": text_history("device-session", "device history") }),
+            )
+            .unwrap();
+        let original_layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        persistence::save_session_history(
+            &original_layout.vault.histories,
+            &text_history("vault-session", "vault history"),
+        )
+        .unwrap();
+        storage::write_state(
+            &original_layout,
+            &storage::CanonicalState::recovery_required(&original_layout),
+        )
+        .unwrap();
+
+        fs::rename(vault.join(".neverwrite"), replacement.join(".neverwrite")).unwrap();
+        fs::remove_dir_all(&vault).unwrap();
+        fs::rename(&replacement, &vault).unwrap();
+
+        let diagnostic = service
+            .invoke("ai_get_history_recovery_diagnostic", &vault, json!({}))
+            .unwrap();
+        assert_eq!(diagnostic["identityChange"]["scope"], Value::Null);
+        let adopted = service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": diagnostic["identityChange"]["previousFilesystemIdentity"],
+                    "expectedCurrentFilesystemIdentity": diagnostic["identityChange"]["currentFilesystemIdentity"],
+                }),
+            )
+            .unwrap();
+        assert_eq!(adopted["status"], "recovery_required");
+        assert_eq!(adopted["details"]["reason"], "dual_roots");
+        let current_layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        assert!(matches!(
+            storage::read_state(&current_layout),
+            storage::StateRead::Valid(storage::CanonicalState {
+                kind: storage::CanonicalStateKind::RecoveryRequired,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn identity_adoption_rejects_an_invalid_canonical_root_without_rewriting_state() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        let replacement = parent.path().join("replacement");
+        fs::create_dir(&vault).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        service
+            .invoke(
+                "ai_save_session_history",
+                &vault,
+                json!({ "history": text_history("device-session", "device history") }),
+            )
+            .unwrap();
+
+        fs::remove_dir_all(&vault).unwrap();
+        fs::rename(&replacement, &vault).unwrap();
+        let layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        fs::write(layout.device.histories.join("unknown-artifact"), b"invalid").unwrap();
+        let state_before = fs::read(&layout.state_file).unwrap();
+        let storage::StateRead::FilesystemIdentityChanged(state) = storage::read_state(&layout)
+        else {
+            panic!("expected identity recovery to be available");
+        };
+
+        assert!(service
+            .invoke(
+                "ai_adopt_history_storage_identity",
+                &vault,
+                json!({
+                    "expectedPreviousFilesystemIdentity": state.filesystem_identity,
+                    "expectedCurrentFilesystemIdentity": layout.filesystem_identity,
+                }),
+            )
+            .is_err());
+        assert_eq!(fs::read(&layout.state_file).unwrap(), state_before);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai_history/mod.rs
+++ b/apps/desktop/native-backend/src/ai_history/mod.rs
@@ -80,6 +80,7 @@ struct RecoveryDetails {
     reason: String,
     message: String,
     can_reconcile: bool,
+    can_adopt_identity: bool,
     conflicting_session_ids: Vec<String>,
     conflicting_attachment_ids: Vec<String>,
     renamed_device_history: bool,
@@ -91,9 +92,19 @@ struct RecoveryDiagnostic {
     reason: String,
     message: String,
     can_reconcile: bool,
+    can_adopt_identity: bool,
     conflicting_session_ids: Vec<String>,
     conflicting_attachment_ids: Vec<String>,
     roots: Vec<RecoveryDiagnosticRoot>,
+    identity_change: Option<IdentityChangeDiagnostic>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IdentityChangeDiagnostic {
+    previous_filesystem_identity: String,
+    current_filesystem_identity: String,
+    scope: Option<storage::AIStorageScope>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -131,6 +142,9 @@ enum RecoveryPlan {
     MultipleLocalRoots {
         source: storage::ScopeLayout,
     },
+    FilesystemIdentityChange {
+        state: storage::CanonicalState,
+    },
 }
 
 impl RecoveryPlan {
@@ -138,7 +152,7 @@ impl RecoveryPlan {
         match self {
             Self::Roots { inspection } => inspection.can_reconcile(),
             Self::RenamedDevice { .. } => true,
-            Self::MultipleLocalRoots { .. } => false,
+            Self::MultipleLocalRoots { .. } | Self::FilesystemIdentityChange { .. } => false,
         }
     }
 }
@@ -430,6 +444,9 @@ impl AiHistoryStorageService {
         &self,
         layout: &storage::VaultStorageLayout,
     ) -> Result<CanonicalResolution, String> {
+        if let storage::StateRead::FilesystemIdentityChanged(state) = storage::read_state(layout) {
+            return self.inspect_filesystem_identity_change(layout, state);
+        }
         self.recover_pending_operation(layout)?;
         match storage::read_state(layout) {
             storage::StateRead::Missing => self.initialize_missing_state(layout),
@@ -438,12 +455,16 @@ impl AiHistoryStorageService {
                     reason: "invalid_state".to_string(),
                     message,
                     can_reconcile: false,
+                    can_adopt_identity: false,
                     conflicting_session_ids: Vec::new(),
                     conflicting_attachment_ids: Vec::new(),
                     renamed_device_history: false,
                 },
                 None,
             )),
+            storage::StateRead::FilesystemIdentityChanged(state) => {
+                self.inspect_filesystem_identity_change(layout, state)
+            }
             storage::StateRead::Valid(state) => match state.kind {
                 storage::CanonicalStateKind::Ready { scope } => {
                     self.validate_active_scope_once(layout, scope)?;
@@ -454,6 +475,60 @@ impl AiHistoryStorageService {
                 }
             },
         }
+    }
+
+    fn inspect_filesystem_identity_change(
+        &self,
+        layout: &storage::VaultStorageLayout,
+        state: storage::CanonicalState,
+    ) -> Result<CanonicalResolution, String> {
+        let operation_pending = storage::read_operation(layout)?.is_some()
+            || migration::has_pending(&self.app_data_root)?;
+        let validation = match &state.kind {
+            storage::CanonicalStateKind::Ready { scope } => {
+                migration::inspect_layout(&layout.scope(*scope).transaction_layout()).map(|_| ())
+            }
+            storage::CanonicalStateKind::RecoveryRequired => {
+                migration::inspect_layout(&layout.device.transaction_layout())
+                    .and_then(|_| migration::inspect_layout(&layout.vault.transaction_layout()))
+                    .map(|_| ())
+            }
+        };
+        let (reason, message, can_adopt_identity) = if operation_pending {
+            (
+                "filesystem_identity_changed_during_operation".to_string(),
+                "The vault folder identity changed while an AI history transaction was pending. Automatic recovery is paused."
+                    .to_string(),
+                false,
+            )
+        } else if let Err(error) = validation {
+            (
+                "filesystem_identity_changed".to_string(),
+                format!(
+                    "The vault folder identity changed, but the saved AI history could not be validated: {error}"
+                ),
+                false,
+            )
+        } else {
+            (
+                "filesystem_identity_changed".to_string(),
+                "The vault folder identity changed. Confirm that this is the same vault to restore access to AI chats."
+                    .to_string(),
+                true,
+            )
+        };
+        Ok(CanonicalResolution::Recovery(
+            RecoveryDetails {
+                reason,
+                message,
+                can_reconcile: false,
+                can_adopt_identity,
+                conflicting_session_ids: Vec::new(),
+                conflicting_attachment_ids: Vec::new(),
+                renamed_device_history: false,
+            },
+            Some(RecoveryPlan::FilesystemIdentityChange { state }),
+        ))
     }
 
     fn initialize_missing_state(
@@ -475,6 +550,7 @@ impl AiHistoryStorageService {
                         reason: "unreadable_storage".to_string(),
                         message,
                         can_reconcile: false,
+                        can_adopt_identity: false,
                         conflicting_session_ids: Vec::new(),
                         conflicting_attachment_ids: Vec::new(),
                         renamed_device_history: false,
@@ -494,6 +570,7 @@ impl AiHistoryStorageService {
                             reason: "multiple_local_roots".to_string(),
                             message: "Local AI history from the previous vault path exists alongside current storage.".to_string(),
                             can_reconcile: false,
+                            can_adopt_identity: false,
                             conflicting_session_ids: Vec::new(),
                             conflicting_attachment_ids: Vec::new(),
                             renamed_device_history: true,
@@ -511,6 +588,7 @@ impl AiHistoryStorageService {
                             "Local AI chats from this vault's previous path are ready to import."
                                 .to_string(),
                         can_reconcile: true,
+                        can_adopt_identity: false,
                         conflicting_session_ids: Vec::new(),
                         conflicting_attachment_ids: Vec::new(),
                         renamed_device_history: true,
@@ -598,6 +676,7 @@ impl AiHistoryStorageService {
                             "Local AI chats from this vault's previous path are ready to import."
                                 .to_string(),
                         can_reconcile: true,
+                        can_adopt_identity: false,
                         conflicting_session_ids: Vec::new(),
                         conflicting_attachment_ids: Vec::new(),
                         renamed_device_history: true,
@@ -623,6 +702,7 @@ impl AiHistoryStorageService {
                             .or_else(|| vault.err())
                             .unwrap_or_else(|| "AI history storage is not readable.".to_string()),
                         can_reconcile: false,
+                        can_adopt_identity: false,
                         conflicting_session_ids: Vec::new(),
                         conflicting_attachment_ids: Vec::new(),
                         renamed_device_history: false,
@@ -638,6 +718,7 @@ impl AiHistoryStorageService {
                     message: "AI history recovery is still required before chats can be loaded."
                         .to_string(),
                     can_reconcile: false,
+                    can_adopt_identity: false,
                     conflicting_session_ids: Vec::new(),
                     conflicting_attachment_ids: Vec::new(),
                     renamed_device_history: false,
@@ -664,6 +745,7 @@ impl AiHistoryStorageService {
                     .to_string()
             },
             can_reconcile,
+            can_adopt_identity: false,
             conflicting_session_ids: inspection.conflicting_session_ids.clone(),
             conflicting_attachment_ids: inspection.conflicting_attachment_ids.clone(),
             renamed_device_history: false,
@@ -711,11 +793,12 @@ impl AiHistoryStorageService {
         let CanonicalResolution::Recovery(details, plan) = resolution else {
             return Err("AI history recovery is not required.".to_string());
         };
-        let device = migration::inspect_layout(&layout.device.transaction_layout())?;
-        let vault = migration::inspect_layout(&layout.vault.transaction_layout())?;
         let mut roots = Vec::new();
+        let mut identity_change = None;
         match plan {
             Some(RecoveryPlan::Roots { .. }) => {
+                let device = migration::inspect_layout(&layout.device.transaction_layout())?;
+                let vault = migration::inspect_layout(&layout.vault.transaction_layout())?;
                 roots.push(RecoveryDiagnosticRoot {
                     id: RecoveryRootId::Device,
                     label: "Device data",
@@ -737,6 +820,8 @@ impl AiHistoryStorageService {
             }
             Some(RecoveryPlan::MultipleLocalRoots { source }) => {
                 let previous = migration::inspect_layout(&source.transaction_layout())?;
+                let device = migration::inspect_layout(&layout.device.transaction_layout())?;
+                let vault = migration::inspect_layout(&layout.vault.transaction_layout())?;
                 roots.push(RecoveryDiagnosticRoot {
                     id: RecoveryRootId::PreviousDevice,
                     label: "Previous local data",
@@ -753,17 +838,60 @@ impl AiHistoryStorageService {
                     has_data: !vault.empty,
                 });
             }
+            Some(RecoveryPlan::FilesystemIdentityChange { state }) => {
+                let scope = match state.kind {
+                    storage::CanonicalStateKind::Ready { scope } => {
+                        let inspection =
+                            migration::inspect_layout(&layout.scope(scope).transaction_layout())?;
+                        let (id, label) = match scope {
+                            storage::AIStorageScope::Device => {
+                                (RecoveryRootId::Device, "Device data")
+                            }
+                            storage::AIStorageScope::Vault => (RecoveryRootId::Vault, "Vault data"),
+                        };
+                        roots.push(RecoveryDiagnosticRoot {
+                            id,
+                            label,
+                            has_data: !inspection.empty,
+                        });
+                        Some(scope)
+                    }
+                    storage::CanonicalStateKind::RecoveryRequired => {
+                        let device =
+                            migration::inspect_layout(&layout.device.transaction_layout())?;
+                        let vault = migration::inspect_layout(&layout.vault.transaction_layout())?;
+                        roots.push(RecoveryDiagnosticRoot {
+                            id: RecoveryRootId::Device,
+                            label: "Device data",
+                            has_data: !device.empty,
+                        });
+                        roots.push(RecoveryDiagnosticRoot {
+                            id: RecoveryRootId::Vault,
+                            label: "Vault data",
+                            has_data: !vault.empty,
+                        });
+                        None
+                    }
+                };
+                identity_change = Some(IdentityChangeDiagnostic {
+                    previous_filesystem_identity: state.filesystem_identity,
+                    current_filesystem_identity: layout.filesystem_identity.clone(),
+                    scope,
+                });
+            }
             None => {}
         }
         Ok(RecoveryDiagnostic {
             reason: details.reason,
             message: details.message,
             can_reconcile: details.can_reconcile,
+            can_adopt_identity: details.can_adopt_identity,
             conflicting_session_ids: details.conflicting_session_ids,
             conflicting_attachment_ids: details.conflicting_attachment_ids,
             // Paths remain backend-only. The UI receives stable root IDs that
             // can be resolved by the reveal command without leaking locations.
             roots,
+            identity_change,
         })
     }
 
@@ -792,6 +920,30 @@ impl AiHistoryStorageService {
                     "The previous local data root is not part of this recovery state.".to_string(),
                 ),
             },
+            CanonicalResolution::Recovery(
+                _,
+                Some(RecoveryPlan::FilesystemIdentityChange { state }),
+            ) => match (state.kind, root) {
+                (
+                    storage::CanonicalStateKind::Ready {
+                        scope: storage::AIStorageScope::Device,
+                    },
+                    RecoveryRootId::Device,
+                )
+                | (storage::CanonicalStateKind::RecoveryRequired, RecoveryRootId::Device) => {
+                    Ok(layout.device.histories.clone())
+                }
+                (
+                    storage::CanonicalStateKind::Ready {
+                        scope: storage::AIStorageScope::Vault,
+                    },
+                    RecoveryRootId::Vault,
+                )
+                | (storage::CanonicalStateKind::RecoveryRequired, RecoveryRootId::Vault) => {
+                    Ok(layout.vault.histories.clone())
+                }
+                _ => Err("This data root is not part of the identity recovery state.".to_string()),
+            },
             CanonicalResolution::Recovery(_, _) => {
                 Err("This recovery state does not have a safe data location to reveal.".to_string())
             }
@@ -805,6 +957,12 @@ impl AiHistoryStorageService {
         &self,
         layout: &storage::VaultStorageLayout,
     ) -> Result<StorageStatusSnapshot, String> {
+        if matches!(
+            storage::read_state(layout),
+            storage::StateRead::FilesystemIdentityChanged(_)
+        ) {
+            return Ok(self.storage_status(layout));
+        }
         self.recover_pending_operation(layout)?;
         if !matches!(
             storage::read_state(layout),
@@ -901,6 +1059,10 @@ impl AiHistoryStorageService {
                     ),
                     RecoveryPlan::MultipleLocalRoots { .. } => {
                         return Err("Multiple local AI history roots require manual resolution."
+                            .to_string());
+                    }
+                    RecoveryPlan::FilesystemIdentityChange { .. } => {
+                        return Err("The vault folder identity must be restored before AI history storage can change."
                             .to_string());
                     }
                 }
@@ -2035,7 +2197,7 @@ mod tests {
     }
 
     #[test]
-    fn recreating_a_vault_path_never_reuses_its_device_history_namespace() {
+    fn recreating_a_vault_path_requires_explicit_identity_recovery() {
         let app_data = tempfile::tempdir().unwrap();
         let parent = tempfile::tempdir().unwrap();
         let vault = parent.path().join("vault");
@@ -2060,14 +2222,79 @@ mod tests {
             .invoke("ai_get_history_storage_status", &vault, json!({}))
             .unwrap();
         assert_eq!(status["status"], "recovery_required");
-        assert_eq!(status["details"]["reason"], "invalid_state");
-        assert!(status["details"]["message"]
-            .as_str()
-            .unwrap()
-            .contains("previous vault"));
+        assert_eq!(status["details"]["reason"], "filesystem_identity_changed");
+        assert_eq!(status["details"]["canAdoptIdentity"], true);
         assert!(service
             .invoke("ai_load_session_histories", &vault, json!({}))
             .is_err());
+
+        let current_layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        let diagnostic = service
+            .invoke("ai_get_history_recovery_diagnostic", &vault, json!({}))
+            .unwrap();
+        assert_eq!(diagnostic["canAdoptIdentity"], true);
+        assert_eq!(diagnostic["identityChange"]["scope"], "device");
+        assert_eq!(
+            diagnostic["identityChange"]["currentFilesystemIdentity"],
+            current_layout.filesystem_identity
+        );
+        assert_ne!(
+            diagnostic["identityChange"]["previousFilesystemIdentity"],
+            diagnostic["identityChange"]["currentFilesystemIdentity"]
+        );
+        assert_eq!(diagnostic["roots"][0]["id"], "device");
+        assert_eq!(diagnostic["roots"][0]["hasData"], true);
+    }
+
+    #[test]
+    fn identity_change_pauses_a_pending_storage_operation_without_mutating_it() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        let replacement = parent.path().join("replacement");
+        fs::create_dir(&vault).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        let service = AiHistoryStorageService::new(app_data.path().to_path_buf());
+        service
+            .invoke(
+                "ai_save_session_history",
+                &vault,
+                json!({ "history": text_history("original", "before replacement") }),
+            )
+            .unwrap();
+
+        fs::remove_dir_all(&vault).unwrap();
+        fs::rename(&replacement, &vault).unwrap();
+        let layout = storage::resolve_layout(app_data.path(), &vault).unwrap();
+        let operation = storage::PendingOperation::new(
+            &layout,
+            uuid::Uuid::new_v4().simple().to_string(),
+            storage::AIStorageScope::Device,
+            storage::AIStorageScope::Vault,
+            None,
+        );
+        storage::write_operation(&layout, &operation).unwrap();
+        let state_before = fs::read(&layout.state_file).unwrap();
+        let operation_before = fs::read(&layout.operation_file).unwrap();
+
+        let status = service
+            .invoke("ai_get_history_storage_status", &vault, json!({}))
+            .unwrap();
+        assert_eq!(
+            status["details"]["reason"],
+            "filesystem_identity_changed_during_operation"
+        );
+        assert_eq!(status["details"]["canAdoptIdentity"], false);
+
+        let retried = service
+            .invoke("ai_retry_history_recovery", &vault, json!({}))
+            .unwrap();
+        assert_eq!(
+            retried["details"]["reason"],
+            "filesystem_identity_changed_during_operation"
+        );
+        assert_eq!(fs::read(&layout.state_file).unwrap(), state_before);
+        assert_eq!(fs::read(&layout.operation_file).unwrap(), operation_before);
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/ai_history/storage.rs
+++ b/apps/desktop/native-backend/src/ai_history/storage.rs
@@ -74,7 +74,7 @@ impl VaultStorageLayout {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub(super) struct CanonicalState {
     version: u32,
@@ -84,7 +84,7 @@ pub(super) struct CanonicalState {
     pub kind: CanonicalStateKind,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
 pub(super) enum CanonicalStateKind {
     Ready { scope: AIStorageScope },
@@ -110,6 +110,20 @@ impl CanonicalState {
             vault_path: layout.canonical_vault_path.clone(),
             kind: CanonicalStateKind::RecoveryRequired,
         }
+    }
+
+    pub(super) fn adopt_filesystem_identity(
+        mut self,
+        layout: &VaultStorageLayout,
+    ) -> Result<Self, String> {
+        if self.version != STATE_VERSION
+            || self.vault_key != layout.vault_key
+            || self.vault_path != layout.canonical_vault_path
+        {
+            return Err("AI history state cannot be adopted by this vault.".to_string());
+        }
+        self.filesystem_identity = layout.filesystem_identity.clone();
+        Ok(self)
     }
 }
 

--- a/apps/desktop/native-backend/src/ai_history/storage.rs
+++ b/apps/desktop/native-backend/src/ai_history/storage.rs
@@ -117,6 +117,7 @@ impl CanonicalState {
 pub(super) enum StateRead {
     Missing,
     Valid(CanonicalState),
+    FilesystemIdentityChanged(CanonicalState),
     Invalid(String),
 }
 
@@ -242,9 +243,7 @@ pub(super) fn read_state(layout: &VaultStorageLayout) -> StateRead {
         return StateRead::Invalid("AI history state belongs to another vault path.".to_string());
     }
     if state.filesystem_identity != layout.filesystem_identity {
-        return StateRead::Invalid(
-            "AI history state belongs to a previous vault at this path.".to_string(),
-        );
+        return StateRead::FilesystemIdentityChanged(state);
     }
     StateRead::Valid(state)
 }
@@ -881,6 +880,36 @@ mod tests {
         value["version"] = serde_json::json!(2);
         fs::write(&layout.state_file, serde_json::to_vec(&value).unwrap()).unwrap();
         assert!(matches!(read_state(&layout), StateRead::Invalid(_)));
+    }
+
+    #[test]
+    fn state_classifies_only_a_filesystem_identity_change_as_recoverable() {
+        let app_data = tempfile::tempdir().unwrap();
+        let parent = tempfile::tempdir().unwrap();
+        let vault = parent.path().join("vault");
+        let replacement = parent.path().join("replacement");
+        fs::create_dir(&vault).unwrap();
+        fs::create_dir(&replacement).unwrap();
+        let original_layout = resolve_layout(app_data.path(), &vault).unwrap();
+        write_state(
+            &original_layout,
+            &CanonicalState::ready(&original_layout, AIStorageScope::Device),
+        )
+        .unwrap();
+
+        fs::remove_dir(&vault).unwrap();
+        fs::rename(&replacement, &vault).unwrap();
+        let current_layout = resolve_layout(app_data.path(), &vault).unwrap();
+
+        let StateRead::FilesystemIdentityChanged(state) = read_state(&current_layout) else {
+            panic!("expected a typed filesystem identity change");
+        };
+        assert_eq!(state.vault_key, current_layout.vault_key);
+        assert_eq!(state.vault_path, current_layout.canonical_vault_path);
+        assert_ne!(
+            state.filesystem_identity,
+            current_layout.filesystem_identity
+        );
     }
 
     #[test]

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -104,6 +104,7 @@ const SUPPORTED_COMMANDS = new Set([
     "ai_get_history_recovery_diagnostic",
     "ai_reveal_history_recovery_root",
     "ai_retry_history_recovery",
+    "ai_adopt_history_storage_identity",
     "reconcile_ai_history_storage",
     "forget_ai_history_device_data",
     "ai_register_file_baseline",

--- a/apps/desktop/src-electron/main/vaultBackend.test.ts
+++ b/apps/desktop/src-electron/main/vaultBackend.test.ts
@@ -170,6 +170,7 @@ describe("native backend AI history recovery command support", () => {
         "ai_get_history_recovery_diagnostic",
         "ai_reveal_history_recovery_root",
         "ai_retry_history_recovery",
+        "ai_adopt_history_storage_identity",
     ])("declares %s for the native sidecar", (command) => {
         expect(supportsNativeBackendCommand(command)).toBe(true);
     });

--- a/apps/desktop/src/features/ai/api.ts
+++ b/apps/desktop/src/features/ai/api.ts
@@ -86,6 +86,7 @@ export interface AIHistoryRecoveryDetails {
     reason: string;
     message: string;
     canReconcile: boolean;
+    canAdoptIdentity: boolean;
     conflictingSessionIds: string[];
     conflictingAttachmentIds: string[];
     renamedDeviceHistory: boolean;
@@ -100,6 +101,7 @@ export interface AIHistoryRecoveryDiagnostic {
     reason: string;
     message: string;
     canReconcile: boolean;
+    canAdoptIdentity: boolean;
     conflictingSessionIds: string[];
     conflictingAttachmentIds: string[];
     roots: Array<{
@@ -107,6 +109,11 @@ export interface AIHistoryRecoveryDiagnostic {
         label: string;
         hasData: boolean;
     }>;
+    identityChange: {
+        previousFilesystemIdentity: string;
+        currentFilesystemIdentity: string;
+        scope: AIStorageScope | null;
+    } | null;
 }
 
 export type AIHistoryStorageStatus =
@@ -1062,6 +1069,21 @@ export async function retryAiHistoryRecovery(
     return invoke<AIHistoryStorageStatus>("ai_retry_history_recovery", {
         vaultPath,
     });
+}
+
+export async function adoptAiHistoryStorageIdentity(
+    vaultPath: string,
+    expectedPreviousFilesystemIdentity: string,
+    expectedCurrentFilesystemIdentity: string,
+): Promise<AIHistoryStorageStatus> {
+    return invoke<AIHistoryStorageStatus>(
+        "ai_adopt_history_storage_identity",
+        {
+            vaultPath,
+            expectedPreviousFilesystemIdentity,
+            expectedCurrentFilesystemIdentity,
+        },
+    );
 }
 
 export async function listenToAiHistoryStorageChanged(

--- a/apps/desktop/src/features/ai/components/AIHistoryStorageControl.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIHistoryStorageControl.test.tsx
@@ -19,6 +19,7 @@ describe("AIHistoryStorageControl", () => {
             },
             refreshAiHistoryStorageStatus: vi.fn(async () => undefined),
             changeAiHistoryStorage: vi.fn(async () => true),
+            adoptAiHistoryStorageIdentity: vi.fn(async () => true),
         });
     });
 
@@ -116,6 +117,7 @@ describe("AIHistoryStorageControl", () => {
                 reason: "multiple_local_roots",
                 message: "Manual recovery required.",
                 canReconcile: false,
+                canAdoptIdentity: false,
                 conflictingSessionIds: [],
                 conflictingAttachmentIds: [],
                 roots: [
@@ -135,6 +137,7 @@ describe("AIHistoryStorageControl", () => {
                         hasData: true,
                     },
                 ],
+                identityChange: null,
             };
         });
         useChatStore.setState({
@@ -146,6 +149,7 @@ describe("AIHistoryStorageControl", () => {
                     reason: "multiple_local_roots",
                     message: "Manual recovery required.",
                     canReconcile: false,
+                    canAdoptIdentity: false,
                     conflictingSessionIds: [],
                     conflictingAttachmentIds: [],
                     renamedDeviceHistory: false,
@@ -191,5 +195,124 @@ describe("AIHistoryStorageControl", () => {
                 "/previous-local-history",
             ),
         );
+    });
+
+    it("confirms the exact filesystem identity transition before restoring access", async () => {
+        vi.mocked(invoke).mockResolvedValue({
+            reason: "filesystem_identity_changed",
+            message:
+                "The vault folder identity changed. Confirm that this is the same vault to restore access to AI chats.",
+            canReconcile: false,
+            canAdoptIdentity: true,
+            conflictingSessionIds: [],
+            conflictingAttachmentIds: [],
+            roots: [
+                {
+                    id: "device",
+                    label: "Device data",
+                    hasData: true,
+                },
+            ],
+            identityChange: {
+                previousFilesystemIdentity: "previous-identity",
+                currentFilesystemIdentity: "current-identity",
+                scope: "device",
+            },
+        });
+        useChatStore.setState({
+            historyStorageStatus: {
+                vaultKey: "vault-key",
+                generation: 2,
+                status: "recovery_required",
+                details: {
+                    reason: "filesystem_identity_changed",
+                    message:
+                        "The vault folder identity changed. Confirm that this is the same vault to restore access to AI chats.",
+                    canReconcile: false,
+                    canAdoptIdentity: true,
+                    conflictingSessionIds: [],
+                    conflictingAttachmentIds: [],
+                    renamedDeviceHistory: false,
+                },
+            },
+        });
+
+        renderComponent(<AIHistoryStorageControl vaultPath="/vault" />);
+
+        const restore = await screen.findByRole("button", {
+            name: "Restore access to AI chats",
+        });
+        expect(
+            screen.queryByRole("button", { name: "Use this device" }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole("button", { name: "Use this vault" }),
+        ).not.toBeInTheDocument();
+        fireEvent.click(restore);
+
+        await waitFor(() =>
+            expect(confirm).toHaveBeenCalledWith(
+                "NeverWrite will attach the existing AI chat history to this folder without moving or deleting any chats. Continue only if this is the same vault.",
+                {
+                    title: "Trust this vault at its current location?",
+                    kind: "warning",
+                    okLabel: "Trust and restore chats",
+                    cancelLabel: "Cancel",
+                },
+            ),
+        );
+        expect(
+            useChatStore.getState().adoptAiHistoryStorageIdentity,
+        ).toHaveBeenCalledWith(
+            "/vault",
+            "previous-identity",
+            "current-identity",
+        );
+    });
+
+    it("leaves identity recovery untouched when the user cancels", async () => {
+        vi.mocked(confirm).mockResolvedValue(false);
+        vi.mocked(invoke).mockResolvedValue({
+            reason: "filesystem_identity_changed",
+            message: "Identity changed.",
+            canReconcile: false,
+            canAdoptIdentity: true,
+            conflictingSessionIds: [],
+            conflictingAttachmentIds: [],
+            roots: [],
+            identityChange: {
+                previousFilesystemIdentity: "previous-identity",
+                currentFilesystemIdentity: "current-identity",
+                scope: "device",
+            },
+        });
+        useChatStore.setState({
+            historyStorageStatus: {
+                vaultKey: "vault-key",
+                generation: 2,
+                status: "recovery_required",
+                details: {
+                    reason: "filesystem_identity_changed",
+                    message: "Identity changed.",
+                    canReconcile: false,
+                    canAdoptIdentity: true,
+                    conflictingSessionIds: [],
+                    conflictingAttachmentIds: [],
+                    renamedDeviceHistory: false,
+                },
+            },
+        });
+
+        renderComponent(<AIHistoryStorageControl vaultPath="/vault" />);
+        fireEvent.click(
+            await screen.findByRole("button", {
+                name: "Restore access to AI chats",
+            }),
+        );
+        await waitFor(() => expect(confirm).toHaveBeenCalled());
+
+        expect(
+            useChatStore.getState().adoptAiHistoryStorageIdentity,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/apps/desktop/src/features/ai/components/AIHistoryStorageControl.tsx
+++ b/apps/desktop/src/features/ai/components/AIHistoryStorageControl.tsx
@@ -30,6 +30,9 @@ export function AIHistoryStorageControl({
     const changeStorage = useChatStore(
         (state) => state.changeAiHistoryStorage,
     );
+    const adoptStorageIdentity = useChatStore(
+        (state) => state.adoptAiHistoryStorageIdentity,
+    );
     const [changing, setChanging] = useState(false);
     const [recoveryActionPending, setRecoveryActionPending] = useState(false);
     const [recoveryDiagnostic, setRecoveryDiagnostic] =
@@ -162,6 +165,36 @@ export function AIHistoryStorageControl({
         }
     }, [recoveryActionPending, refreshStatus, vaultPath]);
 
+    const adoptIdentity = useCallback(async () => {
+        const identityChange = recoveryDiagnostic?.identityChange;
+        if (!vaultPath || !identityChange || recoveryActionPending) return;
+        const accepted = await confirm(
+            "NeverWrite will attach the existing AI chat history to this folder without moving or deleting any chats. Continue only if this is the same vault.",
+            {
+                title: "Trust this vault at its current location?",
+                kind: "warning",
+                okLabel: "Trust and restore chats",
+                cancelLabel: "Cancel",
+            },
+        );
+        if (!accepted) return;
+        setRecoveryActionPending(true);
+        try {
+            await adoptStorageIdentity(
+                vaultPath,
+                identityChange.previousFilesystemIdentity,
+                identityChange.currentFilesystemIdentity,
+            );
+        } finally {
+            setRecoveryActionPending(false);
+        }
+    }, [
+        adoptStorageIdentity,
+        recoveryActionPending,
+        recoveryDiagnostic,
+        vaultPath,
+    ]);
+
     if (!vaultPath) return null;
 
     const isMoving =
@@ -254,6 +287,23 @@ export function AIHistoryStorageControl({
                     {conflictingIds.length > 0 ? (
                         <div className="mt-1 font-mono">
                             Conflicts: {conflictingIds.join(", ")}
+                        </div>
+                    ) : null}
+                    {recovery.canAdoptIdentity &&
+                    recoveryDiagnostic?.identityChange ? (
+                        <div className="mt-2 flex flex-wrap gap-2">
+                            <button
+                                type="button"
+                                disabled={isMoving}
+                                onClick={() => void adoptIdentity()}
+                                className="rounded px-2 py-1 text-[11px]"
+                                style={{
+                                    color: "var(--text-primary)",
+                                    border: "1px solid var(--border)",
+                                }}
+                            >
+                                Restore access to AI chats
+                            </button>
                         </div>
                     ) : null}
                     {recovery.canReconcile ? (

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -1073,6 +1073,135 @@ describe("chatStore", () => {
         });
     });
 
+    it("applies an adopted identity snapshot before reloading persisted history", async () => {
+        disposeChatStoreRuntime();
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            historyStorageVaultPath: "/vault",
+            historyStorageStatus: {
+                vaultKey: "vault-key",
+                generation: 1,
+                status: "recovery_required",
+                details: {
+                    reason: "filesystem_identity_changed",
+                    message: "Identity changed.",
+                    canReconcile: false,
+                    canAdoptIdentity: true,
+                    conflictingSessionIds: [],
+                    conflictingAttachmentIds: [],
+                    renamedDeviceHistory: false,
+                },
+            },
+        });
+        invokeMock.mockImplementation((command) => {
+            if (command === "ai_adopt_history_storage_identity") {
+                return Promise.resolve({
+                    vaultKey: "vault-key",
+                    generation: 2,
+                    status: "ready",
+                    scope: "device",
+                    orphanedDeviceHistories: [],
+                });
+            }
+            if (command === "ai_load_session_histories") {
+                return Promise.resolve([]);
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        await expect(
+            useChatStore
+                .getState()
+                .adoptAiHistoryStorageIdentity(
+                    "/vault",
+                    "previous-identity",
+                    "current-identity",
+                ),
+        ).resolves.toBe(true);
+
+        expect(invokeMock).toHaveBeenCalledWith(
+            "ai_adopt_history_storage_identity",
+            {
+                vaultPath: "/vault",
+                expectedPreviousFilesystemIdentity: "previous-identity",
+                expectedCurrentFilesystemIdentity: "current-identity",
+            },
+        );
+        expect(useChatStore.getState().historyStorageStatus).toMatchObject({
+            generation: 2,
+            status: "ready",
+            scope: "device",
+        });
+        expect(invokeMock).toHaveBeenCalledWith(
+            "ai_load_session_histories",
+            { vaultPath: "/vault", includeMessages: false },
+        );
+    });
+
+    it("refreshes identity recovery after a stale adoption fails", async () => {
+        disposeChatStoreRuntime();
+        useVaultStore.setState({ vaultPath: "/vault" });
+        useChatStore.setState({
+            historyStorageVaultPath: "/vault",
+            historyStorageStatus: {
+                vaultKey: "vault-key",
+                generation: 1,
+                status: "recovery_required",
+                details: {
+                    reason: "filesystem_identity_changed",
+                    message: "Identity changed.",
+                    canReconcile: false,
+                    canAdoptIdentity: true,
+                    conflictingSessionIds: [],
+                    conflictingAttachmentIds: [],
+                    renamedDeviceHistory: false,
+                },
+            },
+        });
+        invokeMock.mockImplementation((command) => {
+            if (command === "ai_adopt_history_storage_identity") {
+                return Promise.reject(new Error("stale identity"));
+            }
+            if (command === "ai_get_history_storage_status") {
+                return Promise.resolve({
+                    vaultKey: "vault-key",
+                    generation: 2,
+                    status: "recovery_required",
+                    details: {
+                        reason: "filesystem_identity_changed",
+                        message: "Identity changed again.",
+                        canReconcile: false,
+                        canAdoptIdentity: true,
+                        conflictingSessionIds: [],
+                        conflictingAttachmentIds: [],
+                        renamedDeviceHistory: false,
+                    },
+                });
+            }
+            throw new Error(`Unexpected command: ${command}`);
+        });
+
+        await expect(
+            useChatStore
+                .getState()
+                .adoptAiHistoryStorageIdentity(
+                    "/vault",
+                    "previous-identity",
+                    "current-identity",
+                ),
+        ).resolves.toBe(false);
+
+        expect(useChatStore.getState().historyStorageStatus).toMatchObject({
+            generation: 2,
+            status: "recovery_required",
+            details: { message: "Identity changed again." },
+        });
+        expect(invokeMock).not.toHaveBeenCalledWith(
+            "ai_load_session_histories",
+            expect.anything(),
+        );
+    });
+
     it("ignores a completed storage move after switching vaults", async () => {
         disposeChatStoreRuntime();
         useVaultStore.setState({ vaultPath: "/vault" });

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -38,6 +38,7 @@ import {
     aiSetModel,
     aiUpdateSetup,
     aiRegisterFileBaseline,
+    adoptAiHistoryStorageIdentity as adoptAiHistoryStorageIdentityApi,
     getAiHistoryStorageStatus,
     reconcileAiHistoryStorage,
     listenToAiHistoryStorageChanged,
@@ -1673,6 +1674,11 @@ interface ChatStore {
         vaultPath: string,
         targetScope: AIStorageScope,
         sourceVaultKey?: string,
+    ) => Promise<boolean>;
+    adoptAiHistoryStorageIdentity: (
+        vaultPath: string,
+        expectedPreviousFilesystemIdentity: string,
+        expectedCurrentFilesystemIdentity: string,
     ) => Promise<boolean>;
     reconcileRestoredWorkspaceTabs: (
         tabs: Array<{
@@ -10223,6 +10229,37 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 logWarn(
                     "chat-store",
                     "Failed to change AI history storage",
+                    error,
+                );
+                return false;
+            }
+        },
+
+        adoptAiHistoryStorageIdentity: async (
+            vaultPath,
+            expectedPreviousFilesystemIdentity,
+            expectedCurrentFilesystemIdentity,
+        ) => {
+            activateAiHistoryStorageContext(vaultPath);
+            try {
+                const snapshot = await adoptAiHistoryStorageIdentityApi(
+                    vaultPath,
+                    expectedPreviousFilesystemIdentity,
+                    expectedCurrentFilesystemIdentity,
+                );
+                applyAiHistoryStorageSnapshot(snapshot, vaultPath);
+                if (
+                    snapshot.status === "ready" &&
+                    useVaultStore.getState().vaultPath === vaultPath
+                ) {
+                    await refreshPersistedHistoryInventory(vaultPath);
+                }
+                return true;
+            } catch (error) {
+                await get().refreshAiHistoryStorageStatus(vaultPath);
+                logWarn(
+                    "chat-store",
+                    "Failed to restore AI history storage identity",
                     error,
                 );
                 return false;

--- a/docs/ai-session-history.md
+++ b/docs/ai-session-history.md
@@ -127,6 +127,10 @@ vault also keep separate local scope state. Filesystem changes made by another
 device are treated as external changes and are checked during initialization,
 recovery, and an explicit scope change.
 
+The vault root's filesystem identity is a replacement signal, not a permanent logical identity. Cloud sync, File Provider rematerialization, restore operations, and storage reconnects can replace the root directory while preserving its canonical path and contents. NeverWrite blocks AI history when that identity changes and requires `Restore access to AI chats`; the confirmation updates only the canonical state identity after validating the saved scope, without moving or deleting histories.
+
+A newly created folder at the previous path never inherits device-local AI history automatically. Confirm the recovery action only when the current folder represents the same logical vault. If the identity changed while a storage transaction was pending, automatic recovery remains paused and the diagnostic must be reviewed before any manual repair.
+
 After a crash, freeze, renderer reload, or AI runtime disconnect:
 
 1. Reopen the same vault.
@@ -183,4 +187,4 @@ send a new message so NeverWrite can continue with the stored transcript.
 - Pasted screenshot drafts and managed blobs are plaintext local image files;
   review them before sharing app data or a vault archive.
 
-Last updated: July 19, 2026.
+Last updated: August 25, 2026.

--- a/docs/data-and-privacy.md
+++ b/docs/data-and-privacy.md
@@ -120,6 +120,8 @@ than silently reusing a namespace. Separate devices do not share a canonical
 scope state: synced vault changes are treated as external filesystem changes and
 are checked during initialization, recovery, and an explicit scope move.
 
+Cloud sync, restore, and virtual filesystem providers can replace a vault root without changing its canonical path. NeverWrite treats the resulting filesystem identity change as a manual recovery boundary: normal history access remains blocked until the user confirms `Restore access to AI chats` and the backend validates the saved history root. For device scope, this restores the association with private history already held in app data and does not upload that history into the cloud-synced vault. For vault scope, it restores access to the validated `.neverwrite` data already present in the current folder.
+
 ### AI Screenshot Drafts And Managed Blobs
 
 Pasted chat screenshots are written as temporary local drafts before they are

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -363,6 +363,8 @@ If a session does not recover:
 
 - Reopen the same vault first. Session history is per-vault.
 - Open `Chat History`, select the saved conversation, and click `Restore`.
+- If Chat History reports that the vault folder identity changed, reveal or export the offered diagnostic root, confirm that the current folder is the same logical vault, and use `Restore access to AI chats`.
+- Do not edit `state.json` or move `.neverwrite` as the first response to an identity warning. A pending storage transaction or invalid history root intentionally prevents automatic adoption.
 - Check whether retention settings or manual deletion removed the conversation.
 - Confirm `.neverwrite/sessions/` exists and is readable.
 - If the UI shows `The AI runtime lost its connection. Reconnecting with saved


### PR DESCRIPTION
## Summary

- classify filesystem identity changes separately from corrupt or unrelated AI history state
- add an explicit backend adoption flow that validates the existing history storage, preserves the canonical scope, and atomically updates only the filesystem identity
- expose a guarded recovery action in Chat History settings and document the cloud rematerialization recovery flow

## Safety guarantees

- normal AI history access remains fail-closed until the user confirms that the current folder is the same logical vault
- adoption is offered only when the state version, vault key, and canonical path still match
- expected previous and current identities are verified again immediately before adoption to reject stale confirmations
- pending migration operations block automatic recovery and remain intact for diagnosis
- adoption never moves, merges, or deletes chats or attachments, and preserves `device`, `vault`, or `recovery_required` state

## Testing

- `cargo fmt -p neverwrite-native-backend -- --check`
- `cargo test -p neverwrite-native-backend` (367 tests)
- `cargo clippy -p neverwrite-native-backend --all-targets -- -D warnings`
- `npm test -- src-electron/main/vaultBackend.test.ts src/features/ai/components/AIHistoryStorageControl.test.tsx src/features/ai/store/chatStore.test.ts` (365 tests)
- `npm run lint`
- `npm run build`

Closes #417
