### PR TITLE
Promote embedded agent runtime to 0.150.0

### DIFF
--- a/Copyright.md
+++ b/Copyright.md
@@ -279,7 +279,7 @@ The bundled dictionary metadata lives in
 | Package                          | License     | Source                                  |
 | -------------------------------- | ----------- | --------------------------------------- |
 | codex-acp 0.16.0                 | Apache-2.0  | github.com/zed-industries/codex-acp     |
-| OpenAI Codex runtime rust-v0.147.0 | Apache-2.0 | github.com/openai/codex                 |
+| OpenAI Codex runtime rust-v0.150.0 | Apache-2.0 | github.com/openai/codex                 |
 | Claude-agent-acp-upstream        | Apache-2.0  | Anthropic                               |
 | @anthropic-ai/claude-agent-sdk   | Anthropic SDK terms | Anthropic                       |
 | @agentclientprotocol/sdk         | Apache-2.0  | Agent Client Protocol                   |
@@ -297,7 +297,7 @@ Original source: https://github.com/zed-industries/codex-acp (version 0.16.0).
 
 Zed Industries has deprecated Codex ACP. NeverWrite maintains this vendored adapter internally to preserve its Codex integration and compatibility with the application's review and session workflows.
 
-The adapter is built against the OpenAI Codex Rust workspace pinned to `rust-v0.147.0`; its packages are declared as Git dependencies in `vendor/codex-acp/Cargo.toml`.
+The adapter is built against the OpenAI Codex Rust workspace pinned to `rust-v0.150.0`; its packages are declared as Git dependencies in `vendor/codex-acp/Cargo.toml`.
 
 | File                  | Nature of changes                                              |
 | --------------------- | -------------------------------------------------------------- |
@@ -305,7 +305,7 @@ The adapter is built against the OpenAI Codex Rust workspace pinned to `rust-v0.
 | `src/codex_agent.rs`  | Adapted for Agent Client Protocol 0.14 compatibility and session configuration |
 | `src/prompt_args.rs`, `src/subagents.rs` | Added custom-prompt parsing and NeverWrite child-session lifecycle projection |
 | `src/lib.rs`, `src/main.rs` | Adjusted crate wiring and compile limits for the promoted runtime graph |
-| `vendor/codex-utils-pty/` | Maintains the standalone PTY snapshot and NeverWrite's macOS process-group fallback on the upstream 0.147.0 source |
+| `vendor/codex-utils-pty/` | Maintains the standalone PTY snapshot on the upstream 0.150.0 source, including Unix process-group and Windows ConPTY lifecycle hardening |
 
 ### `vendor/Claude-agent-acp-upstream` — Anthropic (Apache-2.0)
 

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -12258,6 +12258,52 @@ mod tests {
     }
 
     #[test]
+    fn backend_shutdown_stops_each_owned_process_once() {
+        let temp = tempfile::tempdir().unwrap();
+        let native_ai = test_native_ai_with_secret_store(
+            temp.path().join("runtime-setup.json"),
+            Arc::new(InMemoryRuntimeSecretStore::default()),
+        );
+        let (command_tx, mut command_rx) = tokio::sync::mpsc::unbounded_channel();
+        let handle = AcpSessionHandle {
+            process_id: 91,
+            command_tx,
+            prompt_capabilities: Arc::new(Mutex::new(AcpPromptCapabilities::default())),
+        };
+        let mut state = native_ai.inner.lock().unwrap();
+        for session_id in ["parent-session", "child-session"] {
+            state.sessions.insert(
+                session_id.to_string(),
+                ManagedAiSession {
+                    session: new_session_with_id(CODEX_RUNTIME_ID, session_id.to_string()).unwrap(),
+                    vault_root: None,
+                    additional_roots: vec![],
+                    runtime_handle: Some(handle.clone()),
+                    active_turn_id: None,
+                },
+            );
+            state.session_order.push(session_id.to_string());
+        }
+        drop(state);
+
+        let shutdown = thread::spawn(move || match command_rx.blocking_recv() {
+            Some(AcpCommand::Shutdown { response_tx }) => {
+                response_tx.send(Ok(())).unwrap();
+                assert!(command_rx.try_recv().is_err());
+            }
+            _ => panic!("expected one shutdown command for the shared process"),
+        });
+
+        native_ai.shutdown().unwrap();
+        shutdown.join().unwrap();
+
+        let state = native_ai.inner.lock().unwrap();
+        assert!(state.sessions.is_empty());
+        assert!(state.session_order.is_empty());
+        assert!(state.conversation_turn_bindings.is_empty());
+    }
+
+    #[test]
     fn send_transport_disconnect_invalidates_the_affected_session_family() {
         let (event_tx, event_rx) = mpsc::channel();
         let native_ai =

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -1261,6 +1261,57 @@ impl NativeAi {
         }
     }
 
+    pub(crate) fn shutdown(&self) -> Result<(), String> {
+        let (session_ids, runtime_handles) = {
+            let mut state = self
+                .inner
+                .lock()
+                .map_err(|error| format!("Internal AI state error: {error}"))?;
+            let session_ids = state.sessions.keys().cloned().collect::<Vec<_>>();
+            let mut runtime_handles = HashMap::new();
+            for managed in state.sessions.drain().map(|(_, managed)| managed) {
+                if let Some(handle) = managed.runtime_handle {
+                    runtime_handles.entry(handle.process_id).or_insert(handle);
+                }
+            }
+            state.session_order.clear();
+            state.conversation_turn_bindings.clear();
+            (session_ids, runtime_handles)
+        };
+
+        if let Ok(mut waiters) = self.user_input_waiters.lock() {
+            waiters.clear();
+        }
+        if let Ok(mut waiters) = self.url_elicitation_waiters.lock() {
+            waiters.clear();
+        }
+        if let Ok(mut completed) = self.completed_url_elicitations.lock() {
+            completed.clear();
+        }
+        if let Ok(mut terminal_sessions) = self.auth_terminal_sessions.lock() {
+            for (_, handle) in terminal_sessions.drain() {
+                handle.closed.store(true, Ordering::Relaxed);
+                handle.release_runtime_resources(true);
+            }
+        }
+        for session_id in session_ids {
+            self.tool_diffs.clear_session(&session_id);
+        }
+
+        let errors = runtime_handles
+            .into_values()
+            .filter_map(|handle| handle.shutdown().err())
+            .collect::<Vec<_>>();
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(format!(
+                "Failed to stop one or more AI runtime processes: {}",
+                errors.join("; ")
+            ))
+        }
+    }
+
     pub(crate) fn list_runtimes(&self) -> Value {
         let custom_runtimes = self.custom_runtimes.list().unwrap_or_else(|error| {
             eprintln!("Failed to load custom ACP runtimes for the runtime catalog: {error}");
@@ -4671,6 +4722,7 @@ async fn run_acp_auth_inner(
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::null());
+    command.kill_on_drop(true);
     apply_acp_process_environment(&mut command, &spec);
     #[cfg(unix)]
     {
@@ -4749,6 +4801,7 @@ async fn run_acp12_auth_inner(
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::null());
+    command.kill_on_drop(true);
     apply_acp_process_environment(&mut command, &spec);
     #[cfg(unix)]
     {
@@ -4863,6 +4916,19 @@ async fn run_acp12_actor(
 }
 
 async fn shutdown_acp_child(child: &mut tokio::process::Child) -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        if let Some(process_id) = child.id() {
+            let result = unsafe { libc::kill(-(process_id as i32), libc::SIGKILL) };
+            if result != 0 {
+                let error = std::io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::ESRCH) {
+                    return Err(format!("Failed to stop AI runtime process group: {error}"));
+                }
+            }
+        }
+    }
+    #[cfg(not(unix))]
     child
         .start_kill()
         .map_err(|error| format!("Failed to stop AI runtime process: {error}"))?;
@@ -4980,6 +5046,7 @@ async fn run_acp12_actor_inner(
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+    command.kill_on_drop(true);
     apply_acp_process_environment(&mut command, &spec);
     #[cfg(unix)]
     {
@@ -5218,6 +5285,7 @@ async fn run_acp_actor_inner(
     command.stdin(std::process::Stdio::piped());
     command.stdout(std::process::Stdio::piped());
     command.stderr(std::process::Stdio::piped());
+    command.kill_on_drop(true);
     apply_acp_process_environment(&mut command, &spec);
     #[cfg(unix)]
     {

--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -7695,7 +7695,7 @@ fn strip_effort_suffix(value: &str) -> &str {
     value
 }
 
-const EFFORT_LEVELS: &[&str] = &["minimal", "low", "medium", "high", "xhigh"];
+const EFFORT_LEVELS: &[&str] = &["minimal", "low", "medium", "high", "xhigh", "max", "ultra"];
 
 fn extract_effort(value: &str) -> Option<&str> {
     let suffix = value.rsplit('/').next()?;
@@ -7708,6 +7708,8 @@ fn extract_effort(value: &str) -> Option<&str> {
 fn reasoning_effort_label(effort: &str) -> String {
     match effort {
         "xhigh" => "Extra High".to_string(),
+        "max" => "Maximum".to_string(),
+        "ultra" => "Ultra".to_string(),
         _ => {
             let mut chars = effort.chars();
             match chars.next() {
@@ -15439,6 +15441,8 @@ mod tests {
                 SessionConfigSelectOption::new("gpt-5.5/medium", "GPT-5.5 (medium)"),
                 SessionConfigSelectOption::new("gpt-5.5/high", "GPT-5.5 (high)"),
                 SessionConfigSelectOption::new("gpt-5.5/xhigh", "GPT-5.5 (xhigh)"),
+                SessionConfigSelectOption::new("gpt-5.5/max", "GPT-5.5 (max)"),
+                SessionConfigSelectOption::new("gpt-5.5/ultra", "GPT-5.5 (ultra)"),
             ],
         )
         .category(SessionConfigOptionCategory::Model)];
@@ -15458,7 +15462,9 @@ mod tests {
                 "low".to_string(),
                 "medium".to_string(),
                 "high".to_string(),
-                "xhigh".to_string()
+                "xhigh".to_string(),
+                "max".to_string(),
+                "ultra".to_string()
             ])
         );
 
@@ -15478,8 +15484,17 @@ mod tests {
                 .iter()
                 .map(|option| option.value.as_str())
                 .collect::<Vec<_>>(),
-            vec!["low", "medium", "high", "xhigh"]
+            vec!["low", "medium", "high", "xhigh", "max", "ultra"]
         );
+    }
+
+    #[test]
+    fn extended_and_custom_reasoning_efforts_have_stable_labels() {
+        assert_eq!(reasoning_effort_label("max"), "Maximum");
+        assert_eq!(reasoning_effort_label("ultra"), "Ultra");
+        assert_eq!(reasoning_effort_label("experimental"), "Experimental");
+        assert_eq!(strip_effort_suffix("gpt-5.6-sol/max"), "gpt-5.6-sol");
+        assert_eq!(strip_effort_suffix("gpt-5.6-sol/ultra"), "gpt-5.6-sol");
     }
 
     #[test]

--- a/apps/desktop/native-backend/src/main.rs
+++ b/apps/desktop/native-backend/src/main.rs
@@ -702,6 +702,12 @@ impl NativeBackend {
             event_tx,
         }
     }
+
+    fn shutdown(&self) {
+        if let Err(error) = self.ai.shutdown() {
+            eprintln!("Failed to shut down AI runtimes: {error}");
+        }
+    }
 }
 
 impl NativeBackend {
@@ -3192,6 +3198,10 @@ fn main() {
             break;
         }
     }
+
+    if let Ok(backend) = backend.lock() {
+        backend.shutdown();
+    };
 }
 
 #[cfg(test)]

--- a/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
@@ -43,6 +43,65 @@ export const CODEX_RUNTIME_COMPONENTS = [
     },
 ];
 
+export const CODEX_RUNTIME_BASELINE = Object.freeze({
+    tag: "rust-v0.150.0",
+    version: "0.150.0",
+    commit: "3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717",
+    v8Version: "150.4.0",
+});
+
+export function validateCodexRuntimeSourceAlignment({
+    adapterManifest,
+    lockfile,
+    ptyManifest,
+}) {
+    const expectedTag = `tag = "${CODEX_RUNTIME_BASELINE.tag}"`;
+    const declaredTags = [
+        ...adapterManifest.matchAll(/tag\s*=\s*"(rust-v[^"]+)"/g),
+    ].map((match) => match[1]);
+    if (
+        declaredTags.length === 0 ||
+        declaredTags.some((tag) => tag !== CODEX_RUNTIME_BASELINE.tag)
+    ) {
+        throw new Error(
+            `Codex runtime dependencies must all use ${expectedTag}`,
+        );
+    }
+
+    const expectedSource = `git+https://github.com/openai/codex?tag=${CODEX_RUNTIME_BASELINE.tag}#${CODEX_RUNTIME_BASELINE.commit}`;
+    const codexSources = [
+        ...lockfile.matchAll(
+            /source = "(git\+https:\/\/github\.com\/openai\/codex\?tag=rust-v[^"]+)"/g,
+        ),
+    ].map((match) => match[1]);
+    if (
+        codexSources.length === 0 ||
+        codexSources.some((source) => source !== expectedSource)
+    ) {
+        throw new Error(
+            `Codex lockfile sources must all resolve to ${expectedSource}`,
+        );
+    }
+
+    const ptyVersion = ptyManifest.match(
+        /\[package\][\s\S]*?\nversion\s*=\s*"([^"]+)"/,
+    )?.[1];
+    if (ptyVersion !== CODEX_RUNTIME_BASELINE.version) {
+        throw new Error(
+            `Codex PTY snapshot must be ${CODEX_RUNTIME_BASELINE.version}; found ${ptyVersion ?? "unknown"}`,
+        );
+    }
+
+    const v8Version = lockfile.match(
+        /\[\[package\]\]\nname = "v8"\nversion = "([^"]+)"/,
+    )?.[1];
+    if (v8Version !== CODEX_RUNTIME_BASELINE.v8Version) {
+        throw new Error(
+            `Codex V8 dependency must remain ${CODEX_RUNTIME_BASELINE.v8Version}; found ${v8Version ?? "unknown"}`,
+        );
+    }
+}
+
 export function executableNameForTarget(baseName, targetTriple) {
     return targetTriple.includes("windows") ? `${baseName}.exe` : baseName;
 }

--- a/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
@@ -55,6 +55,7 @@ export function validateCodexRuntimeSourceAlignment({
     lockfile,
     ptyManifest,
 }) {
+    const normalizedLockfile = lockfile.replace(/\r\n?/g, "\n");
     const expectedTag = `tag = "${CODEX_RUNTIME_BASELINE.tag}"`;
     const declaredTags = [
         ...adapterManifest.matchAll(/tag\s*=\s*"(rust-v[^"]+)"/g),
@@ -70,7 +71,7 @@ export function validateCodexRuntimeSourceAlignment({
 
     const expectedSource = `git+https://github.com/openai/codex?tag=${CODEX_RUNTIME_BASELINE.tag}#${CODEX_RUNTIME_BASELINE.commit}`;
     const codexSources = [
-        ...lockfile.matchAll(
+        ...normalizedLockfile.matchAll(
             /source = "(git\+https:\/\/github\.com\/openai\/codex\?tag=rust-v[^"]+)"/g,
         ),
     ].map((match) => match[1]);
@@ -92,7 +93,7 @@ export function validateCodexRuntimeSourceAlignment({
         );
     }
 
-    const v8Version = lockfile.match(
+    const v8Version = normalizedLockfile.match(
         /\[\[package\]\]\nname = "v8"\nversion = "([^"]+)"/,
     )?.[1];
     if (v8Version !== CODEX_RUNTIME_BASELINE.v8Version) {

--- a/apps/desktop/scripts/stage-electron-sidecar.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.mjs
@@ -13,6 +13,7 @@ import {
     universalMacLipoVerifyArgs,
     validateCodexRuntimeBundleArchitectures,
     validateCodexRuntimeBundleInputs,
+    validateCodexRuntimeSourceAlignment,
 } from "./stage-electron-sidecar-helpers.mjs";
 import { resolveCodexV8CargoEnvironment } from "./codex-v8-artifacts.mjs";
 
@@ -713,6 +714,27 @@ const codexRuntimePlan = createCodexRuntimeBundlePlan({
     targetTriple,
     workspaceRoot,
     skipBuild: args.skipBuild,
+});
+validateCodexRuntimeSourceAlignment({
+    adapterManifest: await fs.readFile(
+        path.join(workspaceRoot, "vendor", "codex-acp", "Cargo.toml"),
+        "utf8",
+    ),
+    lockfile: await fs.readFile(
+        path.join(workspaceRoot, "vendor", "codex-acp", "Cargo.lock"),
+        "utf8",
+    ),
+    ptyManifest: await fs.readFile(
+        path.join(
+            workspaceRoot,
+            "vendor",
+            "codex-acp",
+            "vendor",
+            "codex-utils-pty",
+            "Cargo.toml",
+        ),
+        "utf8",
+    ),
 });
 
 let stagingNativeBackendPath;

--- a/apps/desktop/scripts/stage-electron-sidecar.test.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.test.mjs
@@ -93,6 +93,39 @@ test("keeps runtime, PTY, lock commit, and V8 on one checked-in baseline", async
     );
 });
 
+test("accepts Windows line endings in the runtime lockfile", async () => {
+    const adapterRoot = path.join(
+        checkedInWorkspaceRoot,
+        "vendor",
+        "codex-acp",
+    );
+    const lockfile = await fs.readFile(
+        path.join(adapterRoot, "Cargo.lock"),
+        "utf8",
+    );
+    const adapterManifest = await fs.readFile(
+        path.join(adapterRoot, "Cargo.toml"),
+        "utf8",
+    );
+    const ptyManifest = await fs.readFile(
+        path.join(
+            adapterRoot,
+            "vendor",
+            "codex-utils-pty",
+            "Cargo.toml",
+        ),
+        "utf8",
+    );
+
+    assert.doesNotThrow(() =>
+        validateCodexRuntimeSourceAlignment({
+            adapterManifest,
+            lockfile: lockfile.replace(/\r?\n/g, "\r\n"),
+            ptyManifest,
+        }),
+    );
+});
+
 test("rejects a mixed runtime source baseline before staging", () => {
     assert.throws(
         () =>

--- a/apps/desktop/scripts/stage-electron-sidecar.test.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.test.mjs
@@ -1,5 +1,7 @@
 import assert from "node:assert/strict";
+import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { test } from "vitest";
 
 import {
@@ -9,9 +11,16 @@ import {
     universalMacLipoVerifyArgs,
     validateCodexRuntimeBundleArchitectures,
     validateCodexRuntimeBundleInputs,
+    validateCodexRuntimeSourceAlignment,
 } from "./stage-electron-sidecar-helpers.mjs";
 
 const workspaceRoot = path.resolve("/workspace");
+const checkedInWorkspaceRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "..",
+    "..",
+);
 
 function existingPaths(...paths) {
     const existing = new Set(paths);
@@ -52,6 +61,48 @@ test("derives runtime binary names from the target platform", () => {
             "x86_64-pc-windows-msvc",
         ),
         "codex-code-mode-host.exe",
+    );
+});
+
+test("keeps runtime, PTY, lock commit, and V8 on one checked-in baseline", async () => {
+    const adapterRoot = path.join(
+        checkedInWorkspaceRoot,
+        "vendor",
+        "codex-acp",
+    );
+    await assert.doesNotReject(async () =>
+        validateCodexRuntimeSourceAlignment({
+            adapterManifest: await fs.readFile(
+                path.join(adapterRoot, "Cargo.toml"),
+                "utf8",
+            ),
+            lockfile: await fs.readFile(
+                path.join(adapterRoot, "Cargo.lock"),
+                "utf8",
+            ),
+            ptyManifest: await fs.readFile(
+                path.join(
+                    adapterRoot,
+                    "vendor",
+                    "codex-utils-pty",
+                    "Cargo.toml",
+                ),
+                "utf8",
+            ),
+        }),
+    );
+});
+
+test("rejects a mixed runtime source baseline before staging", () => {
+    assert.throws(
+        () =>
+            validateCodexRuntimeSourceAlignment({
+                adapterManifest:
+                    '[dependencies]\ncodex-core = { tag = "rust-v0.149.0" }',
+                lockfile: "",
+                ptyManifest: '[package]\nversion = "0.150.0"',
+            }),
+        /must all use tag = "rust-v0\.150\.0"/,
     );
 });
 

--- a/apps/desktop/src-electron/main/nativeBackend.ts
+++ b/apps/desktop/src-electron/main/nativeBackend.ts
@@ -345,6 +345,7 @@ class NativeBackendSidecar implements NativeBackendBridge {
     private readonly child: ChildProcessWithoutNullStreams;
     private readonly emitEvent: (eventName: string, payload: unknown) => void;
     private readonly pending = new Map<number, PendingRequest>();
+    private gracefulShutdownTimer: ReturnType<typeof setTimeout> | null = null;
     private forceKillTimer: ReturnType<typeof setTimeout> | null = null;
     private failure: Error | null = null;
     private nextId = 1;
@@ -415,6 +416,10 @@ class NativeBackendSidecar implements NativeBackendBridge {
         this.child.on("exit", (code, signal) => {
             this.closed = true;
             this.exited = true;
+            if (this.gracefulShutdownTimer) {
+                clearTimeout(this.gracefulShutdownTimer);
+                this.gracefulShutdownTimer = null;
+            }
             if (this.forceKillTimer) {
                 clearTimeout(this.forceKillTimer);
                 this.forceKillTimer = null;
@@ -473,16 +478,22 @@ class NativeBackendSidecar implements NativeBackendBridge {
             this.child.stdin.end();
         }
 
-        if (!this.exited) {
-            this.child.kill("SIGTERM");
-            if (!this.forceKillTimer) {
-                this.forceKillTimer = setTimeout(() => {
-                    if (!this.exited) {
-                        this.child.kill("SIGKILL");
-                    }
-                }, 1500);
-                this.forceKillTimer.unref();
-            }
+        if (!this.exited && !this.gracefulShutdownTimer) {
+            this.gracefulShutdownTimer = setTimeout(() => {
+                this.gracefulShutdownTimer = null;
+                if (this.exited) return;
+
+                this.child.kill("SIGTERM");
+                if (!this.forceKillTimer) {
+                    this.forceKillTimer = setTimeout(() => {
+                        if (!this.exited) {
+                            this.child.kill("SIGKILL");
+                        }
+                    }, 1500);
+                    this.forceKillTimer.unref();
+                }
+            }, 1500);
+            this.gracefulShutdownTimer.unref();
         }
     }
 

--- a/apps/desktop/src/features/ai/conversationModel.ts
+++ b/apps/desktop/src/features/ai/conversationModel.ts
@@ -265,6 +265,9 @@ export function updateConversationBindingsFromLegacySession(
             binding.bindingId === current.activeBindingId &&
             binding.runtimeId === projectedBinding.runtimeId,
     );
+    const runtimeContextChanged =
+        activeBinding != null &&
+        activeBinding.runtimeSessionId !== projectedBinding.runtimeSessionId;
     const nextBinding: AcpConversationBinding = activeBinding
         ? {
               ...activeBinding,
@@ -284,6 +287,12 @@ export function updateConversationBindingsFromLegacySession(
               availableCommands: projectedBinding.availableCommands,
               effortsByModel: projectedBinding.effortsByModel,
               runtimeState: projectedBinding.runtimeState,
+              contextCursor: runtimeContextChanged
+                  ? null
+                  : activeBinding.contextCursor,
+              contextGeneration: runtimeContextChanged
+                  ? activeBinding.contextGeneration + 1
+                  : activeBinding.contextGeneration,
               updatedAt: projectedBinding.updatedAt,
           }
         : projectedBinding;

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -16927,7 +16927,28 @@ describe("chatStore", () => {
 
         const persistedSessionId = "persisted:history-native-fallback";
         const historySessionId = "history-native-fallback";
+        const previousRuntimeSessionId = "codex-runtime-before-restart";
         const fallbackSessionId = "codex-fallback-live";
+        let sentContent = "";
+        const persistedSession = {
+            ...createSessionWithTrackedFiles(persistedSessionId, []),
+            historySessionId,
+            runtimeId: "codex-acp",
+            runtimeSessionId: previousRuntimeSessionId,
+            runtimeState: "persisted_only" as const,
+            isPersistedSession: true,
+            persistedMessageCount: 2,
+            loadedPersistedMessageStart: null,
+            resumeContextPending: false,
+        };
+        const conversationBindings =
+            updateConversationBindingsFromLegacySession(persistedSession);
+        conversationBindings.providerBindings[0] = {
+            ...conversationBindings.providerBindings[0],
+            runtimeSessionId: previousRuntimeSessionId,
+            contextCursor: "m2",
+            contextGeneration: 3,
+        };
 
         useChatStore.setState((state) => ({
             ...state,
@@ -16947,22 +16968,8 @@ describe("chatStore", () => {
             ],
             sessionsById: {
                 [persistedSessionId]: {
-                    sessionId: persistedSessionId,
-                    historySessionId,
-                    status: "idle",
-                    runtimeId: "codex-acp",
-                    modelId: "test-model",
-                    modeId: "default",
-                    models: [],
-                    modes: [],
-                    configOptions: [],
-                    messages: [],
-                    attachments: [],
-                    runtimeState: "persisted_only",
-                    isPersistedSession: true,
-                    persistedMessageCount: 2,
-                    loadedPersistedMessageStart: null,
-                    resumeContextPending: false,
+                    ...persistedSession,
+                    conversationBindings,
                 },
             },
             sessionOrder: [persistedSessionId],
@@ -17000,12 +17007,22 @@ describe("chatStore", () => {
                 };
             }
             if (command === "ai_resume_runtime_session") {
-                throw new Error("native resume handle missing");
+                throw new Error(
+                    `thread ${previousRuntimeSessionId} already has an active writer`,
+                );
             }
             if (command === "ai_create_session") {
                 return {
                     ...sessionPayload,
                     session_id: fallbackSessionId,
+                };
+            }
+            if (command === "ai_send_message") {
+                sentContent = (args as { content: string }).content;
+                return {
+                    ...sessionPayload,
+                    session_id: fallbackSessionId,
+                    status: "streaming",
                 };
             }
             return defaultInvokeImplementation(command, args);
@@ -17044,6 +17061,31 @@ describe("chatStore", () => {
                 ([command]) => command === "ai_create_session",
             ),
         ).toBe(true);
+
+        useChatStore
+            .getState()
+            .setComposerParts(
+                createTextParts("What were we discussing?"),
+                fallbackSessionId,
+            );
+        await useChatStore.getState().sendMessage(fallbackSessionId);
+
+        expect(sentContent).toContain("Saved transcript:");
+        expect(sentContent).toContain("User: Original saved request");
+        expect(sentContent).toContain("Assistant: Original saved answer");
+        expect(sentContent).toContain(
+            "New user message: What were we discussing?",
+        );
+        const recoveredBinding = useChatStore
+            .getState()
+            .sessionsById[fallbackSessionId]?.conversationBindings?.providerBindings.at(
+                0,
+            );
+        expect(recoveredBinding).toMatchObject({
+            runtimeSessionId: fallbackSessionId,
+            contextCursor: "m2",
+            contextGeneration: 4,
+        });
     });
 
     it("does not ask the runtime backend to load an unknown persisted-only session id", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -2936,6 +2936,11 @@ function createTurnBinding(
 ) {
     const now = Date.now();
     const selection = getConversationSelection(runtimeSession);
+    const runtimeSessionId = getLiveRuntimeSessionId(runtimeSession);
+    const preservesRuntimeContext =
+        existing != null &&
+        existing.runtimeSessionId != null &&
+        existing.runtimeSessionId === runtimeSessionId;
     return {
         bindingId:
             existing?.bindingId ??
@@ -2946,7 +2951,7 @@ function createTurnBinding(
         runtimeRevision: runtimeSession.runtimeRevision ?? null,
         runtimeLaunchFingerprint:
             runtimeSession.runtimeLaunchFingerprint ?? null,
-        runtimeSessionId: getLiveRuntimeSessionId(runtimeSession),
+        runtimeSessionId,
         continuationStrategy: runtimeSession.continuationStrategy ?? null,
         capabilities: [...capabilities],
         modelId: selection.modelId,
@@ -2958,8 +2963,17 @@ function createTurnBinding(
         availableCommands: runtimeSession.availableCommands,
         effortsByModel: runtimeSession.effortsByModel ?? {},
         runtimeState: runtimeSession.runtimeState ?? "live",
-        contextCursor: existing?.contextCursor ?? null,
-        contextGeneration: existing?.contextGeneration ?? 0,
+        // A cursor is meaningful only to the runtime session that accepted the
+        // corresponding handoff. A replacement runtime must receive the full
+        // saved transcript even when it reuses the durable conversation binding.
+        contextCursor: preservesRuntimeContext
+            ? (existing.contextCursor ?? null)
+            : null,
+        contextGeneration: preservesRuntimeContext
+            ? existing.contextGeneration
+            : existing
+              ? existing.contextGeneration + 1
+              : 0,
         createdAt: existing?.createdAt ?? now,
         updatedAt: now,
     } satisfies AcpConversationBinding;

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -45,12 +45,11 @@ That means the directory is intentionally reproducible, but not yet minimal.
 
 - `codex-acp/`
   - upstream baseline: `zed-industries/codex-acp` `0.16.0`
-  - synced against upstream commit `863d433fc91855d0b5427372bf635c894bf68cb6`
-  - latest upstream adapter sync from adapter `v0.14.0` to `v0.16.0` brought in 5 commits: `d9bf1c1`, `0c2d828`, `8aef91b`, `f67ca5f`, `863d433`
-  - OpenAI Codex Rust crates: `rust-v0.147.0` (`be6e8eac029b183056b7e4402879f15d2c85f61b`)
+  - synced against upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`
+  - OpenAI Codex Rust crates: `rust-v0.150.0` (`3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`)
   - vendor ACP SDK: `agent-client-protocol` `0.14.0`
   - ACP wire protocol: v1; ACP v2 is not enabled by this runtime promotion
-  - local `vendor/codex-utils-pty/` snapshot: `0.147.0`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
+  - local `vendor/codex-utils-pty/` snapshot: `0.150.0`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
   - resolved V8 crate: `150.4.0`, built with OpenAI's verified `ptrcomp_sandbox_release` archive and source binding for the target
   - Rust toolchain: NeverWrite `1.96.0`; upstream Codex `1.95.0`
   - local NeverWrite delta remains intentionally bounded and currently lives in:
@@ -78,7 +77,7 @@ That means the directory is intentionally reproducible, but not yet minimal.
 
 ## Current Codex Delta
 
-The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.147.0`, resolved to `be6e8eac029b183056b7e4402879f15d2c85f61b` in `Cargo.lock`.
+The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.150.0`, resolved to `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717` in `Cargo.lock`.
 
 The remaining NeverWrite-specific delta exists to preserve desktop product behavior:
 
@@ -98,13 +97,19 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - a private `codexAcp*` subagent contract for session creation, navigable activity breadcrumbs, child lifecycle, and receiver-owned inter-agent transcripts
 - per-turn coalescing of equivalent subagent waits; only fully terminal status sets complete the ACP activity
 - localized `StartThreadOptions`, shared models-manager, external code-mode provider, config, auth, MCP, permission, and thread-store adapters at the ACP boundary
-- a local `codex-utils-pty` `0.147.0` snapshot that preserves its standalone manifest and NeverWrite's macOS process-group member fallback while adopting upstream Windows Job Objects, ConPTY/input changes, and tests
+- a local `codex-utils-pty` `0.150.0` snapshot with its standalone manifest, upstream Unix process-group fallback, Windows Job Object and ConPTY path handling, and the upstream platform tests
 
-The 0.147 deferred turn items are handled as localized projections. `SubAgentActivity` is projected through the same canonical activity identity as its `TurnItem` fallback: matching protocol IDs update one ACP tool call, while distinct IDs remain separate rather than being correlated by descriptive metadata. Child `ThreadId` values remain authoritative; paths, nicknames, and roles are display metadata only.
+The 0.150 turn-input boundary uses `TurnInputRequest` with `StartIfIdle` and consumes the runtime acknowledgement before registering the ACP prompt. `NotSubmitted` and an impossible `Steered` acknowledgement resolve as ACP errors instead of leaving a response pending.
+
+The 0.150 event delta is handled as localized projections. MCP policy amendments are exposed only when offered, Guardian stdin reviews redact the input payload, image failures retain their reason, standalone function outputs do not invent a call identity, and `ThreadQueueChanged` stays diagnostic because NeverWrite owns the user-facing queue.
+
+`SubAgentActivity` is projected through the same canonical activity identity as its `TurnItem` fallback: matching protocol IDs update one ACP tool call, while distinct IDs remain separate rather than being correlated by descriptive metadata. `SendMessage`, `FollowupTask`, `InterruptAgent`, `ListAgents`, and `Completed` preserve their runtime IDs and terminal semantics. Child `ThreadId` values remain authoritative; paths, nicknames, and roles are display metadata only.
+
+Reasoning options come from each runtime model preset. `max`, `ultra`, and future custom values cross the adapter dynamically; the native backend recognizes the two new suffixes without treating `xhigh` as a universal maximum.
 
 The desktop release pipeline packages `codex-acp` and `codex-code-mode-host` as one runtime unit for macOS universal, Windows x64/ARM64, and Linux x64/ARM64. Each release build is lockfile-pinned, target-architecture checked, and signed together. Its packaged smoke drives an ACP `initialize`, `session/new`, and `session/prompt` exchange through the standalone host with a deterministic local Responses mock, verifies both the tool completion and assistant response, and proves a missing sibling host fails closed.
 
-When updating Codex again, treat upstream ACP commit `863d433fc91855d0b5427372bf635c894bf68cb6`, OpenAI Codex tag `rust-v0.147.0` at `be6e8eac029b183056b7e4402879f15d2c85f61b`, the local PTY `0.147.0` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
+When updating Codex again, treat upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`, OpenAI Codex tag `rust-v0.150.0` at `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`, the local PTY `0.150.0` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
 
 Canonical compatibility checks:
 
@@ -115,9 +120,9 @@ node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo check --lock
 node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo test --locked --manifest-path ../../vendor/codex-acp/Cargo.toml
 ```
 
-## Codex 0.147.0 Compatibility Baseline
+## Codex 0.150.0 Compatibility Baseline
 
-The embedded runtime is pinned to OpenAI Codex `rust-v0.147.0`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `be6e8eac029b183056b7e4402879f15d2c85f61b`. The local `codex-utils-pty` snapshot is also `0.147.0`; it is part of the same runtime baseline, not an independently updatable crate.
+The embedded runtime is pinned to OpenAI Codex `rust-v0.150.0`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`. The local `codex-utils-pty` snapshot is also `0.150.0`; it is part of the same runtime baseline, not an independently updatable crate.
 
 The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolchain.toml`, which is compatible with the upstream Codex `1.95.0` toolchain. This promotion deliberately does not change these protocol boundaries:
 
@@ -128,7 +133,7 @@ The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolc
 
 ### Lockfile and V8 provisioning
 
-The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.147 lock. A broad lockfile regeneration can select the stable `rama-error 0.3.0` next to prerelease peers and produce an incompatible graph, so future promotions must compare these packages with the candidate tag and update them as a coordinated set.
+The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, `rama-macros`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.150 lock. A broad lockfile regeneration can select stable Rama packages next to prerelease peers and produce an incompatible graph, so future promotions must compare this family with the candidate tag and update it as a coordinated set.
 
 The lockfile resolves `v8 150.4.0`. `apps/desktop/scripts/codex-v8-artifacts.mjs` obtains the target-specific `ptrcomp_sandbox_release` archive, source binding, and SHA-256 manifest from the official `openai/codex` release `rusty-v8-v150.4.0`. It authenticates the downloaded or cached manifest against the target-specific digest pinned in `apps/desktop/scripts/codex-v8-manifest-pins.mjs` before downloading archives or bindings, requires the manifest to cover exactly both artifacts, verifies their checksums before use, and caches the verified set under `apps/desktop/.cache/codex-v8/<version>/<profile>/<target>/`.
 
@@ -136,6 +141,10 @@ Local builds may provide `RUSTY_V8_ARCHIVE` and `RUSTY_V8_SRC_BINDING_PATH` only
 
 ### Product behavior covered by this baseline
 
+- ACP prompts start only while the runtime is idle. The one-shot turn acknowledgement is consumed before local prompt state is registered, so declined submissions cannot hang or steer an active turn.
+- MCP persistent approval, Guardian `WriteStdin`, image-generation failures, optional function-call IDs, `PathUri`, and runtime queue notifications have explicit safe projections.
+- Collaboration tools `SendMessage`, `FollowupTask`, `InterruptAgent`, and `ListAgents` preserve runtime activity identity. `SubAgentActivityKind::Completed` terminalizes that identity once, while internal agent messages remain outside the parent transcript.
+- Reasoning efforts are catalog-driven, including `max`, `ultra`, and future custom values. Load, resume, fork, and model changes retain an effort only when the selected model supports it.
 - `TurnItem::Extension(ExtensionItem::Sleep(...))` is projected as the canonical `Waiting` activity and keeps stable item identity across live events and replay.
 - `ItemCompleted.started_at_ms` is propagated into activity metadata when positive so restored activities keep their upstream start time. Turn-level `started_at` fields are accepted but do not invent a second timeline contract.
 - `TurnComplete.error` emits a visible failed `turn_error` status and fails the pending ACP prompt instead of reporting `EndTurn`; aborts remain cancelled and keep their lifecycle event.
@@ -149,9 +158,9 @@ Local builds may provide `RUSTY_V8_ARCHIVE` and `RUSTY_V8_SRC_BINDING_PATH` only
 
 ### Intentionally deferred capabilities
 
-This baseline does not enable MCP protocol `2026-07-28`, expose `--approve-for-me`, update the ACP SDK beyond `agent-client-protocol 0.14.0`, or migrate the adapter to ACP v2. Each changes a protocol, permission, or client contract and requires separate compatibility work.
+This baseline does not add Bedrock onboarding, visible task references, a second runtime-owned prompt queue, TUI-only commands, MCP protocol `2026-07-28`, `--approve-for-me`, an ACP SDK update beyond `agent-client-protocol 0.14.0`, ACP v2, or an App Server migration. Each changes a product, protocol, permission, or client contract and requires separate compatibility work.
 
-The App Server adapter `1.1.4` remains an architectural follow-up rather than a replacement. It must demonstrate parity for sessions, configuration, permissions, review, inline changes, and accept/reject flows before it can replace the current adapter.
+The App Server adapter remains an architectural follow-up rather than a replacement. It must demonstrate parity for sessions, configuration, permissions, review, inline changes, and accept/reject flows before it can replace the current adapter.
 
 Portable plugins, thread sections/pinning, side conversations, audio/realtime, external imports, and Bedrock support are also deferred. NeverWrite does not expose a local projection merely because the upstream runtime can represent one. The Goal contract remains tracked separately in issue `#387`.
 
@@ -164,15 +173,15 @@ Portable plugins, thread sections/pinning, side conversations, audio/realtime, e
 | Linux x64 | Yes | — |
 | Linux ARM64 | No, because it is cross-compiled | Packaging, sidecar staging, and architecture checks run without executing the foreign binary |
 
-The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.147 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
+The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.150 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
 
 The same smoke starts an isolated copy of `codex-acp` without its sibling host and requires the code-mode tool to fail closed with the missing host path in its diagnostic. It does not require credentials or a network service.
 
 ### Follow-up and rollback
 
-#### Historical rollback baseline
+#### Rollback baseline
 
-The known rollback baseline is OpenAI Codex `rust-v0.144.6` at `5d1fbf26c43abc65a203928b2e31561cb039e06d`, local PTY `0.144.6`, V8 `149.2.0` with the standard `release` artifact profile, and the lockfile recorded by NeverWrite commit `248a743f`. A rollback must restore `vendor/codex-acp/Cargo.toml`, `vendor/codex-acp/Cargo.lock`, `vendor/codex-acp/vendor/codex-utils-pty/`, the V8 artifact profile, and any 0.147-only adapter API changes as one reviewed unit. Never roll back a single Codex crate, PTY snapshot, V8 profile, or lockfile independently.
+The rollback baseline is OpenAI Codex `rust-v0.147.0` at `be6e8eac029b183056b7e4402879f15d2c85f61b`, local PTY `0.147.0`, V8 `150.4.0`, and the lockfile recorded before this promotion. A rollback must restore `vendor/codex-acp/Cargo.toml`, `vendor/codex-acp/Cargo.lock`, `vendor/codex-acp/vendor/codex-utils-pty/`, and the adapter changes that depend exclusively on 0.150 types as one reviewed unit. V8 remains `150.4.0` on both sides of the rollback; never roll back a single Codex crate, PTY snapshot, or lockfile independently.
 
 The desktop backend supports a mixed ACP world: current ACP integration for Claude, Codex, Kilo, and OpenCode, plus the vendored `agent-client-protocol-legacy` crates for Grok. The native backend tests cover the reconstructed diff, permission, status metadata, and legacy runtime compatibility paths that NeverWrite depends on.
 

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+checksum = "c25da0441692de4ad67950cb7ed6c9ce4b669a6609525e547566c2e1ab4d695c"
 dependencies = [
  "futures-core",
  "tokio",
@@ -86,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3716aae056e2f869b7b5cfd8a08fcf98890f8455bec61d69c7dff5d8576f9d2b"
+checksum = "fd8b9d8fac53b9354de76bff6cdd1a5ecc7ccaa4c88043e5ce8333f3ef884f0d"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -123,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.14.1"
+version = "4.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58356675d8c86d2e720480645a0316808471a62d0073f6a3b98810a5e0ca0e73"
+checksum = "bbacab3593b6b4f7be815076fc52d60a83c873426824675417e2abdd229e2e36"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -227,7 +227,7 @@ dependencies = [
  "lazy_static",
  "nom 7.1.3",
  "pin-project",
- "rand 0.8.7",
+ "rand 0.8.8",
  "rust-embed",
  "scrypt",
  "sha2 0.10.9",
@@ -248,7 +248,7 @@ dependencies = [
  "hkdf 0.12.4",
  "io_tee",
  "nom 7.1.3",
- "rand 0.8.7",
+ "rand 0.8.8",
  "secrecy",
  "sha2 0.10.9",
 ]
@@ -644,7 +644,7 @@ checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -695,9 +695,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-config"
-version = "1.10.1"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+checksum = "a767267da9e2c2e189b2f9df8b5657e850ecf5352644734ba130d4a57095cf1b"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -719,7 +719,7 @@ dependencies = [
  "hex",
  "http 1.5.0",
  "p256",
- "rand 0.8.7",
+ "rand 0.8.8",
  "sha1 0.10.7",
  "sha2 0.10.9",
  "time",
@@ -793,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-signin"
-version = "1.18.0"
+version = "1.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdce92c2b36186558b99c36a144b3a7343f2425b0613108d39b67e45c333170d"
+checksum = "0bfe75648eaee4b012e13ccbd50d88df640c9fb566310d083513af9fad3befb6"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -819,9 +819,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.105.0"
+version = "1.108.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+checksum = "c15301b04372832947916607983b114b3374b9db0be058a00fb7513800de1f05"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -845,9 +845,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.107.0"
+version = "1.110.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+checksum = "72cc2c205cb27108183cf1856333f7d584c2ba0f505421b4209ca5828f9ea899"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -871,9 +871,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.110.0"
+version = "1.113.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+checksum = "68182ecb449f7537db0f4d5d25917789cf41e32074a9fe47b6a0b847fe1d2032"
 dependencies = [
  "arc-swap",
  "aws-credential-types",
@@ -952,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http-client"
-version = "1.2.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+checksum = "ebfd138fac0337cee7516c352757ea73b9f2266e57d0bcb5bc70e9547e45aef1"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -1009,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.12.1"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+checksum = "b82e438d30e02a825d363bd639a9efaed68a8089d86101054b0081e7e0d3e606"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -1035,9 +1035,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "blocking"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+checksum = "a70e4329df6cb94385eed412ec92375c3cdd8a6e502493d1229b6414e4036dfa"
 dependencies = [
  "async-channel",
  "async-task",
@@ -1398,9 +1398,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
+checksum = "553c5d846a6ba5150c65e3b1b8ec073bcf1abc20f9b7220de384a4443ea4e20a"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.2",
@@ -1417,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
 dependencies = [
  "memchr",
  "regex-automata",
@@ -1449,7 +1449,7 @@ checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1562,9 +1562,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.2"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d262e149917187838d5b42777c8253bcb64500067342904e7d429499a6f277e"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1719,7 +1719,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1816,6 +1816,7 @@ dependencies = [
  "codex-mcp-server",
  "codex-models-manager",
  "codex-protocol",
+ "codex-rollout",
  "codex-shell-command",
  "codex-thread-store",
  "codex-utils-approval-presets",
@@ -1839,8 +1840,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -1850,8 +1851,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1869,9 +1870,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-agent-roles"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+dependencies = [
+ "codex-config",
+ "codex-file-system",
+ "codex-utils-absolute-path",
+ "codex-utils-path-uri",
+ "serde",
+ "toml 0.9.12+spec-1.1.0",
+ "tracing",
+]
+
+[[package]]
 name = "codex-analytics"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1890,8 +1905,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -1921,18 +1936,21 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
  "codex-experimental-api-macros",
  "codex-extension-items",
+ "codex-history",
  "codex-protocol",
+ "codex-rollout",
  "codex-secrets",
  "codex-shell-command",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "inventory",
  "rmcp",
  "serde",
@@ -1947,13 +1965,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1968,8 +1986,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -1982,14 +2000,15 @@ dependencies = [
  "codex-utils-home-dir",
  "codex-windows-sandbox",
  "dotenvy",
+ "pathdiff",
  "tempfile",
  "tokio",
 ]
 
 [[package]]
 name = "codex-async-utils"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -1997,8 +2016,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2011,8 +2030,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2029,8 +2048,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "serde",
  "serde_json",
@@ -2039,8 +2058,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2048,37 +2067,51 @@ dependencies = [
  "http 1.5.0",
  "rand 0.9.5",
  "tokio",
-]
-
-[[package]]
-name = "codex-code-mode"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
-dependencies = [
- "codex-code-mode-protocol",
- "codex-http-client",
- "codex-install-context",
- "codex-websocket-client",
- "futures",
- "tokio",
- "tokio-tungstenite 0.28.0",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
+name = "codex-code-mode"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+dependencies = [
+ "codex-code-mode-protocol",
+ "codex-http-client",
+ "codex-install-context",
+ "codex-protocol",
+ "codex-websocket-client",
+ "futures",
+ "http-body-util",
+ "prost",
+ "reqwest 0.12.28",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tokio-util",
+ "tonic",
+ "tower",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "codex-code-mode-host"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "axum",
  "clap",
  "codex-code-mode-protocol",
  "codex-code-mode-runtime",
+ "codex-protocol",
  "futures",
+ "prost",
+ "serde_json",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -2086,20 +2119,26 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
+ "glob",
+ "prost",
+ "protoc-bin-vendored",
  "serde",
  "serde_json",
  "tokio",
  "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
 ]
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-protocol",
@@ -2114,13 +2153,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 
 [[package]]
 name = "codex-config"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2134,6 +2173,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-path",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "core-foundation 0.9.4",
  "dns-lookup",
  "dunce",
@@ -2164,8 +2204,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2186,8 +2226,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2195,8 +2235,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2206,17 +2246,19 @@ dependencies = [
  "chrono",
  "clap",
  "codex-agent-graph-store",
+ "codex-agent-roles",
  "codex-analytics",
  "codex-api",
  "codex-app-server-protocol",
  "codex-apply-patch",
  "codex-async-utils",
+ "codex-client",
  "codex-code-mode",
  "codex-config",
  "codex-connectors",
  "codex-context-fragments",
  "codex-core-plugins",
- "codex-core-skills",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-execpolicy",
  "codex-extension-api",
@@ -2225,6 +2267,7 @@ dependencies = [
  "codex-feedback",
  "codex-file-system",
  "codex-git-utils",
+ "codex-history",
  "codex-hooks",
  "codex-http-client",
  "codex-install-context",
@@ -2294,14 +2337,14 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "which 8.0.5",
+ "which 8.0.6",
  "whoami 1.6.1",
 ]
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2309,7 +2352,6 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-config",
  "codex-connectors",
- "codex-core-skills",
  "codex-exec-server",
  "codex-git-utils",
  "codex-hooks",
@@ -2329,11 +2371,13 @@ dependencies = [
  "codex-utils-plugins",
  "dirs",
  "flate2",
+ "futures",
  "http 1.5.0",
  "regex",
  "semver",
  "serde",
  "serde_json",
+ "serde_with",
  "serde_yaml",
  "sha2 0.10.9",
  "tar",
@@ -2343,43 +2387,23 @@ dependencies = [
  "toml 0.9.12+spec-1.1.0",
  "tracing",
  "url",
- "which 8.0.5",
+ "uuid",
+ "which 8.0.6",
  "zip",
 ]
 
 [[package]]
-name = "codex-core-skills"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+name = "codex-diagnostics"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
- "anyhow",
- "codex-analytics",
- "codex-config",
- "codex-context-fragments",
- "codex-exec-server",
- "codex-login",
- "codex-model-provider",
- "codex-otel",
- "codex-protocol",
- "codex-skills",
- "codex-utils-absolute-path",
- "codex-utils-path-uri",
- "codex-utils-plugins",
- "codex-utils-string",
- "dunce",
- "futures",
- "serde",
- "serde_json",
- "serde_yaml",
- "tokio",
- "tracing",
- "zip",
+ "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "arc-swap",
  "axum",
@@ -2387,6 +2411,7 @@ dependencies = [
  "bytes",
  "clatter",
  "codex-api",
+ "codex-config",
  "codex-exec-server-protocol",
  "codex-file-system",
  "codex-http-client",
@@ -2394,15 +2419,19 @@ dependencies = [
  "codex-otel",
  "codex-protocol",
  "codex-sandboxing",
+ "codex-shell-command",
  "codex-utils-absolute-path",
+ "codex-utils-home-dir",
  "codex-utils-path-uri",
  "codex-utils-pty",
  "codex-utils-rustls-provider",
  "codex-websocket-client",
+ "dirs",
  "futures",
  "http 1.5.0",
  "libc",
  "prost",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "thiserror 2.0.20",
@@ -2418,8 +2447,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -2433,8 +2462,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "clap",
@@ -2451,8 +2480,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2461,8 +2490,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -2471,13 +2500,14 @@ dependencies = [
  "codex-protocol",
  "codex-tools",
  "codex-utils-absolute-path",
+ "codex-utils-path-uri",
  "serde_json",
 ]
 
 [[package]]
 name = "codex-extension-items"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2488,8 +2518,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2501,10 +2531,11 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
+ "codex-http-client",
  "codex-login",
  "codex-protocol",
  "mime_guess",
@@ -2515,8 +2546,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "clap",
@@ -2530,8 +2561,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2543,8 +2574,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -2556,8 +2587,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2581,9 +2612,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-history"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+dependencies = [
+ "codex-protocol",
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
 name = "codex-home"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -2592,16 +2633,19 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
+ "async-channel",
  "chrono",
  "codex-config",
  "codex-plugin",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
+ "codex-utils-path-uri",
+ "codex-utils-pty",
  "futures",
  "regex",
  "schemars 0.8.22",
@@ -2614,13 +2658,14 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
  "futures",
  "http 1.5.0",
+ "native-tls",
  "opentelemetry",
  "reqwest 0.12.28",
  "rustls",
@@ -2640,8 +2685,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2666,17 +2711,20 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
+ "semver",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "keyring",
  "tracing",
@@ -2684,8 +2732,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -2706,8 +2754,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2721,6 +2769,7 @@ dependencies = [
  "codex-secrets",
  "codex-terminal-detection",
  "codex-utils-template",
+ "codex-workload-identity",
  "http 1.5.0",
  "once_cell",
  "os_info",
@@ -2739,8 +2788,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2749,6 +2798,7 @@ dependencies = [
  "codex-async-utils",
  "codex-config",
  "codex-connectors",
+ "codex-diagnostics",
  "codex-exec-server",
  "codex-login",
  "codex-model-provider",
@@ -2773,8 +2823,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2800,13 +2850,12 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
 ]
 
 [[package]]
 name = "codex-memories-read"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -2815,8 +2864,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -2836,11 +2885,12 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-api",
  "codex-protocol",
+ "codex-utils-redacted-string",
  "http 1.5.0",
  "schemars 0.8.22",
  "serde",
@@ -2848,8 +2898,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2867,8 +2917,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2903,8 +2953,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2934,8 +2984,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -2947,16 +2997,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -2969,8 +3019,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "chardetng",
  "chrono",
@@ -2982,6 +3032,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-image",
  "codex-utils-path-uri",
+ "codex-utils-redacted-string",
  "codex-utils-string",
  "encoding_rs",
  "globset",
@@ -3009,8 +3060,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3020,8 +3071,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "axum",
@@ -3032,6 +3083,7 @@ dependencies = [
  "codex-exec-server",
  "codex-http-client",
  "codex-keyring-store",
+ "codex-network-proxy",
  "codex-protocol",
  "codex-secrets",
  "codex-utils-home-dir",
@@ -3040,6 +3092,7 @@ dependencies = [
  "futures",
  "http 1.5.0",
  "keyring",
+ "libc",
  "memchr",
  "oauth2",
  "rmcp",
@@ -3054,19 +3107,21 @@ dependencies = [
  "url",
  "urlencoding",
  "webbrowser",
- "which 8.0.5",
+ "which 8.0.6",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "codex-rollout"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "chrono",
  "codex-extension-items",
  "codex-file-search",
  "codex-git-utils",
+ "codex-history",
  "codex-otel",
  "codex-protocol",
  "codex-state",
@@ -3085,8 +3140,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3100,8 +3155,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "codex-network-proxy",
@@ -3117,13 +3172,13 @@ dependencies = [
  "serde_json",
  "tracing",
  "url",
- "which 8.0.5",
+ "which 8.0.6",
 ]
 
 [[package]]
 name = "codex-secrets"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "age",
  "anyhow",
@@ -3141,8 +3196,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3155,14 +3210,15 @@ dependencies = [
  "shlex 1.3.0",
  "tree-sitter",
  "tree-sitter-bash",
+ "tree-sitter-powershell",
  "url",
- "which 8.0.5",
+ "which 8.0.6",
 ]
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "clap",
@@ -3180,8 +3236,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3197,11 +3253,11 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
+ "codex-analytics",
  "codex-config",
- "codex-core-skills",
  "codex-exec-server",
  "codex-extension-api",
  "codex-mcp",
@@ -3227,11 +3283,12 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "chrono",
+ "codex-history",
  "codex-protocol",
  "codex-utils-absolute-path",
  "libsqlite3-sys",
@@ -3248,19 +3305,20 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
+ "codex-extension-items",
  "codex-git-utils",
  "codex-install-context",
  "codex-otel",
@@ -3283,8 +3341,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -3295,7 +3353,6 @@ dependencies = [
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-output-truncation",
- "codex-utils-pty",
  "codex-utils-string",
  "jsonptr",
  "rmcp",
@@ -3308,8 +3365,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "dirs",
  "dunce",
@@ -3320,16 +3377,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3342,8 +3399,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "lru",
  "sha1 0.10.7",
@@ -3352,8 +3409,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3364,8 +3421,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3373,8 +3430,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3386,8 +3443,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3395,8 +3452,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3404,8 +3461,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3414,8 +3471,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -3429,8 +3486,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -3442,7 +3499,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.147.0"
+version = "0.150.0"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3456,22 +3513,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-utils-redacted-string"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+dependencies = [
+ "schemars 0.8.22",
+ "serde",
+]
+
+[[package]]
 name = "codex-utils-rustls-provider"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "regex-lite",
  "serde",
@@ -3480,13 +3546,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -3499,8 +3565,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.147.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.147.0#be6e8eac029b183056b7e4402879f15d2c85f61b"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3513,7 +3579,7 @@ dependencies = [
  "dirs-next",
  "dunce",
  "glob",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_json",
  "tempfile",
@@ -3521,6 +3587,19 @@ dependencies = [
  "tracing-appender",
  "windows 0.58.0",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "codex-workload-identity"
+version = "0.150.0"
+source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+dependencies = [
+ "codex-http-client",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -3537,9 +3616,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
-version = "4.6.7"
+version = "4.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+checksum = "cfc320937d09e6de266b31b9afb480f197d7a861be86be7cb2ea7e5d1bfffc5e"
 dependencies = [
  "bytes",
  "memchr",
@@ -3731,9 +3810,9 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -3872,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d83cb7e7a873830708d6b02a78cd36a592c6fa14bf267b68725103b85c0d77f"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
 dependencies = [
  "link-section",
  "linktime-proc-macro",
@@ -3947,12 +4026,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88490bf1b990d87eaaa7ac8aa887f629a08e7359765b4911faf63c3763347d23"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.24.0",
- "darling_macro 0.24.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -3984,15 +4063,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "084e274f91c482280130e1e34e0b8d6e66776a060d7b6de7b84289ca778868c4"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4019,13 +4098,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.24.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f5792fa0d41cd2325ce0ffa64f0a340eaebd4971a3a0c5e1ffd2cc488a355e"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.24.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4293,14 +4372,14 @@ dependencies = [
 
 [[package]]
 name = "diplomat"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fdfa02eb9a2e1ff82a375524be1ce9fd50ae63787f5737da6951b25d21e857"
+checksum = "f8b37a6cea72eb6df5143d3e091d4c34cb0cf4046dd1ddcc082988886fe1f809"
 dependencies = [
  "diplomat_core",
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4311,16 +4390,16 @@ checksum = "ae517853d9f82b2d144393b1c32c34c46c2e361de2b6c44a8fdfce23beb211cd"
 
 [[package]]
 name = "diplomat_core"
-version = "0.16.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ede23809e2fcc555d8b2e10ffa7a1c31331ebca8e5477f4f2b48ab8a0a9a6b"
+checksum = "73b18e806f9ecb92df828d080efe47984ae1193958295d4a84fb8b32c9a1aa1b"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde",
  "smallvec",
  "strck",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4393,7 +4472,7 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4501,9 +4580,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 dependencies = [
  "serde",
 ]
@@ -4658,9 +4737,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "etcetera"
@@ -4807,9 +4886,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b73573e6edcd2af0cdf47bd6cb58f0b3839491263c314eaad1ccf24430e1de"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "findshlibs"
@@ -4976,9 +5055,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88cf1f829d945f548cf8fec32c61b1f202b6d93b45848602fc02af4b12ad218"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -4991,9 +5070,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5014,15 +5093,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6754879cc9f2c66f88c6e5c35344bb0bdb0708b0352b1201815667c7eabc7458"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -5042,9 +5121,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-lite"
@@ -5061,32 +5140,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -5993,9 +6072,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
+checksum = "0da1c46491b49458a446cc76f0085860f8164c2290742e0aa8c653ce67240a97"
 dependencies = [
  "bstr",
  "fastrand",
@@ -6005,9 +6084,9 @@ dependencies = [
 
 [[package]]
 name = "gix-validate"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
+checksum = "4dae8780f63ed8a803b8bdabbd7aa5f5c5d74592c8b50eed875c1bb4f6545a6a"
 dependencies = [
  "bstr",
 ]
@@ -6107,9 +6186,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -6182,6 +6261,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -6406,9 +6487,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -6638,15 +6719,15 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar"
-version = "2.2.1"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b2acc6263f494f1df50685b53ff8e57869e47d5c6fe39c23d518ae9a4f3e45"
+checksum = "58655df2f728e46e4eee80bddebefacf52ec3e77cdb925014b47c5a5905eb55c"
 dependencies = [
  "calendrical_calculations",
  "displaydoc",
  "icu_calendar_data",
- "icu_locale",
  "icu_locale_core",
+ "icu_locale_fallback",
  "icu_provider",
  "tinystr",
  "zerovec",
@@ -6654,15 +6735,15 @@ dependencies = [
 
 [[package]]
 name = "icu_calendar_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "118577bcf3a0fa7c6ac0a7d6e951814da84ee56b9b1f68fb4d8d10b08cefaf4d"
+checksum = "dc00caaa3fb3201ff7a18aa458e8c3ab042b9da154cfdf948bdde3936c31c36e"
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -6674,15 +6755,15 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288247df2e32aa776ac54fdd64de552149ac43cb840f2761811f0e8d09719dd4"
+checksum = "9eb8f655bba2d0c0459e43a5b0e6cd3cd388109898fb3d85d048165e8b0abd08"
 dependencies = [
  "displaydoc",
  "fixed_decimal",
  "icu_decimal_data",
- "icu_locale",
  "icu_locale_core",
+ "icu_locale_fallback",
  "icu_plurals",
  "icu_provider",
  "writeable",
@@ -6691,30 +6772,15 @@ dependencies = [
 
 [[package]]
 name = "icu_decimal_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f14a5ca9e8af29eef62064f269078424283d90dbaffeac5225addf62aaabc22"
-
-[[package]]
-name = "icu_locale"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a396343c7208121dc86e35623d3dfe19814a7613cfd14964994cdc9c9a2e26"
-dependencies = [
- "icu_collections",
- "icu_locale_core",
- "icu_locale_data",
- "icu_provider",
- "potential_utf",
- "tinystr",
- "zerovec",
-]
+checksum = "e4c887fc7d4c297cf3f9436864af9e3dba7f8be9415a6c2a7f392f3b1636298c"
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -6725,16 +6791,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locale_data"
-version = "2.2.0"
+name = "icu_locale_fallback"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5fdcc9ac77c6d74ff5cf6e65ef3181d6af32003b16fce3a77fb451d2f695993"
+checksum = "251af8e57c9400e3eb58242fe5b8b1152b2a64fdf4cf632f923c38ccee6f2fa9"
+dependencies = [
+ "icu_locale_core",
+ "icu_locale_fallback_data",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_fallback_data"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "decf2a22ec8fa68f1a0c1129a3f8583f8f8bc24e8b9ccbe98ead99f62a4dc3a8"
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -6746,18 +6826,18 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_plurals"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a50023f1d49ad5c4333380328a0d4a19e4b9d6d842ec06639affd5ba47c8103"
+checksum = "e475e6766ef87b1d3c1f97be6363995b0bfaeddbc789671615df598a97ff0593"
 dependencies = [
  "fixed_decimal",
- "icu_locale",
+ "icu_locale_fallback",
  "icu_plurals_data",
  "icu_provider",
  "zerovec",
@@ -6765,16 +6845,17 @@ dependencies = [
 
 [[package]]
 name = "icu_plurals_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8485497155dc865f901decb93ecc20d3e467df67bfeceb91e3ba34e2b11e8e1d"
+checksum = "1251aa39a95e1333888e499b1263e1c196447a28948acf5bdabd82c046f153bf"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -6785,15 +6866,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -7065,9 +7146,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "ixdtf"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ceaf4c6c48465bead8cb6a0b7c4ee0c86ecbb31239032b9c66ab9a08d2f3ee1"
+checksum = "4d3667095d64c3ecffc96463a21157b04bf3e252f6e8d5750b20c02e33c194e3"
 
 [[package]]
 name = "jiff"
@@ -7340,14 +7421,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
  "plain",
- "redox_syscall 0.9.1",
+ "redox_syscall 0.9.3",
 ]
 
 [[package]]
@@ -7363,15 +7444,15 @@ dependencies = [
 
 [[package]]
 name = "link-section"
-version = "0.19.2"
+version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee1a0d6e252afe82e7bc2db42fba60e02ddf3b1accaf8cb21d96e34ba61f3d4"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
 
 [[package]]
 name = "linktime-proc-macro"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348d0075b1fc163b26d72a7f75fc5141daf2fd1bdf128d873cbaf6785d495bdf"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "linux-keyutils"
@@ -7397,9 +7478,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "litrs"
@@ -7434,9 +7515,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "logos"
@@ -7490,11 +7571,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -7674,9 +7755,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -7872,9 +7953,9 @@ checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -7928,7 +8009,7 @@ dependencies = [
  "chrono",
  "getrandom 0.2.17",
  "http 1.5.0",
- "rand 0.8.7",
+ "rand 0.8.8",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -8439,6 +8520,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pbkdf2"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8481,6 +8568,17 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
+]
 
 [[package]]
 name = "pin-project"
@@ -8537,9 +8635,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plain"
@@ -8599,9 +8697,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -8649,9 +8747,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "serde_core",
  "writeable",
@@ -8781,6 +8879,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-build"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.119",
+ "tempfile",
+]
+
+[[package]]
 name = "prost-derive"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8794,10 +8911,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "psl"
-version = "2.1.223"
+name = "prost-types"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0dedad316e05de220cbf3fd8bfb69f3df8755dde2d7d479211827b595168a93"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
+dependencies = [
+ "prost",
+]
+
+[[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
+name = "psl"
+version = "2.1.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc88482eea924ca3a2f56a547454169af58deef35567965eb4fc2392a834841"
 dependencies = [
  "psl-types",
 ]
@@ -8884,9 +9074,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -9137,9 +9327,9 @@ dependencies = [
 
 [[package]]
 name = "rama-macros"
-version = "0.3.0"
+version = "0.3.0-alpha.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d90ecfc0103cccc2beefe84dac28cccafea616c0243cef021c5fc6a7e92ce624"
+checksum = "ea18a110bcf21e35c5f194168e6914ccea45ffdd0fea51bc4b169fbeafef6428"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -9271,9 +9461,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.7"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -9385,9 +9575,9 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.8"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
+checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
 dependencies = [
  "aws-lc-rs",
  "pem",
@@ -9408,9 +9598,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07507be7b4a5f9f26eeb41eeaebb1f5a7ff29dfb29739facc21d35bf8b11c21e"
+checksum = "d678d17679829e73d371e96880897e98fee2ded7acc0a50bdf8af2affa4b2fe5"
 dependencies = [
  "bitflags 2.13.1",
 ]
@@ -9439,22 +9629,22 @@ dependencies = [
 
 [[package]]
 name = "ref-cast"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+checksum = "7e440fb4e4b4147295338efb76001ab9e4efc0e5839df2c47fc5ac2381d365c3"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.26"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+checksum = "92ecd8964f8453721699a1ed72037b0db49ce2f5a5138486ee89bed6f67cdf3a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -9619,9 +9809,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "3.0.0"
+version = "3.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcd2b6dd3b18129368955f32661a7718969e8c152c7d8866434c09cf15a512e0"
+checksum = "5f17072af977b0f86f714dbd64b3d37d0715bb63064f9d13483f0a1775813374"
 dependencies = [
  "async-trait",
  "base64 0.23.1",
@@ -9631,6 +9821,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
+ "indexmap 2.14.0",
  "oauth2",
  "pastey",
  "pin-project-lite",
@@ -9654,15 +9845,15 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.2"
+version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6898e24cd16342b59bfa8a53c2c04b9cf62fc8a2cfea57b9c038b09984bfc521"
+checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
 dependencies = [
- "darling 0.24.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -9812,9 +10003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -9984,7 +10175,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals 0.30.0",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -10055,7 +10246,7 @@ dependencies = [
  "hkdf 0.12.4",
  "num",
  "once_cell",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "sha2 0.10.9",
  "zbus",
@@ -10117,6 +10308,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "sentry"
@@ -10273,7 +10468,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -10295,7 +10490,7 @@ checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -10354,7 +10549,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -10380,9 +10575,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -10390,6 +10585,7 @@ dependencies = [
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
  "serde_core",
@@ -10400,9 +10596,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -10820,7 +11016,7 @@ dependencies = [
  "time",
  "tracing",
  "uuid",
- "whoami 2.1.2",
+ "whoami 2.1.3",
 ]
 
 [[package]]
@@ -11104,9 +11300,9 @@ checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "symphonia"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1758d6c853020a7244de03cc3e0185eaea3f58715122422dd3cc7452e6d4c16a"
+checksum = "a7edef6a96b696d4e0cab5ee9ebb7ca155ed95f30a6b45bbb8b97d2727f02424"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -11120,9 +11316,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "350f1f2f2e19ad4dd315db94304d1eb361b29af070681f94e51b8fdaad769546"
+checksum = "98ea5ffc8716bff677dfb3b01b420c7b758de901a72b8c330bf2040ab74b4add"
 dependencies = [
  "lazy_static",
  "log",
@@ -11131,9 +11327,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-common"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8257891ffa7f05e02b58f4761e2abf7e5278c8744fd59e981559e050f86eef55"
+checksum = "2acc3fcc18ec9b8cdd48614e259c4cf0d27b71d41e5d9b120b42c5adab12d7c4"
 dependencies = [
  "log",
  "symphonia-core",
@@ -11142,9 +11338,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ec293b5f288383b72a7bffcade6b2860b642cf66f28b3bd5967349a49938b1"
+checksum = "01c412864d599d4750d0c3d684d7e093ec05e5309681ef5252cc1096a437f6e0"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",
@@ -11156,9 +11352,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-isomp4"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d179a01305b3505940135a9f0180d6ef4b487912748fe97554756f120fbd05e"
+checksum = "0e681a70e1870d34e02abf1dbc51e4267c3f1827801474e8870be8c689fc4dc3"
 dependencies = [
  "log",
  "symphonia-common",
@@ -11168,9 +11364,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-mkv"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb17713e134f5ad316c2690fa3104590ccc85842cdbcf82c3cd1a845cb08aa74"
+checksum = "d015c5c0558864665894b3f4cbd95e10abb01b9c868e751c72670f326a56360e"
 dependencies = [
  "lazy_static",
  "log",
@@ -11180,9 +11376,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05a67e02b1e4fca1a261ba4fe06910a9357489ad8c36aafdd2960e9c6559433"
+checksum = "0b5495e7f7e3c7035328d82b6d6e377eef289bb0c4105bdeb557fc93a833f994"
 dependencies = [
  "log",
  "symphonia-common",
@@ -11192,9 +11388,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-riff"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17424452a777666d3eaf09a5c651029b15b6a333812fcc5b5474f2a3f0cff3f0"
+checksum = "1ff70929083a8c1a5f6cd7c904b6071c7914ad04739b510c2f7239dfc9b7dabe"
 dependencies = [
  "extended",
  "log",
@@ -11204,9 +11400,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31acf5cd623398a6208e2225d18f4b20f761c55098a796a5247ad516a4a8681"
+checksum = "83713a97705d77bdef7cdbc0768fd6e5a54e4cd7e48d60a806ae85639e2c87c6"
 dependencies = [
  "lazy_static",
  "log",
@@ -11239,9 +11435,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11432,7 +11628,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -11522,9 +11718,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "serde_core",
@@ -11584,7 +11780,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -11761,8 +11957,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
 dependencies = [
  "async-trait",
+ "axum",
  "base64 0.22.1",
  "bytes",
+ "h2",
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
@@ -11772,6 +11970,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "rustls-native-certs",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -11783,6 +11982,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-build"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c68f61875ac5293cf72e6c8cf0158086428c82c37229e98c840878f1706b0322"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tonic-prost"
 version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11791,6 +12002,22 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "tonic-prost-build"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4556786613791cfef4ed134aa670b61a85cfcacf71543ef33e8d801abae988f"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "prost-types",
+ "quote",
+ "syn 2.0.119",
+ "tempfile",
+ "tonic-build",
 ]
 
 [[package]]
@@ -11962,6 +12189,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-powershell"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3faf304d44b9ddd4a7d97804bb8de7daf564336dd5a526dc6de5b39238243022"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "triomphe"
@@ -12264,9 +12501,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.24.0"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
+checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -12511,9 +12748,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]
@@ -12531,9 +12768,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "widestring"
@@ -12978,9 +13215,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "x25519-dalek"
@@ -13095,7 +13332,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.7",
+ "rand 0.8.8",
  "serde",
  "serde_repr",
  "sha1 0.10.7",
@@ -13196,9 +13433,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -13208,9 +13445,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "serde",
  "yoke",
@@ -13220,13 +13457,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -25,25 +25,26 @@ path = "src/lib.rs"
 agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
 anyhow = "1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
-codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.147.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-rollout = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
 allocative = "=0.3.6"
 diffy = { version = "0.5.0", features = ["std"] }
 itertools = "0.14.0"

--- a/vendor/codex-acp/src/codex_agent.rs
+++ b/vendor/codex-acp/src/codex_agent.rs
@@ -37,8 +37,9 @@ use codex_login::{
 use codex_protocol::{
     ThreadId,
     mcp::ClientMcpExtensions,
-    protocol::{InitialHistory, SessionConfiguredEvent, SessionSource},
+    protocol::{SessionConfiguredEvent, SessionSource},
 };
+use codex_rollout::InitialHistory;
 use codex_thread_store::{
     ListThreadsParams, SortDirection as StoreSortDirection, ThreadSortKey as StoreThreadSortKey,
     ThreadStore,
@@ -139,7 +140,9 @@ impl CodexAgent {
         // The modern MCP protocol remains outside NeverWrite's ACP 0.14 contract.
         apply_runtime_feature_contracts(&mut config)?;
         let auth_manager =
-            AuthManager::shared_from_config(&config, /*enable_codex_api_key_env*/ false).await;
+            AuthManager::shared_from_config(&config, /*enable_codex_api_key_env*/ false)
+                .await
+                .map_err(std::io::Error::other)?;
 
         let client_capabilities: Arc<Mutex<ClientCapabilities>> = Arc::default();
         let session_roots: Arc<Mutex<HashMap<SessionId, PathBuf>>> = Arc::default();
@@ -517,6 +520,7 @@ impl CodexAgent {
                                     Some(headers.into_iter().map(|h| (h.name, h.value)).collect())
                                 },
                                 env_http_headers: None,
+                                http_headers_helper: None,
                             },
                             required: false,
                             enabled: true,
@@ -1104,6 +1108,7 @@ impl CodexAgent {
                 model_providers: None,
                 cwd_filters: cwd.map(|cwd| vec![cwd]),
                 section: None,
+                project_id: None,
                 archived: false,
                 search_term: None,
                 relation_filter: None,
@@ -1485,6 +1490,7 @@ mod tests {
                 bearer_token_env_var: None,
                 http_headers: None,
                 env_http_headers: None,
+                http_headers_helper: None,
             },
             auth: McpServerAuth::ChatGpt,
             environment_id: "base-environment".to_string(),

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -484,6 +484,14 @@ pub(crate) fn projection_for_collab_item(item: &CollabAgentToolCallItem) -> Suba
         (CollabAgentTool::Wait, false) => "waiting_end",
         (CollabAgentTool::CloseAgent, true) => "close_begin",
         (CollabAgentTool::CloseAgent, false) => "close_end",
+        (CollabAgentTool::SendMessage, true) => "message_begin",
+        (CollabAgentTool::SendMessage, false) => "message_end",
+        (CollabAgentTool::FollowupTask, true) => "followup_begin",
+        (CollabAgentTool::FollowupTask, false) => "followup_end",
+        (CollabAgentTool::InterruptAgent, true) => "interrupt_begin",
+        (CollabAgentTool::InterruptAgent, false) => "interrupt_end",
+        (CollabAgentTool::ListAgents, true) => "list_agents_begin",
+        (CollabAgentTool::ListAgents, false) => "list_agents_end",
     };
     let title = collab_item_title(item, &display_name);
     let detail = collab_item_detail(item);
@@ -573,6 +581,32 @@ fn collab_item_title(item: &CollabAgentToolCallItem, display_name: &str) -> Stri
             format!("Failed to close {display_name}")
         }
         (CollabAgentTool::CloseAgent, _) => format!("Closed {display_name}"),
+        (CollabAgentTool::SendMessage, CollabAgentToolCallStatus::InProgress) => {
+            format!("Messaging {display_name}")
+        }
+        (CollabAgentTool::SendMessage, _) if failed => {
+            format!("Failed to message {display_name}")
+        }
+        (CollabAgentTool::SendMessage, _) => format!("Messaged {display_name}"),
+        (CollabAgentTool::FollowupTask, CollabAgentToolCallStatus::InProgress) => {
+            format!("Following up with {display_name}")
+        }
+        (CollabAgentTool::FollowupTask, _) if failed => {
+            format!("Failed to follow up with {display_name}")
+        }
+        (CollabAgentTool::FollowupTask, _) => format!("Followed up with {display_name}"),
+        (CollabAgentTool::InterruptAgent, CollabAgentToolCallStatus::InProgress) => {
+            format!("Interrupting {display_name}")
+        }
+        (CollabAgentTool::InterruptAgent, _) if failed => {
+            format!("Failed to interrupt {display_name}")
+        }
+        (CollabAgentTool::InterruptAgent, _) => format!("Interrupted {display_name}"),
+        (CollabAgentTool::ListAgents, CollabAgentToolCallStatus::InProgress) => {
+            "Listing agents".to_string()
+        }
+        (CollabAgentTool::ListAgents, _) if failed => "Failed to list agents".to_string(),
+        (CollabAgentTool::ListAgents, _) => "Listed agents".to_string(),
     }
 }
 
@@ -618,7 +652,10 @@ fn collab_item_detail(item: &CollabAgentToolCallItem) -> Option<String> {
 }
 
 fn collab_item_tool_status(item: &CollabAgentToolCallItem) -> ToolCallStatus {
-    if item.status == CollabAgentToolCallStatus::Failed {
+    if matches!(
+        item.status,
+        CollabAgentToolCallStatus::Failed | CollabAgentToolCallStatus::Interrupted
+    ) {
         return ToolCallStatus::Failed;
     }
 
@@ -646,7 +683,11 @@ fn collab_item_breadcrumb_meta(
         receiver.and_then(|receiver| receiver.agent_role),
         status,
     );
-    if item.tool == CollabAgentTool::Wait && !item.agents_states.is_empty() {
+    if matches!(
+        item.tool,
+        CollabAgentTool::Wait | CollabAgentTool::ListAgents
+    ) && !item.agents_states.is_empty()
+    {
         meta.insert(
             CODEX_ACP_AGENT_STATUSES_KEY.to_string(),
             json!(agent_status_values(
@@ -719,6 +760,11 @@ fn project_subagent_activity_fields(
             "activity_interrupted",
             format!("Interrupted {display_name}"),
             "interrupted",
+        ),
+        SubAgentActivityKind::Completed => (
+            "activity_completed",
+            format!("Completed {display_name}"),
+            "completed",
         ),
     };
 

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -527,6 +527,10 @@ struct CollabItemReceiver<'a> {
 }
 
 fn collab_item_receiver(item: &CollabAgentToolCallItem) -> Option<CollabItemReceiver<'_>> {
+    if item.tool == CollabAgentTool::ListAgents {
+        return None;
+    }
+
     item.receiver_agents
         .first()
         .map(|agent| CollabItemReceiver {
@@ -745,26 +749,30 @@ fn project_subagent_activity_fields(
     }
 
     let display_name = agent_path.name();
-    let (event_type, title, status) = match kind {
+    let (event_type, title, status, tool_status) = match kind {
         SubAgentActivityKind::Started => (
             "activity_started",
             format!("Started {display_name}"),
             "running",
+            ToolCallStatus::InProgress,
         ),
         SubAgentActivityKind::Interacted => (
             "activity_interacted",
             format!("Contacted {display_name}"),
             "running",
+            ToolCallStatus::InProgress,
         ),
         SubAgentActivityKind::Interrupted => (
             "activity_interrupted",
             format!("Interrupted {display_name}"),
             "interrupted",
+            ToolCallStatus::Failed,
         ),
         SubAgentActivityKind::Completed => (
             "activity_completed",
             format!("Completed {display_name}"),
             "completed",
+            ToolCallStatus::Completed,
         ),
     };
 
@@ -799,7 +807,7 @@ fn project_subagent_activity_fields(
     Some(SubagentProjection::ToolCall(
         ToolCall::new(subagent_activity_tool_call_id(activity_id), title)
             .kind(ToolKind::Other)
-            .status(ToolCallStatus::Completed)
+            .status(tool_status)
             .content(content(Some(format!("Agent: {agent_path}"))))
             .raw_output(raw_event(raw_output))
             .meta(meta),
@@ -1361,24 +1369,27 @@ mod tests {
         let child_thread_id = ThreadId::new();
         let parent_session_id = SessionId::new("parent-runtime-session-id");
 
-        for (kind, event_type, status, title) in [
+        for (kind, event_type, status, title, tool_status) in [
             (
                 SubAgentActivityKind::Started,
                 "activity_started",
                 "running",
                 "Started explorer",
+                ToolCallStatus::InProgress,
             ),
             (
                 SubAgentActivityKind::Interacted,
                 "activity_interacted",
                 "running",
                 "Contacted explorer",
+                ToolCallStatus::InProgress,
             ),
             (
                 SubAgentActivityKind::Interrupted,
                 "activity_interrupted",
                 "interrupted",
                 "Interrupted explorer",
+                ToolCallStatus::Failed,
             ),
         ] {
             let projection = projection_for_event(
@@ -1400,7 +1411,7 @@ mod tests {
             };
 
             assert_eq!(tool_call.title, title);
-            assert_eq!(tool_call.status, ToolCallStatus::Completed);
+            assert_eq!(tool_call.status, tool_status);
             assert_eq!(
                 tool_call.tool_call_id.0.as_ref(),
                 subagent_activity_tool_call_id(&format!("event-{kind:?}"))
@@ -1593,6 +1604,137 @@ mod tests {
         assert_eq!(completed.fields.status, Some(ToolCallStatus::Completed));
         assert_eq!(
             completed
+                .meta
+                .as_ref()
+                .and_then(|meta| meta.get(CODEX_ACP_CHILD_THREAD_ID_KEY))
+                .and_then(serde_json::Value::as_str),
+            Some(child_thread_id.to_string().as_str())
+        );
+    }
+
+    #[test]
+    fn expanded_collaboration_tools_project_stable_and_distinct_lifecycles() {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let item = |id: &str, tool, status| CollabAgentToolCallItem {
+            id: id.to_string(),
+            tool,
+            status,
+            sender_thread_id: parent_thread_id,
+            receiver_thread_ids: vec![child_thread_id],
+            receiver_agents: vec![CollabAgentRef {
+                thread_id: child_thread_id,
+                agent_nickname: Some("Galileo".to_string()),
+                agent_role: Some("explorer".to_string()),
+            }],
+            prompt: Some("private coordination payload".to_string()),
+            model: None,
+            reasoning_effort: None,
+            agents_states: HashMap::from([(child_thread_id, AgentStatus::Running)]),
+        };
+
+        for (tool, expected_begin, expected_end, end_status, expected_event) in [
+            (
+                CollabAgentTool::SendMessage,
+                "Messaging Galileo",
+                "Messaged Galileo",
+                CollabAgentToolCallStatus::Completed,
+                "message_end",
+            ),
+            (
+                CollabAgentTool::FollowupTask,
+                "Following up with Galileo",
+                "Followed up with Galileo",
+                CollabAgentToolCallStatus::Completed,
+                "followup_end",
+            ),
+            (
+                CollabAgentTool::InterruptAgent,
+                "Interrupting Galileo",
+                "Interrupted Galileo",
+                CollabAgentToolCallStatus::Interrupted,
+                "interrupt_end",
+            ),
+            (
+                CollabAgentTool::ListAgents,
+                "Listing agents",
+                "Listed agents",
+                CollabAgentToolCallStatus::Completed,
+                "list_agents_end",
+            ),
+        ] {
+            let id = format!("{tool:?}");
+            let SubagentProjection::ToolCall(begin) =
+                projection_for_collab_item(&item(&id, tool, CollabAgentToolCallStatus::InProgress))
+            else {
+                panic!("{tool:?} begin should create a tool call");
+            };
+            let SubagentProjection::ToolCallUpdate(end) =
+                projection_for_collab_item(&item(&id, tool, end_status))
+            else {
+                panic!("{tool:?} end should update a tool call");
+            };
+
+            assert_eq!(begin.tool_call_id, end.tool_call_id);
+            assert_eq!(begin.title, expected_begin);
+            assert_eq!(end.fields.title.as_deref(), Some(expected_end));
+            assert_eq!(
+                end.fields.status,
+                Some(if tool == CollabAgentTool::InterruptAgent {
+                    ToolCallStatus::Failed
+                } else {
+                    ToolCallStatus::Completed
+                })
+            );
+            assert_eq!(
+                end.meta
+                    .as_ref()
+                    .and_then(|meta| meta.get(CODEX_ACP_SUBAGENT_EVENT_TYPE_KEY))
+                    .and_then(serde_json::Value::as_str),
+                Some(expected_event)
+            );
+            if tool == CollabAgentTool::ListAgents {
+                assert!(
+                    end.meta
+                        .as_ref()
+                        .is_some_and(|meta| !meta.contains_key(CODEX_ACP_CHILD_THREAD_ID_KEY))
+                );
+                assert!(
+                    end.meta
+                        .as_ref()
+                        .is_some_and(|meta| meta.contains_key(CODEX_ACP_AGENT_STATUSES_KEY))
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn completed_activity_is_a_terminal_projection_with_runtime_identity() {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let parent_session_id = SessionId::new(parent_thread_id.to_string());
+        let item = SubAgentActivityItem {
+            id: "activity-1".to_string(),
+            kind: SubAgentActivityKind::Completed,
+            agent_thread_id: child_thread_id,
+            agent_path: "/root/research/explorer"
+                .try_into()
+                .expect("valid agent path"),
+        };
+
+        let Some(SubagentProjection::ToolCall(projection)) =
+            projection_for_subagent_activity_item(&item, parent_thread_id, &parent_session_id)
+        else {
+            panic!("completed activity should project");
+        };
+        assert_eq!(
+            projection.tool_call_id.0.as_ref(),
+            "codex-acp:subagent:activity-1"
+        );
+        assert_eq!(projection.title, "Completed explorer");
+        assert_eq!(projection.status, ToolCallStatus::Completed);
+        assert_eq!(
+            projection
                 .meta
                 .as_ref()
                 .and_then(|meta| meta.get(CODEX_ACP_CHILD_THREAD_ID_KEY))

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -5488,12 +5488,16 @@ impl<A: Auth> ThreadActor<A> {
                 .map_err(|e| Error::internal_error().data(e.to_string()))?,
             PromptSubmission::Turn(request) => match self
                 .thread
-                .submit_turn_input(request, TurnInputMode::StartOrSteer)
+                .submit_turn_input(request, TurnInputMode::StartIfIdle)
                 .await
                 .map_err(|e| Error::internal_error().data(e.to_string()))?
             {
-                TurnInputSubmission::Started { turn_id }
-                | TurnInputSubmission::Steered { turn_id } => turn_id,
+                TurnInputSubmission::Started { turn_id } => turn_id,
+                TurnInputSubmission::Steered { turn_id } => {
+                    return Err(Error::internal_error().data(format!(
+                        "runtime unexpectedly steered active turn {turn_id} for a start-if-idle prompt"
+                    )));
+                }
                 TurnInputSubmission::NotSubmitted { reason } => {
                     return Err(Error::invalid_params()
                         .data(format!("runtime declined prompt submission: {reason:?}")));
@@ -7017,10 +7021,75 @@ mod tests {
                     text: "Hi".to_string(),
                     text_elements: vec![]
                 }],
+                mode: TurnInputMode::StartIfIdle,
             }],
             "ops don't match {ops:?}"
         );
 
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn busy_runtime_declines_prompt_without_leaving_a_pending_response() -> anyhow::Result<()>
+    {
+        let (session_id, _client, thread, message_tx, local_set) = setup(vec![]).await?;
+        thread.set_next_turn_submission(TurnInputSubmission::NotSubmitted {
+            reason: codex_protocol::turn_input::NotSubmittedReason::NotIdle,
+        });
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id, vec!["queued too early".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), prompt_response_rx).await??;
+        let error = match result {
+            Ok(_) => anyhow::bail!("busy runtime unexpectedly accepted the prompt"),
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:?}").contains("NotIdle"),
+            "unexpected submission error: {error:?}"
+        );
+        assert!(matches!(
+            thread.ops.lock().unwrap().as_slice(),
+            [RecordedOp::TurnInput {
+                mode: TurnInputMode::StartIfIdle,
+                ..
+            }]
+        ));
+
+        drop(message_tx);
+        drop(local_set.await);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn start_if_idle_rejects_an_unexpected_steered_acknowledgement() -> anyhow::Result<()> {
+        let (session_id, _client, thread, message_tx, local_set) = setup(vec![]).await?;
+        thread.set_next_turn_submission(TurnInputSubmission::Steered {
+            turn_id: "active-turn".to_string(),
+        });
+        let (prompt_response_tx, prompt_response_rx) = tokio::sync::oneshot::channel();
+
+        message_tx.send(ThreadMessage::Prompt {
+            request: PromptRequest::new(session_id, vec!["must not steer".into()]),
+            response_tx: prompt_response_tx,
+        })?;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), prompt_response_rx).await??;
+        let error = match result {
+            Ok(_) => anyhow::bail!("start-if-idle unexpectedly accepted a steered prompt"),
+            Err(error) => error,
+        };
+        assert!(
+            format!("{error:?}").contains("unexpectedly steered active turn active-turn"),
+            "unexpected submission error: {error:?}"
+        );
+
+        drop(message_tx);
+        drop(local_set.await);
         Ok(())
     }
 
@@ -7596,6 +7665,7 @@ mod tests {
                     text: INIT_COMMAND_PROMPT.to_string(),
                     text_elements: vec![]
                 }],
+                mode: TurnInputMode::StartIfIdle,
             }],
             "ops don't match {ops:?}"
         );
@@ -7881,6 +7951,7 @@ mod tests {
                     text: "Custom prompt with foo arg.".into(),
                     text_elements: vec![]
                 }],
+                mode: TurnInputMode::StartIfIdle,
             }],
             "ops don't match {ops:?}"
         );
@@ -10609,6 +10680,7 @@ mod tests {
     enum RecordedOp {
         TurnInput {
             items: Vec<UserInput>,
+            mode: TurnInputMode,
         },
         Compact,
         Review {
@@ -10628,6 +10700,7 @@ mod tests {
     struct StubCodexThread {
         current_id: AtomicUsize,
         ops: std::sync::Mutex<Vec<RecordedOp>>,
+        next_turn_submission: std::sync::Mutex<Option<TurnInputSubmission>>,
         op_tx: mpsc::UnboundedSender<Event>,
         op_rx: Mutex<mpsc::UnboundedReceiver<Event>>,
     }
@@ -10638,9 +10711,14 @@ mod tests {
             StubCodexThread {
                 current_id: AtomicUsize::new(0),
                 ops: std::sync::Mutex::default(),
+                next_turn_submission: std::sync::Mutex::default(),
                 op_tx,
                 op_rx: Mutex::new(op_rx),
             }
+        }
+
+        fn set_next_turn_submission(&self, submission: TurnInputSubmission) {
+            *self.next_turn_submission.lock().unwrap() = Some(submission);
         }
     }
 
@@ -10655,9 +10733,10 @@ mod tests {
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
                 let recorded_op = match &op {
-                    Op::TurnInput { request, .. } => match &request.input {
+                    Op::TurnInput { request, mode, .. } => match &request.input {
                         TurnInput::UserInput { content, .. } => RecordedOp::TurnInput {
                             items: content.clone(),
+                            mode: mode.clone(),
                         },
                         input => RecordedOp::Other(format!("turn input: {input:?}")),
                     },
@@ -10686,9 +10765,20 @@ mod tests {
                         let TurnInput::UserInput { content: items, .. } = request.input else {
                             unimplemented!()
                         };
-                        drop(reply.send(Ok(TurnInputSubmission::Started {
-                            turn_id: id.to_string(),
-                        })));
+                        let turn_submission = self
+                            .next_turn_submission
+                            .lock()
+                            .unwrap()
+                            .take()
+                            .unwrap_or_else(|| TurnInputSubmission::Started {
+                                turn_id: id.to_string(),
+                            });
+                        let turn_started =
+                            matches!(turn_submission, TurnInputSubmission::Started { .. });
+                        drop(reply.send(Ok(turn_submission)));
+                        if !turn_started {
+                            return Ok(id.to_string());
+                        }
                         let prompt = items
                             .into_iter()
                             .map(|i| match i {

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -10161,6 +10161,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn config_options_expose_max_and_ultra_from_the_runtime_catalog() -> anyhow::Result<()> {
+        let preset = all_model_presets()
+            .iter()
+            .find(|preset| {
+                preset
+                    .supported_reasoning_efforts
+                    .iter()
+                    .any(|effort| effort.effort == ReasoningEffort::Max)
+                    && preset
+                        .supported_reasoning_efforts
+                        .iter()
+                        .any(|effort| effort.effort == ReasoningEffort::Ultra)
+            })
+            .expect("runtime 0.150 catalog should include max and ultra")
+            .clone();
+        let selected_model = preset.model.clone();
+        let (actor, _client, _conversation) = setup_actor(|config| {
+            config.model = Some(selected_model);
+            config.model_reasoning_effort = Some(ReasoningEffort::Ultra);
+        })
+        .await?;
+
+        let options = actor.config_options().await?;
+        let reasoning = options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "reasoning_effort")
+            .expect("reasoning option should be present");
+        let SessionConfigKind::Select(select) = &reasoning.kind else {
+            panic!("reasoning option should be a select");
+        };
+        let SessionConfigSelectOptions::Ungrouped(efforts) = &select.options else {
+            panic!("reasoning options should be ungrouped");
+        };
+        let values = efforts
+            .iter()
+            .map(|effort| effort.value.to_string())
+            .collect::<Vec<_>>();
+        assert!(values.contains(&"max".to_string()), "efforts={values:?}");
+        assert!(values.contains(&"ultra".to_string()), "efforts={values:?}");
+        assert_eq!(select.current_value.0.as_ref(), "ultra");
+        assert_eq!(
+            efforts
+                .iter()
+                .find(|effort| effort.value.0.as_ref() == "max")
+                .map(|effort| effort.name.as_str()),
+            Some("Max")
+        );
+        assert_eq!(
+            efforts
+                .iter()
+                .find(|effort| effort.value.0.as_ref() == "ultra")
+                .map(|effort| effort.name.as_str()),
+            Some("Ultra")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn active_permission_profiles_map_to_neverwrite_session_modes() -> anyhow::Result<()> {
         let mut config = Config::load_with_cli_overrides_and_harness_overrides(
             vec![],

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -51,6 +51,8 @@ use codex_protocol::protocol::{
     WebSearchBeginEvent, WebSearchEndEvent,
 };
 use codex_protocol::review_format::format_review_findings_block;
+#[cfg(test)]
+use codex_protocol::turn_input::TurnInput;
 use codex_protocol::{
     ResponseItemId, ThreadId,
     approvals::{ElicitationRequest, ElicitationRequestEvent},
@@ -69,15 +71,15 @@ use codex_protocol::{
         FileSystemAccessMode, FileSystemPath, FileSystemSandboxEntry, FileSystemSpecialPath,
     },
     plan_tool::{PlanItemArg, StepStatus, UpdatePlanArgs},
-    protocol::{
-        DynamicToolCallResponseEvent, NetworkApprovalContext, NetworkPolicyRuleAction, RolloutItem,
-    },
+    protocol::{DynamicToolCallResponseEvent, NetworkApprovalContext, NetworkPolicyRuleAction},
     request_permissions::{
         PermissionGrantScope, RequestPermissionProfile, RequestPermissionsEvent,
         RequestPermissionsResponse,
     },
+    turn_input::{TurnInputMode, TurnInputRequest, TurnInputSubmission},
     user_input::UserInput,
 };
+use codex_rollout::RolloutItem;
 use codex_shell_command::parse_command::parse_command;
 use codex_utils_approval_presets::{ApprovalPreset, builtin_approval_presets};
 use heck::ToTitleCase;
@@ -252,6 +254,24 @@ struct NeverWriteDiffHunkLine {
 pub trait CodexThreadImpl: Send + Sync {
     fn submit(&self, op: Op)
     -> Pin<Box<dyn Future<Output = Result<String, CodexErr>> + Send + '_>>;
+
+    fn submit_turn_input(
+        &self,
+        request: TurnInputRequest,
+        mode: TurnInputMode,
+    ) -> Pin<Box<dyn Future<Output = Result<TurnInputSubmission, CodexErr>> + Send + '_>> {
+        Box::pin(async move {
+            let (reply_tx, reply_rx) = oneshot::channel();
+            self.submit(Op::TurnInput {
+                request: Box::new(request),
+                mode,
+                reply: reply_tx,
+            })
+            .await?;
+            reply_rx.await.map_err(|_| CodexErr::InternalAgentDied)?
+        })
+    }
+
     fn next_event(&self) -> Pin<Box<dyn Future<Output = Result<Event, CodexErr>> + Send + '_>>;
 }
 
@@ -1437,7 +1457,7 @@ fn format_file_system_entries<'a>(
 
 fn format_file_system_entry(entry: &FileSystemSandboxEntry) -> String {
     match &entry.path {
-        FileSystemPath::Path { path } => path.display().to_string(),
+        FileSystemPath::Path { path } => path.inferred_native_path_string(),
         FileSystemPath::GlobPattern { pattern } => format!("glob `{pattern}`"),
         FileSystemPath::Special { value } => format_file_system_special(value),
     }
@@ -2839,6 +2859,7 @@ impl PromptState {
                                 result: image_item.result,
                                 saved_path: image_item.saved_path,
                                 transparent_background: None,
+                                failure: None,
                             },
                         )
                         .await;
@@ -2853,6 +2874,7 @@ impl PromptState {
                                 result: image_item.result,
                                 saved_path: image_item.saved_path,
                                 transparent_background: None,
+                                failure: None,
                             },
                         )
                         .await;
@@ -3133,6 +3155,14 @@ impl PromptState {
                 info!(
                     "Runtime environment disconnected without ACP projection: environment_id={}",
                     event.environment_id
+                );
+            }
+            EventMsg::ThreadQueueChanged(event) => {
+                // NeverWrite owns the user-facing prompt queue. Keep this runtime signal
+                // diagnostic-only so it cannot create a second source of queue truth.
+                info!(
+                    "Runtime thread queue changed without ACP projection: thread_id={}",
+                    event.thread_id
                 );
             }
             EventMsg::RawResponseItem(..) => {
@@ -4306,6 +4336,15 @@ fn build_exec_permission_options(
                 ),
                 decision: ReviewDecision::ApprovedForSession,
             },
+            ReviewDecision::ApprovedMcpPolicyAmendment => ExecPermissionOption {
+                option_id: "approved-mcp-policy-amendment",
+                permission_option: PermissionOption::new(
+                    "approved-mcp-policy-amendment",
+                    "Yes, and allow this MCP tool in the future",
+                    PermissionOptionKind::AllowAlways,
+                ),
+                decision: ReviewDecision::ApprovedMcpPolicyAmendment,
+            },
             ReviewDecision::NetworkPolicyAmendment {
                 network_policy_amendment,
             } => {
@@ -5291,22 +5330,23 @@ impl<A: Auth> ThreadActor<A> {
             return Ok(response_rx);
         }
 
+        enum PromptSubmission {
+            Operation(Op),
+            Turn(TurnInputRequest),
+        }
+
         let items = build_prompt_items(request.prompt);
-        let op;
+        let submission;
         if let Some((name, rest)) = extract_slash_command(&items) {
             match name {
-                "compact" => op = Op::Compact,
+                "compact" => submission = PromptSubmission::Operation(Op::Compact),
                 "init" => {
-                    op = Op::UserInput {
-                        items: vec![UserInput::Text {
+                    submission = PromptSubmission::Turn(TurnInputRequest::user_input(vec![
+                        UserInput::Text {
                             text: INIT_COMMAND_PROMPT.into(),
                             text_elements: vec![],
-                        }],
-                        final_output_json_schema: None,
-                        responsesapi_client_metadata: None,
-                        additional_context: Default::default(),
-                        thread_settings: Default::default(),
-                    }
+                        },
+                    ]))
                 }
                 "fast" => {
                     if !self.fast_mode_available() {
@@ -5383,35 +5423,35 @@ impl<A: Auth> ThreadActor<A> {
                         }
                     };
 
-                    op = Op::Review {
+                    submission = PromptSubmission::Operation(Op::Review {
                         review_request: ReviewRequest {
                             user_facing_hint: Some(user_facing_hint(&target)),
                             target,
                         },
-                    }
+                    })
                 }
                 "review-branch" if !rest.is_empty() => {
                     let target = ReviewTarget::BaseBranch {
                         branch: rest.trim().to_owned(),
                     };
-                    op = Op::Review {
+                    submission = PromptSubmission::Operation(Op::Review {
                         review_request: ReviewRequest {
                             user_facing_hint: Some(user_facing_hint(&target)),
                             target,
                         },
-                    }
+                    })
                 }
                 "review-commit" if !rest.is_empty() => {
                     let target = ReviewTarget::Commit {
                         sha: rest.trim().to_owned(),
                         title: None,
                     };
-                    op = Op::Review {
+                    submission = PromptSubmission::Operation(Op::Review {
                         review_request: ReviewRequest {
                             user_facing_hint: Some(user_facing_hint(&target)),
                             target,
                         },
-                    }
+                    })
                 }
                 "logout" => {
                     self.auth.logout().await?;
@@ -5425,42 +5465,41 @@ impl<A: Auth> ThreadActor<A> {
                     )
                     .map_err(|e| Error::invalid_params().data(e.user_message()))?
                     {
-                        op = Op::UserInput {
-                            items: vec![UserInput::Text {
+                        submission = PromptSubmission::Turn(TurnInputRequest::user_input(vec![
+                            UserInput::Text {
                                 text: prompt,
                                 text_elements: vec![],
-                            }],
-                            final_output_json_schema: None,
-                            responsesapi_client_metadata: None,
-                            additional_context: Default::default(),
-                            thread_settings: Default::default(),
-                        }
+                            },
+                        ]))
                     } else {
-                        op = Op::UserInput {
-                            items,
-                            final_output_json_schema: None,
-                            responsesapi_client_metadata: None,
-                            additional_context: Default::default(),
-                            thread_settings: Default::default(),
-                        }
+                        submission = PromptSubmission::Turn(TurnInputRequest::user_input(items))
                     }
                 }
             }
         } else {
-            op = Op::UserInput {
-                items,
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
-            }
+            submission = PromptSubmission::Turn(TurnInputRequest::user_input(items))
         }
 
-        let submission_id = self
-            .thread
-            .submit(op.clone())
-            .await
-            .map_err(|e| Error::internal_error().data(e.to_string()))?;
+        let submission_id = match submission {
+            PromptSubmission::Operation(op) => self
+                .thread
+                .submit(op)
+                .await
+                .map_err(|e| Error::internal_error().data(e.to_string()))?,
+            PromptSubmission::Turn(request) => match self
+                .thread
+                .submit_turn_input(request, TurnInputMode::StartOrSteer)
+                .await
+                .map_err(|e| Error::internal_error().data(e.to_string()))?
+            {
+                TurnInputSubmission::Started { turn_id }
+                | TurnInputSubmission::Steered { turn_id } => turn_id,
+                TurnInputSubmission::NotSubmitted { reason } => {
+                    return Err(Error::invalid_params()
+                        .data(format!("runtime declined prompt submission: {reason:?}")));
+                }
+            },
+        };
 
         info!("Submitted prompt with submission_id: {submission_id}");
         info!("Starting to wait for conversation events for submission_id: {submission_id}");
@@ -5833,9 +5872,14 @@ impl<A: Auth> ThreadActor<A> {
             ResponseItem::FunctionCallOutput {
                 call_id, output, ..
             } => {
-                self.client
-                    .send_tool_call_completed(call_id.clone(), serde_json::to_value(output).ok())
-                    .await;
+                if let Some(call_id) = call_id {
+                    self.client
+                        .send_tool_call_completed(
+                            call_id.clone(),
+                            serde_json::to_value(output).ok(),
+                        )
+                        .await;
+                }
             }
             ResponseItem::LocalShellCall {
                 call_id: Some(call_id),
@@ -6673,6 +6717,12 @@ fn guardian_action_summary(
                 .ok()
                 .or_else(|| Some(parts.join(" ")))
         }
+        codex_protocol::approvals::GuardianAssessmentAction::WriteStdin {
+            process_id, cwd, ..
+        } => Some(format!(
+            "write input to process {process_id} in {}",
+            cwd.inferred_native_path_string()
+        )),
         codex_protocol::approvals::GuardianAssessmentAction::ApplyPatch { files, .. } => {
             Some(if files.len() == 1 {
                 format!("apply_patch touching {}", files[0].display())
@@ -6864,7 +6914,7 @@ mod tests {
             let ops = thread.ops.lock().unwrap();
             assert!(matches!(
                 ops.as_slice(),
-                [Op::ExecApproval {
+                [RecordedOp::ExecApproval {
                     id,
                     turn_id: Some(turn_id),
                     decision: ReviewDecision::Denied { rejection },
@@ -6962,15 +7012,11 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::UserInput {
+            &[RecordedOp::TurnInput {
                 items: vec![UserInput::Text {
                     text: "Hi".to_string(),
                     text_elements: vec![]
                 }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -7015,7 +7061,7 @@ mod tests {
             "notifications don't match {notifications:?}"
         );
         let ops = thread.ops.lock().unwrap();
-        assert_eq!(ops.as_slice(), &[Op::Compact]);
+        assert_eq!(ops.as_slice(), &[RecordedOp::Compact]);
 
         Ok(())
     }
@@ -7359,7 +7405,7 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert!(matches!(
             &ops[0],
-            Op::ThreadSettings {
+            RecordedOp::ThreadSettings {
                 thread_settings: ThreadSettingsOverrides {
                     service_tier: Some(Some(tier)),
                     ..
@@ -7409,7 +7455,7 @@ mod tests {
         assert_eq!(ops.len(), 1);
         assert!(matches!(
             &ops[0],
-            Op::ThreadSettings {
+            RecordedOp::ThreadSettings {
                 thread_settings: ThreadSettingsOverrides {
                     service_tier: Some(Some(tier)),
                     ..
@@ -7487,7 +7533,7 @@ mod tests {
         assert_eq!(ops.len(), 2);
         assert!(matches!(
             &ops[0],
-            Op::ThreadSettings {
+            RecordedOp::ThreadSettings {
                 thread_settings: ThreadSettingsOverrides {
                     service_tier: Some(Some(tier)),
                     ..
@@ -7496,7 +7542,7 @@ mod tests {
         ));
         assert!(matches!(
             &ops[1],
-            Op::ThreadSettings {
+            RecordedOp::ThreadSettings {
                 thread_settings: ThreadSettingsOverrides {
                     service_tier: Some(None),
                     ..
@@ -7545,15 +7591,11 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::UserInput {
+            &[RecordedOp::TurnInput {
                 items: vec![UserInput::Text {
                     text: INIT_COMMAND_PROMPT.to_string(),
                     text_elements: vec![]
                 }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -7601,7 +7643,7 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::Review {
+            &[RecordedOp::Review {
                 review_request: ReviewRequest {
                     user_facing_hint: Some(user_facing_hint(&ReviewTarget::UncommittedChanges)),
                     target: ReviewTarget::UncommittedChanges,
@@ -7657,7 +7699,7 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::Review {
+            &[RecordedOp::Review {
                 review_request: ReviewRequest {
                     user_facing_hint: Some(user_facing_hint(&ReviewTarget::Custom {
                         instructions: instructions.to_owned()
@@ -7713,7 +7755,7 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::Review {
+            &[RecordedOp::Review {
                 review_request: ReviewRequest {
                     user_facing_hint: Some(user_facing_hint(&ReviewTarget::Commit {
                         sha: "123456".to_owned(),
@@ -7771,7 +7813,7 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::Review {
+            &[RecordedOp::Review {
                 review_request: ReviewRequest {
                     user_facing_hint: Some(user_facing_hint(&ReviewTarget::BaseBranch {
                         branch: "feature".to_owned()
@@ -7834,15 +7876,11 @@ mod tests {
         let ops = thread.ops.lock().unwrap();
         assert_eq!(
             ops.as_slice(),
-            &[Op::UserInput {
+            &[RecordedOp::TurnInput {
                 items: vec![UserInput::Text {
                     text: "Custom prompt with foo arg.".into(),
                     text_elements: vec![]
                 }],
-                final_output_json_schema: None,
-                responsesapi_client_metadata: None,
-                additional_context: Default::default(),
-                thread_settings: Default::default(),
             }],
             "ops don't match {ops:?}"
         );
@@ -9223,7 +9261,7 @@ mod tests {
             setup(vec![]).await?;
         let (response_tx, response_rx) = oneshot::channel();
         message_tx.send(ThreadMessage::ReplayHistory {
-            history: vec![RolloutItem::ResponseItem(item)],
+            history: vec![RolloutItem::ResponseItem(item.into())],
             response_tx,
         })?;
         response_rx.await??;
@@ -9493,6 +9531,7 @@ mod tests {
                     status: "completed".to_string(),
                     revised_prompt: Some("A clearer prompt".to_string()),
                     result: "base64-image-data".to_string(),
+                    failure: None,
                     saved_path: Some(
                         std::env::current_dir()
                             .expect("current dir should be available")
@@ -9634,6 +9673,7 @@ mod tests {
                 result: "image generation failed".to_string(),
                 saved_path: Some(saved_path),
                 transparent_background: None,
+                failure: None,
             }))
             .await;
 
@@ -9795,7 +9835,7 @@ mod tests {
         );
         assert!(matches!(
             conversation.ops.lock().unwrap().last(),
-            Some(Op::ThreadSettings {
+            Some(RecordedOp::ThreadSettings {
                 thread_settings: ThreadSettingsOverrides {
                     permission_profile: Some(_),
                     ..
@@ -10565,9 +10605,29 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Clone, PartialEq)]
+    enum RecordedOp {
+        TurnInput {
+            items: Vec<UserInput>,
+        },
+        Compact,
+        Review {
+            review_request: ReviewRequest,
+        },
+        ThreadSettings {
+            thread_settings: ThreadSettingsOverrides,
+        },
+        ExecApproval {
+            id: String,
+            turn_id: Option<String>,
+            decision: ReviewDecision,
+        },
+        Other(String),
+    }
+
     struct StubCodexThread {
         current_id: AtomicUsize,
-        ops: std::sync::Mutex<Vec<Op>>,
+        ops: std::sync::Mutex<Vec<RecordedOp>>,
         op_tx: mpsc::UnboundedSender<Event>,
         op_rx: Mutex<mpsc::UnboundedReceiver<Event>>,
     }
@@ -10594,10 +10654,41 @@ mod tests {
                     .current_id
                     .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
 
-                self.ops.lock().unwrap().push(op.clone());
+                let recorded_op = match &op {
+                    Op::TurnInput { request, .. } => match &request.input {
+                        TurnInput::UserInput { content, .. } => RecordedOp::TurnInput {
+                            items: content.clone(),
+                        },
+                        input => RecordedOp::Other(format!("turn input: {input:?}")),
+                    },
+                    Op::Compact => RecordedOp::Compact,
+                    Op::Review { review_request } => RecordedOp::Review {
+                        review_request: review_request.clone(),
+                    },
+                    Op::ThreadSettings { thread_settings } => RecordedOp::ThreadSettings {
+                        thread_settings: thread_settings.clone(),
+                    },
+                    Op::ExecApproval {
+                        id,
+                        turn_id,
+                        decision,
+                    } => RecordedOp::ExecApproval {
+                        id: id.clone(),
+                        turn_id: turn_id.clone(),
+                        decision: decision.clone(),
+                    },
+                    op => RecordedOp::Other(format!("{op:?}")),
+                };
+                self.ops.lock().unwrap().push(recorded_op);
 
                 match op {
-                    Op::UserInput { items, .. } => {
+                    Op::TurnInput { request, reply, .. } => {
+                        let TurnInput::UserInput { content: items, .. } = request.input else {
+                            unimplemented!()
+                        };
+                        drop(reply.send(Ok(TurnInputSubmission::Started {
+                            turn_id: id.to_string(),
+                        })));
                         let prompt = items
                             .into_iter()
                             .map(|i| match i {
@@ -10723,6 +10814,7 @@ mod tests {
                                         message: prompt,
                                         phase: None,
                                         memory_citation: None,
+                                        delivery: None,
                                     }),
                                 })
                                 .unwrap();
@@ -10762,6 +10854,7 @@ mod tests {
                                     message: "Compact task completed".to_string(),
                                     phase: None,
                                     memory_citation: None,
+                                    delivery: None,
                                 }),
                             })
                             .unwrap();

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -29,7 +29,7 @@ use codex_core::{
     config::{Config, PermissionProfileSnapshot, set_project_trust_level},
     review_prompts::user_facing_hint,
 };
-use codex_extension_items::ExtensionItem;
+use codex_extension_items::{ExtensionItem, image_generation::ImageGenerationFailure};
 use codex_features::Feature;
 use codex_http_client::{HttpClientFactory, OutboundProxyPolicy};
 use codex_login::auth::AuthManager;
@@ -1019,8 +1019,24 @@ fn image_generation_completion_parts(
     revised_prompt: Option<String>,
     result: String,
     saved_path: Option<String>,
+    failure: Option<ImageGenerationFailure>,
 ) -> (String, ToolCallStatus, Option<String>, serde_json::Value) {
-    let tool_status = image_generation_tool_status(&status);
+    let failure_detail = failure.as_ref().map(|failure| match failure {
+        ImageGenerationFailure::UsageLimitExceeded {
+            limit_id,
+            resets_at,
+        } => match resets_at {
+            Some(resets_at) => {
+                format!("Usage limit {limit_id} was exceeded; resets at {resets_at}")
+            }
+            None => format!("Usage limit {limit_id} was exceeded"),
+        },
+    });
+    let tool_status = if failure.is_some() {
+        ToolCallStatus::Failed
+    } else {
+        image_generation_tool_status(&status)
+    };
     let is_failure = tool_status == ToolCallStatus::Failed;
     let title = if is_failure {
         "Image generation failed"
@@ -1028,7 +1044,10 @@ fn image_generation_completion_parts(
         "Generated image"
     }
     .to_string();
-    let detail = saved_path.clone().or_else(|| Some(result.clone()));
+    let detail = failure_detail
+        .clone()
+        .or_else(|| saved_path.clone())
+        .or_else(|| Some(result.clone()));
     let mut raw_input = json!({
         "status": status,
         "result": result.clone(),
@@ -1040,8 +1059,11 @@ fn image_generation_completion_parts(
         if let Some(revised_prompt) = revised_prompt {
             object.insert("revised_prompt".to_string(), json!(revised_prompt));
         }
+        if let Some(failure) = failure {
+            object.insert("failure".to_string(), json!(failure));
+        }
         if is_failure {
-            object.insert("error".to_string(), json!(result));
+            object.insert("error".to_string(), json!(failure_detail.unwrap_or(result)));
         }
     }
 
@@ -1054,9 +1076,10 @@ fn completed_image_generation_tool_call(
     revised_prompt: Option<String>,
     result: String,
     saved_path: Option<String>,
+    failure: Option<ImageGenerationFailure>,
 ) -> ToolCall {
     let (title, tool_status, detail, raw_input) =
-        image_generation_completion_parts(status, revised_prompt, result, saved_path);
+        image_generation_completion_parts(status, revised_prompt, result, saved_path, failure);
     let mut tool_call = ToolCall::new(image_generation_tool_call_id(&call_id), title)
         .kind(ToolKind::Other)
         .status(tool_status)
@@ -1074,9 +1097,10 @@ fn completed_image_generation_tool_update(
     revised_prompt: Option<String>,
     result: String,
     saved_path: Option<String>,
+    failure: Option<ImageGenerationFailure>,
 ) -> ToolCallUpdate {
     let (title, tool_status, detail, raw_input) =
-        image_generation_completion_parts(status, revised_prompt, result, saved_path);
+        image_generation_completion_parts(status, revised_prompt, result, saved_path, failure);
     let mut fields = ToolCallUpdateFields::new()
         .title(title)
         .status(tool_status)
@@ -2432,6 +2456,7 @@ impl PromptState {
             revised_prompt,
             result,
             saved_path,
+            failure,
             ..
         } = event;
         let saved_path = saved_path.map(|path| path.display().to_string());
@@ -2442,6 +2467,7 @@ impl PromptState {
                 revised_prompt,
                 result,
                 saved_path,
+                failure,
             ))
             .await;
     }
@@ -3339,14 +3365,15 @@ impl PromptState {
         let call_id = guardian_assessment_tool_call_id(&event.id);
         let status = guardian_assessment_tool_call_status(&event.status);
         let content = guardian_assessment_content(&event);
-        let raw_event = serde_json::json!(&event);
+        let title = guardian_assessment_title(&event.action);
+        let raw_event = guardian_assessment_raw_event(&event);
 
         match event.status {
             GuardianAssessmentStatus::InProgress => {
                 if self.active_guardian_assessments.insert(event.id.clone()) {
                     client
                         .send_tool_call(
-                            ToolCall::new(call_id, "Guardian Review")
+                            ToolCall::new(call_id, title)
                                 .kind(ToolKind::Think)
                                 .status(status)
                                 .content(content)
@@ -3382,7 +3409,7 @@ impl PromptState {
                 } else {
                     client
                         .send_tool_call(
-                            ToolCall::new(call_id, "Guardian Review")
+                            ToolCall::new(call_id, title)
                                 .kind(ToolKind::Think)
                                 .status(status)
                                 .content(content)
@@ -5647,6 +5674,7 @@ impl<A: Auth> ThreadActor<A> {
                 revised_prompt,
                 result,
                 saved_path,
+                failure,
                 ..
             }) => {
                 self.client
@@ -5656,6 +5684,7 @@ impl<A: Auth> ThreadActor<A> {
                         revised_prompt.clone(),
                         result.clone(),
                         saved_path.as_ref().map(|path| path.display().to_string()),
+                        failure.clone(),
                     ))
                     .await;
             }
@@ -6011,6 +6040,7 @@ impl<A: Auth> ThreadActor<A> {
                         status.clone(),
                         revised_prompt.clone(),
                         result.clone(),
+                        None,
                         None,
                     ))
                     .await;
@@ -6706,6 +6736,32 @@ fn guardian_assessment_content(event: &GuardianAssessmentEvent) -> Vec<ToolCallC
     content
 }
 
+fn guardian_assessment_title(
+    action: &codex_protocol::approvals::GuardianAssessmentAction,
+) -> String {
+    match action {
+        codex_protocol::approvals::GuardianAssessmentAction::WriteStdin { process_id, .. } => {
+            format!("Review input to process {process_id}")
+        }
+        _ => "Guardian Review".to_string(),
+    }
+}
+
+fn guardian_assessment_raw_event(event: &GuardianAssessmentEvent) -> serde_json::Value {
+    let mut value = serde_json::json!(event);
+    if matches!(
+        event.action,
+        codex_protocol::approvals::GuardianAssessmentAction::WriteStdin { .. }
+    ) && let Some(action) = value
+        .as_object_mut()
+        .and_then(|event| event.get_mut("action"))
+        .and_then(serde_json::Value::as_object_mut)
+    {
+        action.remove("stdin");
+    }
+    value
+}
+
 fn guardian_action_summary(
     action: &codex_protocol::approvals::GuardianAssessmentAction,
 ) -> Option<String> {
@@ -6852,6 +6908,228 @@ mod tests {
             panic!("denied option should preserve the denied decision");
         };
         assert_eq!(rejection, ACP_COMMAND_REJECTION_REASON);
+    }
+
+    #[test]
+    fn mcp_policy_approval_is_only_projected_when_the_runtime_offers_it() {
+        let without_policy = build_exec_permission_options(
+            &[
+                ReviewDecision::Approved,
+                ReviewDecision::Denied {
+                    rejection: "runtime rejection".to_string(),
+                },
+            ],
+            None,
+            None,
+        );
+        assert_eq!(
+            without_policy
+                .iter()
+                .map(|option| option.option_id)
+                .collect::<Vec<_>>(),
+            vec!["approved", "denied"]
+        );
+
+        let with_policy = build_exec_permission_options(
+            &[
+                ReviewDecision::Approved,
+                ReviewDecision::ApprovedMcpPolicyAmendment,
+                ReviewDecision::Denied {
+                    rejection: "runtime rejection".to_string(),
+                },
+            ],
+            None,
+            None,
+        );
+        assert_eq!(
+            with_policy
+                .iter()
+                .map(|option| option.option_id)
+                .collect::<Vec<_>>(),
+            vec!["approved", "approved-mcp-policy-amendment", "denied"]
+        );
+        assert_eq!(
+            with_policy[1].permission_option.kind,
+            PermissionOptionKind::AllowAlways
+        );
+        assert_eq!(
+            with_policy[1].decision,
+            ReviewDecision::ApprovedMcpPolicyAmendment
+        );
+    }
+
+    #[test]
+    fn path_uri_entries_render_posix_windows_and_opaque_paths() -> anyhow::Result<()> {
+        let cases = [
+            ("file:///home/alice/project", "/home/alice/project"),
+            (
+                "file:///C:/Users/Alice/project",
+                "C:\\Users\\Alice\\project",
+            ),
+            ("file:///%00/bad/path/YQ", "file:///%00/bad/path/YQ"),
+        ];
+
+        for (uri, expected) in cases {
+            let entry = FileSystemSandboxEntry {
+                path: FileSystemPath::Path {
+                    path: codex_utils_path_uri::PathUri::parse(uri)?,
+                },
+                access: FileSystemAccessMode::Read,
+                missing_path_behavior: None,
+            };
+            assert_eq!(format_file_system_entry(&entry), expected);
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn guardian_write_stdin_keeps_identity_and_redacts_input() -> anyhow::Result<()> {
+        let thread_id = ThreadId::new();
+        let (mut state, session_client, client) = prompt_state_for_projection(thread_id);
+        let event = GuardianAssessmentEvent {
+            id: "guardian-stdin-1".to_string(),
+            target_item_id: Some("exec-1".to_string()),
+            plugin_id: None,
+            script_path: None,
+            turn_id: "turn-1".to_string(),
+            started_at_ms: 1,
+            completed_at_ms: None,
+            status: GuardianAssessmentStatus::InProgress,
+            risk_level: None,
+            user_authorization: None,
+            rationale: None,
+            decision_source: None,
+            action: codex_protocol::approvals::GuardianAssessmentAction::WriteStdin {
+                approval_id: "approval-1".to_string(),
+                process_id: "process-42".to_string(),
+                stdin: "super-secret-input".to_string(),
+                cwd: codex_utils_path_uri::PathUri::parse("file:///workspace")?,
+            },
+        };
+
+        state
+            .handle_event(&session_client, EventMsg::GuardianAssessment(event.clone()))
+            .await;
+        let mut completed = event;
+        completed.status = GuardianAssessmentStatus::Approved;
+        completed.completed_at_ms = Some(2);
+        completed.rationale = Some("Input is allowed".to_string());
+        state
+            .handle_event(&session_client, EventMsg::GuardianAssessment(completed))
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let start = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCall(tool_call) => Some(tool_call),
+                _ => None,
+            })
+            .expect("guardian start should create an activity");
+        let end = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .expect("guardian completion should update the activity");
+        assert_eq!(start.tool_call_id, end.tool_call_id);
+        assert_eq!(start.title, "Review input to process process-42");
+        assert_eq!(end.fields.status, Some(ToolCallStatus::Completed));
+        let projection = serde_json::to_string(&*notifications)?;
+        assert!(projection.contains("process-42"));
+        assert!(projection.contains("/workspace"));
+        assert!(!projection.contains("super-secret-input"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn image_failure_reason_overrides_a_success_like_status() -> anyhow::Result<()> {
+        let thread_id = ThreadId::new();
+        let (state, session_client, client) = prompt_state_for_projection(thread_id);
+
+        state
+            .send_image_generation_completed(
+                &session_client,
+                ImageGenerationEndEvent {
+                    call_id: "img-limited".to_string(),
+                    status: "completed".to_string(),
+                    revised_prompt: None,
+                    result: String::new(),
+                    transparent_background: None,
+                    failure: Some(ImageGenerationFailure::UsageLimitExceeded {
+                        limit_id: "images-per-day".to_string(),
+                        resets_at: Some(1234),
+                    }),
+                    saved_path: None,
+                },
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        let update = notifications
+            .iter()
+            .find_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .expect("image failure should produce a tool update");
+        assert_eq!(update.fields.status, Some(ToolCallStatus::Failed));
+        assert_eq!(
+            update.fields.title.as_deref(),
+            Some("Image generation failed")
+        );
+        assert_eq!(
+            update
+                .fields
+                .raw_input
+                .as_ref()
+                .and_then(|raw| raw.get("error"))
+                .and_then(serde_json::Value::as_str),
+            Some("Usage limit images-per-day was exceeded; resets at 1234")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn standalone_function_output_does_not_create_a_tool_activity() -> anyhow::Result<()> {
+        let (actor, client, _conversation) = setup_actor(|_| {}).await?;
+        actor
+            .replay_response_item(&ResponseItem::FunctionCallOutput {
+                id: None,
+                call_id: None,
+                name: Some("external_context".to_string()),
+                namespace: None,
+                output: codex_protocol::models::FunctionCallOutputPayload::from_text(
+                    "context only".to_string(),
+                ),
+                internal_chat_message_metadata_passthrough: None,
+            })
+            .await;
+
+        assert!(client.notifications.lock().unwrap().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn runtime_queue_signal_does_not_project_or_mutate_local_prompt_state() {
+        let thread_id = ThreadId::new();
+        let (mut state, session_client, client) = prompt_state_for_projection(thread_id);
+
+        state
+            .handle_event(
+                &session_client,
+                EventMsg::ThreadQueueChanged(codex_protocol::protocol::ThreadQueueChangedEvent {
+                    thread_id,
+                }),
+            )
+            .await;
+
+        assert_eq!(state.event_count, 1);
+        assert!(client.notifications.lock().unwrap().is_empty());
+        assert!(state.active_commands.is_empty());
+        assert!(state.projected_tool_calls.is_empty());
     }
 
     #[tokio::test]

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -9377,6 +9377,73 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn completed_subagent_activity_updates_the_started_activity_once() -> anyhow::Result<()> {
+        let parent_thread_id = ThreadId::new();
+        let child_thread_id = ThreadId::new();
+        let (mut prompt_state, session_client, client) =
+            prompt_state_for_projection(parent_thread_id);
+        let agent_path: codex_protocol::AgentPath = "/root/research/explorer"
+            .try_into()
+            .expect("valid agent path");
+        let activity = |kind| {
+            EventMsg::SubAgentActivity(codex_protocol::protocol::SubAgentActivityEvent {
+                event_id: "stable-activity".to_string(),
+                occurred_at_ms: 1,
+                agent_thread_id: child_thread_id,
+                agent_path: agent_path.clone(),
+                kind,
+            })
+        };
+
+        prompt_state
+            .handle_event(
+                &session_client,
+                activity(codex_protocol::protocol::SubAgentActivityKind::Started),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                activity(codex_protocol::protocol::SubAgentActivityKind::Completed),
+            )
+            .await;
+        prompt_state
+            .handle_event(
+                &session_client,
+                activity(codex_protocol::protocol::SubAgentActivityKind::Completed),
+            )
+            .await;
+
+        let notifications = client.notifications.lock().unwrap();
+        assert_eq!(
+            notifications
+                .iter()
+                .filter(|notification| matches!(notification.update, SessionUpdate::ToolCall(_)))
+                .count(),
+            1,
+            "notifications={notifications:?}"
+        );
+        let updates = notifications
+            .iter()
+            .filter_map(|notification| match &notification.update {
+                SessionUpdate::ToolCallUpdate(update) => Some(update),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(updates.len(), 1, "notifications={notifications:?}");
+        assert_eq!(
+            updates[0].tool_call_id.0.as_ref(),
+            "codex-acp:subagent:stable-activity"
+        );
+        assert_eq!(
+            updates[0].fields.title.as_deref(),
+            Some("Completed explorer")
+        );
+        assert_eq!(updates[0].fields.status, Some(ToolCallStatus::Completed));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn specific_subagent_activity_prevents_a_later_turn_item_duplicate() -> anyhow::Result<()>
     {
         let parent_thread_id = ThreadId::new();

--- a/vendor/codex-acp/tests/code_mode_host_smoke.rs
+++ b/vendor/codex-acp/tests/code_mode_host_smoke.rs
@@ -23,6 +23,23 @@ impl ChildGuard {
             }
         }
     }
+
+    fn wait_for_clean_exit(mut self) {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match self.0.try_wait() {
+                Ok(Some(status)) => {
+                    assert!(status.success(), "code-mode host exited with {status}");
+                    return;
+                }
+                Ok(None) if Instant::now() < deadline => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Ok(None) => panic!("code-mode host did not close after stdin ended"),
+                Err(error) => panic!("failed to wait for code-mode host: {error}"),
+            }
+        }
+    }
 }
 
 impl Drop for ChildGuard {
@@ -54,4 +71,18 @@ fn code_mode_host_starts_and_waits_for_stdio_handshake() {
     );
 
     child.terminate();
+}
+
+#[test]
+fn code_mode_host_closes_without_leaving_a_process_when_stdio_ends() {
+    let child = Command::new(env!("CARGO_BIN_EXE_codex-code-mode-host"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("code-mode host binary should start");
+    let mut child = ChildGuard(child);
+
+    drop(child.0.stdin.take());
+    child.wait_for_clean_exit();
 }

--- a/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
+++ b/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
@@ -2,12 +2,12 @@
 edition = "2024"
 license = "Apache-2.0"
 name = "codex-utils-pty"
-version = "0.147.0"
+version = "0.150.0"
 
 [dependencies]
 anyhow = "1"
 portable-pty = "0.9.0"
-tokio = { version = "1", features = ["io-util", "macros", "process", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "process", "rt-multi-thread", "sync", "time"] }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"
@@ -21,9 +21,9 @@ winapi = { version = "0.3.9", features = [
     "handleapi",
     "jobapi",
     "jobapi2",
+    "libloaderapi",
     "minwinbase",
     "processthreadsapi",
-    "std",
     "synchapi",
     "winbase",
     "wincon",

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/lib.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/lib.rs
@@ -4,6 +4,8 @@ pub mod process_group;
 pub mod pty;
 #[cfg(test)]
 mod tests;
+#[cfg(unix)]
+mod unix_io;
 #[cfg(windows)]
 mod win;
 #[cfg(windows)]

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
@@ -62,9 +62,14 @@ impl ChildTerminator for PipeChildTerminator {
     }
 
     fn kill(&mut self) -> io::Result<()> {
-        #[cfg(unix)]
+        #[cfg(all(unix, not(target_os = "macos")))]
         {
             crate::process_group::kill_process_group(self.process_group_id)
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            crate::process_group::kill_process_group_with_member_fallback(self.process_group_id)
         }
 
         #[cfg(windows)]
@@ -123,9 +128,8 @@ enum PipeStdinMode {
     Null,
 }
 
-/// On Windows, a Job Object is created before launch and the root is assigned
-/// while suspended. If Job Object creation itself fails, only the root process
-/// can be terminated.
+/// On Windows, process-tree containment is best-effort because Tokio returns
+/// only after the root process starts, so job assignment cannot be atomic.
 async fn spawn_process_with_stdin_mode(
     program: &str,
     args: &[String],
@@ -183,24 +187,32 @@ async fn spawn_process_with_stdin_mode(
     command.stderr(Stdio::piped());
 
     #[cfg(windows)]
-    let (mut child, windows_terminator) = match crate::win::JobObject::create() {
-        Ok(job) => {
-            let job = Arc::new(job);
-            let child = job.spawn_contained(&mut command)?;
-            (child, WindowsChildTerminator::Job(job))
-        }
-        Err(error) => {
-            log::warn!("Windows pipe Job Object creation failed; containing only the root process: {error}");
-            command.kill_on_drop(true);
-            let child = command.spawn()?;
-            let pid = child
-                .id()
-                .ok_or_else(|| io::Error::other("missing child pid"))?;
-            (child, WindowsChildTerminator::Process(pid))
+    let job = crate::win::JobObject::create().map(Arc::new);
+    let mut child = command.spawn()?;
+    #[cfg(windows)]
+    let windows_terminator = {
+        // Accept the small race: a descendant created between spawn and
+        // assignment is not guaranteed to join the job and can escape termination.
+        let pid = child
+            .id()
+            .ok_or_else(|| io::Error::other("missing child pid"))?;
+        let assigned_job = job.and_then(|job| {
+            let process_handle = child
+                .raw_handle()
+                .ok_or_else(|| io::Error::other("missing child process handle"))?;
+            job.assign_process(process_handle)?;
+            Ok(job)
+        });
+        match assigned_job {
+            Ok(job) => WindowsChildTerminator::Job(job),
+            Err(err) => {
+                log::warn!(
+                    "Windows pipe process tree containment unavailable for pid {pid}: {err}"
+                );
+                WindowsChildTerminator::Process(pid)
+            }
         }
     };
-    #[cfg(not(windows))]
-    let mut child = command.spawn()?;
     #[cfg(unix)]
     let process_group_id = child
         .id()

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/process.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/process.rs
@@ -242,7 +242,7 @@ impl ProcessHandle {
         result
     }
 
-    /// Attempts to kill the child and abort helper tasks.
+    /// Attempts to kill the child and abort I/O helper tasks.
     pub fn terminate(&self) {
         self.request_terminate();
 
@@ -264,7 +264,8 @@ impl ProcessHandle {
         if let Ok(mut h) = self.wait_handle.lock()
             && let Some(handle) = h.take()
         {
-            handle.abort();
+            // Even a queued PTY waiter must run to reap the terminated child.
+            drop(handle);
         }
     }
 }

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/process_group.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/process_group.rs
@@ -179,10 +179,9 @@ fn signal_process_group_with_member_fallback(
         if count < 0 {
             return Err(io::Error::last_os_error());
         }
-        // proc_listpgrppids converts proc_listpids' byte count to a PID count.
-        let process_id_count = count as usize;
-        if process_id_count < process_ids.len() {
-            process_ids.truncate(process_id_count);
+        let count = count as usize;
+        if count < process_ids.len() {
+            process_ids.truncate(count);
             break;
         }
         let capacity = process_ids.len().checked_mul(2).ok_or_else(|| {
@@ -190,8 +189,6 @@ fn signal_process_group_with_member_fallback(
         })?;
         process_ids.resize(capacity, 0);
     }
-    // Signal the leader last so its exit cannot change group enumeration before
-    // every still-owned member has received the fallback signal.
     process_ids.sort_unstable_by_key(|process_id| *process_id == process_group_id);
 
     let mut signalled = false;
@@ -263,16 +260,10 @@ pub fn interrupt_process_group(_process_group_id: u32) -> io::Result<()> {
     Ok(())
 }
 
-#[cfg(all(unix, not(target_os = "macos")))]
+#[cfg(unix)]
 /// Kill a specific process group ID (best-effort).
 pub fn kill_process_group(process_group_id: u32) -> io::Result<()> {
     signal_process_group_id(process_group_id as libc::pid_t, libc::SIGKILL).map(|_| ())
-}
-
-#[cfg(target_os = "macos")]
-/// Kill a process group, retrying a denied SIGKILL against its exact members.
-pub fn kill_process_group(process_group_id: u32) -> io::Result<()> {
-    kill_process_group_with_member_fallback(process_group_id)
 }
 
 #[cfg(target_os = "macos")]

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/pty.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/pty.rs
@@ -18,6 +18,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::atomic::AtomicBool;
+#[cfg(not(unix))]
 use std::time::Duration;
 
 use anyhow::Result;
@@ -159,6 +160,12 @@ async fn spawn_process_portable(
 ) -> Result<SpawnedProcess> {
     let pty_system = platform_native_pty_system();
     let pair = pty_system.openpty(size.into())?;
+    #[cfg(unix)]
+    let io = crate::unix_io::PtyIo::new(
+        pair.master
+            .as_raw_fd()
+            .ok_or_else(|| anyhow::anyhow!("PTY master has no file descriptor"))?,
+    )?;
 
     let mut command_builder = CommandBuilder::new(arg0.as_ref().unwrap_or(&program.to_string()));
     command_builder.cwd(cwd);
@@ -178,45 +185,56 @@ async fn spawn_process_portable(
     let process_group_id = child.process_id();
     let killer = child.clone_killer();
 
-    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (writer_tx, writer_rx) = mpsc::channel::<Vec<u8>>(128);
     let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
     let (_stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(1);
-    let mut reader = pair.master.try_clone_reader()?;
-    let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
-        let mut buf = [0u8; 8_192];
-        loop {
-            match reader.read(&mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let _ = stdout_tx.blocking_send(buf[..n].to_vec());
+    #[cfg(unix)]
+    let (reader_handle, writer_handle) = io.spawn(
+        stdout_tx,
+        writer_rx,
+        crate::unix_io::StdinCloseBehavior::SendEof,
+    );
+    #[cfg(not(unix))]
+    let (reader_handle, writer_handle) = {
+        let mut reader = pair.master.try_clone_reader()?;
+        let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
+            let mut buf = [0u8; 8_192];
+            loop {
+                match reader.read(&mut buf) {
+                    Ok(0) => break,
+                    Ok(n) => {
+                        let _ = stdout_tx.blocking_send(buf[..n].to_vec());
+                    }
+                    Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
+                    Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
+                        std::thread::sleep(Duration::from_millis(5));
+                        continue;
+                    }
+                    Err(_) => break,
                 }
-                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                    std::thread::sleep(Duration::from_millis(5));
-                    continue;
-                }
-                Err(_) => break,
             }
-        }
-    });
+        });
 
-    let writer = pair.master.take_writer()?;
-    let writer = Arc::new(tokio::sync::Mutex::new(writer));
-    let writer_handle: JoinHandle<()> = tokio::spawn({
-        let writer = Arc::clone(&writer);
-        async move {
-            #[cfg(windows)]
-            let mut windows_input = crate::WindowsTtyInputNormalizer::default();
-            while let Some(bytes) = writer_rx.recv().await {
+        let mut writer_rx = writer_rx;
+        let writer = pair.master.take_writer()?;
+        let writer = Arc::new(tokio::sync::Mutex::new(writer));
+        let writer_handle: JoinHandle<()> = tokio::spawn({
+            let writer = Arc::clone(&writer);
+            async move {
                 #[cfg(windows)]
-                let bytes = windows_input.normalize(&bytes);
-                let mut guard = writer.lock().await;
-                use std::io::Write;
-                let _ = guard.write_all(&bytes);
-                let _ = guard.flush();
+                let mut windows_input = crate::WindowsTtyInputNormalizer::default();
+                while let Some(bytes) = writer_rx.recv().await {
+                    #[cfg(windows)]
+                    let bytes = windows_input.normalize(&bytes);
+                    let mut guard = writer.lock().await;
+                    use std::io::Write;
+                    let _ = guard.write_all(&bytes);
+                    let _ = guard.flush();
+                }
             }
-        }
-    });
+        });
+        (reader_handle, writer_handle)
+    };
 
     let (exit_tx, exit_rx) = oneshot::channel::<i32>();
     let exit_status = Arc::new(AtomicBool::new(false));
@@ -280,6 +298,7 @@ async fn spawn_process_preserving_fds(
     inherited_fds: &[RawFd],
 ) -> Result<SpawnedProcess> {
     let (master, slave) = open_unix_pty(size)?;
+    let io = crate::unix_io::PtyIo::new(master.as_raw_fd())?;
     let mut command = StdCommand::new(program);
     if let Some(arg0) = arg0 {
         command.arg0(arg0);
@@ -342,40 +361,14 @@ async fn spawn_process_preserving_fds(
     drop(slave);
     let process_group_id = child.id();
 
-    let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
+    let (writer_tx, writer_rx) = mpsc::channel::<Vec<u8>>(128);
     let (stdout_tx, stdout_rx) = mpsc::channel::<Vec<u8>>(128);
     let (_stderr_tx, stderr_rx) = mpsc::channel::<Vec<u8>>(1);
-    let mut reader = master.try_clone()?;
-    let reader_handle: JoinHandle<()> = tokio::task::spawn_blocking(move || {
-        let mut buf = [0u8; 8_192];
-        loop {
-            match std::io::Read::read(&mut reader, &mut buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let _ = stdout_tx.blocking_send(buf[..n].to_vec());
-                }
-                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
-                Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                    std::thread::sleep(Duration::from_millis(5));
-                    continue;
-                }
-                Err(_) => break,
-            }
-        }
-    });
-
-    let writer = Arc::new(tokio::sync::Mutex::new(master.try_clone()?));
-    let writer_handle: JoinHandle<()> = tokio::spawn({
-        let writer = Arc::clone(&writer);
-        async move {
-            while let Some(bytes) = writer_rx.recv().await {
-                let mut guard = writer.lock().await;
-                use std::io::Write;
-                let _ = guard.write_all(&bytes);
-                let _ = guard.flush();
-            }
-        }
-    });
+    let (reader_handle, writer_handle) = io.spawn(
+        stdout_tx,
+        writer_rx,
+        crate::unix_io::StdinCloseBehavior::NoEof,
+    );
 
     let (exit_tx, exit_rx) = oneshot::channel::<i32>();
     let exit_status = Arc::new(AtomicBool::new(false));
@@ -467,7 +460,78 @@ fn set_cloexec(fd: RawFd) -> std::io::Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
+// macOS needs a fork-safe sweep because recvmsg cannot set close-on-exec.
+#[cfg(target_os = "macos")]
+pub fn close_inherited_fds_except(preserved_fds: &[RawFd]) {
+    let mut descriptors = [libc::proc_fdinfo {
+        proc_fd: 0,
+        proc_fdtype: 0,
+    }; 1024];
+    // SAFETY: proc_pidinfo writes descriptor records into the stack buffer.
+    let bytes = unsafe {
+        libc::proc_pidinfo(
+            libc::getpid(),
+            libc::PROC_PIDLISTFDS,
+            /*arg*/ 0,
+            descriptors.as_mut_ptr().cast(),
+            std::mem::size_of_val(&descriptors) as libc::c_int,
+        )
+    };
+    let close_inheritable = |fd| {
+        if fd <= libc::STDERR_FILENO || preserved_fds.contains(&fd) {
+            return;
+        }
+        // std::process keeps a CLOEXEC pipe open until exec to report spawn errors.
+        // SAFETY: fcntl and close only operate on a descriptor owned by this process.
+        unsafe {
+            let flags = libc::fcntl(fd, libc::F_GETFD);
+            if flags >= 0 && flags & libc::FD_CLOEXEC == 0 {
+                libc::close(fd);
+            }
+        }
+    };
+    if bytes > 0 && (bytes as usize) < std::mem::size_of_val(&descriptors) {
+        let count = bytes as usize / std::mem::size_of::<libc::proc_fdinfo>();
+        for descriptor in descriptors.iter().take(count) {
+            close_inheritable(descriptor.proc_fd);
+        }
+        return;
+    }
+
+    // SAFETY: proc_pidinfo accepts a null buffer when its size is zero.
+    let descriptor_table_bytes = unsafe {
+        libc::proc_pidinfo(
+            libc::getpid(),
+            libc::PROC_PIDLISTFDS,
+            /*arg*/ 0,
+            std::ptr::null_mut(),
+            /*buffersize*/ 0,
+        )
+    };
+    if descriptor_table_bytes > 0 {
+        let upper_bound =
+            descriptor_table_bytes as usize / std::mem::size_of::<libc::proc_fdinfo>();
+        for fd in libc::STDERR_FILENO + 1..upper_bound as RawFd {
+            close_inheritable(fd);
+        }
+        return;
+    }
+
+    let mut limit = libc::rlimit {
+        rlim_cur: 0,
+        rlim_max: 0,
+    };
+    // SAFETY: getrlimit writes into the stack-owned resource-limit structure.
+    if unsafe { libc::getrlimit(libc::RLIMIT_NOFILE, &raw mut limit) } == 0 {
+        let upper_bound = limit.rlim_cur.min(RawFd::MAX as _) as RawFd;
+        for fd in libc::STDERR_FILENO + 1..upper_bound {
+            close_inheritable(fd);
+        }
+    }
+}
+
+// Other Unix platforms keep their existing fd cleanup.
+#[cfg(all(unix, not(target_os = "macos")))]
 pub(crate) fn close_inherited_fds_except(preserved_fds: &[RawFd]) {
     if let Ok(dir) = std::fs::read_dir("/dev/fd") {
         let mut fds = Vec::new();

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/tests.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/tests.rs
@@ -827,6 +827,448 @@ async fn pipe_terminate_aborts_detached_readers() -> anyhow::Result<()> {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_terminate_reaps_child() -> anyhow::Result<()> {
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let command = if cfg!(windows) {
+        "ping -n 60 127.0.0.1 > NUL"
+    } else {
+        "sleep 60"
+    };
+    let (program, args) = shell_command(command);
+    let spawned = spawn_pipe_process(&program, &args, Path::new("."), &env_map, &None, &[]).await?;
+    let (session, _output_rx, exit_rx) = combine_spawned_output(spawned);
+
+    session.terminate();
+
+    let exit_code = tokio::time::timeout(tokio::time::Duration::from_secs(5), exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for terminated child to be reaped"))?
+        .map_err(|_| anyhow::anyhow!("child waiter was aborted before reaping"))?;
+    assert_eq!(session.exit_code(), Some(exit_code));
+    assert!(session.has_exited());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pipe_drop_reaps_child() -> anyhow::Result<()> {
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let command = if cfg!(windows) {
+        "ping -n 60 127.0.0.1 > NUL"
+    } else {
+        "sleep 60"
+    };
+    let (program, args) = shell_command(command);
+    let spawned = spawn_pipe_process(&program, &args, Path::new("."), &env_map, &None, &[]).await?;
+    let (session, _output_rx, exit_rx) = combine_spawned_output(spawned);
+
+    drop(session);
+
+    tokio::time::timeout(tokio::time::Duration::from_secs(5), exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for dropped child to be reaped"))?
+        .map_err(|_| anyhow::anyhow!("child waiter was aborted before reaping"))?;
+
+    Ok(())
+}
+
+#[cfg(unix)]
+enum PtyShutdown {
+    Terminate,
+    Drop,
+}
+
+#[cfg(unix)]
+fn assert_pty_shutdown_with_detached_child(
+    inherited_fds: &[i32],
+    shutdown: PtyShutdown,
+) -> anyhow::Result<()> {
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping detached PTY shutdown test");
+        return Ok(());
+    };
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let (session, child_pid) = runtime.block_on(async {
+        let marker = "__codex_detached_pid:";
+        // The detached child retains the slave descriptors but outlives the
+        // original process group. Its alarm bounds a regressed runtime drop.
+        let script = format!(
+            r"import os, select, signal, time, tty
+signal.alarm(10)
+if os.fork() == 0:
+    os.setsid()
+    signal.signal(signal.SIGHUP, signal.SIG_IGN)
+    signal.alarm(10)
+    tty.setraw(0)
+    print('{marker}' + str(os.getpid()), flush=True)
+    select.select([0], [], [])
+    print('__codex_input_ready__', flush=True)
+    time.sleep(10)
+    os._exit(0)
+time.sleep(10)
+"
+        );
+        let env_map: HashMap<String, String> = std::env::vars().collect();
+        let spawned = spawn_pty_process(
+            &python,
+            &["-c".to_string(), script],
+            Path::new("."),
+            &env_map,
+            &None,
+            TerminalSize::default(),
+            inherited_fds,
+        )
+        .await?;
+        let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+        let child_pid = wait_for_marker_pid(&mut output_rx, marker, /*timeout_ms*/ 2_000).await?;
+        let writer = session.writer_sender();
+        writer.send(vec![b'x'; 1024 * 1024]).await?;
+        writer.send(b"pending".to_vec()).await?;
+        // The slave reports readable input without consuming it; the first write
+        // exceeds terminal capacity, so the second chunk must remain queued.
+        wait_for_output_contains(
+            &mut output_rx,
+            "__codex_input_ready__",
+            /*timeout_ms*/ 2_000,
+        )
+        .await?;
+        assert_eq!(writer.capacity(), writer.max_capacity() - 1);
+        drop(writer);
+        let session = match shutdown {
+            PtyShutdown::Terminate => {
+                session.terminate();
+                Some(session)
+            }
+            PtyShutdown::Drop => {
+                drop(session);
+                None
+            }
+        };
+        tokio::time::timeout(std::time::Duration::from_secs(2), exit_rx).await??;
+        Ok::<_, anyhow::Error>((session, child_pid))
+    })?;
+
+    let started = std::time::Instant::now();
+    drop(runtime);
+    let elapsed = started.elapsed();
+    let detached_child_alive = process_exists(child_pid)?;
+    let _ = unsafe { libc::kill(child_pid, libc::SIGKILL) };
+    drop(session);
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "runtime shutdown waited for detached PTY child: {elapsed:?}"
+    );
+    assert!(
+        detached_child_alive,
+        "detached child exited before runtime shutdown"
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_spawn_without_io_driver_returns_error() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()?;
+    let preserved_fd = std::fs::File::open("/dev/null")?;
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let (program, args) = shell_command("true");
+    for inherited_fds in [&[][..], &[preserved_fd.as_raw_fd()][..]] {
+        let Err(error) = runtime.block_on(spawn_pty_process(
+            &program,
+            &args,
+            Path::new("."),
+            &env_map,
+            &None,
+            TerminalSize::default(),
+            inherited_fds,
+        )) else {
+            anyhow::bail!("PTY spawn succeeded without a Tokio I/O driver");
+        };
+        assert_eq!(
+            error.to_string(),
+            "PTY I/O requires a Tokio runtime with I/O enabled"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_terminate_allows_runtime_shutdown_with_detached_child() -> anyhow::Result<()> {
+    assert_pty_shutdown_with_detached_child(&[], PtyShutdown::Terminate)
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_drop_allows_runtime_shutdown_with_detached_child() -> anyhow::Result<()> {
+    assert_pty_shutdown_with_detached_child(&[], PtyShutdown::Drop)
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_preserving_fds_terminate_allows_runtime_shutdown_with_detached_child() -> anyhow::Result<()>
+{
+    use std::os::fd::AsRawFd;
+
+    let preserved_fd = std::fs::File::open("/dev/null")?;
+    assert_pty_shutdown_with_detached_child(&[preserved_fd.as_raw_fd()], PtyShutdown::Terminate)
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_preserving_fds_drop_allows_runtime_shutdown_with_detached_child() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let preserved_fd = std::fs::File::open("/dev/null")?;
+    assert_pty_shutdown_with_detached_child(&[preserved_fd.as_raw_fd()], PtyShutdown::Drop)
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_terminate_allows_runtime_shutdown_with_full_output_channel() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping PTY output backpressure test");
+        return Ok(());
+    };
+    let preserved_fd = std::fs::File::open("/dev/null")?;
+    for inherited_fds in [&[][..], &[preserved_fd.as_raw_fd()][..]] {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()?;
+        let (session, stdout_rx) = runtime.block_on(async {
+            let env_map: HashMap<String, String> = std::env::vars().collect();
+            let script =
+                "import os, signal\nsignal.alarm(10)\nwhile True:\n    os.write(1, b'x' * 8192)\n";
+            let SpawnedProcess {
+                session,
+                stdout_rx,
+                exit_rx,
+                ..
+            } = spawn_pty_process(
+                &python,
+                &["-c".to_string(), script.to_string()],
+                Path::new("."),
+                &env_map,
+                &None,
+                TerminalSize::default(),
+                inherited_fds,
+            )
+            .await?;
+            tokio::time::timeout(std::time::Duration::from_secs(2), async {
+                while stdout_rx.len() < stdout_rx.max_capacity() {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            })
+            .await?;
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            session.terminate();
+            tokio::time::timeout(std::time::Duration::from_secs(2), exit_rx).await??;
+            Ok::<_, anyhow::Error>((session, stdout_rx))
+        })?;
+
+        // Keep the receiver alive through runtime shutdown. An OS-thread
+        // watchdog releases a regressed blocking_send without a Tokio timer.
+        let (shutdown_tx, shutdown_rx) = std::sync::mpsc::channel();
+        let receiver_guard = std::thread::spawn(move || {
+            let _ = shutdown_rx.recv_timeout(std::time::Duration::from_secs(3));
+            drop(stdout_rx);
+        });
+        let started = std::time::Instant::now();
+        drop(runtime);
+        let elapsed = started.elapsed();
+        let _ = shutdown_tx.send(());
+        receiver_guard
+            .join()
+            .map_err(|_| anyhow::anyhow!("output receiver watchdog panicked"))?;
+        drop(session);
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "runtime shutdown waited on a full PTY output channel: {elapsed:?}"
+        );
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_dropped_output_receiver_keeps_draining_child() -> anyhow::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping PTY dropped output receiver test");
+        return Ok(());
+    };
+    let preserved_fd = std::fs::File::open("/dev/null")?;
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let script =
+        "import signal, sys\nsignal.alarm(10)\nsys.stdout.buffer.write(b'x' * (4 * 1024 * 1024))";
+    for inherited_fds in [&[][..], &[preserved_fd.as_raw_fd()][..]] {
+        let SpawnedProcess {
+            session: _session,
+            stdout_rx,
+            exit_rx,
+            ..
+        } = spawn_pty_process(
+            &python,
+            &["-c".to_string(), script.to_string()],
+            Path::new("."),
+            &env_map,
+            &None,
+            TerminalSize::default(),
+            inherited_fds,
+        )
+        .await?;
+        drop(stdout_rx);
+        let code = tokio::time::timeout(std::time::Duration::from_secs(2), exit_rx).await??;
+        assert_eq!(code, 0, "child should finish even when output is discarded");
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn pty_close_stdin_preserves_large_input_and_delivers_eof() -> anyhow::Result<()> {
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping PTY input backpressure and EOF test");
+        return Ok(());
+    };
+    let script = r"import signal, sys, termios, time
+signal.alarm(10)
+attrs = termios.tcgetattr(0)
+attrs[3] &= ~termios.ECHO
+termios.tcsetattr(0, termios.TCSANOW, attrs)
+print('__ready__', flush=True)
+time.sleep(0.2)
+data = sys.stdin.buffer.read()
+# Closing the portable writer appends a newline before VEOF.
+assert data == b'0123456789abcdefghijklmnopqrstuvwxyz\n' * 32768 + b'\n', len(data)
+print('__complete__', flush=True)
+";
+    let env_map: HashMap<String, String> = std::env::vars().collect();
+    let spawned = spawn_pty_process(
+        &python,
+        &["-c".to_string(), script.to_string()],
+        Path::new("."),
+        &env_map,
+        &None,
+        TerminalSize::default(),
+        &[],
+    )
+    .await?;
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
+    wait_for_output_contains(&mut output_rx, "__ready__", /*timeout_ms*/ 2_000).await?;
+    let writer = session.writer_sender();
+    writer
+        .send(b"0123456789abcdefghijklmnopqrstuvwxyz\n".repeat(32_768))
+        .await?;
+    drop(writer);
+    session.close_stdin();
+
+    let (output, code) = collect_output_until_exit(output_rx, exit_rx, /*timeout_ms*/ 5_000).await;
+    assert_eq!(
+        (code, String::from_utf8_lossy(&output).trim()),
+        (0, "__complete__")
+    );
+    Ok(())
+}
+
+#[cfg(unix)]
+#[test]
+fn pty_terminate_reaps_child_when_waiter_is_queued() -> anyhow::Result<()> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .max_blocking_threads(1)
+        .build()?;
+    let (blocker_started_tx, blocker_started_rx) = std::sync::mpsc::channel();
+    let (release_blocker_tx, release_blocker_rx) = std::sync::mpsc::channel();
+    // Keep the PTY's blocking child waiter queued until after termination.
+    runtime.spawn_blocking(move || {
+        let _ = blocker_started_tx.send(());
+        let _ = release_blocker_rx.recv_timeout(std::time::Duration::from_secs(5));
+    });
+    blocker_started_rx.recv_timeout(std::time::Duration::from_secs(2))?;
+
+    let pid_file = std::env::temp_dir().join(format!(
+        "codex-pty-reap-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    runtime.block_on(async {
+        let mut env_map: HashMap<String, String> = std::env::vars().collect();
+        env_map.insert(
+            "CODEX_PTY_TEST_PID_FILE".to_string(),
+            pid_file.display().to_string(),
+        );
+        let (program, args) =
+            shell_command("printf '%s' \"$$\" > \"$CODEX_PTY_TEST_PID_FILE\"; sleep 60");
+        let spawned = spawn_pty_process(
+            &program,
+            &args,
+            Path::new("."),
+            &env_map,
+            &None,
+            TerminalSize::default(),
+            &[],
+        )
+        .await?;
+        let (session, _output_rx, exit_rx) = combine_spawned_output(spawned);
+
+        let child_pid = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if let Ok(pid) = std::fs::read_to_string(&pid_file)
+                    && let Ok(pid) = pid.parse::<libc::pid_t>()
+                {
+                    return pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for the PTY child PID"))?;
+        std::fs::remove_file(&pid_file)?;
+
+        session.terminate();
+        drop(session);
+        release_blocker_tx.send(())?;
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(2), exit_rx)
+            .await
+            .map_err(|_| anyhow::anyhow!("timed out waiting for the PTY child waiter"))?;
+
+        // A returned PID proves an exited child was still an unreaped zombie.
+        let wait_result = tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let result =
+                    unsafe { libc::waitpid(child_pid, std::ptr::null_mut(), libc::WNOHANG) };
+                if result != 0 {
+                    return result;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for the PTY child to exit"))?;
+        let wait_error = std::io::Error::last_os_error();
+        assert_eq!(
+            wait_result, -1,
+            "PTY child {child_pid} remained an unreaped zombie"
+        );
+        assert_eq!(wait_error.raw_os_error(), Some(libc::ECHILD));
+
+        Ok(())
+    })
+}
+
 #[cfg(unix)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn pty_terminate_kills_background_children_in_same_process_group() -> anyhow::Result<()> {
@@ -844,7 +1286,7 @@ async fn pty_terminate_kills_background_children_in_same_process_group() -> anyh
         &[],
     )
     .await?;
-    let (session, mut output_rx, _exit_rx) = combine_spawned_output(spawned);
+    let (session, mut output_rx, exit_rx) = combine_spawned_output(spawned);
 
     let bg_pid = match wait_for_marker_pid(&mut output_rx, marker, /*timeout_ms*/ 2_000).await {
         Ok(pid) => pid,
@@ -859,6 +1301,12 @@ async fn pty_terminate_kills_background_children_in_same_process_group() -> anyh
     );
 
     session.terminate();
+
+    tokio::time::timeout(tokio::time::Duration::from_secs(3), exit_rx)
+        .await
+        .map_err(|_| anyhow::anyhow!("timed out waiting for terminated PTY child to be reaped"))?
+        .map_err(|_| anyhow::anyhow!("PTY child waiter was aborted before reaping"))?;
+    assert!(session.has_exited());
 
     let exited = wait_for_process_exit(bg_pid, /*timeout_ms*/ 3_000).await?;
     if !exited {

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/unix_io.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/unix_io.rs
@@ -1,0 +1,109 @@
+use std::fs::File;
+use std::io;
+use std::io::Read;
+use std::io::Write;
+use std::os::fd::AsRawFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::RawFd;
+use std::sync::Arc;
+
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+pub(crate) enum StdinCloseBehavior {
+    SendEof,
+    NoEof,
+}
+
+pub(crate) struct PtyIo {
+    fd: Arc<AsyncFd<File>>,
+}
+
+impl PtyIo {
+    pub(crate) fn new(master_fd: RawFd) -> io::Result<Self> {
+        // The PTY owner remains alive while its descriptor is duplicated.
+        let fd = unsafe { BorrowedFd::borrow_raw(master_fd) }.try_clone_to_owned()?;
+        let flags = unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_GETFL) };
+        if flags == -1
+            || unsafe { libc::fcntl(fd.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) } == -1
+        {
+            return Err(io::Error::last_os_error());
+        }
+        // Duplicates share O_NONBLOCK, so both reads and writes must use readiness.
+        // Async tasks can be aborted even when a detached child keeps the PTY open
+        // or the output channel is full; blocking read/send tasks cannot.
+        // AsyncFd panics if the current runtime has no I/O driver.
+        let fd = std::panic::catch_unwind(move || AsyncFd::new(File::from(fd)))
+            .map_err(|_| io::Error::other("PTY I/O requires a Tokio runtime with I/O enabled"))??;
+        Ok(Self { fd: Arc::new(fd) })
+    }
+
+    pub(crate) fn spawn(
+        self,
+        stdout_tx: mpsc::Sender<Vec<u8>>,
+        mut writer_rx: mpsc::Receiver<Vec<u8>>,
+        stdin_close: StdinCloseBehavior,
+    ) -> (JoinHandle<()>, JoinHandle<()>) {
+        let fd = self.fd;
+        let reader = Arc::clone(&fd);
+        let reader_handle = tokio::spawn(async move {
+            let mut buf = [0u8; 8_192];
+            loop {
+                match reader
+                    .async_io(Interest::READABLE, |mut file| file.read(&mut buf))
+                    .await
+                {
+                    Ok(0) => break,
+                    Ok(count) => {
+                        // Output caps may close the receiver before the child exits.
+                        let _ = stdout_tx.send(buf[..count].to_vec()).await;
+                    }
+                    Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+                    // Unix PTYs may report EIO rather than EOF when the slave closes.
+                    Err(_) => break,
+                }
+            }
+        });
+        let writer_handle = tokio::spawn(async move {
+            while let Some(bytes) = writer_rx.recv().await {
+                if write_all(&fd, &bytes).await.is_err() {
+                    return;
+                }
+            }
+            match stdin_close {
+                StdinCloseBehavior::SendEof => {
+                    // Preserve portable-pty's newline + current VEOF on stdin close,
+                    // including when the terminal input queue requires waiting.
+                    let mut termios = std::mem::MaybeUninit::<libc::termios>::uninit();
+                    if unsafe { libc::tcgetattr(fd.get_ref().as_raw_fd(), termios.as_mut_ptr()) }
+                        == 0
+                    {
+                        let eof = unsafe { termios.assume_init() }.c_cc[libc::VEOF];
+                        if eof != 0 {
+                            let _ = write_all(&fd, &[b'\n', eof]).await;
+                        }
+                    }
+                }
+                StdinCloseBehavior::NoEof => {}
+            }
+        });
+        (reader_handle, writer_handle)
+    }
+}
+
+async fn write_all(fd: &AsyncFd<File>, mut bytes: &[u8]) -> io::Result<()> {
+    while !bytes.is_empty() {
+        match fd
+            .async_io(Interest::WRITABLE, |mut file| file.write(bytes))
+            .await
+        {
+            Ok(0) => return Err(io::ErrorKind::WriteZero.into()),
+            Ok(count) => bytes = &bytes[count..],
+            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/conpty.rs
@@ -79,7 +79,7 @@ impl RawConPty {
     }
 
     pub fn pseudoconsole_handle(&self) -> RawHandle {
-        self.con.raw_handle()
+        self.con.raw_handle() as RawHandle
     }
 
     pub fn into_handles(self) -> (PsuedoCon, FileDescriptor, FileDescriptor) {

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/job.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/job.rs
@@ -12,11 +12,17 @@ use winapi::um::jobapi2::AssignProcessToJobObject;
 use winapi::um::jobapi2::CreateJobObjectW;
 use winapi::um::jobapi2::SetInformationJobObject;
 use winapi::um::jobapi2::TerminateJobObject;
+use winapi::um::processthreadsapi::OpenProcess;
+use winapi::um::processthreadsapi::TerminateProcess;
 use winapi::um::winbase::CREATE_SUSPENDED;
 use winapi::um::winnt::HANDLE;
+use winapi::um::winnt::JOB_OBJECT_LIMIT_BREAKAWAY_OK;
 use winapi::um::winnt::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
 use winapi::um::winnt::JOBOBJECT_EXTENDED_LIMIT_INFORMATION;
 use winapi::um::winnt::JobObjectExtendedLimitInformation;
+use winapi::um::winnt::PROCESS_SET_QUOTA;
+use winapi::um::winnt::PROCESS_SUSPEND_RESUME;
+use winapi::um::winnt::PROCESS_TERMINATE;
 
 #[link(name = "ntdll")]
 unsafe extern "system" {
@@ -41,12 +47,46 @@ impl JobObject {
         }
         let handle = unsafe { OwnedHandle::from_raw_handle(handle.cast()) };
 
-        Self::set_limit_flags(&handle, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)?;
+        Self::set_limit_flags(
+            &handle,
+            JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE | JOB_OBJECT_LIMIT_BREAKAWAY_OK,
+        )?;
 
         Ok(Self {
             handle,
             preserve_descendants: Mutex::new(false),
         })
+    }
+
+    /// Creates a Job Object whose owned descendants cannot explicitly break away.
+    pub fn create_without_breakaway() -> io::Result<Self> {
+        let job = Self::create()?;
+        Self::set_limit_flags(&job.handle, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE)?;
+        Ok(job)
+    }
+
+    /// Captures an owned process handle before its numeric identifier can be reused.
+    pub fn open_process_handle(process_id: u32) -> io::Result<std::os::windows::io::OwnedHandle> {
+        let handle = unsafe {
+            OpenProcess(PROCESS_TERMINATE, /*bInheritHandle*/ 0, process_id)
+        };
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(unsafe { std::os::windows::io::OwnedHandle::from_raw_handle(handle.cast()) })
+    }
+
+    /// Terminates the exact process identified by a previously captured handle.
+    pub fn terminate_process_handle(handle: &std::os::windows::io::OwnedHandle) -> io::Result<()> {
+        let terminated = unsafe {
+            TerminateProcess(handle.as_raw_handle().cast(), /*uExitCode*/ 1)
+        };
+        if terminated == 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
     }
 
     fn set_limit_flags(handle: &OwnedHandle, flags: u32) -> io::Result<()> {
@@ -81,56 +121,67 @@ impl JobObject {
         }
     }
 
+    /// Prevents a child from running before it can be assigned to this job.
+    pub fn prepare_suspended_spawn(&self, command: &mut Command) {
+        command.creation_flags(CREATE_SUSPENDED).kill_on_drop(true);
+    }
+
+    /// Assigns and resumes a suspended child, returning whether assignment succeeded.
+    ///
+    /// Nested jobs can reject assignment. Such a child is resumed without
+    /// containment so callers can preserve their existing compatibility fallback.
+    pub fn assign_and_resume_process(&self, process_id: u32) -> io::Result<bool> {
+        let process = unsafe {
+            OpenProcess(
+                PROCESS_SET_QUOTA | PROCESS_TERMINATE | PROCESS_SUSPEND_RESUME,
+                /*bInheritHandle*/ 0,
+                process_id,
+            )
+        };
+        if process.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+        let process = unsafe { OwnedHandle::from_raw_handle(process.cast()) };
+        let assignment = self.assign_process(process.as_raw_handle());
+
+        let status = unsafe { NtResumeProcess(process.as_raw_handle().cast()) };
+        if !NT_SUCCESS(status) {
+            unsafe {
+                TerminateProcess(process.as_raw_handle().cast(), /*uExitCode*/ 1)
+            };
+            return Err(io::Error::other(format!(
+                "failed to resume suspended process: NTSTATUS {status:#x}"
+            )));
+        }
+
+        match assignment {
+            Ok(()) => Ok(true),
+            Err(error) => {
+                log::warn!(
+                    "Windows process job assignment unavailable for pid {process_id}: {error}"
+                );
+                Ok(false)
+            }
+        }
+    }
+
     /// Starts a process only after assigning it to this Job Object.
     pub fn spawn_contained(&self, command: &mut Command) -> io::Result<Child> {
-        command.creation_flags(CREATE_SUSPENDED).kill_on_drop(true);
-        let mut child = command.spawn()?;
-        let Some(process_handle) = child.raw_handle() else {
-            let error = io::Error::other("missing child process handle");
-            return Err(self.cleanup_failed_spawn(&mut child, /*assigned_to_job*/ false, error));
-        };
-        if let Err(error) = self.assign_process(process_handle) {
-            return Err(self.cleanup_failed_spawn(&mut child, /*assigned_to_job*/ false, error));
-        }
+        self.prepare_suspended_spawn(command);
+        let child = command.spawn()?;
+        let process_handle = child
+            .raw_handle()
+            .ok_or_else(|| io::Error::other("missing child process handle"))?;
+        self.assign_process(process_handle)?;
 
         let status = unsafe { NtResumeProcess(process_handle.cast()) };
         if !NT_SUCCESS(status) {
-            let error = io::Error::other(format!(
+            return Err(io::Error::other(format!(
                 "failed to resume contained process: NTSTATUS {status:#x}"
-            ));
-            return Err(self.cleanup_failed_spawn(&mut child, /*assigned_to_job*/ true, error));
+            )));
         }
 
         Ok(child)
-    }
-
-    fn cleanup_failed_spawn(
-        &self,
-        child: &mut Child,
-        assigned_to_job: bool,
-        spawn_error: io::Error,
-    ) -> io::Error {
-        let job_cleanup_error = assigned_to_job
-            .then(|| self.terminate().err())
-            .flatten();
-        let process_cleanup_error = if assigned_to_job && job_cleanup_error.is_none() {
-            None
-        } else {
-            child.start_kill().err()
-        };
-
-        match (job_cleanup_error, process_cleanup_error) {
-            (None, None) => spawn_error,
-            (job_error, process_error) => io::Error::new(
-                spawn_error.kind(),
-                format!(
-                    "{spawn_error}; failed to clean up suspended process (job: {}, process: {})",
-                    job_error.map_or_else(|| "not applicable".to_string(), |error| error.to_string()),
-                    process_error
-                        .map_or_else(|| "not applicable".to_string(), |error| error.to_string())
-                ),
-            ),
-        }
     }
 
     /// Allows contained descendants to keep running after the root exits normally.
@@ -148,7 +199,7 @@ impl JobObject {
             return Ok(());
         }
 
-        Self::set_limit_flags(&self.handle, 0)?;
+        Self::set_limit_flags(&self.handle, JOB_OBJECT_LIMIT_BREAKAWAY_OK)?;
         *preserve_descendants = true;
         Ok(())
     }

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/mod.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/mod.rs
@@ -94,10 +94,10 @@ impl WinChild {
 
 impl ChildKiller for WinChild {
     fn kill(&mut self) -> IoResult<()> {
-        self.do_kill().map_err(|err| {
+        if let Err(err) = self.do_kill() {
             log::warn!("ConPTY failed to terminate process tree: {err}");
-            err
-        })
+        }
+        Ok(())
     }
 
     fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/procthreadattr.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/procthreadattr.rs
@@ -21,10 +21,10 @@
 use super::psuedocon::HPCON;
 use anyhow::Error;
 use anyhow::ensure;
-use std::ffi::c_void;
 use std::io::Error as IoError;
 use std::mem;
 use std::ptr;
+use winapi::ctypes::c_void;
 use winapi::shared::minwindef::DWORD;
 use winapi::um::processthreadsapi::*;
 use winapi::um::winnt::HANDLE;

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/win/psuedocon.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/win/psuedocon.rs
@@ -85,20 +85,10 @@ shared_library!(Ntdll,
     ) -> NTSTATUS,
 );
 
-fn load_conpty() -> ConPtyFuncs {
-    let kernel = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
+lazy_static! {
+    static ref CONPTY: ConPtyFuncs = ConPtyFuncs::open(Path::new("kernel32.dll")).expect(
         "this system does not support conpty.  Windows 10 October 2018 or newer is required",
     );
-
-    if let Ok(sideloaded) = ConPtyFuncs::open(Path::new("conpty.dll")) {
-        sideloaded
-    } else {
-        kernel
-    }
-}
-
-lazy_static! {
-    static ref CONPTY: ConPtyFuncs = load_conpty();
 }
 
 pub fn conpty_supported() -> bool {

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/windows_tests.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/windows_tests.rs
@@ -77,14 +77,14 @@ async fn assert_terminate_kills_descendant(
             .duration_since(std::time::UNIX_EPOCH)?
             .as_nanos()
     ));
-    let release_marker = marker.with_extension("release");
     let child_code = format!(
-        "import pathlib,time; marker=pathlib.Path(bytes.fromhex('{}').decode()); release=pathlib.Path(bytes.fromhex('{}').decode()); print('{READY_MARKER}',flush=True); deadline=time.time()+10\nwhile not release.exists() and time.time()<deadline: time.sleep(.025)\nif release.exists(): marker.write_text('survived')",
-        utf8_hex(&marker.to_string_lossy()),
-        utf8_hex(&release_marker.to_string_lossy()),
+        "import pathlib,time; print('{READY_MARKER}',flush=True); time.sleep(1); pathlib.Path(bytes.fromhex('{}').decode()).write_text('survived')",
+        utf8_hex(&marker.to_string_lossy())
     );
+    // Exercise descendants created after the best-effort pipe assignment,
+    // without making the test depend on winning the intentionally accepted race.
     let code = format!(
-        "import subprocess,sys,time; code=bytes.fromhex('{}').decode(); subprocess.Popen([sys.executable,'-u','-c',code]); time.sleep(60)",
+        "import subprocess,sys,time; time.sleep(0.5); code=bytes.fromhex('{}').decode(); subprocess.Popen([sys.executable,'-u','-c',code]); time.sleep(60)",
         utf8_hex(&child_code)
     );
     let args = vec!["-u".to_string(), "-c".to_string(), code];
@@ -110,10 +110,11 @@ async fn assert_terminate_kills_descendant(
         exit_code, -1,
         "{backend} root did not exit after termination"
     );
-    std::fs::write(&release_marker, b"release")?;
-    let survived = wait_for_path(&marker, Duration::from_secs(2)).await;
-    let _ = std::fs::remove_file(&release_marker);
-    let _ = std::fs::remove_file(&marker);
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let survived = marker.exists();
+    if survived {
+        std::fs::remove_file(&marker)?;
+    }
     assert!(!survived, "{backend} descendant survived termination");
     Ok(())
 }
@@ -170,7 +171,8 @@ async fn assert_normal_exit_preserves_descendant(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn terminate_kills_descendants_for_atomic_pipe_and_conpty() -> anyhow::Result<()> {
+async fn terminate_kills_descendants_for_best_effort_pipe_and_atomic_conpty() -> anyhow::Result<()>
+{
     let Some(python) = find_python() else {
         eprintln!("python not found; skipping Windows process-tree termination test");
         return Ok(());
@@ -236,6 +238,65 @@ async fn contained_spawn_owns_immediate_descendant() -> anyhow::Result<()> {
 
     job.terminate()?;
     tokio::time::timeout(Duration::from_secs(10), root.wait()).await??;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn rejected_job_assignment_resumes_existing_job_member() -> anyhow::Result<()> {
+    let Some(python) = find_python() else {
+        eprintln!("python not found; skipping Windows nested-job fallback test");
+        return Ok(());
+    };
+
+    let owning_job = crate::JobObject::create()?;
+    let rejected_job = crate::JobObject::create_without_breakaway()?;
+    let mut occupied_command = Command::new(&python);
+    occupied_command
+        .args(["-c", "import time; time.sleep(60)"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+    let mut existing_member = rejected_job.spawn_contained(&mut occupied_command)?;
+
+    let mut command = Command::new(&python);
+    command
+        .args([
+            "-u",
+            "-c",
+            "import time; print('resumed',flush=True); time.sleep(60)",
+        ])
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null());
+    rejected_job.prepare_suspended_spawn(&mut command);
+    let mut root = command.spawn()?;
+    let process_handle = root
+        .raw_handle()
+        .ok_or_else(|| anyhow::anyhow!("missing suspended process handle"))?;
+    owning_job.assign_process(process_handle)?;
+    let process_id = root
+        .id()
+        .ok_or_else(|| anyhow::anyhow!("missing suspended process id"))?;
+
+    assert!(
+        !rejected_job.assign_and_resume_process(process_id)?,
+        "unrelated nested job unexpectedly accepted the process"
+    );
+    let stdout = root
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("missing resumed process stdout"))?;
+    let mut stdout = BufReader::new(stdout);
+    let mut marker = String::new();
+    tokio::time::timeout(Duration::from_secs(10), stdout.read_line(&mut marker)).await??;
+    assert_eq!(marker.trim(), "resumed");
+
+    let process_handle = crate::JobObject::open_process_handle(process_id)?;
+    crate::JobObject::terminate_process_handle(&process_handle)?;
+    rejected_job.terminate()?;
+    let status = tokio::time::timeout(Duration::from_secs(10), root.wait()).await??;
+    assert_eq!(status.code(), Some(1));
+    tokio::time::timeout(Duration::from_secs(10), existing_member.wait()).await??;
     Ok(())
 }
 

--- a/vendor/codex-acp/vendor/codex-utils-pty/tests/conpty_search_path.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/tests/conpty_search_path.rs
@@ -1,0 +1,70 @@
+#![cfg(windows)]
+
+use codex_utils_pty::RawConPty;
+use std::ffi::OsStr;
+use std::fs;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::path::PathBuf;
+use winapi::um::libloaderapi::GetModuleHandleW;
+
+struct CurrentDirGuard {
+    original: PathBuf,
+}
+
+impl CurrentDirGuard {
+    fn enter(path: &Path) -> std::io::Result<Self> {
+        let original = std::env::current_dir()?;
+        std::env::set_current_dir(path)?;
+        Ok(Self { original })
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        let _ = std::env::set_current_dir(&self.original);
+    }
+}
+
+#[test]
+fn conpty_ignores_dll_in_current_directory() -> anyhow::Result<()> {
+    let temp_dir = std::env::temp_dir().join(format!(
+        "codex-conpty-search-path-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)?
+            .as_nanos()
+    ));
+    fs::create_dir(&temp_dir)?;
+
+    let system_root =
+        std::env::var_os("SystemRoot").ok_or_else(|| anyhow::anyhow!("SystemRoot is not set"))?;
+    let candidate = temp_dir.join("conpty.dll");
+    // A kernel32 copy exports the ConPTY functions, so the old bare-name probe
+    // would successfully load and retain this repository-controlled file.
+    fs::copy(
+        PathBuf::from(system_root)
+            .join("System32")
+            .join("kernel32.dll"),
+        &candidate,
+    )?;
+
+    {
+        let _current_dir = CurrentDirGuard::enter(&temp_dir)?;
+        drop(RawConPty::new(/*cols*/ 80, /*rows*/ 24)?);
+
+        let conpty_dll = OsStr::new("conpty.dll")
+            .encode_wide()
+            .chain(std::iter::once(0))
+            .collect::<Vec<_>>();
+        let module = unsafe { GetModuleHandleW(conpty_dll.as_ptr()) };
+        assert!(
+            module.is_null(),
+            "ConPTY loaded conpty.dll from the process current directory"
+        );
+    }
+
+    fs::remove_file(candidate)?;
+    fs::remove_dir(temp_dir)?;
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- promote the embedded OpenAI agent runtime from 0.147.0 to 0.150.0 while preserving the existing ACP and adapter baselines
- adapt turn submission, approvals, runtime events, collaboration lifecycle, and extended reasoning efforts to the new runtime contracts
- keep the agent runtime and code-mode host packaged and verified as a matched pair
- terminate owned ACP process groups during application shutdown so stale processes cannot retain thread writer locks
- invalidate stale transcript cursors when native resume falls back to a new runtime session, preserving conversation context across application restarts
- document the compatibility baseline and intentionally deferred capabilities

## Regression hardening

Application restarts could leave an ACP process orphaned after the native backend was terminated. The orphan retained the thread writer lock, native resume fell back to a fresh runtime session, and the conversation binding incorrectly kept the previous context cursor. That stale cursor suppressed transcript handoff, making the new runtime appear to forget the conversation.

This PR fixes both sides of that failure: runtime ownership is shut down explicitly, and any runtime-session replacement resets transcript delivery state before the next prompt.

## Verification

- `cargo test -p neverwrite-native-backend` — 369 passed
- `npm test -- --run src/features/ai/store/chatStore.test.ts src/features/ai/conversationModel.test.ts src-electron/main/nativeBackend.test.ts` — 359 passed
- `npm run build`
- `npm run electron:sidecar:build`
- `npm run electron:sidecar:stage`
- `npm run electron:ai-runtime:smoke`
- `npm run electron:build`

## Scope

This keeps adapter version 0.16.0, ACP SDK 0.14.0, ACP v1, V8 150.4.0, and the current Rust toolchain unchanged. Migration to App Server, ACP v2, runtime queue UI, and provider-specific onboarding remain out of scope.