### PR TITLE
Avoid logging AI session identifiers

### DIFF
--- a/apps/desktop/native-backend/src/ai.rs
+++ b/apps/desktop/native-backend/src/ai.rs
@@ -2856,7 +2856,7 @@ impl NativeAi {
         };
 
         eprintln!(
-            "ACP runtime transport disconnected phase=send runtime_id={runtime_id} session_id={session_id} process_id={process_id}"
+            "ACP runtime transport disconnected phase=send runtime_id={runtime_id} process_id={process_id}"
         );
         emit_event(
             &self.event_tx,


### PR DESCRIPTION
## Summary

- remove the AI session identifier from transport disconnect logs
- retain runtime and process context for diagnostics

## Testing

- `cargo test -p neverwrite-native-backend send_transport_disconnect_invalidates_the_affected_session_family`
