### PR TITLE
Fix dark mode composer action contrast

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatComposer.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatComposer.tsx
@@ -2137,12 +2137,14 @@ export function AIChatComposer({
                             width: 28,
                             height: 28,
                             color: canRunPrimaryAction
-                                ? "#fff"
+                                ? primaryAction === "stop"
+                                    ? "#fff"
+                                    : "var(--composer-send-foreground)"
                                 : "var(--text-secondary)",
                             backgroundColor: canRunPrimaryAction
                                 ? primaryAction === "stop"
                                     ? "var(--diff-remove)"
-                                    : "var(--accent)"
+                                    : "var(--composer-send-background)"
                                 : "transparent",
                             border: "none",
                             opacity: canRunPrimaryAction ? 1 : 0.4,

--- a/apps/desktop/src/index.css
+++ b/apps/desktop/src/index.css
@@ -253,6 +253,8 @@
     --text-heading-muted: #737373;
     --border: #e5e5e5;
     --accent: #6366f1;
+    --composer-send-background: var(--accent);
+    --composer-send-foreground: #ffffff;
     --shadow-soft: 0 18px 48px rgba(15, 23, 42, 0.08);
     --highlight-bg: color-mix(
         in srgb,
@@ -334,6 +336,8 @@
     --text-heading-muted: #8a8a8a;
     --border: #383838;
     --accent: #818cf8;
+    --composer-send-background: #ffffff;
+    --composer-send-foreground: #000000;
     --shadow-soft: 0 24px 56px rgba(0, 0, 0, 0.28);
     --highlight-bg: rgba(202, 162, 0, 0.35);
     --highlight-text: #f5e082;


### PR DESCRIPTION
## Summary

- add theme-aware composer send action colors
- render the send and queue action with a white background and black icon in dark mode
- preserve accent styling in light mode and semantic stop-button colors

## Testing

- `npm test -- --run src/features/ai/components/AIChatComposer.test.tsx`
- `npm run build`
- `git diff --check`