### PR TITLE
Fix assistant metadata placement across tool turns

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageItem.tsx
@@ -687,10 +687,12 @@ function AssistantTextMessage({
     message,
     pillMetrics,
     chatFontSize,
+    metadataMode,
 }: {
     message: AIChatMessage;
     pillMetrics: ChatPillMetrics;
     chatFontSize: number;
+    metadataMode: AssistantMessageMetadataMode;
 }) {
     return (
         <div
@@ -709,11 +711,13 @@ function AssistantTextMessage({
                 chatFontSize={chatFontSize}
                 fileReferenceAppearance="link"
             />
-            <MessageMetadata
-                available={message.inProgress !== true}
-                message={message}
-                placement="assistant"
-            />
+            {metadataMode !== "hidden" ? (
+                <MessageMetadata
+                    available={metadataMode === "available"}
+                    message={message}
+                    placement="assistant"
+                />
+            ) : null}
         </div>
     );
 }
@@ -759,6 +763,7 @@ interface AIChatMessageItemProps {
     message: AIChatMessage;
     sessionId?: string | null;
     readOnly?: boolean;
+    assistantMetadataMode?: AssistantMessageMetadataMode;
     pillMetrics: ChatPillMetrics;
     chatFontSize?: number;
     visibleWorkCycleId?: string | null;
@@ -775,6 +780,11 @@ interface AIChatMessageItemProps {
     ) => void;
     onDismissMessage?: (messageId: string) => void;
 }
+
+export type AssistantMessageMetadataMode =
+    | "available"
+    | "reserved"
+    | "hidden";
 
 function stripMarkdownBold(text: string) {
     return text.replace(/\*\*(.+?)\*\*/g, "$1");
@@ -3374,6 +3384,8 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
     message,
     sessionId,
     readOnly = false,
+    assistantMetadataMode =
+        message.inProgress === true ? "reserved" : "available",
     pillMetrics,
     chatFontSize = 14,
     visibleWorkCycleId = null,
@@ -3487,6 +3499,7 @@ export const AIChatMessageItem = memo(function AIChatMessageItem({
             message={message}
             pillMetrics={pillMetrics}
             chatFontSize={chatFontSize}
+            metadataMode={assistantMetadataMode}
         />
     );
 });

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.test.tsx
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { renderComponent } from "../../../test/test-utils";
 import type { AIChatMessage } from "../types";
 import { AIChatMessageList } from "./AIChatMessageList";
+import { deriveAssistantMessageMetadataModes } from "./assistantMessageMetadata";
 import { resetChatMessageListViewState } from "./chatMessageListViewState";
 import { resetChatRowUiStore } from "../store/chatRowUiStore";
 import { useChatStore } from "../store/chatStore";
@@ -102,6 +103,161 @@ function expectSharedChatContentColumn(element: HTMLElement) {
         marginInline: "auto",
     });
 }
+
+describe("AIChatMessageList assistant metadata", () => {
+    const completedToolTurn: AIChatMessage[] = [
+        {
+            id: "user:tool-turn",
+            role: "user",
+            kind: "text",
+            content: "Inspect the project",
+            timestamp: 1,
+            workCycleId: "cycle-tool-turn",
+        },
+        {
+            id: "assistant:before-tool",
+            role: "assistant",
+            kind: "text",
+            content: "I will inspect it.",
+            timestamp: 2,
+            workCycleId: "cycle-tool-turn",
+            inProgress: false,
+        },
+        {
+            id: "tool:inspect",
+            role: "assistant",
+            kind: "tool",
+            content: "Inspected the project",
+            timestamp: 3,
+            workCycleId: "cycle-tool-turn",
+            title: "Inspect project",
+            meta: { status: "completed", tool: "read" },
+        },
+        {
+            id: "assistant:after-tool",
+            role: "assistant",
+            kind: "text",
+            content: "The inspection is complete.",
+            timestamp: 4,
+            workCycleId: "cycle-tool-turn",
+            inProgress: false,
+        },
+    ];
+
+    it("shows metadata only on the final assistant text in a completed tool turn", () => {
+        renderComponent(
+            <AIChatMessageList
+                messages={completedToolTurn}
+                status="idle"
+            />,
+        );
+
+        const beforeToolRow = document.querySelector(
+            '[data-chat-message-id="assistant:before-tool"]',
+        );
+        const afterToolRow = document.querySelector(
+            '[data-chat-message-id="assistant:after-tool"]',
+        );
+
+        expect(
+            beforeToolRow?.querySelector(
+                "[data-assistant-message-metadata]",
+            ),
+        ).toBeNull();
+        expect(
+            afterToolRow?.querySelector(
+                '[data-assistant-message-metadata] button[aria-label="Copy message"]',
+            ),
+        ).not.toBeNull();
+    });
+
+    it("reserves metadata only for the currently streaming assistant text", () => {
+        const messages = completedToolTurn.map((message) =>
+            message.id === "assistant:after-tool"
+                ? { ...message, inProgress: true }
+                : message,
+        );
+
+        renderComponent(
+            <AIChatMessageList messages={messages} status="streaming" />,
+        );
+
+        const beforeToolRow = document.querySelector(
+            '[data-chat-message-id="assistant:before-tool"]',
+        );
+        const afterToolMetadata = document.querySelector(
+            '[data-chat-message-id="assistant:after-tool"] [data-assistant-message-metadata]',
+        );
+
+        expect(
+            beforeToolRow?.querySelector(
+                "[data-assistant-message-metadata]",
+            ),
+        ).toBeNull();
+        expect(afterToolMetadata).not.toBeNull();
+        expect(afterToolMetadata).toBeEmptyDOMElement();
+        expect(
+            document.querySelector(
+                '[data-assistant-message-metadata] button[aria-label="Copy message"]',
+            ),
+        ).toBeNull();
+    });
+
+    it("falls back to the last existing text when a completed turn ends on a tool", () => {
+        const messages = completedToolTurn.slice(0, -1);
+
+        expect(
+            deriveAssistantMessageMetadataModes(messages, "idle").get(
+                "assistant:before-tool",
+            ),
+        ).toBe("available");
+    });
+
+    it("keeps one metadata target per legacy turn without work-cycle ids", () => {
+        const messages: AIChatMessage[] = [
+            {
+                id: "user:legacy-1",
+                role: "user",
+                kind: "text",
+                content: "First turn",
+                timestamp: 1,
+            },
+            {
+                id: "assistant:legacy-1a",
+                role: "assistant",
+                kind: "text",
+                content: "First segment",
+                timestamp: 2,
+            },
+            {
+                id: "assistant:legacy-1b",
+                role: "assistant",
+                kind: "text",
+                content: "First final",
+                timestamp: 3,
+            },
+            {
+                id: "user:legacy-2",
+                role: "user",
+                kind: "text",
+                content: "Second turn",
+                timestamp: 4,
+            },
+            {
+                id: "assistant:legacy-2",
+                role: "assistant",
+                kind: "text",
+                content: "Second final",
+                timestamp: 5,
+            },
+        ];
+        const modes = deriveAssistantMessageMetadataModes(messages, "idle");
+
+        expect(modes.get("assistant:legacy-1a")).toBeUndefined();
+        expect(modes.get("assistant:legacy-1b")).toBe("available");
+        expect(modes.get("assistant:legacy-2")).toBe("available");
+    });
+});
 
 describe("AIChatMessageList streaming run indicator", () => {
     afterEach(() => {

--- a/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatMessageList.tsx
@@ -8,7 +8,11 @@ import {
     useRef,
     useState,
 } from "react";
-import { AIChatMessageItem, PlanMessage } from "./AIChatMessageItem";
+import {
+    AIChatMessageItem,
+    PlanMessage,
+    type AssistantMessageMetadataMode,
+} from "./AIChatMessageItem";
 import { ToolActivitySegment } from "./ToolActivitySegment";
 import {
     ContextMenu,
@@ -55,6 +59,7 @@ import {
     buildChatPromptRingItems,
     resolveChatPromptRingLayout,
 } from "./ChatPromptRing.logic";
+import { deriveAssistantMessageMetadataModes } from "./assistantMessageMetadata";
 
 interface AIChatMessageListProps {
     sessionId?: string | null;
@@ -307,6 +312,10 @@ function renderTimelineRow(
         forceExpandedMessageId?: string | null;
         forceExpandedForSearch?: boolean;
         activityDisplayMode: ActivityDisplayMode;
+        assistantMetadataModes: ReadonlyMap<
+            string,
+            AssistantMessageMetadataMode
+        >;
     },
 ) {
     if (row.kind === "run-indicator") {
@@ -359,10 +368,17 @@ function renderTimelineMessage(
             action: AIUrlElicitationAction,
         ) => void;
         onDismissMessage?: (messageId: string) => void;
+        assistantMetadataModes: ReadonlyMap<
+            string,
+            AssistantMessageMetadataMode
+        >;
     },
 ) {
     return (
         <AIChatMessageItem
+            assistantMetadataMode={
+                options.assistantMetadataModes.get(message.id) ?? "hidden"
+            }
             sessionId={options.sessionId}
             readOnly={options.readOnly}
             message={message}
@@ -635,6 +651,10 @@ export const AIChatMessageList = memo(function AIChatMessageList({
         timelineActivityDisplayMode,
         visiblePinnedPlanId,
     ]);
+    const assistantMetadataModes = useMemo(
+        () => deriveAssistantMessageMetadataModes(messages, status),
+        [messages, status],
+    );
     const promptRingItems = useMemo(
         () => buildChatPromptRingItems(messages),
         [messages],
@@ -680,9 +700,11 @@ export const AIChatMessageList = memo(function AIChatMessageList({
             forceExpandedForSearch: findOpen && findQuery.trim().length > 0,
             highlightedMessageId: outlineHighlightedMessageId,
             activityDisplayMode,
+            assistantMetadataModes,
         }),
         [
             activityDisplayMode,
+            assistantMetadataModes,
             chatFontSize,
             findOpen,
             scrollToMessageId,

--- a/apps/desktop/src/features/ai/components/assistantMessageMetadata.ts
+++ b/apps/desktop/src/features/ai/components/assistantMessageMetadata.ts
@@ -1,0 +1,63 @@
+import { isCancellableChatTurnStatus } from "../chatTurnStatus";
+import type { AIChatMessage, AIChatSessionStatus } from "../types";
+import type { AssistantMessageMetadataMode } from "./AIChatMessageItem";
+
+function workCycleTurnKey(workCycleId: string) {
+    return `work-cycle:${workCycleId}`;
+}
+
+export function deriveAssistantMessageMetadataModes(
+    messages: AIChatMessage[],
+    status: AIChatSessionStatus,
+): ReadonlyMap<string, AssistantMessageMetadataMode> {
+    const lastAssistantMessageByTurn = new Map<string, AIChatMessage>();
+    let legacyTurnIndex = 0;
+    let currentTurnKey = `legacy:${legacyTurnIndex}`;
+    let latestTurnKey = currentTurnKey;
+
+    for (const message of messages) {
+        if (message.kind === "text" && message.role === "user") {
+            currentTurnKey = message.workCycleId
+                ? workCycleTurnKey(message.workCycleId)
+                : `legacy:${++legacyTurnIndex}`;
+            latestTurnKey = currentTurnKey;
+        } else if (message.workCycleId) {
+            currentTurnKey = workCycleTurnKey(message.workCycleId);
+            latestTurnKey = currentTurnKey;
+        }
+
+        if (
+            message.kind !== "text" ||
+            message.role !== "assistant" ||
+            message.content.trim().length === 0
+        ) {
+            continue;
+        }
+
+        const turnKey = message.workCycleId
+            ? workCycleTurnKey(message.workCycleId)
+            : currentTurnKey;
+        lastAssistantMessageByTurn.set(turnKey, message);
+        latestTurnKey = turnKey;
+    }
+
+    const modes = new Map<string, AssistantMessageMetadataMode>();
+    for (const message of lastAssistantMessageByTurn.values()) {
+        modes.set(message.id, "available");
+    }
+
+    if (isCancellableChatTurnStatus(status)) {
+        const activeTurnMessage =
+            lastAssistantMessageByTurn.get(latestTurnKey);
+        if (activeTurnMessage) {
+            modes.set(
+                activeTurnMessage.id,
+                activeTurnMessage.inProgress === true
+                    ? "reserved"
+                    : "hidden",
+            );
+        }
+    }
+
+    return modes;
+}


### PR DESCRIPTION
## Summary

- derive assistant metadata eligibility from complete turns instead of individual text-segment streaming state
- show copy and timestamp controls only on the final assistant text for each turn while preserving reserved space for the active stream
- support persisted legacy transcripts that do not have work-cycle identifiers

## Regression

Assistant text segments are intentionally finalized before tool activity with `turn_complete: false`. The hover metadata treated every non-streaming segment as a completed response, so copy and timestamp controls appeared in the middle of tool-driven turns.

## Testing

- `npm test -- --run src/features/ai/components/AIChatMessageItem.test.tsx src/features/ai/components/AIChatMessageList.test.tsx src/features/ai/store/chatStore.test.ts`
- `npx eslint src/features/ai/components/AIChatMessageItem.tsx src/features/ai/components/AIChatMessageList.tsx src/features/ai/components/AIChatMessageList.test.tsx src/features/ai/components/assistantMessageMetadata.ts`
- `npx tsc -b --pretty false`
- `git diff --check`