### PR TITLE
Prepare 0.8.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,28 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.8.0] - 2026-09-11
+
+### Added
+
+- Added a dedicated, resizable chat pane that can move to either side of the workspace, follow the Agents sidebar, or expand while preserving the editor panes.
+- Added reversible chat archiving with an archived section, an undo action, and automatic reactivation when composing in an archived conversation.
+- Added unread indicators for completed chat turns and keyboard navigation for cycling through sidebar conversations.
+
+### Changed
+
+- Reworked the Agents sidebar into a card-based conversation list with compact timestamps, clearer subagent hierarchy, and a dedicated archived section.
+- Moved conversations out of editor tabs into the dedicated chat pane while preserving navigation, focus, search, and shortcuts across chat and editor surfaces.
+- Simplified chat organization by removing sidebar chat folders and redundant chat header actions.
+
+### Fixed
+
+- Fixed chat ordering, pane splits, divider behavior, and header alignment across workspace surfaces and window restarts.
+
+### Security
+
+- Addressed dependency security alerts in the Desktop and Web Clipper build toolchains, including the Web Clipper browser-launch dependency path.
+
 ## [0.7.7] - 2026-09-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.7.7"
+version = "0.8.0"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.7.7"
+version = "0.8.0"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.7.7",
+    "version": "0.8.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.7.7",
+            "version": "0.8.0",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.7.7",
+    "version": "0.8.0",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.7.7",
+    "version": "0.8.0",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- Add the 0.8.0 changelog entry covering the dedicated chat pane, reversible archiving, unread indicators, and conversation navigation improvements.
- Align the Desktop, native backend, Web Clipper, and Cargo lockfile versions at 0.8.0.
- Document dependency security hardening included in this release.

## Validation

- Release metadata sources are aligned at 0.8.0.
- CHANGELOG.md contains an entry for 0.8.0.
- Native backend cargo check passed with the locked dependency graph.
- Release metadata tests passed: 12 tests, 0 failures.
- git diff --check passed.

This PR prepares the release. The v0.8.0 tag will be created only after this change is merged.