### PR TITLE
Fix macOS chat header window dragging

### DIFF
--- a/apps/desktop/src/features/ai/components/AIChatPane.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatPane.test.tsx
@@ -73,6 +73,11 @@ describe("AIChatPane", () => {
             screen.queryByRole("button", { name: "History" }),
         ).toBeNull();
     });
+    it("keeps the standalone chat header draggable on macOS", () => {
+        useChatTabsStore.getState().showHistory();
+        const { container } = render(<AIChatPane />);
+        expect(container.querySelector("header")).toHaveClass("drag");
+    });
     it("toggles expansion and restores editors when the chat is hidden", () => {
         useEditorStore.getState().openNote("a", "A", "a");
         render(<AIChatPane />);

--- a/apps/desktop/src/features/ai/components/AIChatPane.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatPane.test.tsx
@@ -1,5 +1,6 @@
 import { useEditorStore } from "../../../app/store/editorStore";
 import { useLayoutStore } from "../../../app/store/layoutStore";
+import { getDesktopPlatform } from "../../../app/utils/platform";
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -73,10 +74,12 @@ describe("AIChatPane", () => {
             screen.queryByRole("button", { name: "History" }),
         ).toBeNull();
     });
-    it("keeps the standalone chat header draggable on macOS", () => {
+    it("only makes the standalone chat header draggable on macOS", () => {
         useChatTabsStore.getState().showHistory();
         const { container } = render(<AIChatPane />);
-        expect(container.querySelector("header")).toHaveClass("drag");
+        expect(
+            container.querySelector("header")?.classList.contains("drag"),
+        ).toBe(getDesktopPlatform() === "macos");
     });
     it("toggles expansion and restores editors when the chat is hidden", () => {
         useEditorStore.getState().openNote("a", "A", "a");

--- a/apps/desktop/src/features/ai/components/AIChatPane.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatPane.tsx
@@ -2,6 +2,7 @@ import { useEditorStore } from "../../../app/store/editorStore";
 import { useChatPaneShortcuts } from "../useChatPaneShortcuts";
 import { useState } from "react";
 import { useLayoutStore } from "../../../app/store/layoutStore";
+import { getDesktopPlatform } from "../../../app/utils/platform";
 import {
     ContextMenu,
     type ContextMenuState,
@@ -12,6 +13,8 @@ import { useChatStore } from "../store/chatStore";
 import { AIChatSessionView } from "./AIChatSessionView";
 import { AIChatHistoryWorkspaceView } from "./AIChatHistoryWorkspaceView";
 import { getSessionTitle } from "../sessionPresentation";
+
+const IS_MACOS = getDesktopPlatform() === "macos";
 
 export function AIChatPane() {
     useChatPaneShortcuts();
@@ -109,7 +112,7 @@ export function AIChatPane() {
         >
             {showStandaloneHeader && (
                 <header
-                    className="flex shrink-0 items-center gap-2 border-b px-3 py-1 text-xs"
+                    className={`flex shrink-0 items-center gap-2 border-b px-3 py-1 text-xs ${IS_MACOS ? "drag" : ""}`}
                     style={{ height: 33, minHeight: 33, boxSizing: "border-box", borderColor: "var(--border)" }}
                 >
                     {view.mode === "history" && (

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -217,7 +217,7 @@ describe("AIChatSessionView", () => {
         expect(useEditorStore.getState().panes.every(pane => pane.tabs.length === 0)).toBe(true);
     });
 
-    it("makes the macOS chat header draggable without swallowing title renames", () => {
+    it("only makes the chat header draggable on macOS without swallowing title renames", () => {
         useChatStore.setState({
             sessionsById: {
                 explicit: createSession("explicit", "Draggable conversation"),
@@ -226,7 +226,11 @@ describe("AIChatSessionView", () => {
 
         renderComponent(<AIChatSessionView sessionId="explicit" focused />);
 
-        expect(screen.getByTestId("chat-session-header")).toHaveClass("drag");
+        expect(
+            screen
+                .getByTestId("chat-session-header")
+                .classList.contains("drag"),
+        ).toBe(getDesktopPlatform() === "macos");
         expect(screen.getByText("Draggable conversation")).toHaveClass(
             "no-drag",
         );

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.test.tsx
@@ -217,6 +217,21 @@ describe("AIChatSessionView", () => {
         expect(useEditorStore.getState().panes.every(pane => pane.tabs.length === 0)).toBe(true);
     });
 
+    it("makes the macOS chat header draggable without swallowing title renames", () => {
+        useChatStore.setState({
+            sessionsById: {
+                explicit: createSession("explicit", "Draggable conversation"),
+            },
+        });
+
+        renderComponent(<AIChatSessionView sessionId="explicit" focused />);
+
+        expect(screen.getByTestId("chat-session-header")).toHaveClass("drag");
+        expect(screen.getByText("Draggable conversation")).toHaveClass(
+            "no-drag",
+        );
+    });
+
     it("keeps the composer available in an archived conversation without restoring on open", () => {
         setupWorkspaceSession();
         useArchivedChatsStore.getState().archive("session-a");

--- a/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
+++ b/apps/desktop/src/features/ai/components/AIChatSessionView.tsx
@@ -21,6 +21,7 @@ import {
 import { open as runtimeOpen } from "@neverwrite/runtime";
 import { useShallow } from "zustand/react/shallow";
 import { useSettingsStore } from "../../../app/store/settingsStore";
+import { getDesktopPlatform } from "../../../app/utils/platform";
 import { useVaultStore } from "../../../app/store/vaultStore";
 import { isTextLikeVaultEntry } from "../../../app/utils/vaultEntries";
 import {
@@ -82,6 +83,7 @@ import { getConversationSelection } from "../conversationModel";
 
 const EMPTY_COMPOSER_PARTS: AIComposerPart[] = [];
 const EMPTY_CONVERSATION_BINDINGS: AcpConversationBinding[] = [];
+const IS_MACOS = getDesktopPlatform() === "macos";
 
 function runtimeNeedsModelDiscovery(runtime: AIRuntimeDescriptor) {
     const modelConfig = runtime.configOptions.find(
@@ -989,7 +991,7 @@ export function AIChatSessionView({
             {/* Compact local session header for the workspace chat tab */}
             <div
                 data-testid="chat-session-header"
-                className="flex items-center gap-2 px-3 py-1 text-xs shrink-0"
+                className={`flex items-center gap-2 px-3 py-1 text-xs shrink-0 ${IS_MACOS ? "drag" : ""}`}
                 style={{
                     height: 33,
                     minHeight: 33,
@@ -1023,18 +1025,20 @@ export function AIChatSessionView({
                         onBlur={commitTitleEdit}
                     />
                 ) : (
-                    <span
-                        className="min-w-0 flex-1 overflow-hidden whitespace-nowrap font-medium"
-                        onDoubleClick={startTitleEdit}
-                        title={
-                            isSubagent
-                                ? "Subagents are named by their parent run"
-                                : "Double-click to rename"
-                        }
-                        style={{ color: "var(--text-primary)" }}
-                    >
-                        {sessionTitle}
-                    </span>
+                    <div className="min-w-0 flex-1 overflow-hidden whitespace-nowrap">
+                        <span
+                            className="no-drag inline-block max-w-full overflow-hidden whitespace-nowrap align-middle font-medium"
+                            onDoubleClick={startTitleEdit}
+                            title={
+                                isSubagent
+                                    ? "Subagents are named by their parent run"
+                                    : "Double-click to rename"
+                            }
+                            style={{ color: "var(--text-primary)" }}
+                        >
+                            {sessionTitle}
+                        </span>
+                    </div>
                 )}
                 {isSubagent ? (
                     <span


### PR DESCRIPTION
## Summary

- make the existing chat header a native draggable region on macOS
- preserve inline title renaming and interactive header controls as non-draggable areas
- apply the same behavior to standalone chat headers without adding a title bar

## Testing

- npm test -- --run src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/AIChatPane.test.tsx
- npm run build
- npx eslint src/features/ai/components/AIChatSessionView.tsx src/features/ai/components/AIChatPane.tsx src/features/ai/components/AIChatSessionView.test.tsx src/features/ai/components/AIChatPane.test.tsx
- git diff --check