### PR TITLE
Update embedded runtime to 0.153.4 and expose Astra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ### Changed
 
-- Updated the embedded Codex runtime to `0.153.2`, adding compatibility with the latest account-aware model catalog and GPT-6 Astra while preserving upstream model visibility rules.
+- Updated the embedded Codex runtime to `0.153.4`, making GPT-6 Astra visible and the default in the bundled fallback catalog while preserving account-provided catalogs and explicit model selections.
 
 ## [0.7.6] - 2026-09-02
 

--- a/apps/desktop/scripts/smoke-packaged-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-packaged-sidecar.mjs
@@ -553,6 +553,18 @@ async function runCodeModeTurn({
             );
         }
 
+        const modelOption = session.configOptions?.find(
+            (option) => option.id === "model",
+        );
+        if (
+            modelOption?.currentValue !== "test-gpt-5.1-codex" ||
+            !modelOption.options?.some((option) => option.value === "gpt-6-astra")
+        ) {
+            throw new Error(
+                "Packaged ACP must list bundled Astra and preserve the explicitly configured smoke model",
+            );
+        }
+
         const prompt = await client.request("session/prompt", {
             sessionId,
             prompt: [

--- a/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar-helpers.mjs
@@ -44,9 +44,9 @@ export const CODEX_RUNTIME_COMPONENTS = [
 ];
 
 export const CODEX_RUNTIME_BASELINE = Object.freeze({
-    tag: "rust-v0.153.2",
-    version: "0.153.2",
-    commit: "657a993cbee87acf52d14b758ce49dbd46d1b8eb",
+    tag: "rust-v0.153.4",
+    version: "0.153.4",
+    commit: "3d2ee51ca2d5db578f328aa75e20aa22c0197c9a",
     v8Version: "150.4.0",
 });
 

--- a/apps/desktop/scripts/stage-electron-sidecar.test.mjs
+++ b/apps/desktop/scripts/stage-electron-sidecar.test.mjs
@@ -133,9 +133,9 @@ test("rejects a mixed runtime source baseline before staging", () => {
                 adapterManifest:
                     '[dependencies]\ncodex-core = { tag = "rust-v0.149.0" }',
                 lockfile: "",
-                ptyManifest: '[package]\nversion = "0.153.2"',
+                ptyManifest: '[package]\nversion = "0.153.4"',
             }),
-        /must all use tag = "rust-v0\.153\.2"/,
+        /must all use tag = "rust-v0\.153\.4"/,
     );
 });
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -46,10 +46,10 @@ That means the directory is intentionally reproducible, but not yet minimal.
 - `codex-acp/`
   - upstream baseline: `zed-industries/codex-acp` `0.16.0`
   - synced against upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`
-  - OpenAI Codex Rust crates: `rust-v0.153.2` (`657a993cbee87acf52d14b758ce49dbd46d1b8eb`)
+  - OpenAI Codex Rust crates: `rust-v0.153.4` (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`)
   - vendor ACP SDK: `agent-client-protocol` `0.14.0`
   - ACP wire protocol: v1; ACP v2 is not enabled by this runtime promotion
-  - local `vendor/codex-utils-pty/` snapshot: `0.153.2`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
+  - local `vendor/codex-utils-pty/` snapshot: `0.153.4`, with the matching `[patch."https://github.com/openai/codex"]` entry and a standalone local manifest
   - resolved V8 crate: `150.4.0`, built with OpenAI's verified `ptrcomp_sandbox_release` archive and source binding for the target
   - Rust toolchain: NeverWrite `1.96.0`; upstream Codex `1.95.0`
   - local NeverWrite delta remains intentionally bounded and currently lives in:
@@ -77,7 +77,7 @@ That means the directory is intentionally reproducible, but not yet minimal.
 
 ## Current Codex Delta
 
-The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.153.2`, resolved to `657a993cbee87acf52d14b758ce49dbd46d1b8eb` in `Cargo.lock`.
+The Codex vendor is no longer a raw upstream checkout. Its runtime compatibility baseline is OpenAI Codex `rust-v0.153.4`, resolved to `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a` in `Cargo.lock`.
 
 The remaining NeverWrite-specific delta exists to preserve desktop product behavior:
 
@@ -97,11 +97,11 @@ The remaining NeverWrite-specific delta exists to preserve desktop product behav
 - a private `codexAcp*` subagent contract for session creation, navigable activity breadcrumbs, child lifecycle, and receiver-owned inter-agent transcripts
 - per-turn coalescing of equivalent subagent waits; only fully terminal status sets complete the ACP activity
 - localized `StartThreadOptions`, shared models-manager, external code-mode provider, config, auth, MCP, permission, and thread-store adapters at the ACP boundary
-- a local `codex-utils-pty` `0.153.2` snapshot with its standalone manifest, native executable-path encoding, upstream Unix process-group fallback, Windows Job Object and ConPTY path handling, and the upstream platform tests
+- a local `codex-utils-pty` `0.153.4` snapshot with its standalone manifest, native executable-path encoding, upstream Unix process-group fallback, Windows Job Object and ConPTY path handling, and the upstream platform tests
 
-The 0.153.2 turn-input boundary uses `TurnInputRequest` with `StartIfIdle` and consumes the runtime acknowledgement before registering the ACP prompt. `NotSubmitted` and an impossible `Steered` acknowledgement resolve as ACP errors instead of leaving a response pending.
+The runtime turn-input boundary uses `TurnInputRequest` with `StartIfIdle` and consumes the runtime acknowledgement before registering the ACP prompt. `NotSubmitted` and an impossible `Steered` acknowledgement resolve as ACP errors instead of leaving a response pending.
 
-The 0.153.2 event delta is handled as localized projections. Authentication recovery is visible as status activity, misalignment details survive the ACP error boundary, unsupported OpenAI elicitation forms fail closed, MCP policy amendments are exposed only when offered, Guardian stdin reviews redact the input payload, image failures retain their reason, standalone function outputs do not invent a call identity, and `ThreadQueueChanged` stays diagnostic because NeverWrite owns the user-facing queue.
+The runtime event delta is handled as localized projections. Authentication recovery is visible as status activity, misalignment details survive the ACP error boundary, unsupported OpenAI elicitation forms fail closed, MCP policy amendments are exposed only when offered, Guardian stdin reviews redact the input payload, image failures retain their reason, standalone function outputs do not invent a call identity, and `ThreadQueueChanged` stays diagnostic because NeverWrite owns the user-facing queue.
 
 `SubAgentActivity` is projected through the same canonical activity identity as its `TurnItem` fallback: matching protocol IDs update one ACP tool call, while distinct IDs remain separate rather than being correlated by descriptive metadata. `SendMessage`, `FollowupTask`, `InterruptAgent`, `ListAgents`, and `Completed` preserve their runtime IDs and terminal semantics. Child `ThreadId` values remain authoritative; paths, nicknames, and roles are display metadata only.
 
@@ -109,7 +109,7 @@ Reasoning options come from each runtime model preset. `max`, `ultra`, and futur
 
 The desktop release pipeline packages `codex-acp` and `codex-code-mode-host` as one runtime unit for macOS universal, Windows x64/ARM64, and Linux x64/ARM64. Each release build is lockfile-pinned, target-architecture checked, and signed together. Its packaged smoke drives an ACP `initialize`, `session/new`, and `session/prompt` exchange through the standalone host with a deterministic local Responses mock, verifies both the tool completion and assistant response, and proves a missing sibling host fails closed.
 
-When updating Codex again, treat upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`, OpenAI Codex tag `rust-v0.153.2` at `657a993cbee87acf52d14b758ce49dbd46d1b8eb`, the local PTY `0.153.2` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
+When updating Codex again, treat upstream adapter commit `bb590500e8646f6daf879b8b3c6a659fbd29017d`, OpenAI Codex tag `rust-v0.153.4` at `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`, the local PTY `0.153.4` snapshot, V8 `150.4.0`, and the committed lockfile as one comparison base. Review the bounded delta file by file instead of replacing the vendor tree.
 
 Canonical compatibility checks:
 
@@ -120,9 +120,9 @@ node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo check --lock
 node scripts/run-with-codex-v8.mjs --target "$HOST_TARGET" -- cargo test --locked --manifest-path ../../vendor/codex-acp/Cargo.toml
 ```
 
-## Codex 0.153.2 Compatibility Baseline
+## Codex 0.153.4 Compatibility Baseline
 
-The embedded runtime is pinned to OpenAI Codex `rust-v0.153.2`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `657a993cbee87acf52d14b758ce49dbd46d1b8eb`. The local `codex-utils-pty` snapshot is also `0.153.2`; it is part of the same runtime baseline, not an independently updatable crate.
+The embedded runtime is pinned to OpenAI Codex `rust-v0.153.4`. Every Codex git dependency in `codex-acp/Cargo.toml` uses that tag, and `Cargo.lock` resolves it to `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`. The local `codex-utils-pty` snapshot is also `0.153.4`; it is part of the same runtime baseline, not an independently updatable crate.
 
 The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolchain.toml`, which is compatible with the upstream Codex `1.95.0` toolchain. This promotion deliberately does not change these protocol boundaries:
 
@@ -131,9 +131,17 @@ The vendor toolchain inherits Rust `1.96.0` from the repository-root `rust-toolc
 - the adapter remains on ACP wire protocol v1; `unstable_protocol_v2` is not enabled
 - the desktop native backend remains `agent-client-protocol` `1.2.0`, which it communicates through the serialized ACP protocol rather than a shared Rust crate boundary
 
+### Changes from 0.153.2
+
+The 0.153.4 hotfix makes `gpt-6-astra` visible in the bundled catalog; its existing priority also makes it the bundled default when no model is explicitly configured. Astra's bundled instructions now name the asynchronous question tool correctly and qualify its use by tool availability. The upstream Bedrock catalog also gains Astra, but NeverWrite's Bedrock onboarding remains deferred.
+
+The model-manager implementation, cache policy, and main protocol definitions are unchanged from 0.153.2. Catalog discovery still uses `OnlineIfUncached`; cache entries expire after five minutes and must match the runtime version. No cache deletion or local visibility override is needed. With ChatGPT authentication, a valid remote catalog remains authoritative for model availability and defaults.
+
+The local hidden-model tests use a controlled catalog independent of upstream model names. Separate coverage verifies bundled Astra visibility, the upstream bundled default, and preservation of an explicit model. The upstream PTY source is identical to 0.153.2; the existing local Windows `winapi::ctypes::c_void` compatibility adjustments are retained, and only the standalone package version changes to align the runtime unit. V8 and all non-Codex lockfile dependency versions remain unchanged.
+
 ### Lockfile and V8 provisioning
 
-The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, `rama-macros`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.153.2 dependency graph. A broad lockfile regeneration can select stable Rama packages next to prerelease peers and produce an incompatible graph, so future promotions must compare this family with the candidate tag and update it as a coordinated set.
+The committed `Cargo.lock` is part of the runtime pin. In particular, `rama-core`, `rama-error`, `rama-macros`, and `rama-utils` must remain coordinated at `0.3.0-alpha.4`, matching the upstream 0.153.4 dependency graph. A broad lockfile regeneration can select stable Rama packages next to prerelease peers and produce an incompatible graph, so future promotions must compare this family with the candidate tag and update it as a coordinated set.
 
 The lockfile resolves `v8 150.4.0`. `apps/desktop/scripts/codex-v8-artifacts.mjs` obtains the target-specific `ptrcomp_sandbox_release` archive, source binding, and SHA-256 manifest from the official `openai/codex` release `rusty-v8-v150.4.0`. It authenticates the downloaded or cached manifest against the target-specific digest pinned in `apps/desktop/scripts/codex-v8-manifest-pins.mjs` before downloading archives or bindings, requires the manifest to cover exactly both artifacts, verifies their checksums before use, and caches the verified set under `apps/desktop/.cache/codex-v8/<version>/<profile>/<target>/`.
 
@@ -145,7 +153,7 @@ Local builds may provide `RUSTY_V8_ARCHIVE` and `RUSTY_V8_SRC_BINDING_PATH` only
 - MCP persistent approval, Guardian `WriteStdin`, image-generation failures, optional function-call IDs, `PathUri`, and runtime queue notifications have explicit safe projections.
 - Collaboration tools `SendMessage`, `FollowupTask`, `InterruptAgent`, and `ListAgents` preserve runtime activity identity. `SubAgentActivityKind::Completed` terminalizes that identity once, while internal agent messages remain outside the parent transcript.
 - Reasoning efforts are catalog-driven, including `max`, `ultra`, and future custom values. Load, resume, fork, and model changes retain an effort only when the selected model supports it.
-- The normal model picker follows the authenticated remote catalog and its visibility flags. GPT-6 Astra remains hidden unless the account catalog exposes it or the user enters its exact model ID through the Codex-only advanced selection path.
+- The normal model picker follows the authenticated remote catalog and its visibility flags. The bundled fallback catalog lists GPT-6 Astra and selects it by default when no model is configured. A valid ChatGPT account catalog remains authoritative, and explicit model selections survive the default change. The Codex-only exact model-ID path remains available for unlisted models.
 - `TurnItem::Extension(ExtensionItem::Sleep(...))` is projected as the canonical `Waiting` activity and keeps stable item identity across live events and replay.
 - `ItemCompleted.started_at_ms` is propagated into activity metadata when positive so restored activities keep their upstream start time. Turn-level `started_at` fields are accepted but do not invent a second timeline contract.
 - `TurnComplete.error` emits a visible failed `turn_error` status and fails the pending ACP prompt instead of reporting `EndTurn`; aborts remain cancelled and keep their lifecycle event.
@@ -174,7 +182,7 @@ Portable plugins, thread sections/pinning, side conversations, audio/realtime, e
 | Linux x64 | Yes | — |
 | Linux ARM64 | No, because it is cross-compiled | Packaging, sidecar staging, and architecture checks run without executing the foreign binary |
 
-The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.153.2 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
+The smoke uses a temporary `CODEX_HOME`, a local deterministic Responses mock, and the 0.153.4 install-context layout where the packaged host is a sibling of `codex-acp`. It asserts a real ACP turn reaches both a code-mode tool completion and a final assistant response, and it inspects the ACP process tree to prove the packaged standalone host was launched rather than an in-process fallback.
 
 The same smoke starts an isolated copy of `codex-acp` without its sibling host and requires the code-mode tool to fail closed with the missing host path in its diagnostic. It does not require credentials or a network service.
 
@@ -182,7 +190,7 @@ The same smoke starts an isolated copy of `codex-acp` without its sibling host a
 
 #### Rollback baseline
 
-The rollback baseline is OpenAI Codex `rust-v0.150.0` at `3b3b4f8fb3f6403e72c2d0533ed0d2f309c59717`, local PTY `0.150.0`, V8 `150.4.0`, and the lockfile recorded before this promotion. A rollback must restore `vendor/codex-acp/Cargo.toml`, `vendor/codex-acp/Cargo.lock`, `vendor/codex-acp/vendor/codex-utils-pty/`, and the adapter changes that depend exclusively on 0.153.2 types as one reviewed unit. V8 remains `150.4.0` on both sides of the rollback; never roll back a single Codex crate, PTY snapshot, or lockfile independently.
+The rollback baseline is OpenAI Codex `rust-v0.153.2` at `657a993cbee87acf52d14b758ce49dbd46d1b8eb`, local PTY `0.153.2`, V8 `150.4.0`, and the lockfile recorded before this promotion in NeverWrite commit `74fe2a094abc00572900097e78f53806f4108c5e`. A rollback must restore the Codex manifest, lockfile, PTY version, staging baseline and fixtures, catalog tests, and baseline documentation together, then rebuild and stage both `codex-acp` and `codex-code-mode-host`. V8 remains `150.4.0` on both sides; never roll back a single Codex crate, binary, PTY snapshot, or lockfile independently.
 
 The desktop backend supports a mixed ACP world: current ACP integration for Claude, Codex, Kilo, and OpenCode, plus the vendored `agent-client-protocol-legacy` crates for Grok. The native backend tests cover the reconstructed diff, permission, status metadata, and legacy runtime compatibility paths that NeverWrite depends on.
 

--- a/vendor/codex-acp/Cargo.lock
+++ b/vendor/codex-acp/Cargo.lock
@@ -1866,8 +1866,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-graph-store"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "codex-state",
@@ -1877,8 +1877,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-identity"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -1897,8 +1897,8 @@ dependencies = [
 
 [[package]]
 name = "codex-agent-roles"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-config",
  "codex-file-system",
@@ -1911,8 +1911,8 @@ dependencies = [
 
 [[package]]
 name = "codex-analytics"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-app-server-protocol",
  "codex-git-utils",
@@ -1931,8 +1931,8 @@ dependencies = [
 
 [[package]]
 name = "codex-api"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "async-channel",
  "base64 0.22.1",
@@ -1962,8 +1962,8 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-app-server-protocol-noop-macros",
@@ -1991,13 +1991,13 @@ dependencies = [
 
 [[package]]
 name = "codex-app-server-protocol-noop-macros"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 
 [[package]]
 name = "codex-apply-patch"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-exec-server",
@@ -2012,8 +2012,8 @@ dependencies = [
 
 [[package]]
 name = "codex-arg0"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-apply-patch",
@@ -2034,8 +2034,8 @@ dependencies = [
 
 [[package]]
 name = "codex-async-utils"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "tokio",
  "tokio-util",
@@ -2043,8 +2043,8 @@ dependencies = [
 
 [[package]]
 name = "codex-aws-auth"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "aws-config",
  "aws-credential-types",
@@ -2057,8 +2057,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-client"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-api",
@@ -2075,8 +2075,8 @@ dependencies = [
 
 [[package]]
 name = "codex-backend-openapi-models"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "serde",
  "serde_json",
@@ -2085,8 +2085,8 @@ dependencies = [
 
 [[package]]
 name = "codex-client"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-http-client",
  "eventsource-stream",
@@ -2099,8 +2099,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-code-mode-protocol",
  "codex-http-client",
@@ -2122,8 +2122,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-host"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "axum",
@@ -2147,8 +2147,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-protocol"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "glob",
@@ -2165,8 +2165,8 @@ dependencies = [
 
 [[package]]
 name = "codex-code-mode-runtime"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-code-mode-protocol",
@@ -2183,13 +2183,13 @@ dependencies = [
 
 [[package]]
 name = "codex-collaboration-mode-templates"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 
 [[package]]
 name = "codex-config"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2234,8 +2234,8 @@ dependencies = [
 
 [[package]]
 name = "codex-connectors"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2256,8 +2256,8 @@ dependencies = [
 
 [[package]]
 name = "codex-context-fragments"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -2265,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2374,8 +2374,8 @@ dependencies = [
 
 [[package]]
 name = "codex-core-plugins"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2425,16 +2425,16 @@ dependencies = [
 
 [[package]]
 name = "codex-diagnostics"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-exec-server"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "arc-swap",
  "axum",
@@ -2478,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "codex-exec-server-protocol"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-file-system",
@@ -2493,8 +2493,8 @@ dependencies = [
 
 [[package]]
 name = "codex-execpolicy"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "clap",
@@ -2511,8 +2511,8 @@ dependencies = [
 
 [[package]]
 name = "codex-experimental-api-macros"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2521,8 +2521,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-api"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-config",
  "codex-context-fragments",
@@ -2537,8 +2537,8 @@ dependencies = [
 
 [[package]]
 name = "codex-extension-items"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-utils-absolute-path",
  "schemars 0.8.22",
@@ -2549,8 +2549,8 @@ dependencies = [
 
 [[package]]
 name = "codex-features"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-otel",
  "codex-protocol",
@@ -2562,8 +2562,8 @@ dependencies = [
 
 [[package]]
 name = "codex-feedback"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2582,8 +2582,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-search"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "clap",
@@ -2597,8 +2597,8 @@ dependencies = [
 
 [[package]]
 name = "codex-file-system"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "bytes",
  "codex-protocol",
@@ -2610,8 +2610,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-attribution"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-backend-client",
  "codex-extension-api",
@@ -2623,8 +2623,8 @@ dependencies = [
 
 [[package]]
 name = "codex-git-utils"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2649,8 +2649,8 @@ dependencies = [
 
 [[package]]
 name = "codex-guardian-context"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "serde_json",
@@ -2658,8 +2658,8 @@ dependencies = [
 
 [[package]]
 name = "codex-history"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "schemars 0.8.22",
@@ -2668,8 +2668,8 @@ dependencies = [
 
 [[package]]
 name = "codex-home"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-extension-api",
  "codex-utils-absolute-path",
@@ -2678,8 +2678,8 @@ dependencies = [
 
 [[package]]
 name = "codex-hooks"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -2703,8 +2703,8 @@ dependencies = [
 
 [[package]]
 name = "codex-http-client"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "bytes",
  "codex-utils-rustls-provider",
@@ -2730,8 +2730,8 @@ dependencies = [
 
 [[package]]
 name = "codex-image-generation-extension"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -2756,8 +2756,8 @@ dependencies = [
 
 [[package]]
 name = "codex-install-context"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-utils-absolute-path",
  "codex-utils-home-dir",
@@ -2768,8 +2768,8 @@ dependencies = [
 
 [[package]]
 name = "codex-keyring-store"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "keyring",
  "tracing",
@@ -2777,8 +2777,8 @@ dependencies = [
 
 [[package]]
 name = "codex-linux-sandbox"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "clap",
  "codex-install-context",
@@ -2800,8 +2800,8 @@ dependencies = [
 
 [[package]]
 name = "codex-login"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2834,8 +2834,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2869,8 +2869,8 @@ dependencies = [
 
 [[package]]
 name = "codex-mcp-server"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-arg0",
@@ -2900,8 +2900,8 @@ dependencies = [
 
 [[package]]
 name = "codex-memories-read"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -2910,8 +2910,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-agent-identity",
  "codex-api",
@@ -2931,8 +2931,8 @@ dependencies = [
 
 [[package]]
 name = "codex-model-provider-info"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-api",
  "codex-protocol",
@@ -2944,8 +2944,8 @@ dependencies = [
 
 [[package]]
 name = "codex-models-manager"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "chrono",
  "codex-collaboration-mode-templates",
@@ -2963,8 +2963,8 @@ dependencies = [
 
 [[package]]
 name = "codex-network-proxy"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2999,8 +2999,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "chrono",
  "codex-api",
@@ -3030,8 +3030,8 @@ dependencies = [
 
 [[package]]
 name = "codex-otel-trace-websocket"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "axum",
@@ -3042,8 +3042,8 @@ dependencies = [
 
 [[package]]
 name = "codex-plugin"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-config",
  "codex-protocol",
@@ -3056,16 +3056,16 @@ dependencies = [
 
 [[package]]
 name = "codex-process-hardening"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "codex-prompts"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-context-fragments",
@@ -3078,8 +3078,8 @@ dependencies = [
 
 [[package]]
 name = "codex-protocol"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "chardetng",
  "chrono",
@@ -3120,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "codex-response-debug-context"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-api",
@@ -3131,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rmcp-client"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "axum",
@@ -3173,8 +3173,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3200,8 +3200,8 @@ dependencies = [
 
 [[package]]
 name = "codex-rollout-trace"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "codex-code-mode",
@@ -3215,8 +3215,8 @@ dependencies = [
 
 [[package]]
 name = "codex-sandboxing"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "appcontainer_common",
@@ -3241,8 +3241,8 @@ dependencies = [
 
 [[package]]
 name = "codex-secrets"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "age",
  "anyhow",
@@ -3260,8 +3260,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-command"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3281,8 +3281,8 @@ dependencies = [
 
 [[package]]
 name = "codex-shell-escalation"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "clap",
@@ -3300,8 +3300,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "codex-shell-command",
@@ -3317,8 +3317,8 @@ dependencies = [
 
 [[package]]
 name = "codex-skills-extension"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-analytics",
  "codex-config",
@@ -3347,8 +3347,8 @@ dependencies = [
 
 [[package]]
 name = "codex-state"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3369,16 +3369,16 @@ dependencies = [
 
 [[package]]
 name = "codex-terminal-detection"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "codex-thread-store"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "chrono",
  "codex-app-server-protocol",
@@ -3405,8 +3405,8 @@ dependencies = [
 
 [[package]]
 name = "codex-tools"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "bitflags 2.13.1",
  "codex-code-mode",
@@ -3429,8 +3429,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-absolute-path"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "dirs",
  "dunce",
@@ -3441,16 +3441,16 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-approval-presets"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
 ]
 
 [[package]]
 name = "codex-utils-audio"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-protocol",
@@ -3463,8 +3463,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cache"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "lru",
  "sha1 0.10.7",
@@ -3473,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-cli"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "clap",
  "codex-protocol",
@@ -3485,8 +3485,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-git-discovery"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-git-utils",
  "codex-utils-absolute-path",
@@ -3497,8 +3497,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-home-dir"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-utils-absolute-path",
  "dirs",
@@ -3506,8 +3506,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-image"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-cache",
@@ -3519,8 +3519,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-json-to-toml"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "serde_json",
  "toml 0.9.12+spec-1.1.0",
@@ -3528,8 +3528,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-output-truncation"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-protocol",
  "codex-utils-string",
@@ -3537,8 +3537,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-utils-absolute-path",
  "dunce",
@@ -3547,8 +3547,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-path-uri"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "base64 0.22.1",
  "codex-utils-absolute-path",
@@ -3562,8 +3562,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-plugins"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-exec-server",
  "codex-exec-server-protocol",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-pty"
-version = "0.153.2"
+version = "0.153.4"
 dependencies = [
  "anyhow",
  "filedescriptor",
@@ -3590,8 +3590,8 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-redacted-string"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "schemars 0.8.22",
  "serde",
@@ -3599,21 +3599,21 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-rustls-provider"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "rustls",
 ]
 
 [[package]]
 name = "codex-utils-stream-parser"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 
 [[package]]
 name = "codex-utils-string"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "regex-lite",
  "serde",
@@ -3622,13 +3622,13 @@ dependencies = [
 
 [[package]]
 name = "codex-utils-template"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 
 [[package]]
 name = "codex-websocket-client"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-http-client",
  "futures",
@@ -3641,8 +3641,8 @@ dependencies = [
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3667,8 +3667,8 @@ dependencies = [
 
 [[package]]
 name = "codex-workload-identity"
-version = "0.153.2"
-source = "git+https://github.com/openai/codex?tag=rust-v0.153.2#657a993cbee87acf52d14b758ce49dbd46d1b8eb"
+version = "0.153.4"
+source = "git+https://github.com/openai/codex?tag=rust-v0.153.4#3d2ee51ca2d5db578f328aa75e20aa22c0197c9a"
 dependencies = [
  "codex-http-client",
  "serde",

--- a/vendor/codex-acp/Cargo.toml
+++ b/vendor/codex-acp/Cargo.toml
@@ -25,26 +25,26 @@ path = "src/lib.rs"
 agent-client-protocol = { version = "=0.14.0", features = ["unstable"] }
 anyhow = "1"
 clap = "4"
-codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-rollout = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
-codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.153.2" }
+codex-apply-patch = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-arg0 = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-code-mode-host = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-config = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-core = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-exec-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-extension-api = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-extension-items = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-features = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-http-client = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-login = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-mcp-server = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-models-manager = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-protocol = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-rollout = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-shell-command = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-thread-store = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-utils-approval-presets = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-utils-cli = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
+codex-utils-path-uri = { git = "https://github.com/openai/codex", tag = "rust-v0.153.4" }
 allocative = "=0.3.6"
 diffy = { version = "0.5.0", features = ["std"] }
 itertools = "0.14.0"

--- a/vendor/codex-acp/README.md
+++ b/vendor/codex-acp/README.md
@@ -27,7 +27,7 @@ Learn more about the [Agent Client Protocol](https://agentclientprotocol.com/).
 
 ## NeverWrite compatibility boundary
 
-NeverWrite's vendored build keeps the ACP Rust SDK at `0.14.0` and the wire protocol at ACP v1 while running the OpenAI Codex `rust-v0.153.2` crates.
+NeverWrite's vendored build keeps the ACP Rust SDK at `0.14.0` and the wire protocol at ACP v1 while running the OpenAI Codex `rust-v0.153.4` crates.
 
 MCP protocol `2026-07-28` remains disabled for this adapter because ACP `0.14.0` does not provide the trusted client-extension boundary required to adopt it; client-provided stdio environment variables, HTTP headers, working directories, and existing server authentication or approval configuration remain supported through the legacy MCP path.
 

--- a/vendor/codex-acp/src/thread.rs
+++ b/vendor/codex-acp/src/thread.rs
@@ -9835,7 +9835,7 @@ mod tests {
         let session_client =
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
-        let models_manager = Arc::new(StubModelsManager);
+        let models_manager = Arc::new(StubModelsManager::default());
         let config = Config::load_with_cli_overrides_and_harness_overrides(
             vec![],
             ConfigOverrides::default(),
@@ -9934,7 +9934,7 @@ mod tests {
         let client = Arc::new(StubClient::new());
         let session_client = SessionClient::with_client(session_id, client, Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
-        let models_manager = Arc::new(StubModelsManager);
+        let models_manager = Arc::new(StubModelsManager::default());
         let config = Config::load_with_cli_overrides_and_harness_overrides(
             vec![],
             ConfigOverrides::default(),
@@ -10229,7 +10229,7 @@ mod tests {
                         .iter()
                         .any(|effort| effort.effort == ReasoningEffort::Ultra)
             })
-            .expect("runtime 0.153.2 catalog should include max and ultra")
+            .expect("runtime catalog should include max and ultra")
             .clone();
         let selected_model = preset.model.clone();
         let (actor, _client, _conversation) = setup_actor(|config| {
@@ -10274,21 +10274,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn config_options_respect_hidden_catalog_models() -> anyhow::Result<()> {
-        let presets = all_model_presets();
-        let astra = presets
+    async fn config_options_include_astra_from_bundled_catalog() -> anyhow::Result<()> {
+        let astra = all_model_presets()
             .iter()
             .find(|preset| preset.model == "gpt-6-astra")
-            .expect("runtime 0.153.2 catalog should include GPT-6 Astra");
-        assert!(!astra.show_in_picker, "Astra should remain hidden upstream");
-        let visible_model = presets
-            .iter()
-            .find(|preset| preset.show_in_picker && preset.model != astra.model)
-            .expect("catalog should include a visible model")
-            .model
+            .expect("runtime catalog should include GPT-6 Astra")
             .clone();
+        assert!(astra.show_in_picker, "bundled Astra should be visible");
+        assert_eq!(
+            codex_models_manager::test_support::get_model_offline_for_tests(None),
+            astra.model,
+            "Astra should be the bundled default without an explicit model"
+        );
+        assert_eq!(
+            codex_models_manager::test_support::get_model_offline_for_tests(Some("gpt-5.6-sol")),
+            "gpt-5.6-sol",
+            "the new default must not replace an explicit model"
+        );
         let (actor, _client, _conversation) = setup_actor(|config| {
-            config.model = Some(visible_model);
+            config.model = Some("gpt-5.6-sol".to_string());
         })
         .await?;
 
@@ -10296,55 +10300,67 @@ mod tests {
         let model = options
             .iter()
             .find(|option| option.id.0.as_ref() == "model")
-            .expect("model option should be present");
+            .unwrap();
         let SessionConfigKind::Select(select) = &model.kind else {
             panic!("model option should be a select");
         };
         let SessionConfigSelectOptions::Ungrouped(models) = &select.options else {
             panic!("model options should be ungrouped");
         };
-
+        assert_eq!(select.current_value.0.as_ref(), "gpt-5.6-sol");
         assert!(
             models
                 .iter()
-                .all(|model| model.value.0.as_ref() != astra.id.as_str()),
-            "hidden Astra must not appear without an account-visible catalog entry"
+                .any(|model| model.value.0.as_ref() == astra.id.as_str())
         );
         Ok(())
     }
 
     #[tokio::test]
-    async fn config_options_preserve_an_explicit_hidden_model() -> anyhow::Result<()> {
-        let astra = all_model_presets()
-            .iter()
-            .find(|preset| preset.model == "gpt-6-astra")
-            .expect("runtime 0.153.2 catalog should include GPT-6 Astra")
-            .clone();
-        let selected_model = astra.model.clone();
-        let (actor, _client, _conversation) = setup_actor(|config| {
-            config.model = Some(selected_model);
-        })
-        .await?;
+    async fn config_options_respect_hidden_catalog_models() -> anyhow::Result<()> {
+        // Use a controlled catalog so upstream model launches cannot weaken this contract.
+        let mut hidden = all_model_presets()[0].clone();
+        hidden.id = "test-hidden-model".to_string();
+        hidden.model = hidden.id.clone();
+        hidden.show_in_picker = false;
+        let mut visible = hidden.clone();
+        visible.id = "test-visible-model".to_string();
+        visible.model = visible.id.clone();
+        visible.show_in_picker = true;
 
-        let options = actor.config_options().await?;
-        let model = options
-            .iter()
-            .find(|option| option.id.0.as_ref() == "model")
-            .expect("model option should be present");
-        let SessionConfigKind::Select(select) = &model.kind else {
-            panic!("model option should be a select");
-        };
-        let SessionConfigSelectOptions::Ungrouped(models) = &select.options else {
-            panic!("model options should be ungrouped");
-        };
-
-        assert_eq!(select.current_value.0.as_ref(), astra.model.as_str());
-        assert!(
-            models
+        for selected in [&visible.model, &hidden.model] {
+            let (mut actor, _client, _conversation) = setup_actor(|config| {
+                config.model = Some(selected.clone());
+            })
+            .await?;
+            actor.models_manager = Arc::new(StubModelsManager {
+                presets: vec![hidden.clone(), visible.clone()],
+            });
+            let options = actor.config_options().await?;
+            let model = options
                 .iter()
-                .any(|model| model.value.0.as_ref() == astra.id.as_str()),
-            "an explicitly selected hidden model must remain selectable"
-        );
+                .find(|option| option.id.0.as_ref() == "model")
+                .unwrap();
+            let SessionConfigKind::Select(select) = &model.kind else {
+                panic!("model option should be a select");
+            };
+            let SessionConfigSelectOptions::Ungrouped(models) = &select.options else {
+                panic!("model options should be ungrouped");
+            };
+            assert_eq!(select.current_value.0.as_ref(), selected.as_str());
+            assert!(
+                models
+                    .iter()
+                    .any(|model| model.value.0.as_ref() == visible.id.as_str())
+            );
+            assert_eq!(
+                models
+                    .iter()
+                    .any(|model| model.value.0.as_ref() == hidden.id.as_str()),
+                selected == &hidden.model,
+                "a hidden model is listed only when explicitly selected"
+            );
+        }
         Ok(())
     }
 
@@ -10963,7 +10979,7 @@ mod tests {
         let session_client =
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
-        let models_manager = Arc::new(StubModelsManager);
+        let models_manager = Arc::new(StubModelsManager::default());
         let config = Config::load_with_cli_overrides_and_harness_overrides(
             vec![],
             ConfigOverrides::default(),
@@ -10998,7 +11014,7 @@ mod tests {
         let session_client =
             SessionClient::with_client(session_id.clone(), client.clone(), Arc::default());
         let conversation = Arc::new(StubCodexThread::new());
-        let models_manager = Arc::new(StubModelsManager);
+        let models_manager = Arc::new(StubModelsManager::default());
         let config = Config::load_with_cli_overrides_and_harness_overrides(
             vec![],
             ConfigOverrides::default(),
@@ -11190,7 +11206,17 @@ mod tests {
         }
     }
 
-    struct StubModelsManager;
+    struct StubModelsManager {
+        presets: Vec<ModelPreset>,
+    }
+
+    impl Default for StubModelsManager {
+        fn default() -> Self {
+            Self {
+                presets: all_model_presets().to_owned(),
+            }
+        }
+    }
 
     impl ModelsManagerImpl for StubModelsManager {
         fn get_model(
@@ -11200,13 +11226,21 @@ mod tests {
             let model_id = model_id.clone();
             // Mirror the runtime contract: an explicit configured model takes precedence over
             // the catalog default. Tests for model changes rely on this distinction being real.
-            Box::pin(
-                async move { model_id.unwrap_or_else(|| all_model_presets()[0].to_owned().id) },
-            )
+            Box::pin(async move {
+                model_id.unwrap_or_else(|| {
+                    self.presets
+                        .iter()
+                        .find(|preset| preset.show_in_picker)
+                        .or_else(|| self.presets.first())
+                        .unwrap()
+                        .model
+                        .clone()
+                })
+            })
         }
 
         fn list_models(&self) -> Pin<Box<dyn Future<Output = Vec<ModelPreset>> + Send + '_>> {
-            Box::pin(async { all_model_presets().to_owned() })
+            Box::pin(async { self.presets.clone() })
         }
     }
 

--- a/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
+++ b/vendor/codex-acp/vendor/codex-utils-pty/Cargo.toml
@@ -2,7 +2,7 @@
 edition = "2024"
 license = "Apache-2.0"
 name = "codex-utils-pty"
-version = "0.153.2"
+version = "0.153.4"
 
 [dependencies]
 anyhow = "1"


### PR DESCRIPTION
The bundled catalog in runtime 0.153.2 hides GPT-6 Astra. Update the embedded runtime to 0.153.4 so Astra appears in the bundled fallback picker and becomes its default when no model is explicitly configured. Valid account-provided catalogs remain authoritative, and existing explicit selections are preserved.

Align all OpenAI runtime dependencies, the local PTY package, lockfile, and staging pins with `rust-v0.153.4` (`3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`). Keep the adapter at 0.16.0, ACP SDK at 0.14.0, V8 at 150.4.0, the existing Windows PTY adjustments, and the full non-runtime dependency graph unchanged.

Replace the Astra-specific hidden-model fixture with a controlled catalog, verify bundled Astra visibility and default selection, and extend the packaged smoke to check Astra visibility while preserving the configured model. Update the changelog, compatibility baseline, and coordinated rollback instructions.

Validation:

- Runtime `cargo check --locked` and 104 Rust tests passed.
- Native backend: 370 tests passed.
- Focused model-picker, chat, inline-review, and accept/reject coverage: 567 tests passed.
- Staging and V8 provisioning: 63 tests passed.
- Both runtime binaries built in release mode for macOS ARM64 and staged; executable architecture and SHA-256 equality with build outputs verified.
- Staged-runtime smoke passed: bundled Astra visible, explicit model retained, standalone code-mode host executed JavaScript, missing host failed closed, and backend ping succeeded.
- `git diff --check` passed.

Local execution was limited to macOS ARM64; other package targets were not built or executed. Account-specific Astra access was not tested against the live service. Rollback restores the coordinated 0.153.2 baseline and rebuilds both runtime binaries.
