### PR TITLE
Update embedded runtime to 0.153.2 and add explicit model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Added an advanced Codex model-ID selector for explicitly choosing account-gated or upstream-hidden models without forcing them into the normal model catalog.
+
+### Changed
+
+- Updated the embedded Codex runtime to `0.153.2`, adding compatibility with the latest account-aware model catalog and GPT-6 Astra while preserving upstream model visibility rules.
+
 ## [0.7.6] - 2026-09-02
 
 ### Changed

--- a/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
@@ -44,9 +44,9 @@ export const CODEX_RUNTIME_COMPONENTS = [
 ];
 
 export const CODEX_RUNTIME_BASELINE = Object.freeze({
-    tag: "rust-v0.150.0",
-    version: "0.150.0",
-    commit: "3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717",
+    tag: "rust-v0.153.2",
+    version: "0.153.2",
+    commit: "657a993cbee87acf52d14b758ce49dbd46d1b8eb",
     v8Version: "150.4.0",
 });
 

--- a/apps/desktop/scripts/stage-electron-sidecar.test.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.test.mjs
@@ -133,9 +133,9 @@ test("rejects a mixed runtime source baseline before staging", () => {
                 adapterManifest:
                     '[dependencies]\ncodex-core = { tag = "rust-v0.149.0" }',
                 lockfile: "",
-                ptyManifest: '[package]\nversion = "0.150.0"',
+                ptyManifest: '[package]\nversion = "0.153.2"',
             }),
-        /must all use tag = "rust-v0\.150\.0"/,
+        /must all use tag = "rust-v0\.153\.2"/,
     );
 });
 

--- a/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatAgentControls.test.tsx
@@ -103,6 +103,98 @@ describe("AIChatAgentControls", () => {
     expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-5");
   });
 
+  it("allows an explicit Codex model ID without adding it to the catalog", async () => {
+    const user = userEvent.setup();
+    const onProviderChange = vi.fn();
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-5"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            allowsExplicitModelId: true,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={onProviderChange}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByTitle("Provider and model"));
+    await user.type(
+      screen.getByLabelText("Provider and model search"),
+      "gpt-6-astra",
+    );
+
+    expect(screen.queryByText("GPT-6 Astra")).not.toBeInTheDocument();
+    expect(
+      screen.getByText(/Not listed for this account\./),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("button", {
+        name: "Use exact model ID gpt-6-astra",
+      }),
+    );
+
+    expect(onProviderChange).toHaveBeenCalledWith("codex-acp", "gpt-6-astra");
+  });
+
+  it("shows an explicitly selected model ID that is absent from the catalog", () => {
+    renderComponent(
+      <AIChatAgentControls
+        runtimeId="codex-acp"
+        modelId="gpt-6-astra"
+        modeId="default"
+        models={[]}
+        modes={[]}
+        configOptions={[]}
+        providers={[
+          {
+            runtimeId: "codex-acp",
+            label: "Codex",
+            description: "Codex provider",
+            disabledReason: null,
+            allowsExplicitModelId: true,
+            defaultModelId: "gpt-5",
+            models: [
+              {
+                modelId: "gpt-5",
+                label: "GPT-5",
+                disabledReason: null,
+              },
+            ],
+          },
+        ]}
+        onProviderModelChange={() => {}}
+        onModelChange={() => {}}
+        onModeChange={() => {}}
+        onConfigOptionChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTitle("Provider and model")).toHaveTextContent(
+      "gpt-6-astra",
+    );
+  });
+
   it("leaves Escape available to the global agent shortcut", async () => {
     const user = userEvent.setup();
     renderComponent(

--- a/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
+++ b/apps/desktop/src/features/ai/components/AIProviderModelPicker.tsx
@@ -263,11 +263,30 @@ export function AIProviderModelPicker({
         () => visibleRows.filter((row) => !row.disabledReason),
         [visibleRows],
     );
-    const selectedRow =
-        rows.find(
-            (row) => row.runtimeId === runtimeId && row.modelId === modelId,
-        ) ?? rows.find((row) => row.runtimeId === runtimeId);
-    const triggerLabel = selectedRow?.modelLabel ?? (modelId || "Model");
+    const selectedRow = rows.find(
+        (row) => row.runtimeId === runtimeId && row.modelId === modelId,
+    );
+    const triggerLabel =
+        selectedRow?.modelLabel ??
+        (modelId ||
+            rows.find((row) => row.runtimeId === runtimeId)?.modelLabel ||
+            "Model");
+    const explicitModelId = query.trim();
+    const explicitModelProvider = providers.find(
+        (provider) =>
+            provider.runtimeId === selectedProviderId &&
+            provider.allowsExplicitModelId === true &&
+            provider.disabledReason == null,
+    );
+    const canUseExplicitModelId = Boolean(
+        explicitModelProvider &&
+        explicitModelId &&
+        !rows.some(
+            (row) =>
+                row.runtimeId === explicitModelProvider.runtimeId &&
+                row.modelId === explicitModelId,
+        ),
+    );
     const blockedProvider = providers.find(
         (provider) =>
             provider.runtimeId === blockedProviderId &&
@@ -357,6 +376,12 @@ export function AIProviderModelPicker({
         }
         if (row.disabledReason) return;
         onChange(row.runtimeId, row.modelId);
+        closePicker(true);
+    };
+
+    const selectExplicitModelId = () => {
+        if (!explicitModelProvider || !canUseExplicitModelId) return;
+        onChange(explicitModelProvider.runtimeId, explicitModelId);
         closePicker(true);
     };
 
@@ -580,7 +605,7 @@ export function AIProviderModelPicker({
                         <div className="min-h-0 flex-1 overflow-y-auto p-2">
                             {visibleRows.length === 0 ? (
                                 <div
-                                    className="px-2 py-8 text-center text-xs"
+                                    className="px-2 py-6 text-center text-xs"
                                     style={{ color: "var(--text-secondary)" }}
                                 >
                                     {selectedProviderId === FAVORITES_PROVIDER_ID &&
@@ -692,6 +717,30 @@ export function AIProviderModelPicker({
                                     })}
                                 </div>
                             )}
+                            {canUseExplicitModelId && explicitModelProvider ? (
+                                <button
+                                    aria-label={`Use exact model ID ${explicitModelId}`}
+                                    className="mt-2 w-full rounded-lg px-3 py-2 text-left"
+                                    onClick={selectExplicitModelId}
+                                    style={{
+                                        backgroundColor: "var(--bg-tertiary)",
+                                        border: "1px solid var(--border)",
+                                        color: "var(--text-primary)",
+                                    }}
+                                    title={`Use ${explicitModelId} even though it is not listed in the ${explicitModelProvider.label} catalog`}
+                                    type="button"
+                                >
+                                    <span className="block truncate text-xs font-medium">
+                                        Use exact model ID “{explicitModelId}”
+                                    </span>
+                                    <span
+                                        className="mt-1 block text-[11px] leading-snug"
+                                        style={{ color: "var(--text-secondary)" }}
+                                    >
+                                        Not listed for this account. {explicitModelProvider.label} will verify access when used.
+                                    </span>
+                                </button>
+                            ) : null}
                         </div>
                     </div>
 

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -106,6 +106,51 @@ describe("conversation provider picker model", () => {
       "provider-a",
       "provider-b",
     ]);
+    expect(options.every((option) => !option.allowsExplicitModelId)).toBe(true);
+  });
+
+  it("enables explicit model IDs only for the Codex provider", () => {
+    const current = session();
+    current.runtimeId = "codex-acp";
+    const bindings = createConversationBindingsFromLegacySession(current);
+    const conversation = {
+      ...current,
+      conversationId: bindings.conversationId,
+      parentConversationId: null,
+      vaultPath: null,
+      closedAt: null,
+      activeWorkCycleId: null,
+      visibleWorkCycleId: null,
+      preferredSelection: bindings.preferredSelection,
+      activeBindingId: bindings.activeBindingId,
+      persistedCreatedAt: null,
+      persistedUpdatedAt: null,
+      persistedTitle: null,
+      customTitle: null,
+      persistedPreview: null,
+      isPersistedSession: false,
+      isPendingSessionCreation: false,
+      isResumingSession: false,
+    };
+
+    const options = buildConversationProviderOptions({
+      runtimes: [runtime("codex-acp"), runtime("provider-b")],
+      setupStatusByRuntimeId: {
+        "codex-acp": ready("codex-acp"),
+        "provider-b": ready("provider-b"),
+      },
+      conversation,
+      bindings: bindings.providerBindings,
+      activeRuntimeId: "codex-acp",
+      hasQueuedMessages: false,
+    });
+
+    expect(
+      options.find((option) => option.runtimeId === "codex-acp"),
+    ).toMatchObject({ allowsExplicitModelId: true });
+    expect(
+      options.find((option) => option.runtimeId === "provider-b"),
+    ).toMatchObject({ allowsExplicitModelId: false });
   });
 
   it("blocks another provider during a running turn", () => {

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -17,6 +17,7 @@ export interface ConversationProviderPickerOption {
   label: string;
   description: string;
   disabledReason: string | null;
+  allowsExplicitModelId?: boolean;
   defaultModelId: string;
   models: ConversationProviderModelOption[];
 }
@@ -193,6 +194,7 @@ export function buildConversationProviderOptions(input: {
         label: runtime.runtime.name.replace(/ ACP$/, ""),
         description: runtime.runtime.description,
         disabledReason,
+        allowsExplicitModelId: runtimeId === "codex-acp",
         ...modelOptions,
       };
     });

--- a/docs/ai-runtime-setup.md
+++ b/docs/ai-runtime-setup.md
@@ -342,7 +342,7 @@ Current packaging expectations:
 - Kilo is integrated but not bundled by default.
 - OpenCode is integrated but not bundled by default.
 
-The packaged sidecar smoke sends ACP `initialize`, `session/new`, and `session/prompt` requests to `codex-acp` using an isolated temporary `CODEX_HOME` and deterministic local Responses mock. It keeps the packaged host beside the ACP executable as required by the 0.147 install context, verifies the code-mode tool output and final assistant response, and inspects the ACP process tree to prove the standalone `codex-code-mode-host` process was launched.
+The packaged sidecar smoke sends ACP `initialize`, `session/new`, and `session/prompt` requests to `codex-acp` using an isolated temporary `CODEX_HOME` and deterministic local Responses mock. It keeps the packaged host beside the ACP executable as required by the current install context, verifies the code-mode tool output and final assistant response, and inspects the ACP process tree to prove the standalone `codex-code-mode-host` process was launched.
 
 The smoke also runs a fail-closed case from an isolated ACP directory without a sibling host and requires an actionable missing-host diagnostic before checking that the native backend responds to ping. This catches missing, non-executable, wrong-architecture, or silently bypassed companion binaries before release assets are staged.
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -46,10 +46,10 @@ That means the directory is intentionally reproducible, but not yet minimal.
 - `codex-acp/`
   - upstream baseline: `zed-industries/codex-acp` `0.16.0`
   - synced against upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`
-  - OpenAI Codex Rust crates: `rust-v0.150.0` (`3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`)
+  - OpenAI Codex Rust crates: `rust-v0.153.2` (`657a993cbee87acf52d14b758ce49dbd46d1b8eb`)
   - vendor ACP SDK: `agent-client-protocol` `0.14.0`
   - ACP wire protocol: v1; ACP v2 is not enabled by this runtime promotion
-  - local `vendor/codex-utils-pty/` snapshot: `0.150.0`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
+  - local `vendor/codex-utils-pty/` snapshot: `0.153.2`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
   - resolved V8 crate: `150.4.0`, built with OpenAI's verified `ptrcomp_sandbox_release` archive and source binding for the target
   - Rust toolchain: NeverWrite `1.96.0`; upstream Codex `1.95.0`
   - local NeverWrite delta remains intentionally bounded and currently lives in:
@@ -77,7 +77,7 @@ That means the directory is intentionally reproducible, but not yet minimal.
 
 ## Current Codex Delta
 
-The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.150.0`, resolved to `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717` in `Cargo.lock`.
+The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.153.2`, resolved to `657a993cbee87acf52d14b758ce49dbd46d1b8eb` in `Cargo.lock`.
 
 The remaining NeverWrite-specific delta exists to preserve desktop product behavior:
 
@@ -86,7 +86,7 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - review-mode and review-finding adaptation while preserving inline review and accept/reject flows
 - permission, mode, and approval-preset stability when Codex expands writable roots under `workspace-write`
 - custom slash-prompt discovery and expansion without moving NeverWrite's prompt queue
-- model discovery through the route-aware HTTP client, Fast service-tier controls, and refreshed `ConfigOptionUpdate` values after successful model selection
+- account-aware model discovery through the route-aware HTTP client, upstream visibility filtering, explicit raw model selection, Fast service-tier controls, and refreshed `ConfigOptionUpdate` values after successful model selection
 - session-config synchronization from Codex `SessionConfiguredEvent` and thread snapshots, preserving model, provider, reasoning effort, service tier, and reviewer
 - authentication/keyring selection, async login, reload, logout, and API-key flows without changing NeverWrite's credential policy
 - MCP transport compatibility through `ClientMcpExtensions`, while retaining client-provided environment, cwd, auth, and approval settings
@@ -97,11 +97,11 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - a private `codexAcp*` subagent contract for session creation, navigable activity breadcrumbs, child lifecycle, and receiver-owned inter-agent transcripts
 - per-turn coalescing of equivalent subagent waits; only fully terminal status sets complete the ACP activity
 - localized `StartThreadOptions`, shared models-manager, external code-mode provider, config, auth, MCP, permission, and thread-store adapters at the ACP boundary
-- a local `codex-utils-pty` `0.150.0` snapshot with its standalone manifest, upstream Unix process-group fallback, Windows Job Object and ConPTY path handling, and the upstream platform tests
+- a local `codex-utils-pty` `0.153.2` snapshot with its standalone manifest, native executable-path encoding, upstream Unix process-group fallback, Windows Job Object and ConPTY path handling, and the upstream platform tests
 
-The 0.150 turn-input boundary uses `TurnInputRequest` with `StartIfIdle` and consumes the runtime acknowledgement before registering the ACP prompt. `NotSubmitted` and an impossible `Steered` acknowledgement resolve as ACP errors instead of leaving a response pending.
+The 0.153.2 turn-input boundary uses `TurnInputRequest` with `StartIfIdle` and consumes the runtime acknowledgement before registering the ACP prompt. `NotSubmitted` and an impossible `Steered` acknowledgement resolve as ACP errors instead of leaving a response pending.
 
-The 0.150 event delta is handled as localized projections. MCP policy amendments are exposed only when offered, Guardian stdin reviews redact the input payload, image failures retain their reason, standalone function outputs do not invent a call identity, and `ThreadQueueChanged` stays diagnostic because NeverWrite owns the user-facing queue.
+The 0.153.2 event delta is handled as localized projections. Authentication recovery is visible as status activity, misalignment details survive the ACP error boundary, unsupported OpenAI elicitation forms fail closed, MCP policy amendments are exposed only when offered, Guardian stdin reviews redact the input payload, image failures retain their reason, standalone function outputs do not invent a call identity, and `ThreadQueueChanged` stays diagnostic because NeverWrite owns the user-facing queue.
 
 `SubAgentActivity` is projected through the same canonical activity identity as its `TurnItem` fallback: matching protocol IDs update one ACP tool call, while distinct IDs remain separate rather than being correlated by descriptive metadata. `SendMessage`, `FollowupTask`, `InterruptAgent`, `ListAgents`, and `Completed` preserve their runtime IDs and terminal semantics. Child `ThreadId` values remain authoritative; paths, nicknames, and roles are display metadata only.
 
@@ -109,7 +109,7 @@ Reasoning options come from each runtime model preset. `max`, `ultra`, and futur
 
 The desktop release pipeline packages `codex-acp` and `codex-code-mode-host` as one runtime unit for macOS universal, Windows x64/ARM64, and Linux x64/ARM64. Each release build is lockfile-pinned, target-architecture checked, and signed together. Its packaged smoke drives an ACP `initialize`, `session/new`, and `session/prompt` exchange through the standalone host with a deterministic local Responses mock, verifies both the tool completion and assistant response, and proves a missing sibling host fails closed.
 
-When updating Codex again, treat upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`, OpenAI Codex tag `rust-v0.150.0` at `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`, the local PTY `0.150.0` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
+When updating Codex again, treat upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`, OpenAI Codex tag `rust-v0.153.2` at `657a993cbee87acf52d14b758ce49dbd46d1b8eb`, the local PTY `0.153.2` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
 
 Canonical compatibility checks:
 
@@ -120,9 +120,9 @@ node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo check --lock
 node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo test --locked --manifest-path ../../vendor/codex-acp/Cargo.toml
 ```
 
-## Codex 0.150.0 Compatibility Baseline
+## Codex 0.153.2 Compatibility Baseline
 
-The embedded runtime is pinned to OpenAI Codex `rust-v0.150.0`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`. The local `codex-utils-pty` snapshot is also `0.150.0`; it is part of the same runtime baseline, not an independently updatable crate.
+The embedded runtime is pinned to OpenAI Codex `rust-v0.153.2`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `657a993cbee87acf52d14b758ce49dbd46d1b8eb`. The local `codex-utils-pty` snapshot is also `0.153.2`; it is part of the same runtime baseline, not an independently updatable crate.
 
 The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolchain.toml`, which is compatible with the upstream Codex `1.95.0` toolchain. This promotion deliberately does not change these protocol boundaries:
 
@@ -133,7 +133,7 @@ The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolc
 
 ### Lockfile and V8 provisioning
 
-The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, `rama-macros`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.150 lock. A broad lockfile regeneration can select stable Rama packages next to prerelease peers and produce an incompatible graph, so future promotions must compare this family with the candidate tag and update it as a coordinated set.
+The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, `rama-macros`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.153.2 dependency graph. A broad lockfile regeneration can select stable Rama packages next to prerelease peers and produce an incompatible graph, so future promotions must compare this family with the candidate tag and update it as a coordinated set.
 
 The lockfile resolves `v8 150.4.0`. `apps/desktop/scripts/codex-v8-artifacts.mjs` obtains the target-specific `ptrcomp_sandbox_release` archive, source binding, and SHA-256 manifest from the official `openai/codex` release `rusty-v8-v150.4.0`. It authenticates the downloaded or cached manifest against the target-specific digest pinned in `apps/desktop/scripts/codex-v8-manifest-pins.mjs` before downloading archives or bindings, requires the manifest to cover exactly both artifacts, verifies their checksums before use, and caches the verified set under `apps/desktop/.cache/codex-v8/<version>/<profile>/<target>/`.
 
@@ -145,6 +145,7 @@ Local builds may provide `RUSTY_V8_ARCHIVE` and `RUSTY_V8_SRC_BINDING_PATH` only
 - MCP persistent approval, Guardian `WriteStdin`, image-generation failures, optional function-call IDs, `PathUri`, and runtime queue notifications have explicit safe projections.
 - Collaboration tools `SendMessage`, `FollowupTask`, `InterruptAgent`, and `ListAgents` preserve runtime activity identity. `SubAgentActivityKind::Completed` terminalizes that identity once, while internal agent messages remain outside the parent transcript.
 - Reasoning efforts are catalog-driven, including `max`, `ultra`, and future custom values. Load, resume, fork, and model changes retain an effort only when the selected model supports it.
+- The normal model picker follows the authenticated remote catalog and its visibility flags. GPT-6 Astra remains hidden unless the account catalog exposes it or the user enters its exact model ID through the Codex-only advanced selection path.
 - `TurnItem::Extension(ExtensionItem::Sleep(...))` is projected as the canonical `Waiting` activity and keeps stable item identity across live events and replay.
 - `ItemCompleted.started_at_ms` is propagated into activity metadata when positive so restored activities keep their upstream start time. Turn-level `started_at` fields are accepted but do not invent a second timeline contract.
 - `TurnComplete.error` emits a visible failed `turn_error` status and fails the pending ACP prompt instead of reporting `EndTurn`; aborts remain cancelled and keep their lifecycle event.
@@ -173,7 +174,7 @@ Portable plugins, thread sections/pinning, side conversations, audio/realtime, e
 | Linux x64 | Yes | — |
 | Linux ARM64 | No, because it is cross-compiled | Packaging, sidecar staging, and architecture checks run without executing the foreign binary |
 
-The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.150 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
+The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.153.2 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
 
 The same smoke starts an isolated copy of `codex-acp` without its sibling host and requires the code-mode tool to fail closed with the missing host path in its diagnostic. It does not require credentials or a network service.
 
@@ -181,7 +182,7 @@ The same smoke starts an isolated copy of `codex-acp` without its sibling host a
 
 #### Rollback baseline
 
-The rollback baseline is OpenAI Codex `rust-v0.147.0` at `be6e8eac029b183056b7e4402879f15d2c85f61b`, local PTY `0.147.0`, V8 `150.4.0`, and the lockfile recorded before this promotion. A rollback must restore `vendor/codex-acp/Cargo.toml`, `vendor/codex-acp/Cargo.lock`, `vendor/codex-acp/vendor/codex-utils-pty/`, and the adapter changes that depend exclusively on 0.150 types as one reviewed unit. V8 remains `150.4.0` on both sides of the rollback; never roll back a single Codex crate, PTY snapshot, or lockfile independently.
+The rollback baseline is OpenAI Codex `rust-v0.150.0` at `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`, local PTY `0.150.0`, V8 `150.4.0`, and the lockfile recorded before this promotion. A rollback must restore `vendor/codex-acp/Cargo.toml`, `vendor/codex-acp/Cargo.lock`, `vendor/codex-acp/vendor/codex-utils-pty/`, and the adapter changes that depend exclusively on 0.153.2 types as one reviewed unit. V8 remains `150.4.0` on both sides of the rollback; never roll back a single Codex crate, PTY snapshot, or lockfile independently.
 
 The desktop backend supports a mixed ACP world: current ACP integration for Claude, Codex, Kilo, and OpenCode, plus the vendored `agent-client-protocol-legacy` crates for Grok. The native backend tests cover the reconstructed diff, permission, status metadata, and legacy runtime compatibility paths that NeverWrite depends on.
 

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "actix-codec"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+checksum = "31404e1443b7b7bcaa311c1af456775cc3f668e34573f1503d7ce4844327629e"
 dependencies = [
  "bitflags 2.13.1",
  "bytes",
@@ -31,12 +31,11 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.13.3"
+version = "3.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11004b0e9b44b4eb3d15e0c3132b96fb178c7e50a74758b2f17bb9cc9a7fb4f6"
+checksum = "86d62d1a48894ec9450bcde7ef1e3681205771ff6ea9c61cc5ae031145192787"
 dependencies = [
  "actix-codec",
- "actix-rt",
  "actix-service",
  "actix-utils",
  "bitflags 2.13.1",
@@ -76,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.12.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25da0441692de4ad67950cb7ed6c9ce4b669a6609525e547566c2e1ab4d695c"
+checksum = "6a16bf2f19c2ad84842bdfe6f3665620e93197d5c607889bfa3aaac45e762fd1"
 dependencies = [
  "futures-core",
  "tokio",
@@ -86,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.9.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd8b9d8fac53b9354de76bff6cdd1a5ecc7ccaa4c88043e5ce8333f3ef884f0d"
+checksum = "5d44ae8a6516f4ac7bfc7b61aabcd286104e96b4b24c747ce220832a016056d9"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -428,6 +427,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
+name = "appcontainer_common"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "flatbuffers",
+ "getrandom 0.2.17",
+ "learning_mode_core",
+ "learning_mode_windows",
+ "process_security_environment_spec",
+ "sandbox_spec",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "widestring",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "winreg 0.55.0",
+ "wxc_common",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,9 +764,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -755,9 +775,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -1035,9 +1055,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "954c563ce84507722d2679f07a35d21b9c6466b3872d513020d0281fc8112ac9"
+checksum = "9c054752dd9e4dc73d0b75748c99ac2d0feafbf2f25c7b0516f03a3534161223"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api-macros",
@@ -1075,9 +1095,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.6.2"
+version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce83ce9abbb198d25bc7131e468d0f9fe1257125e58c39f3f9fc9f5098c9647"
+checksum = "8f94d16e797ec62cd999fc9d5942b48fa7050c3093ddadff48e4d7528d16fcb9"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -1183,7 +1203,7 @@ dependencies = [
  "addr2line",
  "cfg-if",
  "libc",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "object",
  "rustc-demangle",
  "windows-link",
@@ -1612,12 +1632,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -1664,6 +1684,12 @@ name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e4de3bc4ea267985becf712dc6d9eed8b04c953b3fcfb339ebc87acd9804901"
+
+[[package]]
+name = "cidr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579504560394e388085d0c080ea587dfa5c15f7e251b4d5247d1e1a61d1d6928"
 
 [[package]]
 name = "cipher"
@@ -1730,9 +1756,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clatter"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fed49fa357a85c377c0f920e86100f5326111b09ad69f6de684e324e3ad8097"
+checksum = "5b16a94521ffa1f8116782dfa8d0aef3c921c3b73f7072f9a5079899eec13b92"
 dependencies = [
  "aes-gcm",
  "arrayvec",
@@ -1840,8 +1866,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -1851,8 +1877,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1871,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-roles"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-config",
  "codex-file-system",
@@ -1885,8 +1911,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1905,8 +1931,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -1936,8 +1962,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -1965,13 +1991,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -1986,11 +2012,12 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
+ "codex-async-utils",
  "codex-exec-server",
  "codex-install-context",
  "codex-linux-sandbox",
@@ -2007,8 +2034,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2016,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2030,8 +2057,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2048,8 +2075,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "serde",
  "serde_json",
@@ -2058,8 +2085,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2072,21 +2099,20 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
  "codex-install-context",
+ "codex-otel",
  "codex-protocol",
- "codex-websocket-client",
  "futures",
  "http-body-util",
  "prost",
  "reqwest 0.12.28",
  "serde_json",
  "tokio",
- "tokio-tungstenite 0.28.0",
  "tokio-util",
  "tonic",
  "tower",
@@ -2096,14 +2122,16 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "axum",
  "clap",
  "codex-code-mode-protocol",
  "codex-code-mode-runtime",
+ "codex-otel",
+ "codex-otel-trace-websocket",
  "codex-protocol",
  "futures",
  "prost",
@@ -2119,8 +2147,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -2137,13 +2165,15 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
+ "base64 0.22.1",
  "codex-code-mode-protocol",
  "codex-protocol",
  "deno_core_icudata",
  "futures",
+ "opentelemetry",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -2153,13 +2183,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 
 [[package]]
 name = "codex-config"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2179,7 +2209,7 @@ dependencies = [
  "dunce",
  "futures",
  "gethostname",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "libc",
  "multimap",
  "prost",
@@ -2204,8 +2234,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2214,7 +2244,7 @@ dependencies = [
  "codex-otel",
  "codex-plugin",
  "codex-protocol",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde",
  "serde_json",
  "sha1 0.10.7",
@@ -2226,8 +2256,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2235,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2244,7 +2274,6 @@ dependencies = [
  "base64 0.22.1",
  "bm25",
  "chrono",
- "clap",
  "codex-agent-graph-store",
  "codex-agent-roles",
  "codex-analytics",
@@ -2267,6 +2296,7 @@ dependencies = [
  "codex-feedback",
  "codex-file-system",
  "codex-git-utils",
+ "codex-guardian-context",
  "codex-history",
  "codex-hooks",
  "codex-http-client",
@@ -2298,6 +2328,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-audio",
  "codex-utils-cache",
+ "codex-utils-git-discovery",
  "codex-utils-home-dir",
  "codex-utils-image",
  "codex-utils-output-truncation",
@@ -2315,7 +2346,7 @@ dependencies = [
  "http 1.5.0",
  "iana-time-zone",
  "image",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "libc",
  "once_cell",
  "openssl-sys",
@@ -2343,8 +2374,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2394,16 +2425,16 @@ dependencies = [
 
 [[package]]
 name = "codex-diagnostics"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "arc-swap",
  "axum",
@@ -2447,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -2462,8 +2493,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "clap",
@@ -2480,8 +2511,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2490,8 +2521,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -2506,8 +2537,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2518,8 +2549,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2531,23 +2562,28 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
+ "bytes",
  "codex-http-client",
  "codex-login",
  "codex-protocol",
+ "flate2",
+ "http 1.5.0",
+ "httpdate",
  "mime_guess",
  "sentry",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "codex-file-search"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "clap",
@@ -2561,8 +2597,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2574,8 +2610,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -2587,8 +2623,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2612,9 +2648,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-guardian-context"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+dependencies = [
+ "codex-protocol",
+ "serde_json",
+]
+
+[[package]]
 name = "codex-history"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "schemars 0.8.22",
@@ -2623,8 +2668,8 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -2633,8 +2678,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2658,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2685,8 +2730,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2711,8 +2756,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -2723,8 +2768,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "keyring",
  "tracing",
@@ -2732,8 +2777,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -2745,6 +2790,7 @@ dependencies = [
  "globset",
  "landlock",
  "libc",
+ "rustix 1.1.4",
  "seccompiler",
  "serde",
  "serde_json",
@@ -2754,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2788,8 +2834,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2823,8 +2869,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2854,8 +2900,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -2864,8 +2910,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -2885,8 +2931,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2898,8 +2944,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2917,8 +2963,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2953,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "chrono",
  "codex-api",
@@ -2983,30 +3029,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-otel-trace-websocket"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+dependencies = [
+ "anyhow",
+ "axum",
+ "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-plugin"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-config",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-path-uri",
  "codex-utils-plugins",
+ "serde_json",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3019,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3035,6 +3094,7 @@ dependencies = [
  "codex-utils-redacted-string",
  "codex-utils-string",
  "encoding_rs",
+ "gix-url",
  "globset",
  "http 1.5.0",
  "icu_decimal",
@@ -3060,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3071,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "axum",
@@ -3113,8 +3173,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3140,8 +3200,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3155,11 +3215,13 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
+ "appcontainer_common",
  "codex-network-proxy",
+ "codex-otel",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -3170,6 +3232,8 @@ dependencies = [
  "libc",
  "regex-lite",
  "serde_json",
+ "tokio",
+ "tracelogging",
  "tracing",
  "url",
  "which 8.0.6",
@@ -3177,8 +3241,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "age",
  "anyhow",
@@ -3196,8 +3260,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3217,8 +3281,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "clap",
@@ -3236,8 +3300,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3253,8 +3317,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-analytics",
  "codex-config",
@@ -3283,8 +3347,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3305,16 +3369,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3341,8 +3405,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -3365,8 +3429,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "dirs",
  "dunce",
@@ -3377,16 +3441,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3399,8 +3463,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "lru",
  "sha1 0.10.7",
@@ -3409,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3420,9 +3484,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "codex-utils-git-discovery"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+dependencies = [
+ "codex-git-utils",
+ "codex-utils-absolute-path",
+ "futures",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "codex-utils-home-dir"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3430,8 +3506,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3443,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3452,8 +3528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3461,8 +3537,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3471,8 +3547,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -3486,8 +3562,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -3499,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.150.0"
+version = "0.153.2"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3514,8 +3590,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-redacted-string"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3523,21 +3599,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "regex-lite",
  "serde",
@@ -3546,13 +3622,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -3565,8 +3641,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3591,8 +3667,8 @@ dependencies = [
 
 [[package]]
 name = "codex-workload-identity"
-version = "0.150.0"
-source = "git+https://github.com/openai/codex?tag=rust-v0.150.0#3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717"
+version = "0.153.2"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
 dependencies = [
  "codex-http-client",
  "serde",
@@ -3786,9 +3862,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -4339,9 +4415,9 @@ checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
 name = "diffy"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10aec8f7f9393bd6a4f2762be0ceb012d3cbe2478987258cc9960de148561914"
+checksum = "3e3dc2f773b6aaa63b1a7684b8589f670a8a0146a510b74d23a401c882364b49"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -4920,13 +4996,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
-name = "flate2"
-version = "1.1.9"
+name = "flatbuffers"
+version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.13.1",
+ "rustc_version",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "zlib-rs",
 ]
 
@@ -6196,7 +6282,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.5.0",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -6331,9 +6417,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -6536,9 +6622,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -7021,9 +7107,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -7297,7 +7383,7 @@ checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem",
+ "pem 3.0.6",
  "ring",
  "serde",
  "serde_json",
@@ -7389,6 +7475,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "learning_mode_core"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "same-file",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "learning_mode_windows"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "learning_mode_core",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "wxc_common",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7421,9 +7533,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.20"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "bitflags 2.13.1",
  "libc",
@@ -7571,9 +7683,9 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.18.2"
+version = "0.18.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
 dependencies = [
  "hashbrown 0.17.1",
 ]
@@ -7729,10 +7841,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "mio"
-version = "1.2.2"
+name = "miniz_oxide"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -7787,6 +7909,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "mxc_config_contract"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "mxc_telemetry"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "tracelogging",
+ "uuid",
 ]
 
 [[package]]
@@ -8447,7 +8588,7 @@ dependencies = [
  "either",
  "erased-serde 0.4.10",
  "fancy-regex",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "inventory",
  "num-bigint",
  "once_cell",
@@ -8546,6 +8687,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8577,7 +8728,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
 ]
 
 [[package]]
@@ -8655,7 +8806,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -8728,7 +8879,7 @@ dependencies = [
  "shared_library",
  "shell-words",
  "winapi",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -8837,11 +8988,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
 dependencies = [
  "futures",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "nix 0.31.3",
  "tokio",
  "tracing",
  "windows 0.62.2",
+]
+
+[[package]]
+name = "process_security_environment_spec"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "flatbuffers",
 ]
 
 [[package]]
@@ -8985,9 +9144,9 @@ checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
 
 [[package]]
 name = "psl"
-version = "2.1.226"
+version = "2.1.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc88482eea924ca3a2f56a547454169af58deef35567965eb4fc2392a834841"
+checksum = "158b8294dde3909df5a4ec68a35f8c39720151834b1f87050b87b37435150011"
 dependencies = [
  "psl-types",
 ]
@@ -9259,7 +9418,7 @@ dependencies = [
  "futures-channel",
  "httparse",
  "httpdate",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "parking_lot",
  "pin-project-lite",
@@ -9486,7 +9645,7 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.1",
+ "chacha20 0.10.2",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
@@ -9575,12 +9734,12 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.14.9"
+version = "0.14.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091e7a8e7d86e6feb87a27ce8e2cba29d49eff9507afeebefab7eeb2ca667fb4"
+checksum = "8774e05a7d0de114588e6a28fe7e71694b82614ed569d86d8b389dfbc98b8ad8"
 dependencies = [
  "aws-lc-rs",
- "pem",
+ "pem 4.0.0",
  "rustls-pki-types",
  "time",
  "x509-parser",
@@ -9821,7 +9980,7 @@ dependencies = [
  "http 1.5.0",
  "http-body 1.1.0",
  "http-body-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "oauth2",
  "pastey",
  "pin-project-lite",
@@ -9845,9 +10004,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "3.1.4"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a85d45508e9b4ba024fe996c2638799635d75b6dd0ba8f32ccf08f8026f0c780"
+checksum = "cdf1c49bd4d52014b94db0877410db273c2008f01628b0252a2e9460ad9b7fda"
 dependencies = [
  "darling 0.24.1",
  "proc-macro2",
@@ -10063,6 +10222,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "sandbox_spec"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "flatbuffers",
 ]
 
 [[package]]
@@ -10500,7 +10667,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acf96b1d9364968fce46ebb548f1c0e1d7eceae27bdff73865d42e6c7369d94"
 dependencies = [
  "form_urlencoded",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde_core",
@@ -10522,7 +10689,7 @@ version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "memchr",
  "serde",
@@ -10584,7 +10751,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "jiff",
  "schemars 0.9.0",
  "schemars 1.2.2",
@@ -10612,7 +10779,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "itoa",
  "ryu",
  "serde",
@@ -10648,7 +10815,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -10686,7 +10853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -10805,9 +10972,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -10894,7 +11061,7 @@ dependencies = [
  "futures-util",
  "hashbrown 0.16.1",
  "hashlink",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "log",
  "memchr",
  "percent-encoding",
@@ -11048,9 +11215,9 @@ dependencies = [
 
 [[package]]
 name = "sse-stream"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c123f296ade4ec4b8b0f6162116e6629f5146922ca5ab40ca9d3c2e73ab4761e"
+checksum = "c25ac7aff0abd1dbc474536e40416e1102c7dd9bfba0b9861c6d357f835dcfb4"
 dependencies = [
  "bytes",
  "futures-util",
@@ -11085,7 +11252,7 @@ dependencies = [
  "either",
  "erased-serde 0.3.31",
  "hashbrown 0.16.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "inventory",
  "itertools 0.14.0",
  "maplit",
@@ -11729,9 +11896,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+checksum = "4cf0ded5c4e56918d8f8a339e1bb67d038d3bc6d144ac407904015ba2e4cde9b"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -11883,7 +12050,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "serde_core",
  "serde_spanned",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -11916,7 +12083,7 @@ version = "0.24.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01f2eadbbc6b377a847be05f60791ef1058d9f696ecb51d2c07fe911d8569d8e"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 0.7.5+spec-1.1.0",
  "toml_parser",
  "toml_writer",
@@ -11929,7 +12096,7 @@ version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.4",
@@ -12028,7 +12195,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -12068,6 +12235,21 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracelogging"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4314470f3f54b29d582ff6776fceb7c819b023141828d559f19c790cee40e94"
+dependencies = [
+ "tracelogging_macros",
+]
+
+[[package]]
+name = "tracelogging_macros"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95e2d891464ff33bc1814c4cbbb251bae7800458b1efdb6ac8b7c01ee6382563"
 
 [[package]]
 name = "tracing"
@@ -12186,9 +12368,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-language"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+checksum = "ca0d1bf6fdd806e43ae5198f82f527056d359def39e54e67a0f478ac09dac081"
 
 [[package]]
 name = "tree-sitter-powershell"
@@ -12361,6 +12543,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12501,9 +12689,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.25.0"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f053576934f05a761a402421fbbe3d425d9366f75f978806a037b3ca481abecc"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -12523,7 +12711,7 @@ dependencies = [
  "fslock",
  "gzip-header",
  "home",
- "miniz_oxide",
+ "miniz_oxide 0.8.9",
  "paste",
  "temporal_capi",
  "which 6.0.3",
@@ -13202,6 +13390,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13218,6 +13416,30 @@ name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "wxc_common"
+version = "0.8.0"
+source = "git+https://github.com/microsoft/mxc?rev=6cd3d58f05d3447e67109cfb75e042803b843ca4#6cd3d58f05d3447e67109cfb75e042803b843ca4"
+dependencies = [
+ "base64 0.22.1",
+ "cidr",
+ "getrandom 0.2.17",
+ "libc",
+ "mxc_config_contract",
+ "mxc_telemetry",
+ "semver",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "thiserror 2.0.20",
+ "unicode-general-category",
+ "url",
+ "widestring",
+ "windows 0.62.2",
+ "windows-core 0.62.2",
+ "winreg 0.55.0",
+]
 
 [[package]]
 name = "x25519-dalek"
@@ -13483,7 +13705,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac 0.12.1",
- "indexmap 2.14.0",
+ "indexmap 2.14.1",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -25,26 +25,26 @@ path = "src/lib.rs"
 agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
 anyhow = "1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-rollout = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
-codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.150.0" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-rollout = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
 allocative = "=0.3.6"
 diffy = { version = "0.5.0", features = ["std"] }
 itertools = "0.14.0"

--- a/vendor/codex-acp/README.md
+++ b/vendor/codex-acp/README.md
@@ -27,7 +27,7 @@ Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
 
 ## NeverWrite compatibility boundary
 
-NeverWrite's vendored build keeps the ACP Rust SDK at `0.14.0` and the wire protocol at ACP v1 while running the OpenAI Codex `rust-v0.147.0` crates.
+NeverWrite's vendored build keeps the ACP Rust SDK at `0.14.0` and the wire protocol at ACP v1 while running the OpenAI Codex `rust-v0.153.2` crates.
 
 MCP protocol `2026-07-28` remains disabled for this adapter because ACP `0.14.0` does not provide the trusted client-extension boundary required to adopt it; client-provided stdio environment variables, HTTP headers, working directories, and existing server authentication or approval configuration remain supported through the legacy MCP path.
 

--- a/vendor/codex-acp/src/subagents.rs
+++ b/vendor/codex-acp/src/subagents.rs
@@ -1226,6 +1226,7 @@ mod tests {
             approval_policy: AskForApproval::OnRequest,
             approvals_reviewer: ApprovalsReviewer::default(),
             permission_profile: PermissionProfile::default(),
+            full_access: false,
             active_permission_profile: None,
             environments: TurnEnvironmentSelections::new(cwd, Vec::new()),
             workspace_roots: Vec::new(),

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -699,6 +699,7 @@ fn elicitation_request_message(request: &ElicitationRequest) -> &str {
     match request {
         ElicitationRequest::Form { message, .. }
         | ElicitationRequest::OpenAiForm { message, .. }
+        | ElicitationRequest::OpenAiElicitationForm { message, .. }
         | ElicitationRequest::Url { message, .. } => message,
     }
 }
@@ -1154,6 +1155,7 @@ fn format_thread_goal_update(event: &ThreadGoalUpdatedEvent) -> String {
 fn turn_item_id(item: &TurnItem) -> &str {
     match item {
         TurnItem::UserMessage(item) => &item.id,
+        TurnItem::FunctionCallOutput(item) => &item.id,
         TurnItem::HookPrompt(item) => &item.id,
         TurnItem::AgentMessage(item) => &item.id,
         TurnItem::Plan(item) => &item.id,
@@ -1195,9 +1197,10 @@ struct StatusToolCall {
 
 fn turn_item_projection(item: &TurnItem) -> TurnItemProjection {
     match item {
-        TurnItem::UserMessage(..) | TurnItem::AgentMessage(..) | TurnItem::Reasoning(..) => {
-            TurnItemProjection::Hidden
-        }
+        TurnItem::UserMessage(..)
+        | TurnItem::FunctionCallOutput(..)
+        | TurnItem::AgentMessage(..)
+        | TurnItem::Reasoning(..) => TurnItemProjection::Hidden,
         TurnItem::Plan(..)
         | TurnItem::ImageGeneration(..)
         | TurnItem::Extension(ExtensionItem::ImageGeneration(..))
@@ -1234,6 +1237,7 @@ fn turn_item_tool_kind(item: &TurnItem) -> ToolKind {
         | TurnItem::HookPrompt(..)
         | TurnItem::ContextCompaction(..)
         | TurnItem::UserMessage(..)
+        | TurnItem::FunctionCallOutput(..)
         | TurnItem::AgentMessage(..)
         | TurnItem::Plan(..)
         | TurnItem::Reasoning(..)
@@ -1368,6 +1372,7 @@ fn canonical_update_can_materialize(update: &ToolCallUpdate) -> bool {
 fn describe_turn_item(item: &TurnItem) -> (&'static str, Option<String>) {
     match item {
         TurnItem::UserMessage(..) => ("Preparing input", None),
+        TurnItem::FunctionCallOutput(..) => ("Processing tool output", None),
         TurnItem::HookPrompt(..) => ("Awaiting hook guidance", None),
         TurnItem::AgentMessage(..) => ("Drafting response", None),
         TurnItem::Plan(item) => ("Updating plan", Some(item.text.clone())),
@@ -2569,6 +2574,36 @@ impl PromptState {
                 })
                 .await;
             }
+            EventMsg::AuthRecoveryStarted(event) => {
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!(
+                        "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}auth_recovery:{}",
+                        event.provider
+                    )
+                    .into(),
+                    kind: "auth_recovery",
+                    title: format!("Reconnecting {}", event.provider),
+                    detail: Some(event.message),
+                    emphasis: "neutral",
+                    status: ToolCallStatus::InProgress,
+                })
+                .await;
+            }
+            EventMsg::AuthRecoveryCompleted(event) => {
+                self.send_status_tool_call(client, StatusToolCall {
+                    call_id: format!(
+                        "{NEVERWRITE_STATUS_EVENT_ID_PREFIX}auth_recovery:{}",
+                        event.provider
+                    )
+                    .into(),
+                    kind: "auth_recovery",
+                    title: format!("Reconnected {}", event.provider),
+                    detail: Some(event.message),
+                    emphasis: "success",
+                    status: ToolCallStatus::Completed,
+                })
+                .await;
+            }
             EventMsg::TokenCount(TokenCountEvent { info, .. }) => {
                 if let Some(info) = info
                     && let Some(size) = info.model_context_window {
@@ -2991,13 +3026,20 @@ impl PromptState {
             EventMsg::Error(ErrorEvent {
                 message,
                 codex_error_info,
+                misalignment,
             }) => {
-                error!("Unhandled error during turn: {message} {codex_error_info:?}");
+                error!(
+                    "Unhandled error during turn: {message} {codex_error_info:?} {misalignment:?}"
+                );
                 self.detach_pending_interactions();
                 if let Some(response_tx) = self.response_tx.take() {
                     response_tx
                         .send(Err(Error::internal_error().data(
-                            json!({ "message": message, "codex_error_info": codex_error_info }),
+                            json!({
+                                "message": message,
+                                "codex_error_info": codex_error_info,
+                                "misalignment": misalignment,
+                            }),
                         )))
                         .ok();
                 }
@@ -3274,6 +3316,7 @@ impl PromptState {
             ElicitationRequest::Form { .. } => "form",
             ElicitationRequest::Url { .. } => "url",
             ElicitationRequest::OpenAiForm { .. } => "openai_form",
+            ElicitationRequest::OpenAiElicitationForm { .. } => "openai_elicitation_form",
         };
 
         info!(
@@ -3777,7 +3820,17 @@ impl PromptState {
             file_extension,
             locations,
             kind,
-        } = parse_command_tool_call(parsed_cmd, &cwd.to_path_buf());
+        } = parse_command_tool_call(
+            parsed_cmd,
+            cwd.to_inferred_abs_path()
+                .ok_or_else(|| {
+                    Error::invalid_params().data(json!({
+                        "message": "command approval cwd is not an absolute host-native path",
+                        "cwd": cwd.as_str(),
+                    }))
+                })?
+                .as_path(),
+        );
         self.active_commands.insert(
             call_id.clone(),
             ActiveCommand {
@@ -8827,6 +8880,7 @@ mod tests {
                     error: Some(ErrorEvent {
                         message: "The upstream response was rejected".to_string(),
                         codex_error_info: None,
+                        misalignment: None,
                     }),
                     started_at: Some(10),
                     completed_at: Some(11),
@@ -8995,6 +9049,7 @@ mod tests {
             EventMsg::RawResponseCompleted(codex_protocol::protocol::RawResponseCompletedEvent {
                 response_id: "response-1".to_string(),
                 token_usage: Some(TokenUsage::default()),
+                usage_metadata: None,
             }),
             EventMsg::EnvironmentConnected(codex_protocol::protocol::EnvironmentConnectionEvent {
                 environment_id: "environment-1".to_string(),
@@ -10174,7 +10229,7 @@ mod tests {
                         .iter()
                         .any(|effort| effort.effort == ReasoningEffort::Ultra)
             })
-            .expect("runtime 0.150 catalog should include max and ultra")
+            .expect("runtime 0.153.2 catalog should include max and ultra")
             .clone();
         let selected_model = preset.model.clone();
         let (actor, _client, _conversation) = setup_actor(|config| {
@@ -10214,6 +10269,81 @@ mod tests {
                 .find(|effort| effort.value.0.as_ref() == "ultra")
                 .map(|effort| effort.name.as_str()),
             Some("Ultra")
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn config_options_respect_hidden_catalog_models() -> anyhow::Result<()> {
+        let presets = all_model_presets();
+        let astra = presets
+            .iter()
+            .find(|preset| preset.model == "gpt-6-astra")
+            .expect("runtime 0.153.2 catalog should include GPT-6 Astra");
+        assert!(!astra.show_in_picker, "Astra should remain hidden upstream");
+        let visible_model = presets
+            .iter()
+            .find(|preset| preset.show_in_picker && preset.model != astra.model)
+            .expect("catalog should include a visible model")
+            .model
+            .clone();
+        let (actor, _client, _conversation) = setup_actor(|config| {
+            config.model = Some(visible_model);
+        })
+        .await?;
+
+        let options = actor.config_options().await?;
+        let model = options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "model")
+            .expect("model option should be present");
+        let SessionConfigKind::Select(select) = &model.kind else {
+            panic!("model option should be a select");
+        };
+        let SessionConfigSelectOptions::Ungrouped(models) = &select.options else {
+            panic!("model options should be ungrouped");
+        };
+
+        assert!(
+            models
+                .iter()
+                .all(|model| model.value.0.as_ref() != astra.id.as_str()),
+            "hidden Astra must not appear without an account-visible catalog entry"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn config_options_preserve_an_explicit_hidden_model() -> anyhow::Result<()> {
+        let astra = all_model_presets()
+            .iter()
+            .find(|preset| preset.model == "gpt-6-astra")
+            .expect("runtime 0.153.2 catalog should include GPT-6 Astra")
+            .clone();
+        let selected_model = astra.model.clone();
+        let (actor, _client, _conversation) = setup_actor(|config| {
+            config.model = Some(selected_model);
+        })
+        .await?;
+
+        let options = actor.config_options().await?;
+        let model = options
+            .iter()
+            .find(|option| option.id.0.as_ref() == "model")
+            .expect("model option should be present");
+        let SessionConfigKind::Select(select) = &model.kind else {
+            panic!("model option should be a select");
+        };
+        let SessionConfigSelectOptions::Ungrouped(models) = &select.options else {
+            panic!("model options should be ungrouped");
+        };
+
+        assert_eq!(select.current_value.0.as_ref(), astra.model.as_str());
+        assert!(
+            models
+                .iter()
+                .any(|model| model.value.0.as_ref() == astra.id.as_str()),
+            "an explicitly selected hidden model must remain selectable"
         );
         Ok(())
     }
@@ -10902,6 +11032,7 @@ mod tests {
             .clone()
             .expect("test configuration must select a model");
         EventMsg::ThreadSettingsApplied(ThreadSettingsAppliedEvent {
+            thread_id: None,
             thread_settings: ThreadSettingsSnapshot {
                 model: model.clone(),
                 model_provider_id: config.model_provider_id.clone(),
@@ -11308,6 +11439,7 @@ mod tests {
                                         phase: None,
                                         memory_citation: None,
                                         delivery: None,
+                                        questions: None,
                                     }),
                                 })
                                 .unwrap();
@@ -11348,6 +11480,7 @@ mod tests {
                                     phase: None,
                                     memory_citation: None,
                                     delivery: None,
+                                    questions: None,
                                 }),
                             })
                             .unwrap();

--- a/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
+++ b/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 license = "Apache-2.0"
 name = "codex-utils-pty"
-version = "0.150.0"
+version = "0.153.2"
 
 [dependencies]
 anyhow = "1"

--- a/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
+++ b/vendor/codex-acp/vendor/codex-utils-pty/src/pipe.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::io;
 use std::io::ErrorKind;
 use std::path::Path;
@@ -131,7 +132,7 @@ enum PipeStdinMode {
 /// On Windows, process-tree containment is best-effort because Tokio returns
 /// only after the root process starts, so job assignment cannot be atomic.
 async fn spawn_process_with_stdin_mode(
-    program: &str,
+    program: &OsStr,
     args: &[String],
     cwd: &Path,
     env: &HashMap<String, String>,
@@ -325,9 +326,9 @@ async fn spawn_process_with_stdin_mode(
 }
 
 /// Spawn a process using regular pipes and preserve selected inherited file
-/// descriptors across exec on Unix.
+/// descriptors across exec on Unix. The executable path retains its native encoding.
 pub async fn spawn_process(
-    program: &str,
+    program: impl AsRef<OsStr>,
     args: &[String],
     cwd: &Path,
     env: &HashMap<String, String>,
@@ -335,7 +336,7 @@ pub async fn spawn_process(
     inherited_fds: &[i32],
 ) -> Result<SpawnedProcess> {
     spawn_process_with_stdin_mode(
-        program,
+        program.as_ref(),
         args,
         cwd,
         env,
@@ -347,9 +348,10 @@ pub async fn spawn_process(
 }
 
 /// Spawn a process using regular pipes, close stdin immediately, and preserve
-/// selected inherited file descriptors across exec on Unix.
+/// selected inherited file descriptors across exec on Unix. The executable path
+/// retains its native encoding.
 pub async fn spawn_process_no_stdin(
-    program: &str,
+    program: impl AsRef<OsStr>,
     args: &[String],
     cwd: &Path,
     env: &HashMap<String, String>,
@@ -357,7 +359,7 @@ pub async fn spawn_process_no_stdin(
     inherited_fds: &[i32],
 ) -> Result<SpawnedProcess> {
     spawn_process_with_stdin_mode(
-        program,
+        program.as_ref(),
         args,
         cwd,
         env,


### PR DESCRIPTION
## Summary

- update the vendored OpenAI runtime from `rust-v0.150.0` to `rust-v0.153.2`
- adapt the ACP bridge to the new protocol events, metadata, and native path APIs
- keep upstream model visibility authoritative while allowing controlled explicit model IDs for the Codex provider
- align sidecar baseline validation, documentation, and regression coverage with the new runtime

## Early-access model selection

Models that remain hidden by the upstream catalog, such as GPT-6 Astra during its early-access rollout, are not shown automatically. Users with account access can select them by entering the exact model ID in the provider/model search. Once upstream marks the model as visible, it will appear normally without requiring explicit selection.

## Validation

- `cargo check --locked` passed with the pinned V8 environment
- all 104 ACP Rust tests passed, including the code-mode host smoke tests
- all 53 targeted renderer and staging tests passed
- `tsc -b --pretty false` passed
- scoped ESLint checks passed
- ARM64 debug and staged release binaries compiled successfully
- a hot NeverWrite session was verified running the newly staged ACP binary