### PR TITLE
Prepare 0.7.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,31 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.7.4] - 2026-08-27
+
+### Added
+
+- Added the Automata theme with dedicated light and dark interface, editor syntax, and terminal palettes.
+- Added a **Copy Path** action to note-tab context menus for copying the note path relative to the current vault.
+- Added hover metadata to assistant messages, matching user messages with a timestamp and one-click copy action while keeping the transcript uncluttered when idle.
+- Added a guarded **Restore access to AI chats** recovery action when cloud sync, a filesystem provider, a restore, or a storage reconnect replaces the vault folder identity without changing the logical vault.
+
+### Changed
+
+- Refreshed the default theme with a neutral monochrome accent, updated editor and Vim cursors to follow the active theme accent, and made chat stop and action controls adapt more reliably to light and dark palettes.
+- Updated the embedded Claude ACP runtime to `0.70.0`, including changed-file auditing for more reliable AI change tracking and improved provider handling for loaded sessions.
+- Updated the embedded Codex runtime to `0.150.0`, with explicit turn acknowledgements, expanded runtime approval and failure reporting, broader collaboration lifecycle support, and model-provided `max` and `ultra` reasoning efforts.
+
+### Fixed
+
+- Fixed AI chat history becoming inaccessible after cloud sync, File Provider rematerialization, restore operations, or storage reconnects replaced the vault root while preserving its path and contents.
+- Fixed unavailable vaults remaining stuck in Recents by allowing their local registration, per-vault settings, snapshots, drafts, and device-local AI history to be removed even when the original folder no longer exists.
+- Fixed restarted Codex conversations appearing to forget earlier messages when an orphaned runtime retained the thread writer lock and native resume fell back to a fresh runtime session.
+- Fixed application shutdown leaving owned ACP runtime processes alive, preventing stale processes from retaining thread locks across restarts.
+- Fixed declined or mistimed runtime submissions steering an active turn or leaving an ACP prompt pending instead of returning a clear failure.
+- Fixed the AI composer drop target losing its visual highlight while files are dragged over it.
+- Fixed low-contrast composer action and stop controls in dark themes.
+
 ## [0.7.3] - 2026-08-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.7.3",
+    "version": "0.7.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.7.3",
+            "version": "0.7.4",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.7.3",
+    "version": "0.7.4",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.7.3",
+    "version": "0.7.4",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- add the detailed 0.7.4 user-facing changelog
- align the desktop app, native backend, workspace lockfile, and Web Clipper at version 0.7.4
- prepare release metadata for the future v0.7.4 tag

## Validation

- `node scripts/validate-release-metadata.mjs --tag v0.7.4`
- `cargo check --locked -p neverwrite-native-backend`
- `node --test scripts/release-metadata.test.mjs`
- `git diff --check`

## Release note

This PR only prepares release metadata. It does not create or push the v0.7.4 tag and does not launch the production release workflow.