### PR TITLE
Fix stale ACP effort options blocking OpenCode chats

### DIFF
--- a/apps/desktop/src/features/ai/acpSelection.test.ts
+++ b/apps/desktop/src/features/ai/acpSelection.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import { reconcileInheritedAcpOptions } from "./acpSelection";
+import type { AIConfigOption, ConversationSelection } from "./types";
+
+const effort: AIConfigOption = {
+    id: "effort",
+    runtimeId: "opencode-acp",
+    category: "reasoning",
+    label: "Effort",
+    type: "select",
+    value: "high",
+    options: ["low", "high"].map((value) => ({ value, label: value })),
+};
+const selection: ConversationSelection = {
+    runtimeId: effort.runtimeId,
+    modelId: "model",
+    modeId: "default",
+    options: { effort: "high" },
+};
+const session = { runtimeId: effort.runtimeId, modelId: "model", configOptions: [] as AIConfigOption[] };
+
+describe("reconcileInheritedAcpOptions", () => {
+    it("drops a saved option absent from the new session without mutating the preference", () => {
+        expect(reconcileInheritedAcpOptions(session, selection, [effort]).options).toEqual({});
+        expect(selection.options).toEqual({ effort: "high" });
+    });
+
+    it("preserves supported values, including options first exposed by the target model", () => {
+        expect(reconcileInheritedAcpOptions(
+            { ...session, configOptions: [effort] }, selection, [],
+        )).toEqual(selection);
+    });
+
+    it("adopts the agent's current value when a previously supported value expires", () => {
+        const current = { ...effort, value: "medium", options: [{ value: "medium", label: "Medium" }] };
+        expect(reconcileInheritedAcpOptions(
+            { ...session, configOptions: [current] }, selection, [effort],
+        ).options).toEqual({ effort: "medium" });
+    });
+
+    it("preserves unknown ids and never-advertised values for strict validation", () => {
+        const requested = { ...selection, options: { effort: "invented", unknown: "high" } };
+        expect(reconcileInheritedAcpOptions(session, requested, [effort])).toEqual(requested);
+    });
+
+    it("does not treat a rejected supported change as a fallback", () => {
+        const current = { ...effort, value: "low" };
+        expect(reconcileInheritedAcpOptions(
+            { ...session, configOptions: [current] }, selection, [effort],
+        ).options).toEqual({ effort: "high" });
+    });
+
+    it("does not inherit catalogs from another provider or reconcile before selecting the target model", () => {
+        expect(reconcileInheritedAcpOptions(session, selection, [{ ...effort, runtimeId: "other" }])).toEqual(selection);
+        expect(reconcileInheritedAcpOptions({ ...session, modelId: "other" }, selection, [effort])).toEqual(selection);
+        expect(reconcileInheritedAcpOptions({ ...session, runtimeId: "other" }, selection, [effort])).toEqual(selection);
+    });
+
+    it("keeps model and mode options strict even when their ids are provider-defined", () => {
+        const previous = [
+            { ...effort, id: "agent", category: "mode" as const },
+            { ...effort, id: "llm", category: "model" as const },
+        ];
+        const requested = { ...selection, options: { agent: "high", llm: "high" } };
+        expect(reconcileInheritedAcpOptions(session, requested, previous)).toEqual(requested);
+    });
+});

--- a/apps/desktop/src/features/ai/acpSelection.test.ts
+++ b/apps/desktop/src/features/ai/acpSelection.test.ts
@@ -17,43 +17,86 @@ const selection: ConversationSelection = {
     modeId: "default",
     options: { effort: "high" },
 };
-const session = { runtimeId: effort.runtimeId, modelId: "model", configOptions: [] as AIConfigOption[] };
+const session = {
+    runtimeId: effort.runtimeId,
+    modelId: "model",
+    configOptions: [] as AIConfigOption[],
+};
 
 describe("reconcileInheritedAcpOptions", () => {
     it("drops a saved option absent from the new session without mutating the preference", () => {
-        expect(reconcileInheritedAcpOptions(session, selection, [effort]).options).toEqual({});
+        expect(
+            reconcileInheritedAcpOptions(session, selection, [effort]).options,
+        ).toEqual({});
         expect(selection.options).toEqual({ effort: "high" });
     });
 
     it("preserves supported values, including options first exposed by the target model", () => {
-        expect(reconcileInheritedAcpOptions(
-            { ...session, configOptions: [effort] }, selection, [],
-        )).toEqual(selection);
+        expect(
+            reconcileInheritedAcpOptions(
+                { ...session, configOptions: [effort] },
+                selection,
+                [],
+            ),
+        ).toEqual(selection);
     });
 
     it("adopts the agent's current value when a previously supported value expires", () => {
-        const current = { ...effort, value: "medium", options: [{ value: "medium", label: "Medium" }] };
-        expect(reconcileInheritedAcpOptions(
-            { ...session, configOptions: [current] }, selection, [effort],
-        ).options).toEqual({ effort: "medium" });
+        const current = {
+            ...effort,
+            value: "medium",
+            options: [{ value: "medium", label: "Medium" }],
+        };
+        expect(
+            reconcileInheritedAcpOptions(
+                { ...session, configOptions: [current] },
+                selection,
+                [effort],
+            ).options,
+        ).toEqual({ effort: "medium" });
     });
 
     it("preserves unknown ids and never-advertised values for strict validation", () => {
-        const requested = { ...selection, options: { effort: "invented", unknown: "high" } };
-        expect(reconcileInheritedAcpOptions(session, requested, [effort])).toEqual(requested);
+        const requested = {
+            ...selection,
+            options: { effort: "invented", unknown: "high" },
+        };
+        expect(
+            reconcileInheritedAcpOptions(session, requested, [effort]),
+        ).toEqual(requested);
     });
 
     it("does not treat a rejected supported change as a fallback", () => {
         const current = { ...effort, value: "low" };
-        expect(reconcileInheritedAcpOptions(
-            { ...session, configOptions: [current] }, selection, [effort],
-        ).options).toEqual({ effort: "high" });
+        expect(
+            reconcileInheritedAcpOptions(
+                { ...session, configOptions: [current] },
+                selection,
+                [effort],
+            ).options,
+        ).toEqual({ effort: "high" });
     });
 
     it("does not inherit catalogs from another provider or reconcile before selecting the target model", () => {
-        expect(reconcileInheritedAcpOptions(session, selection, [{ ...effort, runtimeId: "other" }])).toEqual(selection);
-        expect(reconcileInheritedAcpOptions({ ...session, modelId: "other" }, selection, [effort])).toEqual(selection);
-        expect(reconcileInheritedAcpOptions({ ...session, runtimeId: "other" }, selection, [effort])).toEqual(selection);
+        expect(
+            reconcileInheritedAcpOptions(session, selection, [
+                { ...effort, runtimeId: "other" },
+            ]),
+        ).toEqual(selection);
+        expect(
+            reconcileInheritedAcpOptions(
+                { ...session, modelId: "other" },
+                selection,
+                [effort],
+            ),
+        ).toEqual(selection);
+        expect(
+            reconcileInheritedAcpOptions(
+                { ...session, runtimeId: "other" },
+                selection,
+                [effort],
+            ),
+        ).toEqual(selection);
     });
 
     it("keeps model and mode options strict even when their ids are provider-defined", () => {
@@ -61,7 +104,12 @@ describe("reconcileInheritedAcpOptions", () => {
             { ...effort, id: "agent", category: "mode" as const },
             { ...effort, id: "llm", category: "model" as const },
         ];
-        const requested = { ...selection, options: { agent: "high", llm: "high" } };
-        expect(reconcileInheritedAcpOptions(session, requested, previous)).toEqual(requested);
+        const requested = {
+            ...selection,
+            options: { agent: "high", llm: "high" },
+        };
+        expect(
+            reconcileInheritedAcpOptions(session, requested, previous),
+        ).toEqual(requested);
     });
 });

--- a/apps/desktop/src/features/ai/acpSelection.ts
+++ b/apps/desktop/src/features/ai/acpSelection.ts
@@ -1,0 +1,51 @@
+import type { AIChatSession, AIConfigOption, ConversationSelection } from "./types";
+
+/**
+ * Restore preferences against the target model's authoritative ACP catalog.
+ * Only values advertised by an earlier catalog are eligible for fallback;
+ * unknown requests and provider/model/mode validation remain strict.
+ */
+export function reconcileInheritedAcpOptions(
+    session: Pick<AIChatSession, "runtimeId" | "modelId" | "configOptions">,
+    selection: ConversationSelection,
+    previousOptions: readonly AIConfigOption[],
+): ConversationSelection {
+    const modelValue = session.configOptions.find(
+        (option) => option.category === "model",
+    )?.value;
+    if (
+        selection.runtimeId !== session.runtimeId ||
+        (selection.modelId !== session.modelId && selection.modelId !== modelValue)
+    ) {
+        return selection;
+    }
+
+    const options = { ...selection.options };
+    for (const [id, value] of Object.entries(options)) {
+        const current = session.configOptions.find((option) => option.id === id);
+        const previous = previousOptions.filter(
+            (option) => option.runtimeId === selection.runtimeId && option.id === id,
+        );
+        if (
+            id === "model" || id === "mode" ||
+            [current, ...previous].some(
+                (option) => option?.category === "model" || option?.category === "mode",
+            ) ||
+            !previous.some(
+                (option) => option.value === value ||
+                    option.options.some((candidate) => candidate.value === value),
+            )
+        ) {
+            continue;
+        }
+        if (!current) {
+            delete options[id];
+        } else if (
+            current.value !== value &&
+            !current.options.some((candidate) => candidate.value === value)
+        ) {
+            options[id] = current.value;
+        }
+    }
+    return { ...selection, options };
+}

--- a/apps/desktop/src/features/ai/acpSelection.ts
+++ b/apps/desktop/src/features/ai/acpSelection.ts
@@ -1,4 +1,8 @@
-import type { AIChatSession, AIConfigOption, ConversationSelection } from "./types";
+import type {
+    AIChatSession,
+    AIConfigOption,
+    ConversationSelection,
+} from "./types";
 
 /**
  * Restore preferences against the target model's authoritative ACP catalog.
@@ -15,25 +19,34 @@ export function reconcileInheritedAcpOptions(
     )?.value;
     if (
         selection.runtimeId !== session.runtimeId ||
-        (selection.modelId !== session.modelId && selection.modelId !== modelValue)
+        (selection.modelId !== session.modelId &&
+            selection.modelId !== modelValue)
     ) {
         return selection;
     }
 
     const options = { ...selection.options };
     for (const [id, value] of Object.entries(options)) {
-        const current = session.configOptions.find((option) => option.id === id);
+        const current = session.configOptions.find(
+            (option) => option.id === id,
+        );
         const previous = previousOptions.filter(
-            (option) => option.runtimeId === selection.runtimeId && option.id === id,
+            (option) =>
+                option.runtimeId === selection.runtimeId && option.id === id,
         );
         if (
-            id === "model" || id === "mode" ||
+            id === "model" ||
+            id === "mode" ||
             [current, ...previous].some(
-                (option) => option?.category === "model" || option?.category === "mode",
+                (option) =>
+                    option?.category === "model" || option?.category === "mode",
             ) ||
             !previous.some(
-                (option) => option.value === value ||
-                    option.options.some((candidate) => candidate.value === value),
+                (option) =>
+                    option.value === value ||
+                    option.options.some(
+                        (candidate) => candidate.value === value,
+                    ),
             )
         ) {
             continue;

--- a/apps/desktop/src/features/ai/conversationPickerModel.test.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.test.ts
@@ -3,6 +3,7 @@ import { createConversationBindingsFromLegacySession } from "./conversationModel
 import {
   buildConversationProviderOptions,
   getConversationTurnCatalog,
+  getSessionCatalogKey,
   updateConversationSelection,
 } from "./conversationPickerModel";
 import type {
@@ -371,4 +372,91 @@ describe("conversation provider picker model", () => {
     ]);
   });
 
+  it.each(["prepared", "live", "refreshed probe"])(
+    "does not resurrect effort from an old catalog when the %s catalog is empty",
+    (source) => {
+      const current = session();
+      const provider = runtime(current.runtimeId);
+      provider.configOptions = [
+        {
+          id: "effort",
+          runtimeId: current.runtimeId,
+          category: "reasoning",
+          label: "Effort",
+          type: "select",
+          value: "high",
+          options: [{ value: "high", label: "High" }],
+        },
+      ];
+      if (source !== "live") current.configOptions = provider.configOptions;
+      const bindings = createConversationBindingsFromLegacySession({
+        ...current,
+        configOptions: provider.configOptions,
+      });
+      const selection = {
+        runtimeId: current.runtimeId,
+        modelId: source === "prepared" ? "next-model" : current.modelId,
+        modeId: "default",
+        options: {},
+      };
+      const catalog = getConversationTurnCatalog({
+        session: current,
+        selection,
+        runtimes: [provider],
+        bindings: bindings.providerBindings,
+        preparedCatalog:
+          source === "live"
+            ? null
+            : {
+                runtimeId: selection.runtimeId,
+                modelId: selection.modelId,
+                models: [],
+                modes: [],
+                configOptions: [],
+                effortsByModel: {},
+                sourceSessionCatalogKey: getSessionCatalogKey(current),
+              },
+      });
+      expect(catalog.configOptions).toEqual([]);
+    },
+  );
+
+  it("shows reasoning again when a newer live catalog advertises it", () => {
+    const current = session();
+    const sourceSessionCatalogKey = getSessionCatalogKey(current);
+    current.configOptions = [
+      {
+        id: "effort",
+        runtimeId: current.runtimeId,
+        category: "reasoning",
+        label: "Effort",
+        type: "select",
+        value: "high",
+        options: [{ value: "high", label: "High" }],
+      },
+    ];
+    const catalog = getConversationTurnCatalog({
+      session: current,
+      selection: {
+        runtimeId: current.runtimeId,
+        modelId: current.modelId,
+        modeId: "default",
+        options: {},
+      },
+      runtimes: [],
+      bindings: [],
+      preparedCatalog: {
+        runtimeId: current.runtimeId,
+        modelId: current.modelId,
+        models: [],
+        modes: [],
+        configOptions: [],
+        effortsByModel: {},
+        sourceSessionCatalogKey,
+      },
+    });
+    expect(catalog.configOptions.map((option) => option.id)).toEqual([
+      "effort",
+    ]);
+  });
 });

--- a/apps/desktop/src/features/ai/conversationPickerModel.ts
+++ b/apps/desktop/src/features/ai/conversationPickerModel.ts
@@ -41,6 +41,15 @@ export interface PreparedConversationTurnCatalog
   extends ConversationTurnCatalog {
   runtimeId: string;
   modelId: string;
+  sourceSessionCatalogKey?: string;
+}
+
+export function getSessionCatalogKey(session: AIChatSession): string {
+  return JSON.stringify([
+    session.runtimeId,
+    session.modelId,
+    session.configOptions,
+  ]);
 }
 
 function isRuntimeReady(status?: AIRuntimeSetupStatus | null) {
@@ -229,10 +238,12 @@ export function getConversationTurnCatalog(input: {
   const selectionMatchesLiveSession =
     input.session.runtimeId === input.selection.runtimeId &&
     liveModelId === input.selection.modelId;
-  // Prepared catalogs are only a bridge for staged selections. Once the live
-  // session reaches that provider/model, its latest ACP catalog wins again.
+  // A probe can refresh the catalog even for the current model. Use it while
+  // the source catalog is unchanged; a subsequent live catalog takes priority.
   const preparedCatalog =
-    !selectionMatchesLiveSession &&
+    (!selectionMatchesLiveSession ||
+      input.preparedCatalog?.sourceSessionCatalogKey ===
+        getSessionCatalogKey(input.session)) &&
     input.preparedCatalog?.runtimeId === input.selection.runtimeId &&
     input.preparedCatalog.modelId === input.selection.modelId
       ? input.preparedCatalog
@@ -266,8 +277,10 @@ export function getConversationTurnCatalog(input: {
         ? binding.modes
         : runtime?.modes) ?? [];
   const configOptions =
-    (preparedCatalog?.configOptions.length
+    (preparedCatalog
       ? preparedCatalog.configOptions
+      : selectionMatchesLiveSession && input.session.runtimeState === "live"
+      ? input.session.configOptions
       : sessionMatches && input.session.configOptions.length > 0
       ? input.session.configOptions
       : binding?.configOptions.length

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -24,6 +24,7 @@ import type {
     AIComposerPart,
     DraftAttachmentId,
     ManagedAttachmentId,
+    PersistedSessionHistory,
     QueuedChatMessage,
 } from "../types";
 import { deriveReviewItems } from "../diff/editedFilesPresentationModel";
@@ -15447,7 +15448,8 @@ describe("chatStore", () => {
         async (path) => {
             await useChatStore.getState().initialize();
             const sourceSessionId = getActiveSessionId();
-            const conversationId = useChatStore.getState().activeConversationId!;
+            const conversationId =
+                useChatStore.getState().activeConversationId!;
             const runtimeId = "opencode-acp";
             const liveSession = {
                 ...sessionPayload,
@@ -15455,22 +15457,53 @@ describe("chatStore", () => {
                 runtime_id: runtimeId,
                 model_id: "plain-model",
                 mode_id: "",
-                models: [{ id: "plain-model", runtime_id: runtimeId, name: "Plain", description: "" }],
+                models: [
+                    {
+                        id: "plain-model",
+                        runtime_id: runtimeId,
+                        name: "Plain",
+                        description: "",
+                    },
+                ],
                 modes: [],
                 config_options: [],
                 efforts_by_model: {},
             };
             useChatStore.setState((state) => ({
-                runtimes: [...state.runtimes, {
-                    runtime: { id: runtimeId, name: "OpenCode", description: "", capabilities: ["create_session"] },
-                    models: [{ id: "plain-model", runtimeId, name: "Plain", description: "" }],
-                    modes: [],
-                    configOptions: [{
-                        id: "effort", runtimeId, category: "reasoning", label: "Effort", type: "select",
-                        value: "low",
-                        options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }],
-                    }],
-                }],
+                runtimes: [
+                    ...state.runtimes,
+                    {
+                        runtime: {
+                            id: runtimeId,
+                            name: "OpenCode",
+                            description: "",
+                            capabilities: ["create_session"],
+                        },
+                        models: [
+                            {
+                                id: "plain-model",
+                                runtimeId,
+                                name: "Plain",
+                                description: "",
+                            },
+                        ],
+                        modes: [],
+                        configOptions: [
+                            {
+                                id: "effort",
+                                runtimeId,
+                                category: "reasoning",
+                                label: "Effort",
+                                type: "select",
+                                value: "low",
+                                options: [
+                                    { value: "low", label: "Low" },
+                                    { value: "high", label: "High" },
+                                ],
+                            },
+                        ],
+                    },
+                ],
                 setupStatusByRuntimeId: {
                     ...state.setupStatusByRuntimeId,
                     [runtimeId]: { ...readySetupStatusState, runtimeId },
@@ -15479,32 +15512,75 @@ describe("chatStore", () => {
             invokeMock.mockImplementation(async (command, args) => {
                 if (command === "ai_create_session") return liveSession;
                 if (command === "ai_start_conversation_turn") return null;
-                if (command === "ai_send_message") return { ...liveSession, status: "streaming" };
+                if (command === "ai_send_message")
+                    return { ...liveSession, status: "streaming" };
                 return defaultInvokeImplementation(command, args);
             });
             // Different from the runtime default: discovery must preserve this
             // explicit model selection while reconciling its saved effort.
-            const selection = { runtimeId, modelId: "plain-model", modeId: "", options: { effort: "high" } };
-            useChatStore.getState().setConversationTurnSelection(conversationId, selection);
+            const selection = {
+                runtimeId,
+                modelId: "plain-model",
+                modeId: "",
+                options: { effort: "high" },
+            };
+            useChatStore
+                .getState()
+                .setConversationTurnSelection(conversationId, selection);
             invokeMock.mockClear();
             if (path === "catalog") {
-                await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
-                expect(useChatStore.getState().preparedTurnCatalogByConversationId[conversationId]).toMatchObject({
-                    runtimeId, modelId: "plain-model", configOptions: [],
+                await useChatStore
+                    .getState()
+                    .prepareConversationTurnCatalog(conversationId, selection);
+                expect(
+                    useChatStore.getState().preparedTurnCatalogByConversationId[
+                        conversationId
+                    ],
+                ).toMatchObject({
+                    runtimeId,
+                    modelId: "plain-model",
+                    configOptions: [],
                 });
             } else {
-                useChatStore.getState().setComposerParts(createTextParts("Use OpenCode"), sourceSessionId);
+                useChatStore
+                    .getState()
+                    .setComposerParts(
+                        createTextParts("Use OpenCode"),
+                        sourceSessionId,
+                    );
                 await useChatStore.getState().sendMessage(sourceSessionId);
-                expect(invokeMock).toHaveBeenCalledWith("ai_start_conversation_turn", expect.objectContaining({
-                    input: expect.objectContaining({ selection: {
-                        runtime_id: runtimeId, model_id: "plain-model", mode_id: "", options: {},
-                    } }),
-                }));
-                expect(invokeMock.mock.calls.some(([command]) => command === "ai_send_message")).toBe(true);
+                expect(invokeMock).toHaveBeenCalledWith(
+                    "ai_start_conversation_turn",
+                    expect.objectContaining({
+                        input: expect.objectContaining({
+                            selection: {
+                                runtime_id: runtimeId,
+                                model_id: "plain-model",
+                                mode_id: "",
+                                options: {},
+                            },
+                        }),
+                    }),
+                );
+                expect(
+                    invokeMock.mock.calls.some(
+                        ([command]) => command === "ai_send_message",
+                    ),
+                ).toBe(true);
             }
-            expect(invokeMock.mock.calls.some(([command]) => command === "ai_set_config_option")).toBe(false);
-            expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection).toEqual({
-                runtimeId, modelId: "plain-model", modeId: "", options: {},
+            expect(
+                invokeMock.mock.calls.some(
+                    ([command]) => command === "ai_set_config_option",
+                ),
+            ).toBe(false);
+            expect(
+                useChatStore.getState().conversationsById[conversationId]
+                    ?.preferredSelection,
+            ).toEqual({
+                runtimeId,
+                modelId: "plain-model",
+                modeId: "",
+                options: {},
             });
         },
     );
@@ -15514,45 +15590,80 @@ describe("chatStore", () => {
         async (change) => {
             await useChatStore.getState().initialize();
             const sourceSessionId = getActiveSessionId();
-            const conversationId = useChatStore.getState().activeConversationId!;
-            const sourceSession = useChatStore.getState().sessionsById[sourceSessionId]!;
+            const conversationId =
+                useChatStore.getState().activeConversationId!;
+            const sourceSession =
+                useChatStore.getState().sessionsById[sourceSessionId]!;
             const selection = {
                 ...getConversationSelection(sourceSession),
                 options: { model: "test-model", reasoning_effort: "high" },
             };
-            useChatStore.getState().setConversationTurnSelection(conversationId, selection);
+            useChatStore
+                .getState()
+                .setConversationTurnSelection(conversationId, selection);
             // Remove runtime-wide metadata so only the conversation proves
             // that the saved effort was previously advertised.
             useChatStore.setState((state) => ({
-                runtimes: state.runtimes.map((runtime) => ({ ...runtime, configOptions: [] })),
+                runtimes: state.runtimes.map((runtime) => ({
+                    ...runtime,
+                    configOptions: [],
+                })),
             }));
             const liveSession = {
                 ...sessionPayload,
                 session_id: "probe-with-changed-effort",
-                config_options: change === "removed" ? [acpConfigOptions[0]] : [
-                    acpConfigOptions[0],
-                    {
-                        ...acpConfigOptions[1],
-                        value: "medium",
-                        options: change === "expired"
-                            ? [{ value: "medium", label: "Medium" }]
-                            : acpConfigOptions[1].options,
-                    },
-                ],
+                config_options:
+                    change === "removed"
+                        ? [acpConfigOptions[0]]
+                        : [
+                              acpConfigOptions[0],
+                              {
+                                  ...acpConfigOptions[1],
+                                  value: "medium",
+                                  options:
+                                      change === "expired"
+                                          ? [
+                                                {
+                                                    value: "medium",
+                                                    label: "Medium",
+                                                },
+                                            ]
+                                          : acpConfigOptions[1].options,
+                              },
+                          ],
             };
             invokeMock.mockImplementation(async (command, args) => {
-                if (command === "ai_create_session" || command === "ai_set_config_option") return liveSession;
+                if (
+                    command === "ai_create_session" ||
+                    command === "ai_set_config_option"
+                )
+                    return liveSession;
                 return defaultInvokeImplementation(command, args);
             });
-            await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
-            const prepared = useChatStore.getState().preparedTurnCatalogByConversationId[conversationId];
+            await useChatStore
+                .getState()
+                .prepareConversationTurnCatalog(conversationId, selection);
+            const prepared =
+                useChatStore.getState().preparedTurnCatalogByConversationId[
+                    conversationId
+                ];
             if (change === "rejected") {
                 expect(prepared).toBeUndefined();
-                expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection).toEqual(selection);
+                expect(
+                    useChatStore.getState().conversationsById[conversationId]
+                        ?.preferredSelection,
+                ).toEqual(selection);
             } else {
-                expect(prepared?.configOptions).toHaveLength(change === "removed" ? 1 : 2);
-                expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection.options).toEqual(
-                    change === "removed" ? { model: "test-model" } : { model: "test-model", reasoning_effort: "medium" },
+                expect(prepared?.configOptions).toHaveLength(
+                    change === "removed" ? 1 : 2,
+                );
+                expect(
+                    useChatStore.getState().conversationsById[conversationId]
+                        ?.preferredSelection.options,
+                ).toEqual(
+                    change === "removed"
+                        ? { model: "test-model" }
+                        : { model: "test-model", reasoning_effort: "medium" },
                 );
             }
         },
@@ -15563,11 +15674,18 @@ describe("chatStore", () => {
         const sourceSessionId = getActiveSessionId();
         const conversationId = useChatStore.getState().activeConversationId!;
         const serviceTier = {
-            ...acpConfigOptions[1], id: "service_tier", category: "service_tier",
-            value: "standard", options: [{ value: "standard", label: "Standard" }, { value: "fast", label: "Fast" }],
+            ...acpConfigOptions[1],
+            id: "service_tier",
+            category: "service_tier",
+            value: "standard",
+            options: [
+                { value: "standard", label: "Standard" },
+                { value: "fast", label: "Fast" },
+            ],
         };
         const liveSession = {
-            ...sessionPayload, session_id: "dependent-options",
+            ...sessionPayload,
+            session_id: "dependent-options",
             config_options: [...acpConfigOptions, serviceTier],
         };
         invokeMock.mockImplementation(async (command, args) => {
@@ -15576,22 +15694,292 @@ describe("chatStore", () => {
                 const input = (args as { input: { option_id: string } }).input;
                 expect(input.option_id).toBe("service_tier");
                 // Fast service removes the reasoning control entirely.
-                return { ...liveSession, config_options: [acpConfigOptions[0], { ...serviceTier, value: "fast" }] };
+                return {
+                    ...liveSession,
+                    config_options: [
+                        acpConfigOptions[0],
+                        { ...serviceTier, value: "fast" },
+                    ],
+                };
             }
             return defaultInvokeImplementation(command, args);
         });
         const selection = {
-            ...getConversationSelection(useChatStore.getState().sessionsById[sourceSessionId]!),
-            options: { model: "test-model", service_tier: "fast", reasoning_effort: "high" },
+            ...getConversationSelection(
+                useChatStore.getState().sessionsById[sourceSessionId]!,
+            ),
+            options: {
+                model: "test-model",
+                service_tier: "fast",
+                reasoning_effort: "high",
+            },
         };
-        useChatStore.getState().setConversationTurnSelection(conversationId, selection);
-        await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
-        expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection.options).toEqual({
-            model: "test-model", service_tier: "fast",
+        useChatStore
+            .getState()
+            .setConversationTurnSelection(conversationId, selection);
+        await useChatStore
+            .getState()
+            .prepareConversationTurnCatalog(conversationId, selection);
+        expect(
+            useChatStore.getState().conversationsById[conversationId]
+                ?.preferredSelection.options,
+        ).toEqual({
+            model: "test-model",
+            service_tier: "fast",
         });
-        expect(useChatStore.getState().preparedTurnCatalogByConversationId[conversationId]?.configOptions.map((option) => option.id)).toEqual([
-            "model", "service_tier",
-        ]);
+        expect(
+            useChatStore
+                .getState()
+                .preparedTurnCatalogByConversationId[
+                    conversationId
+                ]?.configOptions.map((option) => option.id),
+        ).toEqual(["model", "service_tier"]);
+    });
+
+    it.each(["model", "effort"])(
+        "does not overwrite a newer %s selection when an old ACP probe completes",
+        async (changedField) => {
+            await useChatStore.getState().initialize();
+            const sessionId = getActiveSessionId();
+            const conversationId =
+                useChatStore.getState().activeConversationId!;
+            const selection = {
+                ...getConversationSelection(
+                    useChatStore.getState().sessionsById[sessionId]!,
+                ),
+                options: { model: "test-model", reasoning_effort: "high" },
+            };
+            useChatStore
+                .getState()
+                .setConversationTurnSelection(conversationId, selection);
+            let resolveProbe!: (value: typeof sessionPayload) => void;
+            const probe = new Promise<typeof sessionPayload>((resolve) => {
+                resolveProbe = resolve;
+            });
+            invokeMock.mockImplementation(async (command, args) => {
+                if (command === "ai_create_session") return probe;
+                return defaultInvokeImplementation(command, args);
+            });
+            const preparing = useChatStore
+                .getState()
+                .prepareConversationTurnCatalog(conversationId, selection);
+            const newerSelection =
+                changedField === "model"
+                    ? {
+                          ...selection,
+                          modelId: "wide-model",
+                          options: {
+                              model: "wide-model",
+                              reasoning_effort: "high",
+                          },
+                      }
+                    : {
+                          ...selection,
+                          options: {
+                              model: "test-model",
+                              reasoning_effort: "medium",
+                          },
+                      };
+            useChatStore
+                .getState()
+                .setConversationTurnSelection(conversationId, newerSelection);
+            resolveProbe({
+                ...sessionPayload,
+                session_id: "late-probe",
+                config_options: [acpConfigOptions[0]],
+            });
+            await preparing;
+            expect(
+                useChatStore.getState().conversationsById[conversationId]
+                    ?.preferredSelection,
+            ).toEqual(newerSelection);
+            expect(
+                useChatStore.getState().preparedTurnCatalogByConversationId[
+                    conversationId
+                ],
+            ).toBeUndefined();
+            expect(invokeMock).toHaveBeenCalledWith(
+                "ai_delete_runtime_session",
+                { sessionId: "late-probe" },
+            );
+        },
+    );
+
+    it.each(["latest-first", "oldest-first"])(
+        "publishes only the newest catalog across A -> B -> A effort changes (%s)",
+        async (order) => {
+            await useChatStore.getState().initialize();
+            const sessionId = getActiveSessionId();
+            const conversationId =
+                useChatStore.getState().activeConversationId!;
+            const initial = getConversationSelection(
+                useChatStore.getState().sessionsById[sessionId]!,
+            );
+            const resolvers: Array<(value: typeof sessionPayload) => void> = [];
+            invokeMock.mockImplementation(async (command, args) => {
+                if (command === "ai_create_session") {
+                    return new Promise<typeof sessionPayload>((resolve) =>
+                        resolvers.push(resolve),
+                    );
+                }
+                return defaultInvokeImplementation(command, args);
+            });
+            const preparations = ["high", "medium", "high"].map((effort) => {
+                const selection = {
+                    ...initial,
+                    options: { model: "test-model", reasoning_effort: effort },
+                };
+                useChatStore
+                    .getState()
+                    .setConversationTurnSelection(conversationId, selection);
+                return useChatStore
+                    .getState()
+                    .prepareConversationTurnCatalog(conversationId, selection);
+            });
+            expect(resolvers).toHaveLength(3);
+            for (const index of order === "latest-first"
+                ? [2, 0, 1]
+                : [0, 1, 2]) {
+                resolvers[index]({
+                    ...sessionPayload,
+                    session_id: `concurrent-probe-${index}`,
+                    config_options:
+                        index === 2
+                            ? [
+                                  acpConfigOptions[0],
+                                  { ...acpConfigOptions[1], value: "high" },
+                              ]
+                            : [acpConfigOptions[0]],
+                });
+                await preparations[index];
+                if (order === "oldest-first" && index !== 2) {
+                    expect(
+                        useChatStore.getState()
+                            .preparedTurnCatalogByConversationId[
+                            conversationId
+                        ],
+                    ).toBeUndefined();
+                }
+            }
+            expect(
+                useChatStore.getState().conversationsById[conversationId]
+                    ?.preferredSelection.options,
+            ).toEqual({
+                model: "test-model",
+                reasoning_effort: "high",
+            });
+            expect(
+                useChatStore
+                    .getState()
+                    .preparedTurnCatalogByConversationId[
+                        conversationId
+                    ]?.configOptions.map((option) => option.id),
+            ).toEqual(["model", "reasoning_effort"]);
+            for (const index of [0, 1, 2]) {
+                expect(invokeMock).toHaveBeenCalledWith(
+                    "ai_delete_runtime_session",
+                    { sessionId: `concurrent-probe-${index}` },
+                );
+            }
+        },
+    );
+
+    it("keeps queued and reopened conversations free of effort removed by a model change", async () => {
+        useVaultStore.setState({ vaultPath: "/vault", notes: [] });
+        await useChatStore.getState().initialize();
+        const sessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const liveSession = {
+            ...sessionPayload,
+            model_id: "wide-model",
+            efforts_by_model: {},
+            config_options: [{ ...acpConfigOptions[0], value: "wide-model" }],
+        };
+        let savedHistory: PersistedSessionHistory | undefined;
+        invokeMock.mockImplementation(async (command, args) => {
+            if (
+                command === "ai_set_config_option" ||
+                command === "ai_create_session" ||
+                command === "ai_load_session"
+            )
+                return liveSession;
+            if (command === "ai_start_conversation_turn") return null;
+            if (command === "ai_send_message")
+                return { ...liveSession, status: "streaming" };
+            if (command === "ai_save_session_history") {
+                savedHistory = (args as { history: PersistedSessionHistory })
+                    .history;
+                return undefined;
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+        const queued = {
+            ...createQueuedMessage("queue-with-effort", "Use the plain model"),
+            modelId: "wide-model",
+            optionsSnapshot: { model: "wide-model", reasoning_effort: "high" },
+        };
+        useChatStore.getState().enqueueMessage(sessionId, queued);
+        useChatStore
+            .getState()
+            .enqueueMessage(sessionId, { ...queued, id: "second-queued-turn" });
+        useChatStore.getState().enqueueMessage(sessionId, {
+            ...queued,
+            id: "other-model-turn",
+            modelId: "test-model",
+            optionsSnapshot: { model: "test-model", reasoning_effort: "high" },
+        });
+        await useChatStore.getState().tryDrainQueue(sessionId);
+        expect(invokeMock).toHaveBeenCalledWith(
+            "ai_start_conversation_turn",
+            expect.objectContaining({
+                input: expect.objectContaining({
+                    selection: expect.objectContaining({
+                        model_id: "wide-model",
+                        options: { model: "wide-model" },
+                    }),
+                }),
+            }),
+        );
+        const remaining =
+            useChatStore.getState().queuedMessagesBySessionId[sessionId];
+        expect(
+            remaining?.find((item) => item.id === "second-queued-turn")
+                ?.optionsSnapshot,
+        ).toEqual({ model: "wide-model" });
+        expect(
+            remaining?.find((item) => item.id === "other-model-turn")
+                ?.optionsSnapshot,
+        ).toEqual({ model: "test-model", reasoning_effort: "high" });
+        await vi.waitFor(() => {
+            expect(
+                savedHistory?.conversation_bindings?.preferred_selection
+                    .options,
+            ).toEqual({ model: "wide-model" });
+        });
+        const history = savedHistory!;
+        resetChatStore();
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_load_session_histories") return [history];
+            if (
+                command === "ai_create_session" ||
+                command === "ai_load_session"
+            )
+                return liveSession;
+            if (command === "ai_load_session_history_page")
+                return {
+                    session_id: history.session_id,
+                    total_messages: history.messages.length,
+                    start_index: 0,
+                    end_index: history.messages.length,
+                    messages: history.messages,
+                };
+            return defaultInvokeImplementation(command, args);
+        });
+        await useChatStore.getState().initialize();
+        expect(
+            useChatStore.getState().conversationsById[conversationId]
+                ?.preferredSelection.options,
+        ).toEqual({ model: "wide-model" });
     });
 
     it("drops an ACP option removed after applying the selected model", async () => {

--- a/apps/desktop/src/features/ai/store/chatStore.test.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.test.ts
@@ -15442,6 +15442,158 @@ describe("chatStore", () => {
         ).toHaveLength(1);
     });
 
+    it.each(["catalog", "turn"])(
+        "reconciles saved OpenCode effort absent from a fresh session during %s preparation",
+        async (path) => {
+            await useChatStore.getState().initialize();
+            const sourceSessionId = getActiveSessionId();
+            const conversationId = useChatStore.getState().activeConversationId!;
+            const runtimeId = "opencode-acp";
+            const liveSession = {
+                ...sessionPayload,
+                session_id: "opencode-no-effort",
+                runtime_id: runtimeId,
+                model_id: "plain-model",
+                mode_id: "",
+                models: [{ id: "plain-model", runtime_id: runtimeId, name: "Plain", description: "" }],
+                modes: [],
+                config_options: [],
+                efforts_by_model: {},
+            };
+            useChatStore.setState((state) => ({
+                runtimes: [...state.runtimes, {
+                    runtime: { id: runtimeId, name: "OpenCode", description: "", capabilities: ["create_session"] },
+                    models: [{ id: "plain-model", runtimeId, name: "Plain", description: "" }],
+                    modes: [],
+                    configOptions: [{
+                        id: "effort", runtimeId, category: "reasoning", label: "Effort", type: "select",
+                        value: "low",
+                        options: [{ value: "low", label: "Low" }, { value: "high", label: "High" }],
+                    }],
+                }],
+                setupStatusByRuntimeId: {
+                    ...state.setupStatusByRuntimeId,
+                    [runtimeId]: { ...readySetupStatusState, runtimeId },
+                },
+            }));
+            invokeMock.mockImplementation(async (command, args) => {
+                if (command === "ai_create_session") return liveSession;
+                if (command === "ai_start_conversation_turn") return null;
+                if (command === "ai_send_message") return { ...liveSession, status: "streaming" };
+                return defaultInvokeImplementation(command, args);
+            });
+            // Different from the runtime default: discovery must preserve this
+            // explicit model selection while reconciling its saved effort.
+            const selection = { runtimeId, modelId: "plain-model", modeId: "", options: { effort: "high" } };
+            useChatStore.getState().setConversationTurnSelection(conversationId, selection);
+            invokeMock.mockClear();
+            if (path === "catalog") {
+                await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
+                expect(useChatStore.getState().preparedTurnCatalogByConversationId[conversationId]).toMatchObject({
+                    runtimeId, modelId: "plain-model", configOptions: [],
+                });
+            } else {
+                useChatStore.getState().setComposerParts(createTextParts("Use OpenCode"), sourceSessionId);
+                await useChatStore.getState().sendMessage(sourceSessionId);
+                expect(invokeMock).toHaveBeenCalledWith("ai_start_conversation_turn", expect.objectContaining({
+                    input: expect.objectContaining({ selection: {
+                        runtime_id: runtimeId, model_id: "plain-model", mode_id: "", options: {},
+                    } }),
+                }));
+                expect(invokeMock.mock.calls.some(([command]) => command === "ai_send_message")).toBe(true);
+            }
+            expect(invokeMock.mock.calls.some(([command]) => command === "ai_set_config_option")).toBe(false);
+            expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection).toEqual({
+                runtimeId, modelId: "plain-model", modeId: "", options: {},
+            });
+        },
+    );
+
+    it.each(["removed", "expired", "rejected"])(
+        "uses the conversation catalog when a fresh ACP session has %s effort",
+        async (change) => {
+            await useChatStore.getState().initialize();
+            const sourceSessionId = getActiveSessionId();
+            const conversationId = useChatStore.getState().activeConversationId!;
+            const sourceSession = useChatStore.getState().sessionsById[sourceSessionId]!;
+            const selection = {
+                ...getConversationSelection(sourceSession),
+                options: { model: "test-model", reasoning_effort: "high" },
+            };
+            useChatStore.getState().setConversationTurnSelection(conversationId, selection);
+            // Remove runtime-wide metadata so only the conversation proves
+            // that the saved effort was previously advertised.
+            useChatStore.setState((state) => ({
+                runtimes: state.runtimes.map((runtime) => ({ ...runtime, configOptions: [] })),
+            }));
+            const liveSession = {
+                ...sessionPayload,
+                session_id: "probe-with-changed-effort",
+                config_options: change === "removed" ? [acpConfigOptions[0]] : [
+                    acpConfigOptions[0],
+                    {
+                        ...acpConfigOptions[1],
+                        value: "medium",
+                        options: change === "expired"
+                            ? [{ value: "medium", label: "Medium" }]
+                            : acpConfigOptions[1].options,
+                    },
+                ],
+            };
+            invokeMock.mockImplementation(async (command, args) => {
+                if (command === "ai_create_session" || command === "ai_set_config_option") return liveSession;
+                return defaultInvokeImplementation(command, args);
+            });
+            await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
+            const prepared = useChatStore.getState().preparedTurnCatalogByConversationId[conversationId];
+            if (change === "rejected") {
+                expect(prepared).toBeUndefined();
+                expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection).toEqual(selection);
+            } else {
+                expect(prepared?.configOptions).toHaveLength(change === "removed" ? 1 : 2);
+                expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection.options).toEqual(
+                    change === "removed" ? { model: "test-model" } : { model: "test-model", reasoning_effort: "medium" },
+                );
+            }
+        },
+    );
+
+    it("reconciles dependent options after each ACP configuration response", async () => {
+        await useChatStore.getState().initialize();
+        const sourceSessionId = getActiveSessionId();
+        const conversationId = useChatStore.getState().activeConversationId!;
+        const serviceTier = {
+            ...acpConfigOptions[1], id: "service_tier", category: "service_tier",
+            value: "standard", options: [{ value: "standard", label: "Standard" }, { value: "fast", label: "Fast" }],
+        };
+        const liveSession = {
+            ...sessionPayload, session_id: "dependent-options",
+            config_options: [...acpConfigOptions, serviceTier],
+        };
+        invokeMock.mockImplementation(async (command, args) => {
+            if (command === "ai_create_session") return liveSession;
+            if (command === "ai_set_config_option") {
+                const input = (args as { input: { option_id: string } }).input;
+                expect(input.option_id).toBe("service_tier");
+                // Fast service removes the reasoning control entirely.
+                return { ...liveSession, config_options: [acpConfigOptions[0], { ...serviceTier, value: "fast" }] };
+            }
+            return defaultInvokeImplementation(command, args);
+        });
+        const selection = {
+            ...getConversationSelection(useChatStore.getState().sessionsById[sourceSessionId]!),
+            options: { model: "test-model", service_tier: "fast", reasoning_effort: "high" },
+        };
+        useChatStore.getState().setConversationTurnSelection(conversationId, selection);
+        await useChatStore.getState().prepareConversationTurnCatalog(conversationId, selection);
+        expect(useChatStore.getState().conversationsById[conversationId]?.preferredSelection.options).toEqual({
+            model: "test-model", service_tier: "fast",
+        });
+        expect(useChatStore.getState().preparedTurnCatalogByConversationId[conversationId]?.configOptions.map((option) => option.id)).toEqual([
+            "model", "service_tier",
+        ]);
+    });
+
     it("drops an ACP option removed after applying the selected model", async () => {
         await useChatStore.getState().initialize();
 

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -180,6 +180,7 @@ import {
 } from "../conversationTurnRouting";
 import {
     getDefaultConversationSelection,
+    getSessionCatalogKey,
     type PreparedConversationTurnCatalog,
 } from "../conversationPickerModel";
 import {
@@ -7329,7 +7330,7 @@ const _pendingTurnSelectionByConversationId = new Map<
     string,
     ConversationSelection
 >();
-const _pendingTurnCatalogKeyByConversationId = new Map<string, string>();
+const _pendingTurnCatalogSelectionByConversationId = new Map<string, ConversationSelection>();
 // Keep probe ids on globalThis so Vite HMR cannot forget them while an async
 // ACP probe is running. Session-created/list events must never project these
 // implementation-detail sessions as user-visible conversations.
@@ -8878,9 +8879,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
     async function syncQueuedMessageConfig(
         sessionId: string,
         queuedItem: QueuedChatMessage,
+        previousOptions: AIChatSession["configOptions"],
     ) {
         let session = get().sessionsById[sessionId];
         if (!session) return null;
+        const knownOptions = [...previousOptions, ...session.configOptions];
 
         const selectedModelId =
             getModelConfigOption(session)?.value ?? session.modelId;
@@ -8930,6 +8933,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             normalizedModeId !== session.modeId &&
             normalizedModeIsAvailable
         ) {
+            knownOptions.push(...session.configOptions);
             session = await aiSetMode(sessionId, normalizedModeId);
             get().upsertSession(session);
         }
@@ -8939,16 +8943,30 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
 
         const modeOptionId = getModeConfigOption(session)?.id ?? null;
         const modelOptionId = getModelConfigOption(session)?.id ?? null;
-        for (const option of session.configOptions) {
+        let effectiveSelection = reconcileInheritedAcpOptions(
+            session,
+            {
+                runtimeId: session.runtimeId,
+                modelId: queuedItem.modelId ?? session.modelId,
+                modeId: normalizedModeId,
+                options: queuedItem.optionsSnapshot,
+            },
+            knownOptions,
+        );
+        for (const optionId of Object.keys(effectiveSelection.options)) {
+            const option = session.configOptions.find(
+                (candidate) => candidate.id === optionId,
+            );
             if (
+                !option ||
                 option.id === modeOptionId ||
                 option.id === modelOptionId ||
-                !(option.id in queuedItem.optionsSnapshot)
+                !(option.id in effectiveSelection.options)
             ) {
                 continue;
             }
 
-            const nextValue = queuedItem.optionsSnapshot[option.id];
+            const nextValue = effectiveSelection.options[option.id];
             if (
                 nextValue === option.value ||
                 !option.options.some(
@@ -8958,10 +8976,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 continue;
             }
 
+            knownOptions.push(...session.configOptions);
             session = await aiSetConfigOption(sessionId, option.id, nextValue);
             get().upsertSession(session);
             session = get().sessionsById[sessionId] ?? session;
             if (!session) return null;
+            effectiveSelection = reconcileInheritedAcpOptions(
+                session,
+                effectiveSelection,
+                knownOptions,
+            );
         }
 
         const normalizedSelection = normalizeConversationSelectionForSession(
@@ -8977,15 +9001,17 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         const modeOption = getModeConfigOption(session);
         const nextOptionsSnapshot = modeOption
             ? {
-                  ...queuedItem.optionsSnapshot,
+                  ...effectiveSelection.options,
                   [modeOption.id]: normalizedSelection.modeId,
               }
-            : queuedItem.optionsSnapshot;
+            : effectiveSelection.options;
         const nextQueuedItem =
             queuedItem.modeId === normalizedSelection.modeId &&
-            (!modeOption ||
-                queuedItem.optionsSnapshot[modeOption.id] ===
-                    normalizedSelection.modeId)
+            Object.keys(queuedItem.optionsSnapshot).length ===
+                Object.keys(nextOptionsSnapshot).length &&
+            Object.entries(nextOptionsSnapshot).every(
+                ([id, value]) => queuedItem.optionsSnapshot[id] === value,
+            )
                 ? queuedItem
                 : {
                       ...queuedItem,
@@ -9000,19 +9026,52 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             );
         }
 
+        // Waiting messages for this same model also own saved preferences.
+        // Reconcile them while the old catalog is still available, before a
+        // later turn can lose the evidence that these values were inherited.
+        const configuredSession = session;
+        set((state) => {
+            const queued = state.queuedMessagesBySessionId[sessionId];
+            if (!queued?.length) return state;
+            const reconciled = queued.map((item) => {
+                const selection = {
+                    runtimeId: item.runtimeId ?? configuredSession.runtimeId,
+                    modelId: item.modelId ?? configuredSession.modelId,
+                    modeId: item.modeId ?? configuredSession.modeId,
+                    options: item.optionsSnapshot,
+                };
+                const nextSelection = reconcileInheritedAcpOptions(
+                    configuredSession,
+                    selection,
+                    knownOptions,
+                );
+                return conversationSelectionsEqual(selection, nextSelection)
+                    ? item
+                    : { ...item, optionsSnapshot: nextSelection.options };
+            });
+            if (reconciled.every((item, index) => item === queued[index]))
+                return state;
+            return {
+                queuedMessagesBySessionId: {
+                    ...state.queuedMessagesBySessionId,
+                    [sessionId]: reconciled,
+                },
+            };
+        });
+
         return { session, queuedItem: nextQueuedItem };
     }
 
     function inheritedConversationOptions(
         sourceSession: AIChatSession,
-        runtime: AIRuntimeDescriptor,
+        runtime: AIRuntimeDescriptor | undefined,
     ) {
         return [
             ...sourceSession.configOptions,
             ...(sourceSession.conversationBindings?.providerBindings.flatMap(
                 (binding) => binding.configOptions,
             ) ?? []),
-            ...runtime.configOptions,
+            ...(runtime?.configOptions ?? []),
         ];
     }
 
@@ -9022,7 +9081,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         previousOptions: AIChatSession["configOptions"],
     ) {
         let session = initialSession;
-        const knownOptions = [...previousOptions, ...initialSession.configOptions];
+        const knownOptions = [
+            ...previousOptions,
+            ...initialSession.configOptions,
+        ];
         if (
             selection.modelId &&
             selection.modelId !==
@@ -9455,6 +9517,13 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
 
         const requestedRuntimeId = currentItem.runtimeId ?? session.runtimeId;
+        // Capture persisted metadata before resume/model mutations replace it.
+        const inheritedOptions = inheritedConversationOptions(
+            session,
+            get().runtimes.find(
+                (runtime) => runtime.runtime.id === requestedRuntimeId,
+            ),
+        );
         const initialProviderChangeRequested =
             requestedRuntimeId !== session.runtimeId;
         if (
@@ -9608,6 +9677,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const synced = await syncQueuedMessageConfig(
                     activeSessionId,
                     currentItem,
+                    inheritedOptions,
                 );
                 if (!synced) return;
                 session = synced.session;
@@ -10404,7 +10474,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     setupStatusByRuntimeId,
                 ) ??
                 defaultRuntimeId ??
-                getImplicitDefaultAcpRuntimeId(runtimes, setupStatusByRuntimeId);
+                getImplicitDefaultAcpRuntimeId(
+                    runtimes,
+                    setupStatusByRuntimeId,
+                );
 
             set({
                 runtimes,
@@ -13425,13 +13498,16 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
 
         prepareConversationTurnCatalog: async (conversationId, selection) => {
             const requestKey = getPreparedTurnCatalogKey(selection);
+            const pending =
+                _pendingTurnCatalogSelectionByConversationId.get(
+                    conversationId,
+                );
             const prepared =
                 get().preparedTurnCatalogByConversationId[conversationId];
             if (
                 (prepared &&
                     getPreparedTurnCatalogKey(prepared) === requestKey) ||
-                _pendingTurnCatalogKeyByConversationId.get(conversationId) ===
-                    requestKey
+                (pending && conversationSelectionsEqual(pending, selection))
             ) {
                 return;
             }
@@ -13461,9 +13537,15 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 return;
             }
 
-            _pendingTurnCatalogKeyByConversationId.set(
+            // Object identity also distinguishes A -> B -> A requests. An old
+            // A response must never publish over a newer request for A.
+            const pendingSelection = {
+                ...selection,
+                options: { ...selection.options },
+            };
+            _pendingTurnCatalogSelectionByConversationId.set(
                 conversationId,
-                requestKey,
+                pendingSelection,
             );
             let probeSessionId: string | null = null;
             try {
@@ -13498,9 +13580,9 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const resolvedSelection = configured.selection;
 
                 if (
-                    _pendingTurnCatalogKeyByConversationId.get(
+                    _pendingTurnCatalogSelectionByConversationId.get(
                         conversationId,
-                    ) !== requestKey
+                    ) !== pendingSelection
                 ) {
                     // A newer selection won the race; never publish stale
                     // options from the superseded probe.
@@ -13517,9 +13599,10 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     get().conversationsById[conversationId];
                 if (
                     !currentConversation ||
-                    getPreparedTurnCatalogKey(
+                    !conversationSelectionsEqual(
                         currentConversation.preferredSelection,
-                    ) !== requestKey
+                        selection,
+                    )
                 ) {
                     // Provider previews still warm the shared runtime catalog,
                     // but must not change this conversation's staged choice.
@@ -13527,10 +13610,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 }
 
                 if (
-                    !conversationSelectionsEqual(
-                        selection,
-                        resolvedSelection,
-                    )
+                    !conversationSelectionsEqual(selection, resolvedSelection)
                 ) {
                     get().setConversationTurnSelection(
                         conversationId,
@@ -13555,6 +13635,8 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                         [conversationId]: {
                             runtimeId: resolvedSelection.runtimeId,
                             modelId: resolvedSelection.modelId,
+                            sourceSessionCatalogKey:
+                                getSessionCatalogKey(sourceSession),
                             models: configuredSession.models,
                             modes: configuredSession.modes,
                             configOptions: configuredSession.configOptions,
@@ -13607,11 +13689,11 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                     _turnCatalogProbeSessionIds.delete(probeSessionId);
                 }
                 if (
-                    _pendingTurnCatalogKeyByConversationId.get(
+                    _pendingTurnCatalogSelectionByConversationId.get(
                         conversationId,
-                    ) === requestKey
+                    ) === pendingSelection
                 ) {
-                    _pendingTurnCatalogKeyByConversationId.delete(
+                    _pendingTurnCatalogSelectionByConversationId.delete(
                         conversationId,
                     );
                 }
@@ -16714,7 +16796,7 @@ export function resetChatStore() {
     _queueDrainLocks.clear();
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
-    _pendingTurnCatalogKeyByConversationId.clear();
+    _pendingTurnCatalogSelectionByConversationId.clear();
     _turnCatalogProbeSessionIds.clear();
     _pendingConversationTurnEventRouteBySessionId.clear();
     _pendingSessionPersistence.clear();
@@ -16790,7 +16872,7 @@ export function disposeChatStoreRuntime() {
     chatRuntimeInitialized = false;
     _composerPreflightOwnershipBySessionId.clear();
     _pendingStopBySessionId.clear();
-    _pendingTurnCatalogKeyByConversationId.clear();
+    _pendingTurnCatalogSelectionByConversationId.clear();
     _turnCatalogProbeSessionIds.clear();
     _pendingConversationTurnEventRouteBySessionId.clear();
     clearTrackedPersistedReconciliationTimers();

--- a/apps/desktop/src/features/ai/store/chatStore.ts
+++ b/apps/desktop/src/features/ai/store/chatStore.ts
@@ -115,6 +115,7 @@ import {
 } from "../../editor/editorTargetResolver";
 import { getExternalReloadBaselineCandidate } from "../../editor/externalReloadBaselineCache";
 import { useUnreadChatsStore } from "./unreadChatsStore";
+import { reconcileInheritedAcpOptions } from "../acpSelection";
 import { usePinnedChatsStore } from "./pinnedChatsStore";
 import { useChatTabsStore } from "./chatTabsStore";
 import {
@@ -9002,14 +9003,26 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         return { session, queuedItem: nextQueuedItem };
     }
 
+    function inheritedConversationOptions(
+        sourceSession: AIChatSession,
+        runtime: AIRuntimeDescriptor,
+    ) {
+        return [
+            ...sourceSession.configOptions,
+            ...(sourceSession.conversationBindings?.providerBindings.flatMap(
+                (binding) => binding.configOptions,
+            ) ?? []),
+            ...runtime.configOptions,
+        ];
+    }
+
     async function configureConversationTurnSession(
         initialSession: AIChatSession,
         selection: ConversationSelection,
+        previousOptions: AIChatSession["configOptions"],
     ) {
         let session = initialSession;
-        const initiallyAvailableOptionIds = new Set(
-            initialSession.configOptions.map((option) => option.id),
-        );
+        const knownOptions = [...previousOptions, ...initialSession.configOptions];
         if (
             selection.modelId &&
             selection.modelId !==
@@ -9044,6 +9057,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             normalizedSelection.modeId !== session.modeId &&
             normalizedModeIsAvailable
         ) {
+            knownOptions.push(...session.configOptions);
             session = await aiSetMode(
                 session.sessionId,
                 normalizedSelection.modeId,
@@ -9051,34 +9065,23 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
         }
         const modeOption = getModeConfigOption(session);
 
-        const effectiveSelection = {
-            ...normalizedSelection,
-            options: Object.fromEntries(
-                Object.entries({
+        let effectiveSelection = reconcileInheritedAcpOptions(
+            session,
+            {
+                ...normalizedSelection,
+                options: {
                     ...normalizedSelection.options,
                     ...(modeOption
                         ? { [modeOption.id]: normalizedSelection.modeId }
                         : {}),
-                }).filter(([optionId]) => {
-                    const isAvailable = session.configOptions.some(
-                        (option) => option.id === optionId,
-                    );
-                    // ACP option catalogs may change after selecting a model.
-                    // An option that was valid for the session's initial model
-                    // is no longer part of the requested selection when the
-                    // target model removes it. Truly unknown option ids remain
-                    // strict and are rejected by the validation below.
-                    return (
-                        isAvailable ||
-                        !initiallyAvailableOptionIds.has(optionId)
-                    );
-                }),
-            ),
-        };
+                },
+            },
+            knownOptions,
+        );
         const modelOptionId = getModelConfigOption(session)?.id ?? null;
-        for (const [optionId, value] of Object.entries(
-            effectiveSelection.options,
-        )) {
+        for (const optionId of Object.keys(effectiveSelection.options)) {
+            if (!(optionId in effectiveSelection.options)) continue;
+            const value = effectiveSelection.options[optionId];
             const option = session.configOptions.find(
                 (candidate) => candidate.id === optionId,
             );
@@ -9091,10 +9094,18 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             ) {
                 continue;
             }
+            knownOptions.push(...session.configOptions);
             session = await aiSetConfigOption(
                 session.sessionId,
                 option.id,
                 value,
+            );
+            // Each response replaces the full catalog, including dependencies
+            // of options applied earlier in this loop.
+            effectiveSelection = reconcileInheritedAcpOptions(
+                session,
+                effectiveSelection,
+                knownOptions,
             );
         }
 
@@ -9346,6 +9357,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
             const configured = await configureConversationTurnSession(
                 runtimeSession,
                 resolvedSelection,
+                inheritedConversationOptions(input.sourceSession, runtime),
             );
             runtimeSession = configured.session;
             resolvedSelection = configured.selection;
@@ -13480,6 +13492,7 @@ const createChatStore: StateCreator<ChatStore> = (set, get) => {
                 const configured = await configureConversationTurnSession(
                     probeSession,
                     discoveredSelection,
+                    inheritedConversationOptions(sourceSession, runtime),
                 );
                 const configuredSession = configured.session;
                 const resolvedSelection = configured.selection;


### PR DESCRIPTION
OpenCode chats can fail with `The selected ACP option is unavailable: effort` when a saved selection contains an effort setting that a fresh ACP session no longer advertises. Reconcile inherited preferences against the selected model's live catalog so catalog preparation and message sending can proceed with the agent's supported configuration.

- Recognize inherited options through conversation, persisted binding, and runtime catalogs. Drop removed options and use the agent's current value when an inherited value expires. Keep unknown requests and unapplied supported changes strict.
- Reconcile after configuration responses and update queued snapshots and persisted conversation selections, including across reopening. Preserve queued preferences for other models.
- Treat empty live/prepared option catalogs as authoritative. Allow refreshed catalogs for the current model while giving subsequent live updates priority. Prevent superseded probes, including A → B → A selections, from publishing stale state.

Implemented in three commits: reconciliation helper and unit tests; turn/catalog integration and regressions; persistence, queue, picker, and concurrent-probe handling.

Validation:
- Full desktop suite: 2,602 passed, 2 existing TODOs.
- Final affected/integration suites after the last changes and rebase: 449 passed across 7 files, including chat pane and session view tests.
- Desktop ESLint, TypeScript (`tsc -b`), Electron main/preload/renderer builds, and `git diff --check` passed.
- Real OpenCode on Windows 11 was not exercised; regression coverage uses simulated ACP responses.

Closes #427

Replaces #448 after renaming the source branch to `fix/acp-effort-option-reconciliation`.
