### PR TITLE
Prepare 0.8.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ refactors, dependency updates, CI changes, and code cleanup do not belong here.
 
 ---
 
+## [0.8.1] - 2026-09-12
+
+### Fixed
+
+- Fixed chat headers on macOS so they can once again be used to drag the application window while keeping conversation titles interactive.
+- Fixed OpenCode chats failing to send after a model or runtime exposed different ACP options by reconciling stale saved effort and configuration choices with the current catalog.
+
 ## [0.8.0] - 2026-09-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "neverwrite-native-backend"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-legacy",

--- a/apps/desktop/native-backend/Cargo.toml
+++ b/apps/desktop/native-backend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "neverwrite-native-backend"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 
 [dependencies]

--- a/apps/desktop/package-lock.json
+++ b/apps/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "desktop",
-    "version": "0.8.0",
+    "version": "0.8.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "desktop",
-            "version": "0.8.0",
+            "version": "0.8.1",
             "hasInstallScript": true,
             "dependencies": {
                 "@codemirror/commands": "^6.10.3",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
     "name": "desktop",
     "private": true,
-    "version": "0.8.0",
+    "version": "0.8.1",
     "homepage": "https://github.com/jsgrrchg/NeverWrite",
     "type": "module",
     "main": "out/electron/main/index.js",

--- a/apps/web-clipper/package.json
+++ b/apps/web-clipper/package.json
@@ -2,7 +2,7 @@
     "name": "neverwrite-web-clipper",
     "description": "NeverWrite browser extension built as an isolated WXT app inside the monorepo.",
     "private": true,
-    "version": "0.8.0",
+    "version": "0.8.1",
     "type": "module",
     "packageManager": "pnpm@10.33.0",
     "engines": {


### PR DESCRIPTION
## Summary

- bump the Desktop, native backend, and Web Clipper versions to 0.8.1
- add the 0.8.1 changelog entry for the macOS chat-header dragging fix
- document the ACP option reconciliation fix for OpenCode chats

## Validation

- node scripts/validate-release-metadata.mjs --tag v0.8.1
- node --test scripts/release-metadata.test.mjs
- cargo metadata --locked --no-deps --format-version 1
- git diff --check